### PR TITLE
feat: add presets page to explore curated design systems

### DIFF
--- a/www/src/config/site.tsx
+++ b/www/src/config/site.tsx
@@ -33,5 +33,6 @@ export const navItems: { name: string; href: ToOptions }[] = [
 	{ name: "Docs", href: { to: "/docs/$", params: { _splat: "" } } },
 	{ name: "Components", href: { to: "/components" } },
 	{ name: "Blocks", href: { to: "/blocks" } },
+	{ name: "Presets", href: { to: "/presets" } },
 	{ name: "Create", href: { to: "/create" } },
 ];

--- a/www/src/modules/presets/data.ts
+++ b/www/src/modules/presets/data.ts
@@ -1,0 +1,206 @@
+import type { DesignSystem } from "@/modules/create/preset";
+
+/**
+ * A curated design system preset shown on the explore page. The `system` field
+ * is encoded at runtime via `encodePreset` and used as the `?preset=` query
+ * passed to `/create`.
+ */
+export interface PresetDefinition {
+	id: string;
+	name: string;
+	description: string;
+	tags: string[];
+	system: DesignSystem;
+}
+
+const accent = (ramp: Record<number, string>): Record<string, string> => {
+	const out: Record<string, string> = {};
+	for (const [shade, value] of Object.entries(ramp)) {
+		out[`--accent-${shade}`] = value;
+	}
+	return out;
+};
+
+const baseSystem = (): DesignSystem => ({
+	componentParams: {},
+	tokens: {},
+	density: "compact",
+});
+
+export const presets: PresetDefinition[] = [
+	{
+		id: "minimal",
+		name: "Minimal",
+		description: "Sharp edges, tight spacing, monochrome — the no-nonsense baseline.",
+		tags: ["sharp", "compact", "neutral"],
+		system: {
+			...baseSystem(),
+			tokens: {
+				"--radius-factor": "0",
+			},
+			density: "compact",
+		},
+	},
+	{
+		id: "default",
+		name: "Default",
+		description: "The opinionated starting point shipped out of the box.",
+		tags: ["balanced", "neutral"],
+		system: {
+			...baseSystem(),
+			tokens: {
+				"--radius-factor": "1",
+			},
+			density: "default",
+		},
+	},
+	{
+		id: "soft",
+		name: "Soft",
+		description: "Generously rounded, comfortable density, gentle sky accent.",
+		tags: ["rounded", "comfortable", "sky"],
+		system: {
+			...baseSystem(),
+			tokens: {
+				"--radius-factor": "1.5",
+				...accent({
+					50: "hsl(204, 100%, 95%)",
+					100: "hsl(204, 100%, 90%)",
+					200: "hsl(204, 100%, 82%)",
+					300: "hsl(204, 95%, 72%)",
+					400: "hsl(204, 90%, 62%)",
+					500: "hsl(204, 85%, 52%)",
+					600: "hsl(204, 80%, 42%)",
+					700: "hsl(204, 75%, 34%)",
+					800: "hsl(204, 70%, 26%)",
+					900: "hsl(204, 65%, 18%)",
+					950: "hsl(204, 60%, 12%)",
+				}),
+			},
+			density: "comfortable",
+		},
+	},
+	{
+		id: "vivid",
+		name: "Vivid",
+		description: "High-energy magenta accent on a rounded, pointer-driven shell.",
+		tags: ["rounded", "magenta", "pointer"],
+		system: {
+			...baseSystem(),
+			tokens: {
+				"--radius-factor": "1.25",
+				"--cursor-interactive": "pointer",
+				...accent({
+					50: "hsl(322, 100%, 95%)",
+					100: "hsl(322, 100%, 88%)",
+					200: "hsl(322, 95%, 80%)",
+					300: "hsl(322, 90%, 70%)",
+					400: "hsl(322, 85%, 60%)",
+					500: "hsl(322, 80%, 50%)",
+					600: "hsl(322, 78%, 42%)",
+					700: "hsl(322, 76%, 34%)",
+					800: "hsl(322, 74%, 26%)",
+					900: "hsl(322, 70%, 18%)",
+					950: "hsl(322, 65%, 12%)",
+				}),
+			},
+			density: "default",
+		},
+	},
+	{
+		id: "brutalist",
+		name: "Brutalist",
+		description: "Zero radius, raw neutrals, compact spacing. Edges intact.",
+		tags: ["sharp", "compact", "neutral"],
+		system: {
+			...baseSystem(),
+			tokens: {
+				"--radius-factor": "0",
+				"--cursor-interactive": "default",
+			},
+			density: "compact",
+		},
+	},
+	{
+		id: "verdant",
+		name: "Verdant",
+		description: "Forest green accent paired with balanced spacing and rounded edges.",
+		tags: ["green", "rounded", "default"],
+		system: {
+			...baseSystem(),
+			tokens: {
+				"--radius-factor": "1.15",
+				...accent({
+					50: "hsl(150, 60%, 94%)",
+					100: "hsl(150, 60%, 86%)",
+					200: "hsl(150, 55%, 75%)",
+					300: "hsl(150, 50%, 62%)",
+					400: "hsl(150, 50%, 50%)",
+					500: "hsl(150, 60%, 38%)",
+					600: "hsl(150, 65%, 30%)",
+					700: "hsl(150, 65%, 24%)",
+					800: "hsl(150, 65%, 18%)",
+					900: "hsl(150, 60%, 12%)",
+					950: "hsl(150, 60%, 8%)",
+				}),
+			},
+			density: "default",
+		},
+	},
+	{
+		id: "playful",
+		name: "Playful",
+		description: "Pillowy radius, generous spacing, warm orange accent.",
+		tags: ["rounded", "comfortable", "orange"],
+		system: {
+			...baseSystem(),
+			tokens: {
+				"--radius-factor": "2",
+				"--cursor-interactive": "pointer",
+				...accent({
+					50: "hsl(28, 100%, 94%)",
+					100: "hsl(28, 100%, 86%)",
+					200: "hsl(28, 95%, 76%)",
+					300: "hsl(28, 95%, 66%)",
+					400: "hsl(28, 95%, 58%)",
+					500: "hsl(28, 90%, 50%)",
+					600: "hsl(28, 90%, 42%)",
+					700: "hsl(28, 90%, 34%)",
+					800: "hsl(28, 85%, 26%)",
+					900: "hsl(28, 80%, 18%)",
+					950: "hsl(28, 75%, 12%)",
+				}),
+			},
+			density: "comfortable",
+		},
+	},
+	{
+		id: "corporate",
+		name: "Corporate",
+		description: "Conservative deep-blue accent, default radii, dependable density.",
+		tags: ["blue", "default", "compact"],
+		system: {
+			...baseSystem(),
+			tokens: {
+				"--radius-factor": "0.5",
+				...accent({
+					50: "hsl(220, 50%, 95%)",
+					100: "hsl(220, 50%, 88%)",
+					200: "hsl(220, 50%, 78%)",
+					300: "hsl(220, 50%, 64%)",
+					400: "hsl(220, 55%, 50%)",
+					500: "hsl(220, 65%, 40%)",
+					600: "hsl(220, 70%, 32%)",
+					700: "hsl(220, 70%, 26%)",
+					800: "hsl(220, 70%, 20%)",
+					900: "hsl(220, 65%, 14%)",
+					950: "hsl(220, 60%, 9%)",
+				}),
+			},
+			density: "default",
+		},
+	},
+];
+
+/** Subset of token keys we surface as swatches in the preset card preview. */
+export const PREVIEW_SHADES = [200, 400, 500, 700, 900] as const;

--- a/www/src/modules/presets/preset-card.tsx
+++ b/www/src/modules/presets/preset-card.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from "react";
+
+import { Link as RouterLink } from "@tanstack/react-router";
+
+import { ArrowRightIcon } from "lucide-react";
+
+import { encodePreset } from "@/modules/create/preset";
+import { Badge } from "@/registry/ui/badge";
+import { buttonStyles } from "@/registry/ui/button";
+
+import { PREVIEW_SHADES, type PresetDefinition } from "./data";
+
+interface PresetCardProps {
+	preset: PresetDefinition;
+}
+
+const FALLBACK_ACCENT_RAMP: Record<number, string> = {
+	200: "hsl(0, 0%, 94%)",
+	400: "hsl(0, 0%, 85%)",
+	500: "hsl(0, 0%, 80%)",
+	700: "hsl(0, 0%, 70%)",
+	900: "hsl(0, 0%, 16%)",
+};
+
+export function PresetCard({ preset }: PresetCardProps) {
+	const { name, description, tags, system } = preset;
+
+	const encoded = useMemo(() => encodePreset(system), [system]);
+
+	const radiusFactor = Number.parseFloat(system.tokens["--radius-factor"] ?? "1") || 1;
+	const swatches = PREVIEW_SHADES.map((shade) => system.tokens[`--accent-${shade}`] ?? FALLBACK_ACCENT_RAMP[shade]);
+
+	return (
+		<RouterLink
+			to="/create"
+			search={{ preset: encoded }}
+			className="group relative flex flex-col gap-4 rounded-xl border bg-card p-5 transition-colors hover:bg-muted/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-fg"
+		>
+			<div
+				aria-hidden="true"
+				className="relative flex h-32 items-end justify-between overflow-hidden border bg-bg p-3"
+				style={{ borderRadius: `calc(0.75rem * ${radiusFactor})` }}
+			>
+				<div className="flex items-end gap-1.5">
+					{swatches.map((color, i) => (
+						<div
+							key={i}
+							className="size-7 border border-bg shadow-sm"
+							style={{
+								background: color,
+								borderRadius: `calc(0.5rem * ${radiusFactor})`,
+							}}
+						/>
+					))}
+				</div>
+				<div className="flex flex-col items-end gap-1.5">
+					<div
+						className="h-3 w-16 bg-fg/80"
+						style={{ borderRadius: `calc(0.375rem * ${radiusFactor})` }}
+					/>
+					<div
+						className="h-2 w-10 bg-fg-muted/60"
+						style={{ borderRadius: `calc(0.375rem * ${radiusFactor})` }}
+					/>
+					<div
+						className="mt-2 h-6 w-20 bg-fg text-[10px] leading-6 text-bg"
+						style={{ borderRadius: `calc(0.375rem * ${radiusFactor})` }}
+					>
+						<span className="block text-center">Button</span>
+					</div>
+				</div>
+			</div>
+
+			<div className="flex flex-col gap-1.5">
+				<div className="flex items-center justify-between gap-3">
+					<h3 className="text-base font-medium tracking-tight">{name}</h3>
+					<ArrowRightIcon className="size-4 -translate-x-1 text-fg-muted opacity-0 transition-all group-hover:translate-x-0 group-hover:opacity-100" />
+				</div>
+				<p className="text-sm text-fg-muted">{description}</p>
+			</div>
+
+			<div className="mt-auto flex flex-wrap items-center gap-1.5">
+				<Badge size="sm" variant="neutral" className="capitalize">
+					{system.density}
+				</Badge>
+				<Badge size="sm" variant="neutral">
+					radius {radiusFactor}x
+				</Badge>
+				{tags.map((tag) => (
+					<Badge key={tag} size="sm" variant="neutral">
+						{tag}
+					</Badge>
+				))}
+			</div>
+
+			<span
+				className={buttonStyles({
+					size: "sm",
+					variant: "default",
+					className: "pointer-events-none w-full justify-center",
+				})}
+			>
+				Open in customizer
+			</span>
+		</RouterLink>
+	);
+}

--- a/www/src/modules/presets/presets-gallery.tsx
+++ b/www/src/modules/presets/presets-gallery.tsx
@@ -1,0 +1,12 @@
+import { presets } from "./data";
+import { PresetCard } from "./preset-card";
+
+export function PresetsGallery() {
+	return (
+		<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+			{presets.map((preset) => (
+				<PresetCard key={preset.id} preset={preset} />
+			))}
+		</div>
+	);
+}

--- a/www/src/routeTree.gen.ts
+++ b/www/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as AppIndexRouteImport } from './routes/_app/index'
 import { Route as ViewBlockRouteImport } from './routes/view/$block'
 import { Route as PreviewSlugRouteImport } from './routes/preview/$slug'
 import { Route as DemosSlugRouteImport } from './routes/demos/$slug'
+import { Route as AppPresetsRouteImport } from './routes/_app/presets'
 import { Route as AppCreateRouteImport } from './routes/_app/create'
 import { Route as AppComponentsRouteImport } from './routes/_app/components'
 import { Route as AppDocsRouteRouteImport } from './routes/_app/docs/route'
@@ -57,6 +58,11 @@ const DemosSlugRoute = DemosSlugRouteImport.update({
   id: '/demos/$slug',
   path: '/demos/$slug',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AppPresetsRoute = AppPresetsRouteImport.update({
+  id: '/presets',
+  path: '/presets',
+  getParentRoute: () => AppRouteRoute,
 } as any)
 const AppCreateRoute = AppCreateRouteImport.update({
   id: '/create',
@@ -104,6 +110,7 @@ export interface FileRoutesByFullPath {
   '/docs': typeof AppDocsRouteRouteWithChildren
   '/components': typeof AppComponentsRoute
   '/create': typeof AppCreateRoute
+  '/presets': typeof AppPresetsRoute
   '/demos/$slug': typeof DemosSlugRoute
   '/preview/$slug': typeof PreviewSlugRoute
   '/view/$block': typeof ViewBlockRoute
@@ -118,6 +125,7 @@ export interface FileRoutesByTo {
   '/docs': typeof AppDocsRouteRouteWithChildren
   '/components': typeof AppComponentsRoute
   '/create': typeof AppCreateRoute
+  '/presets': typeof AppPresetsRoute
   '/demos/$slug': typeof DemosSlugRoute
   '/preview/$slug': typeof PreviewSlugRoute
   '/view/$block': typeof ViewBlockRoute
@@ -135,6 +143,7 @@ export interface FileRoutesById {
   '/_app/docs': typeof AppDocsRouteRouteWithChildren
   '/_app/components': typeof AppComponentsRoute
   '/_app/create': typeof AppCreateRoute
+  '/_app/presets': typeof AppPresetsRoute
   '/demos/$slug': typeof DemosSlugRoute
   '/preview/$slug': typeof PreviewSlugRoute
   '/view/$block': typeof ViewBlockRoute
@@ -153,6 +162,7 @@ export interface FileRouteTypes {
     | '/docs'
     | '/components'
     | '/create'
+    | '/presets'
     | '/demos/$slug'
     | '/preview/$slug'
     | '/view/$block'
@@ -167,6 +177,7 @@ export interface FileRouteTypes {
     | '/docs'
     | '/components'
     | '/create'
+    | '/presets'
     | '/demos/$slug'
     | '/preview/$slug'
     | '/view/$block'
@@ -183,6 +194,7 @@ export interface FileRouteTypes {
     | '/_app/docs'
     | '/_app/components'
     | '/_app/create'
+    | '/_app/presets'
     | '/demos/$slug'
     | '/preview/$slug'
     | '/view/$block'
@@ -251,6 +263,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/demos/$slug'
       preLoaderRoute: typeof DemosSlugRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_app/presets': {
+      id: '/_app/presets'
+      path: '/presets'
+      fullPath: '/presets'
+      preLoaderRoute: typeof AppPresetsRouteImport
+      parentRoute: typeof AppRouteRoute
     }
     '/_app/create': {
       id: '/_app/create'
@@ -335,6 +354,7 @@ interface AppRouteRouteChildren {
   AppDocsRouteRoute: typeof AppDocsRouteRouteWithChildren
   AppComponentsRoute: typeof AppComponentsRoute
   AppCreateRoute: typeof AppCreateRoute
+  AppPresetsRoute: typeof AppPresetsRoute
   AppIndexRoute: typeof AppIndexRoute
 }
 
@@ -343,6 +363,7 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppDocsRouteRoute: AppDocsRouteRouteWithChildren,
   AppComponentsRoute: AppComponentsRoute,
   AppCreateRoute: AppCreateRoute,
+  AppPresetsRoute: AppPresetsRoute,
   AppIndexRoute: AppIndexRoute,
 }
 

--- a/www/src/routes/_app/presets.tsx
+++ b/www/src/routes/_app/presets.tsx
@@ -1,0 +1,46 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { siteConfig } from "@/config/site";
+import { PageHeader, PageHeaderDescription, PageHeaderHeading, PageLayout } from "@/modules/docs/page-layout";
+import { PresetsGallery } from "@/modules/presets/presets-gallery";
+
+const title = "Presets";
+const description = "Explore curated design system presets. Pick one to open it in the customizer and make it yours.";
+
+export const Route = createFileRoute("/_app/presets")({
+	component: PresetsPage,
+	head: () => {
+		const ogImageUrl = `${siteConfig.url}/og?title=${encodeURIComponent(title)}&description=${encodeURIComponent(description)}`;
+
+		return {
+			meta: [
+				{ title: `${title} - ${siteConfig.name}` },
+				{ name: "description", content: description },
+				{ property: "og:title", content: title },
+				{ property: "og:description", content: description },
+				{ property: "og:type", content: "article" },
+				{ property: "og:url", content: `${siteConfig.url}/presets` },
+				{ property: "og:image", content: ogImageUrl },
+				{ name: "twitter:card", content: "summary_large_image" },
+				{ name: "twitter:title", content: title },
+				{ name: "twitter:description", content: description },
+				{ name: "twitter:image", content: ogImageUrl },
+				{ name: "twitter:creator", content: siteConfig.twitter.creator },
+			],
+		};
+	},
+});
+
+function PresetsPage() {
+	return (
+		<PageLayout>
+			<PageHeader>
+				<PageHeaderHeading>{title}</PageHeaderHeading>
+				<PageHeaderDescription>{description}</PageHeaderDescription>
+			</PageHeader>
+			<div className="container pb-16">
+				<PresetsGallery />
+			</div>
+		</PageLayout>
+	);
+}


### PR DESCRIPTION
## Summary

Adds a new `/presets` route that surfaces a gallery of curated design system presets, so users can browse pre-built looks before opening the customizer.

- New page at `/presets` rendering 8 curated presets (Minimal, Default, Soft, Vivid, Brutalist, Verdant, Playful, Corporate) with distinct radius, density, accent palette, and cursor combinations.
- Each card encodes its `DesignSystem` via the existing `encodePreset` codec and links to `/create?preset=<encoded>` — the customizer already decodes that param, so picking a preset opens the customizer with the look applied.
- Card preview uses live values: swatches and mock UI elements pick up the preset's radius factor and accent ramp so the card itself previews the design.
- Adds a "Presets" nav item between Blocks and Create.

## Files

- `www/src/modules/presets/data.ts` — preset definitions (`PresetDefinition[]`) keyed off the existing `DesignSystem` type.
- `www/src/modules/presets/preset-card.tsx` — individual card with swatches, mock UI preview, and badges.
- `www/src/modules/presets/presets-gallery.tsx` — responsive grid.
- `www/src/routes/_app/presets.tsx` — TanStack Start route with `head` meta + OG tags.
- `www/src/config/site.tsx` — adds nav item.
- `www/src/routeTree.gen.ts` — adds the new file route entry (auto-regenerated by the router plugin).

## Test plan

- [x] `pnpm typecheck` — clean for new files (pre-existing `starter-themes` resolution error unrelated).
- [x] `pnpm dev` → `GET /presets` returns 200, renders 8 cards with correct titles and per-preset swatches.
- [x] Click a card → navigates to `/create?preset=<hash>`; customizer panel reflects that preset's radius factor and density (verified Minimal → 0.00x / Compact and Soft → 1.50x / comfortable).
- [ ] Manual smoke on different viewports (responsive grid: 1/2/3/4 cols).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUtUADGqD5oSsd3YWUEu7a)_