### PR TITLE
Introduce publisher pipeline (flatten/resolve/serialize), central token maps, and unify `Density` type

### DIFF
--- a/www/src/modules/core/styles.tsx
+++ b/www/src/modules/core/styles.tsx
@@ -6,7 +6,7 @@ import { tv } from "tailwind-variants";
 
 import type { ClassValue, TVReturnType, VariantProps } from "tailwind-variants";
 
-import type { Density } from "@/modules/create/preset/types";
+import type { Density } from "@/registry/types";
 import type { EnumParamDef, ParamDef, RegistryItem } from "@/registry/types";
 
 /* --------------------------------- Types --------------------------------- */

--- a/www/src/modules/create/components-config.tsx
+++ b/www/src/modules/create/components-config.tsx
@@ -7,6 +7,7 @@ import { Description, Label } from "@/registry/ui/field";
 import { ListBox, ListBoxItem } from "@/registry/ui/list-box";
 import { Popover } from "@/registry/ui/popover";
 import { registryUi } from "@/registry/ui/registry";
+import { BLUR_OPTIONS, CURSOR_OPTIONS, OPACITY_OPTIONS, RADIUS_OPTIONS, SHADOW_OPTIONS } from "@/registry/publisher/token-map";
 import { Select, SelectValue } from "@/registry/ui/select";
 import { Slider, SliderControl, SliderOutput } from "@/registry/ui/slider";
 
@@ -91,59 +92,6 @@ export function AllComponentsView({ onSelect }: AllComponentsViewProps) {
 
 /* -------------------- Component detail view -------------------- */
 
-const radiusOptions = [
-	{ label: "none", value: "0" },
-	{ label: "sm", value: "--radius-sm" },
-	{ label: "md", value: "--radius-md" },
-	{ label: "lg", value: "--radius-lg" },
-	{ label: "xl", value: "--radius-xl" },
-	{ label: "2xl", value: "--radius-2xl" },
-	{ label: "full", value: "--radius-full" },
-] as const;
-
-const blurOptions = [
-	{ label: "None", value: "0px" },
-	{ label: "Extra Small", value: "--blur-xs" },
-	{ label: "Small", value: "--blur-sm" },
-	{ label: "Medium", value: "--blur-md" },
-	{ label: "Large", value: "--blur-lg" },
-	{ label: "Extra Large", value: "--blur-xl" },
-];
-
-const opacityOptions = [
-	{ label: "20%", value: "20%" },
-	{ label: "40%", value: "40%" },
-	{ label: "60%", value: "60%" },
-	{ label: "80%", value: "80%" },
-];
-
-const shadowOptions = [
-	{ label: "None", value: "none" },
-	{ label: "Extra Small", value: "--shadow-xs" },
-	{ label: "Small", value: "--shadow-sm" },
-	{ label: "Medium", value: "--shadow-md" },
-	{ label: "Large", value: "--shadow-lg" },
-	{ label: "Extra Large", value: "--shadow-xl" },
-	{ label: "2XL", value: "--shadow-2xl" },
-	{ label: "Shine", value: "--shadow-shine" },
-] as const;
-
-const cursorOptions = [
-	{ label: "Interactive", value: "--cursor-interactive" },
-	{ label: "Disabled", value: "--cursor-disabled" },
-	{ label: "Default", value: "default" },
-	{ label: "Pointer", value: "pointer" },
-	{ label: "Grab", value: "grab" },
-	{ label: "Grabbing", value: "grabbing" },
-	{ label: "Not allowed", value: "not-allowed" },
-	{ label: "Wait", value: "wait" },
-	{ label: "Help", value: "help" },
-	{ label: "Crosshair", value: "crosshair" },
-	{ label: "Text", value: "text" },
-	{ label: "Move", value: "move" },
-	{ label: "Progress", value: "progress" },
-] as const;
-
 const SPACING_REM_PER_UNIT = 0.25;
 
 const colorOptions = Object.entries(COLOR_TOKENS)
@@ -227,12 +175,12 @@ function ParamEditor({ paramName, def, selected, onChange }: ParamEditorProps) {
 	}
 
 	const optionsByType = {
-		blur: blurOptions,
+		blur: BLUR_OPTIONS,
 		color: colorOptions,
-		cursor: cursorOptions,
+		cursor: CURSOR_OPTIONS,
 		"font-size": [],
-		opacity: opacityOptions,
-		shadow: shadowOptions,
+		opacity: OPACITY_OPTIONS,
+		shadow: SHADOW_OPTIONS,
 	} satisfies Record<Exclude<TokenType, "radius" | "spacing">, readonly { label: string; value: string }[]>;
 	const options = optionsByType[def.type];
 
@@ -268,30 +216,30 @@ interface ScalarParamEditorProps {
 
 function RadiusParamSlider({ paramName, def, selected, onChange }: ScalarParamEditorProps) {
 	const value = selected ?? def.default;
-	const selectedIndex = radiusOptions.findIndex((opt) => opt.value === value);
-	const fallbackIndex = radiusOptions.findIndex((opt) => opt.value === def.default);
+	const selectedIndex = RADIUS_OPTIONS.findIndex((opt) => opt.value === value);
+	const fallbackIndex = RADIUS_OPTIONS.findIndex((opt) => opt.value === def.default);
 	const index = selectedIndex >= 0 ? selectedIndex : fallbackIndex >= 0 ? fallbackIndex : 0;
-	const current = radiusOptions[index] ?? radiusOptions[0];
+	const current = RADIUS_OPTIONS[index] ?? RADIUS_OPTIONS[0];
 	return (
 		<div className="flex flex-col gap-2">
 			<Slider
 				aria-label={toTitleCase(paramName)}
 				value={index}
 				minValue={0}
-				maxValue={radiusOptions.length - 1}
+				maxValue={RADIUS_OPTIONS.length - 1}
 				step={1}
 				onChange={(value) => {
 					const rawIndex = Array.isArray(value) ? value[0] : value;
 					if (typeof rawIndex !== "number") return;
 
-					const nextIndex = Math.min(Math.max(Math.round(rawIndex), 0), radiusOptions.length - 1);
-					const next = radiusOptions[nextIndex];
+					const nextIndex = Math.min(Math.max(Math.round(rawIndex), 0), RADIUS_OPTIONS.length - 1);
+					const next = RADIUS_OPTIONS[nextIndex];
 					if (next) onChange(next.value);
 				}}
 			>
 				<div className="flex items-center justify-between">
 					<Label>{toTitleCase(paramName)}</Label>
-					<SliderOutput>{current.label}</SliderOutput>
+					<SliderOutput>{current?.label ?? RADIUS_OPTIONS[0]?.label}</SliderOutput>
 				</div>
 				<SliderControl />
 				{def.description && <Description className="text-xs text-fg-muted/60">{def.description}</Description>}

--- a/www/src/modules/create/preset/types.ts
+++ b/www/src/modules/create/preset/types.ts
@@ -1,4 +1,5 @@
-export type Density = "compact" | "default" | "comfortable";
+export type { Density } from "@/registry/types";
+import type { Density } from "@/registry/types";
 
 /**
  * Compact representation for URL serialization. Short keys keep the encoded

--- a/www/src/registry/publisher/flatten.ts
+++ b/www/src/registry/publisher/flatten.ts
@@ -1,0 +1,62 @@
+import type { Density, RegistryItem } from "@/registry/types";
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeValues(baseValue: unknown, overrideValue: unknown): unknown {
+	if (typeof baseValue === "string" && typeof overrideValue === "string") {
+		return `${baseValue} ${overrideValue}`.trim();
+	}
+
+	if (Array.isArray(baseValue) && Array.isArray(overrideValue)) {
+		return [...baseValue, ...overrideValue];
+	}
+
+	if (isRecord(baseValue) && isRecord(overrideValue)) {
+		return mergeRecords(baseValue, overrideValue);
+	}
+
+	return overrideValue;
+}
+
+function mergeRecords(base: JsonRecord, override: JsonRecord): JsonRecord {
+	const merged: JsonRecord = { ...base };
+	for (const [key, overrideValue] of Object.entries(override)) {
+		const baseValue = merged[key];
+		merged[key] = baseValue === undefined ? overrideValue : mergeValues(baseValue, overrideValue);
+	}
+	return merged;
+}
+
+export function flattenStylesConfig(
+	stylesConfig: JsonRecord,
+	meta: Pick<RegistryItem, "params" | "name">,
+	options: { density: Density; componentParams: Record<string, string> },
+): JsonRecord {
+	const base = isRecord(stylesConfig.base) ? stylesConfig.base : {};
+	const densities = isRecord(stylesConfig.density) ? stylesConfig.density : {};
+	const params = isRecord(stylesConfig.params) ? stylesConfig.params : {};
+
+	let flattened = mergeRecords({}, base);
+
+	const densityConfig = densities[options.density];
+	if (isRecord(densityConfig)) {
+		flattened = mergeRecords(flattened, densityConfig);
+	}
+
+	for (const [paramName, def] of Object.entries(meta.params ?? {})) {
+		if (def.kind !== "enum") continue;
+		const selected = options.componentParams[paramName] ?? def.default;
+		const paramValues = params[paramName];
+		if (!isRecord(paramValues)) continue;
+		const selectedConfig = paramValues[selected];
+		if (isRecord(selectedConfig)) {
+			flattened = mergeRecords(flattened, selectedConfig);
+		}
+	}
+
+	return flattened;
+}

--- a/www/src/registry/publisher/pipeline.spec.ts
+++ b/www/src/registry/publisher/pipeline.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+
+import { flattenStylesConfig } from "./flatten";
+import { resolveScalarClasses } from "./resolve-classes";
+import { serializeTvConfig } from "./serialize";
+
+import type { RegistryItem } from "@/registry/types";
+
+const fixtureMeta = {
+	name: "button",
+	params: {
+		radius: {
+			kind: "scalar",
+			type: "radius",
+			cssVar: "--btn-radius",
+			default: "--radius-sm",
+		},
+		style: {
+			kind: "enum",
+			default: "default",
+			values: ["default", "quiet"],
+		},
+	},
+} satisfies Pick<RegistryItem, "name" | "params">;
+
+const fixtureConfig = {
+	base: {
+		base: "rounded-(--btn-radius) bg-neutral",
+		variants: {
+			size: { md: "h-8" },
+		},
+	},
+	density: {
+		comfortable: {
+			variants: {
+				size: { md: "px-4" },
+			},
+		},
+	},
+	params: {
+		style: {
+			quiet: {
+				base: "text-fg-muted",
+			},
+		},
+	},
+};
+
+describe("publisher request-time pipeline", () => {
+	test("flattens density and enum params then resolves scalar utility classes", () => {
+		const flattened = flattenStylesConfig(fixtureConfig, fixtureMeta, {
+			density: "comfortable",
+			componentParams: { style: "quiet", radius: "--radius-lg" },
+		});
+
+		const resolved = resolveScalarClasses(flattened, fixtureMeta, {
+			style: "quiet",
+			radius: "--radius-lg",
+		});
+
+		expect(resolved).toEqual({
+			base: "rounded-lg bg-neutral text-fg-muted",
+			variants: {
+				size: {
+					md: "h-8 px-4",
+				},
+			},
+		});
+
+		const serialized = serializeTvConfig(resolved);
+		expect(serialized).toContain('"base": "rounded-lg bg-neutral text-fg-muted"');
+	});
+});

--- a/www/src/registry/publisher/resolve-classes.ts
+++ b/www/src/registry/publisher/resolve-classes.ts
@@ -1,0 +1,57 @@
+import { BLUR_OPTIONS, CURSOR_OPTIONS, RADIUS_OPTIONS, SHADOW_OPTIONS } from "./token-map";
+
+import type { RegistryItem, TokenType } from "@/registry/types";
+
+const VALUE_TO_TOKEN_BY_TYPE: Record<TokenType, Map<string, string>> = {
+	radius: new Map(RADIUS_OPTIONS.map((opt) => [opt.value, opt.label])),
+	blur: new Map(BLUR_OPTIONS.map((opt) => [opt.value, opt.label.toLowerCase().replace(/\s+/g, "-")])),
+	shadow: new Map(SHADOW_OPTIONS.map((opt) => [opt.value, opt.label.toLowerCase().replace(/\s+/g, "-")])),
+	cursor: new Map(CURSOR_OPTIONS.map((opt) => [opt.value, opt.label.toLowerCase().replace(/\s+/g, "-")])),
+	opacity: new Map(),
+	color: new Map(),
+	"font-size": new Map(),
+	spacing: new Map(),
+};
+
+const CSS_VAR_UTILITY_PATTERN = /([a-z0-9-]+)-\(--([a-z0-9-]+)\)/gi;
+
+function resolveClassString(value: string, scalarVars: Map<string, { type: TokenType; selected: string }>): string {
+	return value.replace(CSS_VAR_UTILITY_PATTERN, (full, utility: string, cssVarName: string) => {
+		const binding = scalarVars.get(`--${cssVarName}`);
+		if (!binding) return full;
+
+		const tokenValue = VALUE_TO_TOKEN_BY_TYPE[binding.type].get(binding.selected);
+		if (!tokenValue) return full;
+
+		return `${utility}-${tokenValue}`;
+	});
+}
+
+function walkAndResolve(input: unknown, scalarVars: Map<string, { type: TokenType; selected: string }>): unknown {
+	if (typeof input === "string") return resolveClassString(input, scalarVars);
+	if (Array.isArray(input)) return input.map((entry) => walkAndResolve(entry, scalarVars));
+	if (!input || typeof input !== "object") return input;
+
+	const output: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(input)) {
+		output[key] = walkAndResolve(value, scalarVars);
+	}
+	return output;
+}
+
+export function resolveScalarClasses(
+	config: Record<string, unknown>,
+	meta: Pick<RegistryItem, "params">,
+	componentParams: Record<string, string>,
+): Record<string, unknown> {
+	const scalarVars = new Map<string, { type: TokenType; selected: string }>();
+	for (const [paramName, def] of Object.entries(meta.params ?? {})) {
+		if (def.kind !== "scalar") continue;
+		scalarVars.set(def.cssVar, {
+			type: def.type,
+			selected: componentParams[paramName] ?? def.default,
+		});
+	}
+
+	return walkAndResolve(config, scalarVars) as Record<string, unknown>;
+}

--- a/www/src/registry/publisher/serialize.ts
+++ b/www/src/registry/publisher/serialize.ts
@@ -1,0 +1,3 @@
+export function serializeTvConfig(config: Record<string, unknown>): string {
+	return JSON.stringify(config, null, 2);
+}

--- a/www/src/registry/publisher/token-map.ts
+++ b/www/src/registry/publisher/token-map.ts
@@ -1,0 +1,57 @@
+export type TokenOption = {
+	label: string;
+	value: string;
+};
+
+export const RADIUS_OPTIONS: readonly TokenOption[] = [
+	{ label: "none", value: "0" },
+	{ label: "sm", value: "--radius-sm" },
+	{ label: "md", value: "--radius-md" },
+	{ label: "lg", value: "--radius-lg" },
+	{ label: "xl", value: "--radius-xl" },
+	{ label: "2xl", value: "--radius-2xl" },
+	{ label: "full", value: "--radius-full" },
+] as const;
+
+export const BLUR_OPTIONS: readonly TokenOption[] = [
+	{ label: "None", value: "0px" },
+	{ label: "Extra Small", value: "--blur-xs" },
+	{ label: "Small", value: "--blur-sm" },
+	{ label: "Medium", value: "--blur-md" },
+	{ label: "Large", value: "--blur-lg" },
+	{ label: "Extra Large", value: "--blur-xl" },
+] as const;
+
+export const OPACITY_OPTIONS: readonly TokenOption[] = [
+	{ label: "20%", value: "20%" },
+	{ label: "40%", value: "40%" },
+	{ label: "60%", value: "60%" },
+	{ label: "80%", value: "80%" },
+] as const;
+
+export const SHADOW_OPTIONS: readonly TokenOption[] = [
+	{ label: "None", value: "none" },
+	{ label: "Extra Small", value: "--shadow-xs" },
+	{ label: "Small", value: "--shadow-sm" },
+	{ label: "Medium", value: "--shadow-md" },
+	{ label: "Large", value: "--shadow-lg" },
+	{ label: "Extra Large", value: "--shadow-xl" },
+	{ label: "2XL", value: "--shadow-2xl" },
+	{ label: "Shine", value: "--shadow-shine" },
+] as const;
+
+export const CURSOR_OPTIONS: readonly TokenOption[] = [
+	{ label: "Interactive", value: "--cursor-interactive" },
+	{ label: "Disabled", value: "--cursor-disabled" },
+	{ label: "Default", value: "default" },
+	{ label: "Pointer", value: "pointer" },
+	{ label: "Grab", value: "grab" },
+	{ label: "Grabbing", value: "grabbing" },
+	{ label: "Not allowed", value: "not-allowed" },
+	{ label: "Wait", value: "wait" },
+	{ label: "Help", value: "help" },
+	{ label: "Crosshair", value: "crosshair" },
+	{ label: "Text", value: "text" },
+	{ label: "Move", value: "move" },
+	{ label: "Progress", value: "progress" },
+] as const;

--- a/www/src/registry/types.ts
+++ b/www/src/registry/types.ts
@@ -26,6 +26,7 @@ export type ComponentGroup =
 /* ------------------------------- Params ------------------------------- */
 
 export type TokenType = "radius" | "color" | "spacing" | "font-size" | "blur" | "opacity" | "cursor" | "shadow";
+export type Density = "compact" | "default" | "comfortable";
 export type RegistryItemFile = NonNullable<ShadcnRegistryItem["files"]>[number];
 
 /**


### PR DESCRIPTION
### Motivation

- Provide a request-time publisher pipeline to flatten component styles, resolve scalar token utilities into concrete classes, and serialize the result for downstream consumption.
- Centralize scalar token option definitions so UI editors and publisher logic share the same option set and labels.
- Unify the `Density` type into the shared registry types to avoid duplicate definitions and keep typings consistent across modules.

### Description

- Added a publisher pipeline with three new modules: `flatten.ts` which merges base/density/enum configs into a single config, `resolve-classes.ts` which replaces CSS-var based scalar utilities with concrete utility tokens, and `serialize.ts` which JSON-serializes a TV config via `serializeTvConfig`.
- Introduced `token-map.ts` to export `RADIUS_OPTIONS`, `BLUR_OPTIONS`, `OPACITY_OPTIONS`, `SHADOW_OPTIONS`, `CURSOR_OPTIONS`, and the `TokenOption` type for reuse by both the editor UI and publisher logic.
- Updated the create UI (`components-config.tsx`) to import and use the centralized token option constants instead of inline option arrays, and adjusted slider logic to reference `RADIUS_OPTIONS` with safer fallbacks.
- Moved `Density` type into `www/src/registry/types.ts` and updated references/imports in `preset/types.ts` and `styles.tsx` to consume the centralized type.
- Added `pipeline.spec.ts` unit test that exercises `flattenStylesConfig`, `resolveScalarClasses`, and `serializeTvConfig` together using a small fixture to validate end-to-end behavior.

### Testing

- Ran `vitest` which executed the new `registry/publisher/pipeline.spec.ts` test and it passed.
- The publisher utilities were exercised by the unit test verifying `flattenStylesConfig` + `resolveScalarClasses` produce the expected flattened/resolved TV config and that `serializeTvConfig` includes the expected output string.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8fa9578832f8c54b84543b78f21)