### PR TITLE
feat(www): add design system presets exploration page

### DIFF
--- a/www/src/config/site.tsx
+++ b/www/src/config/site.tsx
@@ -32,6 +32,7 @@ export const siteConfig = {
 export const navItems: { name: string; href: ToOptions }[] = [
 	{ name: "Docs", href: { to: "/docs/$", params: { _splat: "" } } },
 	{ name: "Components", href: { to: "/components" } },
+	{ name: "Presets", href: { to: "/presets" } },
 	{ name: "Blocks", href: { to: "/blocks" } },
 	{ name: "Create", href: { to: "/create" } },
 ];

--- a/www/src/routeTree.gen.ts
+++ b/www/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as PreviewSlugRouteImport } from './routes/preview/$slug'
 import { Route as DemosSlugRouteImport } from './routes/demos/$slug'
 import { Route as AppCreateRouteImport } from './routes/_app/create'
 import { Route as AppComponentsRouteImport } from './routes/_app/components'
+import { Route as AppPresetsRouteImport } from './routes/_app/presets'
 import { Route as AppDocsRouteRouteImport } from './routes/_app/docs/route'
 import { Route as AppBlocksRouteRouteImport } from './routes/_app/blocks/route'
 import { Route as AppDocsChar123Char125DotmdRouteImport } from './routes/_app/docs/{$}[.]md'
@@ -68,6 +69,11 @@ const AppComponentsRoute = AppComponentsRouteImport.update({
   path: '/components',
   getParentRoute: () => AppRouteRoute,
 } as any)
+const AppPresetsRoute = AppPresetsRouteImport.update({
+  id: '/presets',
+  path: '/presets',
+  getParentRoute: () => AppRouteRoute,
+} as any)
 const AppDocsRouteRoute = AppDocsRouteRouteImport.update({
   id: '/docs',
   path: '/docs',
@@ -103,6 +109,7 @@ export interface FileRoutesByFullPath {
   '/blocks': typeof AppBlocksRouteRouteWithChildren
   '/docs': typeof AppDocsRouteRouteWithChildren
   '/components': typeof AppComponentsRoute
+  '/presets': typeof AppPresetsRoute
   '/create': typeof AppCreateRoute
   '/demos/$slug': typeof DemosSlugRoute
   '/preview/$slug': typeof PreviewSlugRoute
@@ -117,6 +124,7 @@ export interface FileRoutesByTo {
   '/blocks': typeof AppBlocksRouteRouteWithChildren
   '/docs': typeof AppDocsRouteRouteWithChildren
   '/components': typeof AppComponentsRoute
+  '/presets': typeof AppPresetsRoute
   '/create': typeof AppCreateRoute
   '/demos/$slug': typeof DemosSlugRoute
   '/preview/$slug': typeof PreviewSlugRoute
@@ -134,6 +142,7 @@ export interface FileRoutesById {
   '/_app/blocks': typeof AppBlocksRouteRouteWithChildren
   '/_app/docs': typeof AppDocsRouteRouteWithChildren
   '/_app/components': typeof AppComponentsRoute
+  '/_app/presets': typeof AppPresetsRoute
   '/_app/create': typeof AppCreateRoute
   '/demos/$slug': typeof DemosSlugRoute
   '/preview/$slug': typeof PreviewSlugRoute
@@ -152,6 +161,7 @@ export interface FileRouteTypes {
     | '/blocks'
     | '/docs'
     | '/components'
+    | '/presets'
     | '/create'
     | '/demos/$slug'
     | '/preview/$slug'
@@ -166,6 +176,7 @@ export interface FileRouteTypes {
     | '/blocks'
     | '/docs'
     | '/components'
+    | '/presets'
     | '/create'
     | '/demos/$slug'
     | '/preview/$slug'
@@ -182,6 +193,7 @@ export interface FileRouteTypes {
     | '/_app/blocks'
     | '/_app/docs'
     | '/_app/components'
+    | '/_app/presets'
     | '/_app/create'
     | '/demos/$slug'
     | '/preview/$slug'
@@ -266,6 +278,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppComponentsRouteImport
       parentRoute: typeof AppRouteRoute
     }
+    '/_app/presets': {
+      id: '/_app/presets'
+      path: '/presets'
+      fullPath: '/presets'
+      preLoaderRoute: typeof AppPresetsRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
     '/_app/docs': {
       id: '/_app/docs'
       path: '/docs'
@@ -334,6 +353,7 @@ interface AppRouteRouteChildren {
   AppBlocksRouteRoute: typeof AppBlocksRouteRouteWithChildren
   AppDocsRouteRoute: typeof AppDocsRouteRouteWithChildren
   AppComponentsRoute: typeof AppComponentsRoute
+  AppPresetsRoute: typeof AppPresetsRoute
   AppCreateRoute: typeof AppCreateRoute
   AppIndexRoute: typeof AppIndexRoute
 }
@@ -342,6 +362,7 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppBlocksRouteRoute: AppBlocksRouteRouteWithChildren,
   AppDocsRouteRoute: AppDocsRouteRouteWithChildren,
   AppComponentsRoute: AppComponentsRoute,
+  AppPresetsRoute: AppPresetsRoute,
   AppCreateRoute: AppCreateRoute,
   AppIndexRoute: AppIndexRoute,
 }

--- a/www/src/routes/_app/presets.tsx
+++ b/www/src/routes/_app/presets.tsx
@@ -1,0 +1,91 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { siteConfig } from "@/config/site";
+import { PageHeader, PageHeaderDescription, PageHeaderHeading, PageLayout } from "@/modules/docs/page-layout";
+
+const title = "Design System Presets";
+const description = "Explore curated visual foundations and choose a starting point for your brand.";
+
+const presets = [
+	{
+		name: "Minimal Editorial",
+		description: "High contrast typography, generous spacing, and understated surfaces.",
+		chips: ["Type-forward", "Neutral palette", "Content-heavy"],
+		swatches: ["#111827", "#6B7280", "#F9FAFB", "#E5E7EB"],
+	},
+	{
+		name: "Vibrant SaaS",
+		description: "Confident accent colors, sharp UI states, and dashboard-ready density.",
+		chips: ["Product-led", "Bold accents", "Data-dense"],
+		swatches: ["#4338CA", "#0EA5E9", "#10B981", "#F8FAFC"],
+	},
+	{
+		name: "Warm Commerce",
+		description: "Soft tones and rounded UI primitives optimized for conversion flows.",
+		chips: ["Friendly", "Rounded", "Conversion-first"],
+		swatches: ["#7C2D12", "#EA580C", "#FDBA74", "#FFF7ED"],
+	},
+];
+
+export const Route = createFileRoute("/_app/presets")({
+	component: PresetsPage,
+	head: () => {
+		const ogImageUrl = `${siteConfig.url}/og?title=${encodeURIComponent(title)}&description=${encodeURIComponent(description)}`;
+
+		return {
+			meta: [
+				{ title: `${title} - ${siteConfig.name}` },
+				{ name: "description", content: description },
+				{ property: "og:title", content: title },
+				{ property: "og:description", content: description },
+				{ property: "og:type", content: "article" },
+				{ property: "og:url", content: `${siteConfig.url}/presets` },
+				{ property: "og:image", content: ogImageUrl },
+				{ name: "twitter:card", content: "summary_large_image" },
+				{ name: "twitter:title", content: title },
+				{ name: "twitter:description", content: description },
+				{ name: "twitter:image", content: ogImageUrl },
+				{ name: "twitter:creator", content: siteConfig.twitter.creator },
+			],
+		};
+	},
+});
+
+function PresetsPage() {
+	return (
+		<PageLayout>
+			<PageHeader>
+				<PageHeaderHeading>{title}</PageHeaderHeading>
+				<PageHeaderDescription>{description}</PageHeaderDescription>
+			</PageHeader>
+			<div className="container grid gap-4 pb-12 md:grid-cols-2 xl:grid-cols-3">
+				{presets.map((preset) => (
+					<section key={preset.name} className="rounded-xl border border-border/70 bg-bg-elevated p-5">
+						<div className="space-y-3">
+							<div>
+								<h2 className="font-medium text-lg">{preset.name}</h2>
+								<p className="mt-1 text-fg-muted text-sm">{preset.description}</p>
+							</div>
+							<div className="flex gap-2">
+								{preset.swatches.map((swatch) => (
+									<span
+										key={swatch}
+										className="size-8 rounded-md border border-black/10"
+										style={{ backgroundColor: swatch }}
+									/>
+								))}
+							</div>
+							<ul className="flex flex-wrap gap-2">
+								{preset.chips.map((chip) => (
+									<li key={chip} className="rounded-full border border-border px-2.5 py-1 text-xs text-fg-muted">
+										{chip}
+									</li>
+								))}
+							</ul>
+						</div>
+					</section>
+				))}
+			</div>
+		</PageLayout>
+	);
+}


### PR DESCRIPTION
### Motivation
- Provide a discoverable page to explore curated design system visual presets and help users choose a starting foundation for their brand.
- Surface presets from the app shell so they are reachable from the main navigation.
- Ensure the route is correctly registered in the app's route tree/types so routing and tooling recognize the page.

### Description
- Add a new route component at `www/src/routes/_app/presets.tsx` that implements the `/presets` page with SEO/Twitter Open Graph metadata and a responsive card grid showing preset descriptions, color swatches, and style chips.
- Add a new navigation entry in `www/src/config/site.tsx` to expose the `Presets` page from the main header.
- Update the generated router types in `www/src/routeTree.gen.ts` to register the new `/presets` file route and include it in the relevant unions and file maps.

### Testing
- Ran `pnpm -C www typecheck` which failed in this environment due to pre-existing missing/linked modules (`starter-themes` and `@/.source/*`) and unrelated docs typing issues, so a full successful typecheck could not be completed.
- From the same `typecheck` run, there were no new preset-related type errors reported beyond the existing environment/project issues.
- The new files were linted/compiled locally as part of the typecheck attempt (see `pnpm -C www typecheck` output above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10db633b54832f8f6a9f35a6e06fc2)