### PR TITLE
Redesign landing page

### DIFF
--- a/www/src/registry/blocks/showcase/cards/components/cards.tsx
+++ b/www/src/registry/blocks/showcase/cards/components/cards.tsx
@@ -11,24 +11,22 @@ import { cn } from "@/registry/lib/utils";
 
 export function Cards(props: React.ComponentProps<"div">) {
 	return (
-		<div {...props} className={cn("grid grid-cols-11 gap-4", props.className)}>
-			<div className="col-span-11 flex gap-4 max-md:flex-col xl:col-span-8">
-				<Booking className="w-full max-md:col-span-1 md:w-80" />
-				<Filters className="flex-1 max-md:col-span-1" />
-			</div>
-			<Notifications className="col-span-11 max-md:h-100 md:col-span-5 md:contain-[size] xl:col-span-3" />
-			<InviteMembers className="col-span-11 md:col-span-6 lg:col-span-6 xl:col-span-4" />
-			<Backlog className="col-span-11 lg:col-span-8 xl:col-span-7" />
-			<AccountMenu className="max-lg:hidden lg:col-span-3 lg:block xl:hidden" />
-			<div className="col-span-11 grid grid-cols-11 gap-4 lg:items-start">
-				<AccountMenu className="col-span-11 min-w-0 sm:col-span-5 lg:hidden xl:col-span-2 xl:block" />
-				<LoginForm className="col-span-11 max-w-none sm:col-span-6 lg:hidden" />
-				<div className="col-span-11 flex items-start gap-4 max-sm:flex-col max-sm:items-stretch lg:col-span-7 xl:col-span-6">
-					<ColorEditorCard className="max-sm:hidden" />
-					<TeamName className="flex-1" />
-				</div>
-				<LoginForm className="hidden w-full max-w-none lg:col-span-4 lg:block xl:col-span-3" />
-			</div>
+		<div
+			{...props}
+			className={cn(
+				"columns-1 gap-4 sm:columns-2 lg:columns-3 xl:columns-4 *:mb-4 *:break-inside-avoid",
+				props.className,
+			)}
+		>
+			<Booking />
+			<Filters />
+			<Notifications className="h-100" />
+			<InviteMembers />
+			<Backlog />
+			<AccountMenu />
+			<ColorEditorCard />
+			<TeamName />
+			<LoginForm className="max-w-none" />
 		</div>
 	);
 }

--- a/www/src/routes/_app/index.tsx
+++ b/www/src/routes/_app/index.tsx
@@ -22,7 +22,7 @@ function HomePage() {
 			<main>
 				{/* Hero section */}
 				<section className="container flex flex-col pt-6 sm:pt-10 md:pt-18">
-					<div className="mx-auto flex max-w-3xl flex-col items-center gap-2 text-center md:gap-3">
+					<div className="flex flex-col items-center gap-2 text-center md:gap-3">
 						<Announcement />
 						<h1 className="text-3xl tracking-tighter text-balance max-lg:font-medium md:text-4xl lg:text-5xl">
 							Build your design system with a <span className="font-bold italic">unique</span> look.
@@ -35,10 +35,10 @@ function HomePage() {
 							.
 						</p>
 						<div className="flex w-full flex-col gap-2 pt-2 sm:w-auto sm:flex-row sm:items-center sm:gap-4">
-							<LinkButton href="/docs" variant="primary" size="lg" className="h-10">
+							<LinkButton href="/docs" variant="primary" size="lg">
 								Get started
 							</LinkButton>
-							<LinkButton href="/components" variant="default" size="lg" className="h-10">
+							<LinkButton href="/components" variant="default" size="lg">
 								Explore components
 							</LinkButton>
 						</div>

--- a/www/src/routes/_app/index.tsx
+++ b/www/src/routes/_app/index.tsx
@@ -22,7 +22,7 @@ function HomePage() {
 			<main>
 				{/* Hero section */}
 				<section className="container flex flex-col pt-6 sm:pt-10 md:pt-18">
-					<div className="flex max-w-5xl flex-col items-start gap-2 md:gap-3">
+					<div className="mx-auto flex max-w-3xl flex-col items-center gap-2 text-center md:gap-3">
 						<Announcement />
 						<h1 className="text-3xl tracking-tighter text-balance max-lg:font-medium md:text-4xl lg:text-5xl">
 							Build your design system with a <span className="font-bold italic">unique</span> look.

--- a/www/src/routes/_app/index.tsx
+++ b/www/src/routes/_app/index.tsx
@@ -9,7 +9,6 @@ import { ShadcnIcon } from "@/registry/components/icons/shadcn";
 import { TailwindWordmark } from "@/registry/components/icons/tailwind-wordmark";
 import { TypeScriptIcon } from "@/registry/components/icons/typescript";
 import { LinkButton } from "@/registry/ui/button";
-import { Tab, TabList, TabPanel, Tabs } from "@/registry/ui/tabs";
 import { Tooltip, TooltipContent } from "@/registry/ui/tooltip";
 
 export const Route = createFileRoute("/_app/")({
@@ -46,18 +45,7 @@ function HomePage() {
 				</section>
 
 				<section className="container mt-24">
-					<Tabs className="gap-3">
-						<TabList className="gap-2 border-b-0 font-medium **:data-tab:text-base **:data-tab-indicator:hidden">
-							<Tab id="cards">Cards</Tab>
-							<Tab id="dashboard">Dashboard</Tab>
-							<Tab id="tasks">Tasks</Tab>
-							<Tab id="playground">Playground</Tab>
-							<Tab id="authentication">Authentication</Tab>
-						</TabList>
-						<TabPanel id="cards">
-							<Cards />
-						</TabPanel>
-					</Tabs>
+					<Cards />
 				</section>
 
 				{/* Built on modern tools */}


### PR DESCRIPTION
## Landing page redesign

This PR redesigns the marketing landing page (`www`). It's a work in progress — changes will land incrementally.

### Changes so far
- **Centered hero section** — the hero was previously left-aligned. It's now centered:
  - `items-start` → `items-center` so the announcement pill, paragraph, and CTA buttons are horizontally centered
  - added `text-center` for the heading and description
  - centered the block with `mx-auto` and tightened `max-w-5xl` → `max-w-3xl` so the heading reads as a balanced centered block

### Planned / follow-ups
- Further redesign of the showcase, "Built on modern tools", and CTA sections (to be discussed)

https://claude.ai/code/session_01E91uyJu676Lbut4jMLxJkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01E91uyJu676Lbut4jMLxJkQ)_