### PR TITLE
fix(www): invert ratios slider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ catalogs:
       specifier: ^3.43.2
       version: 3.43.2
     react-aria-components:
-      specifier: ^1.12.1
-      version: 1.12.1
+      specifier: ^1.12.2
+      version: 1.12.2
     react-hook-form:
       specifier: ^7.54.2
       version: 7.58.1
@@ -477,7 +477,7 @@ importers:
         version: 3.43.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react-aria-components:
         specifier: catalog:ui
-        version: 1.12.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.12.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react-dom:
         specifier: catalog:react
         version: 19.1.1(react@19.1.1)
@@ -643,7 +643,7 @@ importers:
         version: 3.43.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react-aria-components:
         specifier: catalog:ui
-        version: 1.12.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.12.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react-dom:
         specifier: catalog:react
         version: 19.1.1(react@19.1.1)
@@ -2912,8 +2912,8 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@react-aria/autocomplete@3.0.0-rc.1':
-    resolution: {integrity: sha512-4/+XHkCq9nkC0TNfgPsbuMTu3iwM6Gz4j67rTQRMXrWwCTAqAHJJEmDz/YDt/04Rg+dkGPsauHHMqDxwxZV24Q==}
+  '@react-aria/autocomplete@3.0.0-rc.2':
+    resolution: {integrity: sha512-55KVj5FePFTHk8nWfUUNN8m7rBL+aSRE0CxHI2t8JG3uam3nY7jyuAJy34RBuDEdTsVlMO9Fri/1JragePC2dg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -2942,8 +2942,8 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/collections@3.0.0-rc.6':
-    resolution: {integrity: sha512-N4AzRqzFJ4BztM1x56ot33smDUUsYQ6pzlbz6m4f8ARSqQYl0a2FsM13PYDtuNI5Dt9KtkL6rK/tLaZlTghLyg==}
+  '@react-aria/collections@3.0.0-rc.7':
+    resolution: {integrity: sha512-JMktVhe+OT6rZVcGdmSWgNj3VBq4Owm3L5LD8iMwJrV6SgPGmyzpguX7JTnz1hnSWO/wD2vrwMWEAlcuL7acBg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -7105,8 +7105,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-aria-components@1.12.1:
-    resolution: {integrity: sha512-UTn2y2Pr1QuapXLRoGE/GWHrjcZZSuMf+zhbJjInOHgS+MC4hqXiINufvjQrdjQDzS1llc2aepP9op6+z6QSxA==}
+  react-aria-components@1.12.2:
+    resolution: {integrity: sha512-BTA697VWy6Who9cpSbll447kqqpwxYvN6QF3/+AmXO+M+KgUXtPZAaNXu/9Sv2LdshU0zhIea4w27ZOt57UzPQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -10336,7 +10336,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@react-aria/autocomplete@3.0.0-rc.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@react-aria/autocomplete@3.0.0-rc.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@react-aria/combobox': 3.13.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@react-aria/focus': 3.21.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -10409,7 +10409,7 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@react-aria/collections@3.0.0-rc.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@react-aria/collections@3.0.0-rc.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@react-aria/interactions': 3.25.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@react-aria/ssr': 3.9.10(react@19.1.1)
@@ -15512,12 +15512,12 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-aria-components@1.12.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  react-aria-components@1.12.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@internationalized/date': 3.9.0
       '@internationalized/string': 3.2.7
-      '@react-aria/autocomplete': 3.0.0-rc.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@react-aria/collections': 3.0.0-rc.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@react-aria/autocomplete': 3.0.0-rc.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@react-aria/collections': 3.0.0-rc.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@react-aria/dnd': 3.11.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@react-aria/focus': 3.21.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@react-aria/interactions': 3.25.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ catalogs:
     next: ^15.5.0
     '@next/bundle-analyzer': ^15.5.0
   ui:
-    react-aria-components: ^1.12.1
+    react-aria-components: ^1.12.2
     tailwind-variants: ^1.0.0
     clsx: ^2.1.0
     tailwind-merge: ^3.0.2

--- a/www/modules/style-editor/components/color-scale-editor.tsx
+++ b/www/modules/style-editor/components/color-scale-editor.tsx
@@ -358,7 +358,7 @@ function RatioSlider({ scaleId }: RatioSliderProps) {
 
     const palette = theme.contrastColors[1]!;
 
-    return `linear-gradient(0deg, ${palette.values
+    return `linear-gradient(180deg, ${palette.values
       .map((value) => value.value)
       .join(", ")})`;
   }, [

--- a/www/modules/style-editor/components/color-scale-editor.tsx
+++ b/www/modules/style-editor/components/color-scale-editor.tsx
@@ -375,13 +375,20 @@ function RatioSlider({ scaleId }: RatioSliderProps) {
     <FormControl
       name={`theme.colors.modes.${resolvedMode}.scales.${scaleId}.ratios`}
       control={form.control}
-      render={(props) => (
+      render={({ value, onChange, ...props }) => (
         <SliderRoot
           aria-label="Ratios"
           orientation="vertical"
           minValue={1}
           maxValue={20}
           step={0.05}
+          value={value.map((v: number) => 21 - v)}
+          onChange={(invertedValues) => {
+            const originalValues = (invertedValues as number[]).map(
+              (v) => 21 - v,
+            );
+            onChange(originalValues);
+          }}
           className="h-full"
           {...props}
         >


### PR DESCRIPTION
Invert `RatiosSlider` gradient direction to align it with the table.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8c4ea92-e363-40af-adde-974415c38186">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8c4ea92-e363-40af-adde-974415c38186">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

