### PR TITLE
fix(www): align the docs app with TanStack best practices

### DIFF
--- a/.agents/skills/tanstack-devtools-app-setup/SKILL.md
+++ b/.agents/skills/tanstack-devtools-app-setup/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: devtools-app-setup
+description: >
+  Install TanStack Devtools, pick framework adapter (React/Vue/Solid/Preact),
+  register plugins via plugins prop, configure shell (position, hotkeys, theme,
+  hideUntilHover, requireUrlFlag, eventBusConfig). TanStackDevtools component,
+  defaultOpen, localStorage persistence.
+type: core
+library: '@tanstack/devtools'
+library_version: '0.10.12'
+sources:
+  - docs/quick-start.md
+  - docs/installation.md
+  - docs/configuration.md
+  - docs/overview.md
+  - packages/devtools/src/context/devtools-store.ts
+  - packages/vue-devtools/src/types.ts
+  - packages/react-devtools/src/devtools.tsx
+---
+
+# TanStack Devtools App Setup
+
+## Setup
+
+### React (primary)
+
+Install as dev dependencies:
+
+```bash
+npm install -D @tanstack/react-devtools @tanstack/devtools-vite
+```
+
+Mount `TanStackDevtools` at the root of your application:
+
+```tsx
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { TanStackDevtools } from '@tanstack/react-devtools'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+    <TanStackDevtools />
+  </StrictMode>,
+)
+```
+
+Add plugins via the `plugins` prop. Each plugin needs `name` (string) and `render` (JSX element or render function):
+
+```tsx
+import { TanStackDevtools } from '@tanstack/react-devtools'
+import { ReactQueryDevtoolsPanel } from '@tanstack/react-query-devtools'
+import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
+;<TanStackDevtools
+  plugins={[
+    {
+      name: 'TanStack Query',
+      render: <ReactQueryDevtoolsPanel />,
+    },
+    {
+      name: 'TanStack Router',
+      render: <TanStackRouterDevtoolsPanel />,
+    },
+  ]}
+/>
+```
+
+### Vue
+
+```bash
+npm install -D @tanstack/vue-devtools
+```
+
+Vue uses `component` (not `render`) in plugin definitions. This is the `TanStackDevtoolsVuePlugin` type:
+
+```vue
+<script setup lang="ts">
+import { TanStackDevtools } from '@tanstack/vue-devtools'
+import type { TanStackDevtoolsVuePlugin } from '@tanstack/vue-devtools'
+import { VueQueryDevtoolsPanel } from '@tanstack/vue-query-devtools'
+
+const plugins: TanStackDevtoolsVuePlugin[] = [
+  { name: 'Vue Query', component: VueQueryDevtoolsPanel },
+]
+</script>
+
+<template>
+  <App />
+  <TanStackDevtools :plugins="plugins" />
+</template>
+```
+
+The Vite plugin (`@tanstack/devtools-vite`) is optional for Vue but recommended for enhanced console logs and go-to-source.
+
+### Solid
+
+```bash
+npm install -D @tanstack/solid-devtools @tanstack/devtools-vite
+```
+
+```tsx
+import { render } from 'solid-js/web'
+import { TanStackDevtools } from '@tanstack/solid-devtools'
+import { SolidQueryDevtoolsPanel } from '@tanstack/solid-query-devtools'
+import App from './App'
+
+render(
+  () => (
+    <>
+      <App />
+      <TanStackDevtools
+        plugins={[
+          {
+            name: 'TanStack Query',
+            render: <SolidQueryDevtoolsPanel />,
+          },
+        ]}
+      />
+    </>
+  ),
+  document.getElementById('root')!,
+)
+```
+
+### Preact
+
+```bash
+npm install -D @tanstack/preact-devtools @tanstack/devtools-vite
+```
+
+```tsx
+import { render } from 'preact'
+import { TanStackDevtools } from '@tanstack/preact-devtools'
+import App from './App'
+
+render(
+  <>
+    <App />
+    <TanStackDevtools
+      plugins={[
+        {
+          name: 'Your Plugin',
+          render: <YourPluginComponent />,
+        },
+      ]}
+    />
+  </>,
+  document.getElementById('root')!,
+)
+```
+
+## Core Patterns
+
+### Shell Configuration
+
+Pass a `config` prop to `TanStackDevtools` to set initial shell behavior. These values are persisted to `localStorage` after first load and can be changed through the settings panel at runtime.
+
+Storage keys used internally:
+
+- `tanstack_devtools_settings` -- persisted settings
+- `tanstack_devtools_state` -- persisted UI state (active tab, panel height, active plugins, persistOpen)
+
+All config properties are optional. Defaults shown below:
+
+```tsx
+<TanStackDevtools
+  config={{
+    defaultOpen: false, // open panel on mount
+    hideUntilHover: false, // hide trigger until mouse hover
+    position: 'bottom-right', // trigger position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'middle-left' | 'middle-right'
+    panelLocation: 'bottom', // panel position: 'top' | 'bottom'
+    openHotkey: ['Control', '~'],
+    inspectHotkey: ['Shift', 'Alt', 'CtrlOrMeta'],
+    requireUrlFlag: false, // require URL param to show devtools
+    urlFlag: 'tanstack-devtools', // the URL param name when requireUrlFlag is true
+    theme: 'dark', // 'light' | 'dark' (defaults to system preference)
+    triggerHidden: false, // completely hide trigger (hotkey still works)
+  }}
+/>
+```
+
+### Event Bus Configuration
+
+The `eventBusConfig` prop configures the client-side event bus that plugins use for communication:
+
+```tsx
+<TanStackDevtools
+  eventBusConfig={{
+    debug: false, // enable debug logging for the event bus
+    connectToServerBus: false, // connect to the Vite plugin server event bus
+    port: 3000, // port for server event bus connection
+  }}
+/>
+```
+
+The server event bus requires the `@tanstack/devtools-vite` plugin to be running.
+
+### Plugin Registration with defaultOpen
+
+Each plugin entry can include a `defaultOpen` flag to control whether that plugin tab is active when devtools first opens:
+
+```tsx
+import { TanStackDevtools } from '@tanstack/react-devtools'
+import { FormDevtools } from '@tanstack/react-form'
+;<TanStackDevtools
+  config={{ hideUntilHover: true }}
+  eventBusConfig={{ debug: true }}
+  plugins={[
+    {
+      name: 'TanStack Form',
+      render: <FormDevtools />,
+      defaultOpen: true,
+    },
+  ]}
+/>
+```
+
+### Conditional Devtools with URL Flag
+
+Use `requireUrlFlag` to hide devtools unless a specific URL parameter is present. This is useful for staging environments or team-internal debugging:
+
+```tsx
+<TanStackDevtools
+  config={{
+    requireUrlFlag: true,
+    urlFlag: 'tanstack-devtools', // visit ?tanstack-devtools to enable
+  }}
+/>
+```
+
+## Common Mistakes
+
+### CRITICAL: Vue plugin uses `render` instead of `component`
+
+The Vue adapter uses `component` (a Vue component reference) and optional `props`, not JSX `render`. Using `render` produces a silent failure -- the plugin tab appears but renders nothing.
+
+Wrong:
+
+```vue
+<!-- This silently fails - render is ignored in Vue adapter -->
+<script setup lang="ts">
+const plugins = [{ name: 'My Plugin', render: MyComponent }]
+</script>
+```
+
+Correct:
+
+```vue
+<script setup lang="ts">
+import type { TanStackDevtoolsVuePlugin } from '@tanstack/vue-devtools'
+
+const plugins: TanStackDevtoolsVuePlugin[] = [
+  { name: 'My Plugin', component: MyComponent },
+]
+</script>
+```
+
+The `TanStackDevtoolsVuePlugin` type enforces this at compile time. Always import and use it.
+
+### HIGH: Vite plugin not placed first in plugins array
+
+The `@tanstack/devtools-vite` plugin performs source injection that must run before framework plugins (React, Vue, Solid, etc.) process the code.
+
+Wrong:
+
+```ts
+import { devtools } from '@tanstack/devtools-vite'
+import react from '@vitejs/plugin-react'
+
+export default {
+  plugins: [react(), devtools()],
+}
+```
+
+Correct:
+
+```ts
+import { devtools } from '@tanstack/devtools-vite'
+import react from '@vitejs/plugin-react'
+
+export default {
+  plugins: [devtools(), react()],
+}
+```
+
+### HIGH: Mounting TanStackDevtools in SSR without client guard
+
+The devtools core shell requires DOM APIs (`document`, `window`, `localStorage`). The React adapter includes `'use client'` at its entry point, so standard Next.js/Remix setups work. However, custom SSR setups or frameworks that do not respect the `'use client'` directive need explicit guards.
+
+Wrong:
+
+```tsx
+// In a server-rendered component without framework 'use client' support
+import { TanStackDevtools } from '@tanstack/react-devtools'
+
+export default function Layout({ children }) {
+  return (
+    <>
+      {children}
+      <TanStackDevtools />
+    </>
+  )
+}
+```
+
+Correct:
+
+```tsx
+import { TanStackDevtools } from '@tanstack/react-devtools'
+
+export default function Layout({ children }) {
+  return (
+    <>
+      {children}
+      {typeof window !== 'undefined' && <TanStackDevtools />}
+    </>
+  )
+}
+```
+
+Or use dynamic imports / lazy loading to ensure the component only loads on the client.
+
+### MEDIUM: Installing as regular dependency for dev-only use
+
+When using the Vite plugin for production stripping, devtools packages should be dev dependencies. Installing them as regular dependencies increases production bundle size unnecessarily.
+
+Wrong:
+
+```bash
+npm install @tanstack/react-devtools
+```
+
+Correct:
+
+```bash
+npm install -D @tanstack/react-devtools
+npm install -D @tanstack/devtools-vite
+```
+
+Exception: if you intentionally want devtools in production, install `@tanstack/devtools` (core) as a regular dependency. See the production skill for details.
+
+### MEDIUM: Not keeping devtools packages at latest versions
+
+All `@tanstack/devtools-*` packages share internal protocols (event bus messages, plugin mount lifecycle). Mixing versions can cause silent failures where plugins register but never receive events, or the shell mounts but plugins do not render.
+
+Always update all devtools packages together:
+
+```bash
+npm install -D @tanstack/react-devtools@latest @tanstack/devtools-vite@latest
+```
+
+When building custom plugins, ensure `@tanstack/devtools-event-client` matches the version of `@tanstack/devtools` used by the shell.
+
+## See Also
+
+- **devtools-vite-plugin** -- Vite plugin configuration: source inspection, console piping, production stripping, server event bus setup
+- **devtools-production** -- Production build handling: keeping devtools in prod, tree-shaking, URL flag gating
+- **devtools-plugin-panel** -- Building custom plugin panels with the EventClient API

--- a/.agents/skills/tanstack-devtools-vite-plugin/SKILL.md
+++ b/.agents/skills/tanstack-devtools-vite-plugin/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: devtools-vite-plugin
+description: >
+  Configure @tanstack/devtools-vite for source inspection (data-tsd-source,
+  inspectHotkey, ignore patterns), console piping (client-to-server,
+  server-to-client, levels), enhanced logging, server event bus (port, host,
+  HTTPS), production stripping (removeDevtoolsOnBuild), editor integration
+  (launch-editor, custom editor.open). Must be FIRST plugin in Vite config.
+  Vite ^6 || ^7 only.
+type: core
+library: tanstack-devtools
+library_version: '0.10.12'
+sources:
+  - 'TanStack/devtools:docs/vite-plugin.md'
+  - 'TanStack/devtools:docs/source-inspector.md'
+  - 'TanStack/devtools:packages/devtools-vite/src/plugin.ts'
+---
+
+Configure @tanstack/devtools-vite -- the Vite plugin that enhances TanStack Devtools with source inspection, console piping, enhanced logging, a server event bus, production stripping, editor integration, and a plugin marketplace. The plugin returns an array of sub-plugins, all using `enforce: 'pre'`, so it must be the FIRST plugin in the Vite config.
+
+## Installation and Basic Setup
+
+```ts
+// vite.config.ts
+import { devtools } from '@tanstack/devtools-vite'
+
+export default {
+  plugins: [
+    devtools(),
+    // ... other plugins AFTER devtools
+  ],
+}
+```
+
+Install as a dev dependency:
+
+```sh
+pnpm add -D @tanstack/devtools-vite
+```
+
+There is also a `defineDevtoolsConfig` helper for type-safe config objects:
+
+```ts
+import { devtools, defineDevtoolsConfig } from '@tanstack/devtools-vite'
+
+const config = defineDevtoolsConfig({
+  // fully typed options
+})
+
+export default {
+  plugins: [devtools(config)],
+}
+```
+
+## Exports
+
+From `packages/devtools-vite/src/index.ts`:
+
+- `devtools` -- main plugin factory, returns `Array<Plugin>`
+- `defineDevtoolsConfig` -- identity function for type-safe config
+- `TanStackDevtoolsViteConfig` -- config type (re-exported)
+- `ConsoleLevel` -- `'log' | 'warn' | 'error' | 'info' | 'debug'`
+
+## Architecture: Sub-Plugins
+
+`devtools()` returns an array of Vite plugins. Each has `enforce: 'pre'` and only activates when its conditions are met (dev mode, serve command, etc.).
+
+| Sub-plugin name                               | What it does                                                                                                       | When active                                                |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| `@tanstack/devtools:inject-source`            | Babel transform adding `data-tsd-source` attrs to JSX                                                              | dev mode + `injectSource.enabled`                          |
+| `@tanstack/devtools:config`                   | Reserved for future config modifications                                                                           | serve command only                                         |
+| `@tanstack/devtools:custom-server`            | Starts ServerEventBus, registers middleware for open-source/console-pipe endpoints                                 | dev mode                                                   |
+| `@tanstack/devtools:remove-devtools-on-build` | Strips devtools imports/JSX from production bundles                                                                | build command or production mode + `removeDevtoolsOnBuild` |
+| `@tanstack/devtools:event-client-setup`       | Marketplace: listens for install/add-plugin events via devtoolsEventClient                                         | dev mode + serve + not CI                                  |
+| `@tanstack/devtools:console-pipe-transform`   | Injects runtime console-pipe code into entry files                                                                 | dev mode + serve + `consolePiping.enabled`                 |
+| `@tanstack/devtools:better-console-logs`      | Babel transform prepending source location to `console.log`/`console.error`                                        | dev mode + `enhancedLogs.enabled`                          |
+| `@tanstack/devtools:inject-plugin`            | Detects which file imports TanStackDevtools (for marketplace injection)                                            | dev mode + serve                                           |
+| `@tanstack/devtools:connection-injection`     | Replaces `__TANSTACK_DEVTOOLS_PORT__`, `__TANSTACK_DEVTOOLS_HOST__`, `__TANSTACK_DEVTOOLS_PROTOCOL__` placeholders | dev mode + serve                                           |
+
+## Subsystem Details
+
+### Source Injection
+
+Adds `data-tsd-source="<relative-path>:<line>:<column>"` attributes to every JSX opening element via Babel. This powers the "Go to Source" feature -- hold the inspect hotkey (default: Shift+Alt+Ctrl/Meta), hover over elements, click to open in editor.
+
+**Key behaviors:**
+
+- Skips `<Fragment>` and `<React.Fragment>`
+- Skips elements where the component's props parameter is spread (`{...props}`) -- this is because injecting the attribute would be overwritten by the spread
+- Skips files matching `injectSource.ignore.files` patterns
+- Skips components matching `injectSource.ignore.components` patterns
+- Patterns can be strings (matched via picomatch) or RegExp
+- Transform filter excludes `node_modules`, `?raw` imports, `/dist/`, `/build/`
+
+**Source files:** `packages/devtools-vite/src/inject-source.ts`, `packages/devtools-vite/src/matcher.ts`
+
+```ts
+devtools({
+  injectSource: {
+    enabled: true,
+    ignore: {
+      files: ['node_modules', /.*\.test\.(js|ts|jsx|tsx)$/],
+      components: ['InternalComponent', /.*Provider$/],
+    },
+  },
+})
+```
+
+### Console Piping
+
+Bidirectional console piping between client and server. Injects runtime code (IIFE) into entry files that:
+
+**Client side:**
+
+1. Wraps `console[level]` to batch and POST entries to `/__tsd/console-pipe`
+2. Opens an EventSource on `/__tsd/console-pipe/sse` to receive server logs
+3. Server logs appear in browser console with a purple `[Server]` prefix
+4. Client logs appear in terminal with a cyan `[Client]` prefix
+
+**Server side (SSR/Nitro):**
+
+1. Wraps `console[level]` to batch and POST entries to `<viteServerUrl>/__tsd/console-pipe/server`
+2. These are then broadcast to all SSE clients
+
+**Entry file detection:** looks for `<html` tag, `StartClient`, `hydrateRoot`, `createRoot`, or `solid-js/web` + `render(` in code.
+
+**Source files:** `packages/devtools-vite/src/virtual-console.ts`, `packages/devtools-vite/src/utils.ts` (middleware handlers)
+
+```ts
+devtools({
+  consolePiping: {
+    enabled: true,
+    levels: ['log', 'warn', 'error', 'info', 'debug'],
+  },
+})
+```
+
+### Enhanced Logging
+
+Babel transform that prepends source location info to `console.log()` and `console.error()` calls. In the browser, this renders as a clickable "Go to Source" link. On the server, it shows `LOG <path>:<line>:<column>` in chalk colors.
+
+The transform inserts a spread of a conditional expression: `...(typeof window === 'undefined' ? serverLogMessage : browserLogMessage)` as the first argument of the console call.
+
+**Source file:** `packages/devtools-vite/src/enhance-logs.ts`
+
+```ts
+devtools({
+  enhancedLogs: {
+    enabled: true, // default
+  },
+})
+```
+
+### Production Stripping
+
+Removes all devtools code from production builds. The transform:
+
+1. Finds files importing from these packages: `@tanstack/react-devtools`, `@tanstack/preact-devtools`, `@tanstack/solid-devtools`, `@tanstack/vue-devtools`, `@tanstack/devtools`
+2. Removes the import declarations
+3. Removes the JSX elements that use the imported components
+4. Cleans up leftover imports that were only used inside the removed JSX (e.g., plugin panel components)
+
+Active when: `command !== 'serve'` OR `config.mode === 'production'` (handles hosting providers like Cloudflare/Netlify that may not use `build` command but set mode to production).
+
+**Source file:** `packages/devtools-vite/src/remove-devtools.ts`
+
+```ts
+devtools({
+  removeDevtoolsOnBuild: true, // default
+})
+```
+
+### Server Event Bus
+
+A WebSocket + SSE server for devtools-to-client communication. Managed by `@tanstack/devtools-event-bus/server`.
+
+**Key behaviors:**
+
+- Default port: 4206
+- On EADDRINUSE: falls back to OS-assigned port (port 0)
+- When Vite uses HTTPS: piggybacks on Vite's httpServer instead of creating a standalone one (shares TLS certificate)
+- Uses global variables (`__TANSTACK_DEVTOOLS_SERVER__`, etc.) to survive HMR without restarting
+- The actual port is injected into client code via `__TANSTACK_DEVTOOLS_PORT__` placeholder replacement
+
+**Source file:** `packages/event-bus/src/server/server.ts`
+
+```ts
+devtools({
+  eventBusConfig: {
+    port: 4206, // default
+    enabled: true, // default; set false for storybook/vitest
+    debug: false, // default; logs internal bus activity
+  },
+})
+```
+
+### Editor Integration
+
+Uses `launch-editor` to open source files in the editor. Default editor is VS Code. The `editor.open` callback receives `(path, lineNumber, columnNumber)` as strings.
+
+The open-source flow: browser requests `/__tsd/open-source?source=<encoded-path:line:col>` --> Vite middleware parses source param --> calls `editor.open`.
+
+Supported editors via launch-editor: VS Code, WebStorm, Sublime Text, Atom, and more. For unsupported editors, provide a custom `editor.open` function.
+
+**Source file:** `packages/devtools-vite/src/editor.ts`
+
+```ts
+devtools({
+  editor: {
+    name: 'Cursor',
+    open: async (path, lineNumber, columnNumber) => {
+      // Custom editor open logic
+      // path is the absolute file path
+      // lineNumber and columnNumber are strings or undefined
+    },
+  },
+})
+```
+
+### Plugin Marketplace
+
+When the dev server is running, listens for events via `devtoolsEventClient`:
+
+- `install-devtools` -- runs package manager install, then auto-injects plugin into devtools setup file
+- `add-plugin-to-devtools` -- injects plugin import and JSX/function call into the file containing `<TanStackDevtools>`
+- `bump-package-version` -- updates a package to a minimum version
+- `mounted` -- sends package.json and outdated deps to the UI
+
+Auto-detection of the devtools setup file: the `inject-plugin` sub-plugin scans transforms for files importing from `@tanstack/react-devtools`, `@tanstack/solid-devtools`, `@tanstack/vue-devtools`, etc., and stores the file ID.
+
+**Source files:** `packages/devtools-vite/src/inject-plugin.ts`, `packages/devtools-vite/src/package-manager.ts`
+
+## Common Mistakes
+
+### 1. Not placing devtools() first in Vite plugins (HIGH)
+
+All sub-plugins use `enforce: 'pre'`. They must transform code before framework plugins (React, Vue, Solid, etc.) process it. If devtools is not first, source injection and enhanced logs may silently fail because framework transforms remove the raw JSX before devtools can annotate it.
+
+```ts
+// WRONG
+export default {
+  plugins: [
+    react(),
+    devtools(), // too late -- react() already transformed JSX
+  ],
+}
+
+// CORRECT
+export default {
+  plugins: [devtools(), react()],
+}
+```
+
+### 2. Using devtools-vite with non-Vite bundlers (HIGH)
+
+`@tanstack/devtools-vite` has a peer dependency on `vite ^6.0.0 || ^7.0.0`. It uses Vite-specific APIs (`configureServer`, `handleHotUpdate`, `transform` with filter objects, `Plugin` type). It will not work with webpack, rspack, esbuild, or other bundlers. For non-Vite setups, use `@tanstack/devtools-event-bus` client directly without the Vite plugin.
+
+### 3. Expecting Vite plugin features in production (MEDIUM)
+
+Source injection, console piping, enhanced logging, the server event bus, and the marketplace only operate during development (`config.mode === 'development'` and `command === 'serve'`). In production builds, the only active sub-plugin is `remove-devtools-on-build` (which strips devtools code). Do not rely on any of these features being available at runtime in production.
+
+### 4. Source injection on spread-props elements (MEDIUM)
+
+The Babel transform in `inject-source.ts` explicitly skips any JSX element that has a `{...props}` spread where `props` is the component's parameter name. This is intentional -- the spread would overwrite the injected `data-tsd-source` attribute. If source inspection doesn't work for a specific component, check if it spreads its props parameter.
+
+```tsx
+// data-tsd-source will NOT be injected on <div> here
+const MyComponent = (props) => {
+  return <div {...props}>content</div>
+}
+```
+
+### 5. Event bus port conflict in multi-project setups (MEDIUM)
+
+The default event bus port is 4206. When running multiple Vite dev servers concurrently (monorepo), the second server will hit EADDRINUSE. The event bus handles this by falling back to an OS-assigned port (port 0), and the actual port is injected via placeholder replacement. However, if you need predictable ports (e.g., for firewall rules), set different ports explicitly:
+
+```ts
+// Project A
+devtools({ eventBusConfig: { port: 4206 } })
+
+// Project B
+devtools({ eventBusConfig: { port: 4207 } })
+```
+
+## Internal Middleware Endpoints
+
+These are registered on the Vite dev server (not the event bus server):
+
+| Endpoint                                    | Method | Purpose                                                   |
+| ------------------------------------------- | ------ | --------------------------------------------------------- |
+| `/__tsd/open-source?source=<path:line:col>` | GET    | Opens file in editor, returns HTML that closes the window |
+| `/__tsd/console-pipe`                       | POST   | Receives client console entries (batched JSON)            |
+| `/__tsd/console-pipe/server`                | POST   | Receives server-side console entries                      |
+| `/__tsd/console-pipe/sse`                   | GET    | SSE stream for broadcasting server logs to browser        |
+
+## Cross-References
+
+- **devtools-app-setup** -- How to set up `<TanStackDevtools>` in your app (must be done before the Vite plugin provides value)
+- **devtools-production** -- Details on production stripping configuration and keeping devtools in production builds
+
+## Key Source Files
+
+- `packages/devtools-vite/src/plugin.ts` -- Main plugin factory with all sub-plugins and config type
+- `packages/devtools-vite/src/inject-source.ts` -- Babel transform for data-tsd-source injection
+- `packages/devtools-vite/src/enhance-logs.ts` -- Babel transform for enhanced console logs
+- `packages/devtools-vite/src/remove-devtools.ts` -- Production stripping transform
+- `packages/devtools-vite/src/virtual-console.ts` -- Console pipe runtime code generator
+- `packages/devtools-vite/src/editor.ts` -- Editor config type and launch-editor integration
+- `packages/devtools-vite/src/inject-plugin.ts` -- Marketplace plugin injection into devtools setup file
+- `packages/devtools-vite/src/utils.ts` -- Middleware request handling and helpers
+- `packages/devtools-vite/src/matcher.ts` -- Picomatch/RegExp pattern matcher
+- `packages/event-bus/src/server/server.ts` -- ServerEventBus implementation (WebSocket + SSE + EADDRINUSE fallback)

--- a/.agents/skills/tanstack-react-start/SKILL.md
+++ b/.agents/skills/tanstack-react-start/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: react-start
+description: >-
+  React bindings for TanStack Start: createStart, StartClient,
+  StartServer, React-specific imports, re-exports from
+  @tanstack/react-router, full project setup with React, useServerFn
+  hook.
+type: framework
+library: tanstack-start
+library_version: '1.166.2'
+framework: react
+requires:
+  - start-core
+sources:
+  - TanStack/router:packages/react-start/src
+  - TanStack/router:docs/start/framework/react/build-from-scratch.md
+---
+
+# React Start (`@tanstack/react-start`)
+
+This skill builds on start-core. Read [start-core](../../../start-client-core/skills/start-core/SKILL.md) first for foundational concepts.
+
+This skill covers the React-specific bindings, setup, and patterns for TanStack Start.
+
+> **CRITICAL**: All code is ISOMORPHIC by default. Loaders run on BOTH server and client. Use `createServerFn` for server-only logic.
+
+> **CRITICAL**: Do not confuse `@tanstack/react-start` with Next.js or Remix. They are completely different frameworks with different APIs.
+
+> **CRITICAL**: Types are FULLY INFERRED. Never cast, never annotate inferred values.
+
+## Package API Surface
+
+`@tanstack/react-start` re-exports everything from `@tanstack/start-client-core` plus:
+
+- `useServerFn` — React hook for calling server functions from components
+
+All core APIs (`createServerFn`, `createMiddleware`, `createStart`, `createIsomorphicFn`, `createServerOnlyFn`, `createClientOnlyFn`) are available from `@tanstack/react-start`.
+
+Server utilities (`getRequest`, `getRequestHeader`, `setResponseHeader`, `setResponseHeaders`, `setResponseStatus`) are imported from `@tanstack/react-start/server`.
+
+## Full Project Setup
+
+### 1. Install Dependencies
+
+```bash
+npm i @tanstack/react-start @tanstack/react-router react react-dom
+npm i -D vite @vitejs/plugin-react typescript @types/react @types/react-dom
+```
+
+### 2. package.json
+
+```json
+{
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "start": "node .output/server/index.mjs"
+  }
+}
+```
+
+### 3. tsconfig.json
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "target": "ES2022",
+    "skipLibCheck": true,
+    "strictNullChecks": true
+  }
+}
+```
+
+### 4. vite.config.ts
+
+```ts
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import viteReact from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [
+    tanstackStart(), // MUST come before react()
+    viteReact(),
+  ],
+})
+```
+
+### 5. Router Factory (src/router.tsx)
+
+```tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+export function getRouter() {
+  const router = createRouter({
+    routeTree,
+    scrollRestoration: true,
+  })
+  return router
+}
+```
+
+### 6. Root Route (src/routes/\_\_root.tsx)
+
+```tsx
+import type { ReactNode } from 'react'
+import {
+  Outlet,
+  createRootRoute,
+  HeadContent,
+  Scripts,
+} from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  head: () => ({
+    meta: [
+      { charSet: 'utf-8' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      { title: 'My TanStack Start App' },
+    ],
+  }),
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <RootDocument>
+      <Outlet />
+    </RootDocument>
+  )
+}
+
+function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        {children}
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+### 7. Index Route (src/routes/index.tsx)
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+
+const getGreeting = createServerFn({ method: 'GET' }).handler(async () => {
+  return 'Hello from TanStack Start!'
+})
+
+export const Route = createFileRoute('/')({
+  loader: () => getGreeting(),
+  component: HomePage,
+})
+
+function HomePage() {
+  const greeting = Route.useLoaderData()
+  return <h1>{greeting}</h1>
+}
+```
+
+## useServerFn Hook
+
+Use `useServerFn` to call server functions from React components with proper integration:
+
+```tsx
+import { createServerFn, useServerFn } from '@tanstack/react-start'
+
+const updatePost = createServerFn({ method: 'POST' })
+  .inputValidator((data: { id: string; title: string }) => data)
+  .handler(async ({ data }) => {
+    await db.posts.update(data.id, { title: data.title })
+    return { success: true }
+  })
+
+function EditPostForm({ postId }: { postId: string }) {
+  const updatePostFn = useServerFn(updatePost)
+  const [title, setTitle] = useState('')
+
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault()
+        await updatePostFn({ data: { id: postId, title } })
+      }}
+    >
+      <input value={title} onChange={(e) => setTitle(e.target.value)} />
+      <button type="submit">Save</button>
+    </form>
+  )
+}
+```
+
+## Global Start Configuration (src/start.ts)
+
+```tsx
+import { createStart, createMiddleware } from '@tanstack/react-start'
+
+const requestLogger = createMiddleware().server(async ({ next, request }) => {
+  console.log(`${request.method} ${request.url}`)
+  return next()
+})
+
+export const startInstance = createStart(() => ({
+  requestMiddleware: [requestLogger],
+}))
+```
+
+## React-Specific Components
+
+All routing components from `@tanstack/react-router` work in Start:
+
+- `<RouterProvider>` — not needed in Start (handled automatically)
+- `<Outlet>` — renders matched child route
+- `<Link>` — type-safe navigation
+- `<Navigate>` — declarative redirect
+- `<HeadContent>` — renders head tags (must be in `<head>`)
+- `<Scripts>` — renders body scripts (must be in `<body>`)
+- `<Await>` — renders deferred data with Suspense
+- `<ClientOnly>` — renders children only after hydration
+- `<CatchBoundary>` — error boundary
+
+## Hooks Reference
+
+All hooks from `@tanstack/react-router` work in Start:
+
+- `useRouter()` — router instance
+- `useRouterState()` — subscribe to router state
+- `useNavigate()` — programmatic navigation
+- `useSearch({ from })` — validated search params
+- `useParams({ from })` — path params
+- `useLoaderData({ from })` — loader data
+- `useMatch({ from })` — full route match
+- `useRouteContext({ from })` — route context
+- `Route.useLoaderData()` — typed loader data (preferred in route files)
+- `Route.useSearch()` — typed search params (preferred in route files)
+
+## Common Mistakes
+
+### 1. CRITICAL: Importing from wrong package
+
+```tsx
+// WRONG — this is the SPA router, NOT Start
+import { createServerFn } from '@tanstack/react-router'
+
+// CORRECT — server functions come from react-start
+import { createServerFn } from '@tanstack/react-start'
+
+// CORRECT — routing APIs come from react-router (re-exported by Start too)
+import { createFileRoute, Link } from '@tanstack/react-router'
+```
+
+### 2. HIGH: Using React hooks in beforeLoad or loader
+
+```tsx
+// WRONG — beforeLoad/loader are NOT React components
+beforeLoad: () => {
+  const auth = useAuth() // React hook, cannot be used here
+}
+
+// CORRECT — pass state via router context
+const rootRoute = createRootRouteWithContext<{ auth: AuthState }>()({})
+```
+
+### 3. HIGH: Missing Scripts component
+
+Without `<Scripts />` in the root route's `<body>`, client JavaScript doesn't load and the app won't hydrate.
+
+## Cross-References
+
+- [start-core](../../../start-client-core/skills/start-core/SKILL.md) — core Start concepts
+- [router-core](../../../router-core/skills/router-core/SKILL.md) — routing fundamentals
+- [react-router](../../../react-router/skills/react-router/SKILL.md) — React Router hooks and components

--- a/.agents/skills/tanstack-router-core/SKILL.md
+++ b/.agents/skills/tanstack-router-core/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: router-core
+description: >-
+  Framework-agnostic core concepts for TanStack Router: route trees,
+  createRouter, createRoute, createRootRoute, createRootRouteWithContext,
+  addChildren, Register type declaration, route matching, route sorting,
+  file naming conventions. Entry point for all router skills.
+type: core
+library: tanstack-router
+library_version: '1.166.2'
+---
+
+# TanStack Router Core
+
+TanStack Router is a type-safe router for React and Solid with built-in SWR caching, JSON-first search params, file-based route generation, and end-to-end type inference. The core is framework-agnostic; React and Solid bindings layer on top.
+
+> **CRITICAL**: TanStack Router types are FULLY INFERRED. Never cast, never annotate inferred values. This is the #1 AI agent mistake.
+
+> **CRITICAL**: TanStack Router is CLIENT-FIRST. Loaders run on the client by default, NOT server-only like Remix/Next.js. Do not confuse TanStack Router APIs with Next.js or React Router.
+
+## Sub-Skills
+
+| Task                                               | Sub-Skill                                                                    |
+| -------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Validate, read, write, transform search params     | [router-core/search-params/SKILL.md](./search-params/SKILL.md)               |
+| Dynamic segments, splats, optional params          | [router-core/path-params/SKILL.md](./path-params/SKILL.md)                   |
+| Link, useNavigate, preloading, blocking            | [router-core/navigation/SKILL.md](./navigation/SKILL.md)                     |
+| Route loaders, SWR caching, context, deferred data | [router-core/data-loading/SKILL.md](./data-loading/SKILL.md)                 |
+| Auth guards, RBAC, beforeLoad redirects            | [router-core/auth-and-guards/SKILL.md](./auth-and-guards/SKILL.md)           |
+| Automatic and manual code splitting                | [router-core/code-splitting/SKILL.md](./code-splitting/SKILL.md)             |
+| 404 handling, error boundaries, notFound()         | [router-core/not-found-and-errors/SKILL.md](./not-found-and-errors/SKILL.md) |
+| Inference, Register, from narrowing, TS perf       | [router-core/type-safety/SKILL.md](./type-safety/SKILL.md)                   |
+| Streaming/non-streaming SSR, hydration, head mgmt  | [router-core/ssr/SKILL.md](./ssr/SKILL.md)                                   |
+
+## Quick Decision Tree
+
+```
+Need to add/read/write URL query parameters?
+  → router-core/search-params
+
+Need dynamic URL segments like /posts/$postId?
+  → router-core/path-params
+
+Need to create links or navigate programmatically?
+  → router-core/navigation
+
+Need to fetch data for a route?
+  Is it client-side only or client+server?
+    → router-core/data-loading
+  Using TanStack Query as external cache?
+    → compositions/router-query (separate skill)
+
+Need to protect routes behind auth?
+  → router-core/auth-and-guards
+
+Need to reduce bundle size per route?
+  → router-core/code-splitting
+
+Need custom 404 or error handling?
+  → router-core/not-found-and-errors
+
+Having TypeScript issues or performance problems?
+  → router-core/type-safety
+
+Need server-side rendering?
+  → router-core/ssr
+```
+
+## Minimal Working Example
+
+```tsx
+// src/routes/__root.tsx
+import { createRootRoute, Outlet } from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  component: () => <Outlet />,
+})
+```
+
+```tsx
+// src/routes/index.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/')({
+  component: () => <h1>Home</h1>,
+})
+```
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+const router = createRouter({ routeTree })
+
+// REQUIRED for type safety — without this, Link/useNavigate have no autocomplete
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+
+export default router
+```
+
+```tsx
+// src/main.tsx
+import { RouterProvider } from '@tanstack/react-router'
+import router from './router'
+
+function App() {
+  return <RouterProvider router={router} />
+}
+```
+
+## Common Mistakes
+
+### HIGH: createFileRoute path string must match the file path
+
+The Vite plugin manages the path string in `createFileRoute`. Do not change it manually — it must match the file's location under `src/routes/`:
+
+```tsx
+// File: src/routes/posts/$postId.tsx
+export const Route = createFileRoute('/posts/$postId')({
+  // ✅ matches file path
+  component: PostPage,
+})
+
+export const Route = createFileRoute('/post/$postId')({
+  // ❌ silent mismatch
+  component: PostPage,
+})
+```
+
+The plugin auto-generates this string. If you rename a route file, the plugin updates it. Never edit the path string by hand.
+
+## Version Note
+
+This skill targets `@tanstack/router-core` v1.166.2 and `@tanstack/react-router` v1.166.2. APIs are stable. Splat routes use `$` (not `*`); the `*` compat alias will be removed in v2.

--- a/.agents/skills/tanstack-router-data-loading/SKILL.md
+++ b/.agents/skills/tanstack-router-data-loading/SKILL.md
@@ -1,0 +1,485 @@
+---
+name: router-core/data-loading
+description: >-
+  Route loader option, loaderDeps for cache keys, staleTime/gcTime/
+  defaultPreloadStaleTime SWR caching, pendingComponent/pendingMs/
+  pendingMinMs, errorComponent/onError/onCatch, beforeLoad, router
+  context and createRootRouteWithContext DI pattern, router.invalidate,
+  Await component, deferred data loading with unawaited promises.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/data-loading.md
+  - TanStack/router:docs/router/guide/deferred-data-loading.md
+  - TanStack/router:docs/router/guide/router-context.md
+  - TanStack/router:docs/router/guide/data-mutations.md
+---
+
+# Data Loading
+
+## Setup
+
+Basic loader returning data, consumed via `useLoaderData`:
+
+```tsx
+// src/routes/posts.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  const posts = Route.useLoaderData()
+  return (
+    <ul>
+      {posts.map((post) => (
+        <li key={post.id}>{post.title}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+In code-split components, use `getRouteApi` instead of importing Route:
+
+```tsx
+import { getRouteApi } from '@tanstack/react-router'
+
+const routeApi = getRouteApi('/posts')
+
+function PostsComponent() {
+  const posts = routeApi.useLoaderData()
+  return <ul>{/* ... */}</ul>
+}
+```
+
+## Route Loading Lifecycle
+
+The router executes this sequence on every URL/history update:
+
+1. **Route Matching** (top-down)
+   - `route.params.parse`
+   - `route.validateSearch`
+2. **Route Pre-Loading** (serial)
+   - `route.beforeLoad`
+   - `route.onError` → `route.errorComponent`
+3. **Route Loading** (parallel)
+   - `route.component.preload?`
+   - `route.loader`
+     - `route.pendingComponent` (optional)
+     - `route.component`
+   - `route.onError` → `route.errorComponent`
+
+Key: `beforeLoad` runs before `loader`. `beforeLoad` for a parent runs before its children's `beforeLoad`. Throwing in `beforeLoad` prevents all children from loading.
+
+## Core Patterns
+
+### loaderDeps for Search-Param-Driven Cache Keys
+
+Loaders don't receive search params directly. Use `loaderDeps` to declare which search params affect the cache key:
+
+```tsx
+// src/routes/posts.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts')({
+  validateSearch: (search) => ({
+    offset: Number(search.offset) || 0,
+    limit: Number(search.limit) || 10,
+  }),
+  loaderDeps: ({ search: { offset, limit } }) => ({ offset, limit }),
+  loader: ({ deps: { offset, limit } }) => fetchPosts({ offset, limit }),
+})
+```
+
+When deps change, the route reloads regardless of `staleTime`.
+
+### SWR Caching Configuration
+
+TanStack Router has built-in Stale-While-Revalidate caching keyed on the route's parsed pathname + `loaderDeps`.
+
+Defaults:
+
+- **`staleTime`: 0** — data is always considered stale, reloads in background on re-match
+- **`preloadStaleTime`: 30 seconds** — preloaded data won't be refetched for 30s
+- **`gcTime`: 30 minutes** — unused cache entries garbage collected after 30min
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  staleTime: 10_000, // 10s: data considered fresh for 10 seconds
+  gcTime: 5 * 60 * 1000, // 5min: garbage collect after 5 minutes
+})
+```
+
+Disable SWR caching entirely:
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  staleTime: Infinity,
+})
+```
+
+Globally:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  defaultStaleTime: Infinity,
+})
+```
+
+### Pending States (pendingComponent / pendingMs / pendingMinMs)
+
+By default, a pending component shows after 1 second (`pendingMs: 1000`) and stays for at least 500ms (`pendingMinMs: 500`) to avoid flash.
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  pendingMs: 500,
+  pendingMinMs: 300,
+  pendingComponent: () => <div>Loading posts...</div>,
+  component: PostsComponent,
+})
+```
+
+### Router Context with createRootRouteWithContext (Factory Pattern)
+
+`createRootRouteWithContext` is a factory that returns a function. You must call it twice — the first call passes the generic type, the second passes route options:
+
+```tsx
+// src/routes/__root.tsx
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
+
+interface MyRouterContext {
+  auth: { userId: string }
+  fetchPosts: () => Promise<Post[]>
+}
+
+// NOTE: double call — createRootRouteWithContext<Type>()({...})
+export const Route = createRootRouteWithContext<MyRouterContext>()({
+  component: () => <Outlet />,
+})
+```
+
+Supply the context when creating the router:
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+const router = createRouter({
+  routeTree,
+  context: {
+    auth: { userId: '123' },
+    fetchPosts,
+  },
+})
+```
+
+Consume in loaders and beforeLoad:
+
+```tsx
+// src/routes/posts.tsx
+export const Route = createFileRoute('/posts')({
+  loader: ({ context: { fetchPosts } }) => fetchPosts(),
+})
+```
+
+To pass React hook values into the router context, call the hook above `RouterProvider` and inject via the `context` prop:
+
+```tsx
+import { RouterProvider } from '@tanstack/react-router'
+
+function InnerApp() {
+  const auth = useAuth()
+  return <RouterProvider router={router} context={{ auth }} />
+}
+
+function App() {
+  return (
+    <AuthProvider>
+      <InnerApp />
+    </AuthProvider>
+  )
+}
+```
+
+Route-level context via `beforeLoad`:
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  beforeLoad: () => ({
+    fetchPosts: () => fetch('/api/posts').then((r) => r.json()),
+  }),
+  loader: ({ context: { fetchPosts } }) => fetchPosts(),
+})
+```
+
+### Deferred Data Loading
+
+Return unawaited promises from the loader for non-critical data. Use the `Await` component to render them:
+
+```tsx
+import { createFileRoute, Await } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params: { postId } }) => {
+    // Slow data — do NOT await
+    const slowDataPromise = fetchComments(postId)
+    // Fast data — await
+    const post = await fetchPost(postId)
+
+    return { post, deferredComments: slowDataPromise }
+  },
+  component: PostComponent,
+})
+
+function PostComponent() {
+  const { post, deferredComments } = Route.useLoaderData()
+
+  return (
+    <div>
+      <h1>{post.title}</h1>
+      <Await
+        promise={deferredComments}
+        fallback={<div>Loading comments...</div>}
+      >
+        {(comments) => (
+          <ul>
+            {comments.map((c) => (
+              <li key={c.id}>{c.body}</li>
+            ))}
+          </ul>
+        )}
+      </Await>
+    </div>
+  )
+}
+```
+
+### Invalidation After Mutations
+
+`router.invalidate()` forces all active route loaders to re-run and marks all cached data as stale:
+
+```tsx
+import { useRouter } from '@tanstack/react-router'
+
+function AddPostButton() {
+  const router = useRouter()
+
+  const handleAdd = async () => {
+    await fetch('/api/posts', { method: 'POST', body: '...' })
+    router.invalidate()
+  }
+
+  return <button onClick={handleAdd}>Add Post</button>
+}
+```
+
+For synchronous invalidation (wait until loaders finish):
+
+```tsx
+await router.invalidate({ sync: true })
+```
+
+### Error Handling
+
+```tsx
+import {
+  createFileRoute,
+  ErrorComponent,
+  useRouter,
+} from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  errorComponent: ({ error, reset }) => {
+    const router = useRouter()
+
+    if (error instanceof CustomError) {
+      return <div>{error.message}</div>
+    }
+
+    return (
+      <div>
+        <ErrorComponent error={error} />
+        <button
+          onClick={() => {
+            // For loader errors, invalidate to re-run loader + reset boundary
+            router.invalidate()
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    )
+  },
+})
+```
+
+### Loader Parameters
+
+The `loader` function receives:
+
+- `params` — parsed path params
+- `deps` — object from `loaderDeps`
+- `context` — merged parent + beforeLoad context
+- `abortController` — cancelled when route unloads or becomes stale
+- `cause` — `'enter'`, `'stay'`, or `'preload'`
+- `preload` — `true` during preloading
+- `location` — current location object
+- `parentMatchPromise` — promise of parent route match
+- `route` — the route object itself
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  loader: ({ params: { postId }, abortController }) =>
+    fetchPost(postId, { signal: abortController.signal }),
+})
+```
+
+## Common Mistakes
+
+### CRITICAL: Assuming loaders only run on the server
+
+TanStack Router is **client-first**. Loaders run on the **client** by default. They also run on the server when using TanStack Start for SSR, but the default mental model is client-side execution.
+
+```tsx
+// WRONG — this will crash in the browser
+export const Route = createFileRoute('/posts')({
+  loader: async () => {
+    const fs = await import('fs') // Node.js only!
+    return JSON.parse(fs.readFileSync('...')) // fails in browser
+  },
+})
+
+// CORRECT — loaders run in the browser, use fetch or API calls
+export const Route = createFileRoute('/posts')({
+  loader: async () => {
+    const res = await fetch('/api/posts')
+    return res.json()
+  },
+})
+```
+
+Do NOT put database queries, filesystem access, or server-only code in loaders unless you are using TanStack Start server functions.
+
+### MEDIUM: Not understanding staleTime default is 0
+
+Default `staleTime` is `0`. This means data reloads in the background on every route re-match. This is intentional — it ensures fresh data. But if your data is expensive or static, set `staleTime`:
+
+```tsx
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  staleTime: 60_000, // Consider fresh for 1 minute
+})
+```
+
+### HIGH: Using reset() instead of router.invalidate() in error components
+
+`reset()` only resets the error boundary UI. It does NOT re-run the loader. For loader errors, use `router.invalidate()` which re-runs loaders and resets the boundary:
+
+```tsx
+// WRONG — resets boundary but loader still has stale error
+function PostErrorComponent({ error, reset }) {
+  return <button onClick={reset}>Retry</button>
+}
+
+// CORRECT — re-runs loader and resets the error boundary
+function PostErrorComponent({ error }) {
+  const router = useRouter()
+  return <button onClick={() => router.invalidate()}>Retry</button>
+}
+```
+
+### HIGH: Missing double parentheses on createRootRouteWithContext
+
+`createRootRouteWithContext<Type>()` is a factory — it returns a function. Must call twice:
+
+```tsx
+// WRONG — missing second call, passes options to the factory
+const rootRoute = createRootRouteWithContext<{ auth: AuthState }>({
+  component: RootComponent,
+})
+
+// CORRECT — factory()({options})
+const rootRoute = createRootRouteWithContext<{ auth: AuthState }>()({
+  component: RootComponent,
+})
+```
+
+### HIGH: Using React hooks in beforeLoad or loader
+
+`beforeLoad` and `loader` are NOT React components. You cannot call hooks inside them. Use router context to inject values from hooks:
+
+```tsx
+// WRONG — hooks cannot be called outside React components
+export const Route = createFileRoute('/posts')({
+  loader: () => {
+    const auth = useAuth() // This will crash!
+    return fetchPosts(auth.userId)
+  },
+})
+
+// CORRECT — inject hook values via router context
+// In your App component:
+function InnerApp() {
+  const auth = useAuth()
+  return <RouterProvider router={router} context={{ auth }} />
+}
+
+// In your route:
+export const Route = createFileRoute('/posts')({
+  loader: ({ context: { auth } }) => fetchPosts(auth.userId),
+})
+```
+
+### HIGH: Property order affects TypeScript inference
+
+Router infers types from earlier properties into later ones. Declaring `beforeLoad` after `loader` means context from `beforeLoad` is unknown in the loader:
+
+```tsx
+// WRONG — context.user is unknown because beforeLoad declared after loader
+export const Route = createFileRoute('/admin')({
+  loader: ({ context }) => fetchData(context.user),
+  beforeLoad: () => ({ user: getUser() }),
+})
+
+// CORRECT — validateSearch → loaderDeps → beforeLoad → loader
+export const Route = createFileRoute('/admin')({
+  beforeLoad: () => ({ user: getUser() }),
+  loader: ({ context }) => fetchData(context.user),
+})
+```
+
+### HIGH: Returning entire search object from loaderDeps
+
+```tsx
+// WRONG — loader re-runs on ANY search param change
+loaderDeps: ({ search }) => search
+
+// CORRECT — only re-run when page changes
+loaderDeps: ({ search }) => ({ page: search.page })
+```
+
+Returning the whole `search` object means unrelated param changes (e.g., `sortDirection`, `viewMode`) trigger unnecessary reloads because deep equality fails on the entire object.
+
+## Tensions
+
+- **Client-first loaders vs SSR expectations**: Loaders run on the client by default. When using SSR (TanStack Start), they run on both client and server. Browser-only APIs work by default but break under SSR. Server-only APIs (fs, db) break by default but work under Start server functions. See **router-core/ssr/SKILL.md**.
+- **Built-in SWR cache vs external cache coordination**: Router has built-in caching. When using TanStack Query, set `defaultPreloadStaleTime: 0` to avoid double-caching. See **compositions/router-query/SKILL.md**.
+
+---
+
+## Cross-References
+
+- See also: **router-core/search-params/SKILL.md** — `loaderDeps` consumes validated search params as cache keys
+- See also: **compositions/router-query/SKILL.md** — for external cache coordination with TanStack Query

--- a/.agents/skills/tanstack-router-navigation/SKILL.md
+++ b/.agents/skills/tanstack-router-navigation/SKILL.md
@@ -1,0 +1,448 @@
+---
+name: router-core/navigation
+description: >-
+  Link component, useNavigate, Navigate component, router.navigate,
+  ToOptions/NavigateOptions/LinkOptions, from/to relative navigation,
+  activeOptions/activeProps, preloading (intent/viewport/render),
+  preloadDelay, navigation blocking (useBlocker, Block), createLink,
+  linkOptions helper, scroll restoration, MatchRoute.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/navigation.md
+  - TanStack/router:docs/router/guide/preloading.md
+  - TanStack/router:docs/router/guide/navigation-blocking.md
+  - TanStack/router:docs/router/guide/link-options.md
+  - TanStack/router:docs/router/guide/custom-link.md
+  - TanStack/router:docs/router/guide/scroll-restoration.md
+---
+
+# Navigation
+
+## Setup
+
+Basic type-safe `Link` with `to` and `params`:
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+function PostLink({ postId }: { postId: string }) {
+  return (
+    <Link to="/posts/$postId" params={{ postId }}>
+      View Post
+    </Link>
+  )
+}
+```
+
+## Core Patterns
+
+### Link with Active States
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+function NavLink() {
+  return (
+    <Link
+      to="/posts"
+      activeProps={{ className: 'font-bold' }}
+      inactiveProps={{ className: 'text-gray-500' }}
+      activeOptions={{ exact: true }}
+    >
+      Posts
+    </Link>
+  )
+}
+```
+
+The `data-status` attribute is also set to `"active"` on active links for CSS-based styling.
+
+`activeOptions` controls matching behavior:
+
+- `exact` (default `false`) — when `true`, only matches the exact path (not children)
+- `includeHash` (default `false`) — include hash in active matching
+- `includeSearch` (default `true`) — include search params in active matching
+
+Children can receive `isActive` as a render function:
+
+```tsx
+<Link to="/posts">
+  {({ isActive }) => <span className={isActive ? 'font-bold' : ''}>Posts</span>}
+</Link>
+```
+
+### Relative Navigation with `from`
+
+Without `from`, navigation resolves from root `/`. To use relative paths like `..`, provide `from`:
+
+```tsx
+import { createFileRoute, Link } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  component: PostComponent,
+})
+
+function PostComponent() {
+  return (
+    <div>
+      {/* Relative to current route */}
+      <Link from={Route.fullPath} to="..">
+        Back to Posts
+      </Link>
+
+      {/* "." reloads the current route */}
+      <Link from={Route.fullPath} to=".">
+        Reload
+      </Link>
+    </div>
+  )
+}
+```
+
+### useNavigate for Programmatic Navigation
+
+Use `useNavigate` only for side-effect-driven navigation (e.g., after a form submission). For anything the user clicks, prefer `Link`.
+
+```tsx
+import { useNavigate } from '@tanstack/react-router'
+
+function CreatePostForm() {
+  const navigate = useNavigate({ from: '/posts' })
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const response = await fetch('/api/posts', { method: 'POST', body: '...' })
+    const { id: postId } = await response.json()
+
+    if (response.ok) {
+      navigate({ to: '/posts/$postId', params: { postId } })
+    }
+  }
+
+  return <form onSubmit={handleSubmit}>{/* ... */}</form>
+}
+```
+
+The `Navigate` component performs an immediate client-side navigation on mount:
+
+```tsx
+import { Navigate } from '@tanstack/react-router'
+
+function LegacyRedirect() {
+  return <Navigate to="/posts/$postId" params={{ postId: 'my-first-post' }} />
+}
+```
+
+`router.navigate` is available anywhere you have the router instance, including outside of React.
+
+### Preloading
+
+Strategies: `intent` (hover/touchstart), `viewport` (intersection observer), `render` (on mount).
+
+Set globally:
+
+```tsx
+import { createRouter } from '@tanstack/react-router'
+
+const router = createRouter({
+  routeTree,
+  defaultPreload: 'intent',
+  defaultPreloadDelay: 50, // ms, default is 50
+})
+```
+
+Or per-link:
+
+```tsx
+<Link
+  to="/posts/$postId"
+  params={{ postId }}
+  preload="intent"
+  preloadDelay={100}
+>
+  View Post
+</Link>
+```
+
+Preloaded data stays fresh for 30 seconds by default (`defaultPreloadStaleTime: 30_000`). During that window it won't be refetched. When using an external cache like TanStack Query, set `defaultPreloadStaleTime: 0` to let the external library control freshness.
+
+Manual preloading via the router instance:
+
+```tsx
+import { useRouter } from '@tanstack/react-router'
+
+function Component() {
+  const router = useRouter()
+
+  useEffect(() => {
+    router.preloadRoute({ to: '/posts/$postId', params: { postId: '1' } })
+  }, [router])
+
+  return <div />
+}
+```
+
+### Navigation Blocking
+
+Use `useBlocker` to prevent navigation when a form has unsaved changes:
+
+```tsx
+import { useBlocker } from '@tanstack/react-router'
+import { useState } from 'react'
+
+function EditForm() {
+  const [formIsDirty, setFormIsDirty] = useState(false)
+
+  useBlocker({
+    shouldBlockFn: () => {
+      if (!formIsDirty) return false
+      const shouldLeave = confirm('Are you sure you want to leave?')
+      return !shouldLeave
+    },
+  })
+
+  return <form>{/* ... */}</form>
+}
+```
+
+With custom UI using `withResolver`:
+
+```tsx
+import { useBlocker } from '@tanstack/react-router'
+import { useState } from 'react'
+
+function EditForm() {
+  const [formIsDirty, setFormIsDirty] = useState(false)
+
+  const { proceed, reset, status } = useBlocker({
+    shouldBlockFn: () => formIsDirty,
+    withResolver: true,
+  })
+
+  return (
+    <>
+      <form>{/* ... */}</form>
+      {status === 'blocked' && (
+        <div>
+          <p>Are you sure you want to leave?</p>
+          <button onClick={proceed}>Yes</button>
+          <button onClick={reset}>No</button>
+        </div>
+      )}
+    </>
+  )
+}
+```
+
+Control `beforeunload` separately:
+
+```tsx
+useBlocker({
+  shouldBlockFn: () => formIsDirty,
+  enableBeforeUnload: formIsDirty,
+})
+```
+
+### linkOptions for Reusable Navigation Options
+
+`linkOptions` provides eager type-checking on navigation options objects, so errors surface at definition, not at spread-site:
+
+```tsx
+import {
+  linkOptions,
+  Link,
+  useNavigate,
+  redirect,
+} from '@tanstack/react-router'
+
+const dashboardLinkOptions = linkOptions({
+  to: '/dashboard',
+  search: { search: '' },
+})
+
+// Use anywhere: Link, navigate, redirect
+function Nav() {
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      <Link {...dashboardLinkOptions}>Dashboard</Link>
+      <button onClick={() => navigate(dashboardLinkOptions)}>Go</button>
+    </div>
+  )
+}
+
+// Also works in an array for navigation bars
+const navOptions = linkOptions([
+  { to: '/dashboard', label: 'Summary', activeOptions: { exact: true } },
+  { to: '/dashboard/invoices', label: 'Invoices' },
+  { to: '/dashboard/users', label: 'Users' },
+])
+
+function NavBar() {
+  return (
+    <nav>
+      {navOptions.map((option) => (
+        <Link
+          {...option}
+          key={option.to}
+          activeProps={{ className: 'font-bold' }}
+        >
+          {option.label}
+        </Link>
+      ))}
+    </nav>
+  )
+}
+```
+
+### createLink for Custom Components
+
+Wraps any component with TanStack Router's type-safe navigation:
+
+```tsx
+import * as React from 'react'
+import { createLink, LinkComponent } from '@tanstack/react-router'
+
+interface BasicLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {}
+
+const BasicLinkComponent = React.forwardRef<HTMLAnchorElement, BasicLinkProps>(
+  (props, ref) => {
+    return <a ref={ref} {...props} className="block px-3 py-2 text-blue-700" />
+  },
+)
+
+const CreatedLinkComponent = createLink(BasicLinkComponent)
+
+export const CustomLink: LinkComponent<typeof BasicLinkComponent> = (props) => {
+  return <CreatedLinkComponent preload="intent" {...props} />
+}
+```
+
+Usage retains full type safety:
+
+```tsx
+<CustomLink to="/dashboard/invoices/$invoiceId" params={{ invoiceId: 0 }} />
+```
+
+### Scroll Restoration
+
+Enable globally on the router:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  scrollRestoration: true,
+})
+```
+
+For nested scrollable areas:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  scrollRestoration: true,
+  scrollToTopSelectors: ['#main-scrollable-area'],
+})
+```
+
+Custom cache keys:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  scrollRestoration: true,
+  getScrollRestorationKey: (location) => location.pathname,
+})
+```
+
+Prevent scroll reset for a specific navigation:
+
+```tsx
+<Link to="/posts" resetScroll={false}>
+  Posts
+</Link>
+```
+
+### MatchRoute for Pending UI
+
+```tsx
+import { Link, MatchRoute } from '@tanstack/react-router'
+
+function Nav() {
+  return (
+    <Link to="/users">
+      Users
+      <MatchRoute to="/users" pending>
+        <Spinner />
+      </MatchRoute>
+    </Link>
+  )
+}
+```
+
+## Common Mistakes
+
+### CRITICAL: Interpolating params into the `to` string
+
+```tsx
+// WRONG — breaks type safety and param encoding
+<Link to={`/posts/${postId}`}>Post</Link>
+
+// CORRECT — use the params option
+<Link to="/posts/$postId" params={{ postId }}>Post</Link>
+```
+
+Dynamic segments are declared with `$` in the route path. Always pass them via `params`. This applies to `Link`, `useNavigate`, `Navigate`, and `router.navigate`.
+
+### MEDIUM: Using useNavigate for clickable elements
+
+```tsx
+// WRONG — no href, no cmd+click, no preloading, no accessibility
+function BadNav() {
+  const navigate = useNavigate()
+  return <button onClick={() => navigate({ to: '/posts' })}>Posts</button>
+}
+
+// CORRECT — real <a> tag with href, accessible, preloadable
+function GoodNav() {
+  return <Link to="/posts">Posts</Link>
+}
+```
+
+Use `useNavigate` only for programmatic side-effect navigation (after form submit, async action, etc).
+
+### HIGH: Not providing `from` for relative navigation
+
+```tsx
+// WRONG — without from, ".." resolves from root
+<Link to="..">Back</Link>
+
+// CORRECT — provide from for relative resolution
+<Link from={Route.fullPath} to="..">Back</Link>
+```
+
+Without `from`, only absolute paths are autocompleted and type-safe. Relative paths like `..` resolve from root instead of the current route.
+
+### HIGH: Using search as object instead of function loses existing params
+
+```tsx
+// WRONG — replaces ALL search params with just { page: 2 }
+<Link to="." search={{ page: 2 }}>Page 2</Link>
+
+// CORRECT — preserves existing search params, updates page
+<Link to="." search={(prev) => ({ ...prev, page: 2 })}>Page 2</Link>
+```
+
+When you pass `search` as a plain object, it replaces all search params. Use the function form to spread previous params and selectively update.
+
+---
+
+## Cross-References
+
+- See also: **router-core/search-params/SKILL.md** — Link `search` prop interacts with search param validation
+- See also: **router-core/type-safety/SKILL.md** — `from` narrowing improves type inference on Link

--- a/.agents/skills/tanstack-router-not-found-and-errors/SKILL.md
+++ b/.agents/skills/tanstack-router-not-found-and-errors/SKILL.md
@@ -1,0 +1,435 @@
+---
+name: router-core/not-found-and-errors
+description: >-
+  notFound() function, notFoundComponent, defaultNotFoundComponent,
+  notFoundMode (fuzzy/root), errorComponent, CatchBoundary,
+  CatchNotFound, isNotFound, NotFoundRoute (deprecated), route
+  masking (mask option, createRouteMask, unmaskOnReload).
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/not-found-errors.md
+  - TanStack/router:docs/router/guide/route-masking.md
+---
+
+# Not Found and Errors
+
+TanStack Router handles two categories of "not found": unmatched URL paths (automatic) and missing resources like a post that doesn't exist (manual via `notFound()`). Error boundaries are configured per-route via `errorComponent`.
+
+> **CRITICAL**: Do NOT use the deprecated `NotFoundRoute`. When present, `notFound()` and `notFoundComponent` will NOT work. Remove it and use `notFoundComponent` instead.
+> **CRITICAL**: `useLoaderData` may be undefined inside `notFoundComponent`. Use `useParams`, `useSearch`, or `useRouteContext` instead.
+
+## Not Found Handling
+
+### Global 404: `notFoundComponent` on Root Route
+
+```tsx
+// src/routes/__root.tsx
+import { createRootRoute, Outlet, Link } from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  component: () => <Outlet />,
+  notFoundComponent: () => {
+    return (
+      <div>
+        <h1>404 — Page Not Found</h1>
+        <Link to="/">Go Home</Link>
+      </div>
+    )
+  },
+})
+```
+
+### Router-Wide Default: `defaultNotFoundComponent`
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+const router = createRouter({
+  routeTree,
+  defaultNotFoundComponent: () => {
+    return (
+      <div>
+        <p>Not found!</p>
+        <Link to="/">Go home</Link>
+      </div>
+    )
+  },
+})
+```
+
+### Per-Route 404: Missing Resources with `notFound()`
+
+Throw `notFound()` in `loader` or `beforeLoad` when a resource doesn't exist. It works like `redirect()` — throw it to trigger the not-found boundary.
+
+```tsx
+// src/routes/posts.$postId.tsx
+import { createFileRoute, notFound } from '@tanstack/react-router'
+import { getPost } from '../api'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params: { postId } }) => {
+    const post = await getPost(postId)
+    if (!post) throw notFound()
+    return { post }
+  },
+  component: PostComponent,
+  notFoundComponent: ({ data }) => {
+    const { postId } = Route.useParams()
+    return <p>Post "{postId}" not found</p>
+  },
+})
+
+function PostComponent() {
+  const { post } = Route.useLoaderData()
+  return <h1>{post.title}</h1>
+}
+```
+
+### Targeting a Specific Route with `notFound({ routeId })`
+
+You can force a specific parent route to handle the not-found error:
+
+```tsx
+// src/routes/_layout/posts.$postId.tsx
+import { createFileRoute, notFound } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_layout/posts/$postId')({
+  loader: async ({ params: { postId } }) => {
+    const post = await getPost(postId)
+    if (!post) throw notFound({ routeId: '/_layout' })
+    return { post }
+  },
+})
+```
+
+### Targeting Root Route with `rootRouteId`
+
+```tsx
+import { createFileRoute, notFound, rootRouteId } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params: { postId } }) => {
+    const post = await getPost(postId)
+    if (!post) throw notFound({ routeId: rootRouteId })
+    return { post }
+  },
+})
+```
+
+## `notFoundMode`: Fuzzy vs Root
+
+### `fuzzy` (default)
+
+The router finds the nearest parent route with children and a `notFoundComponent`. Preserves as much parent layout as possible.
+
+Given routes: `__root__` → `posts` → `$postId`, accessing `/posts/1/edit`:
+
+- `<Root>` renders
+- `<Posts>` renders
+- `<Posts.notFoundComponent>` renders (nearest parent with children + notFoundComponent)
+
+### `root`
+
+All not-found errors go to the root route's `notFoundComponent`, regardless of matching:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  notFoundMode: 'root',
+})
+```
+
+## Error Handling
+
+### `errorComponent` Per Route
+
+`errorComponent` receives `error`, `info`, and `reset` props. For loader errors, use `router.invalidate()` to re-run the loader — it automatically resets the error boundary.
+
+```tsx
+// src/routes/posts.$postId.tsx
+import { createFileRoute, useRouter } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params: { postId } }) => {
+    const res = await fetch(`/api/posts/${postId}`)
+    if (!res.ok) throw new Error('Failed to load post')
+    return res.json()
+  },
+  component: PostComponent,
+  errorComponent: PostErrorComponent,
+})
+
+function PostErrorComponent({
+  error,
+}: {
+  error: Error
+  info: { componentStack: string }
+  reset: () => void
+}) {
+  const router = useRouter()
+
+  return (
+    <div>
+      <p>Error: {error.message}</p>
+      <button
+        onClick={() => {
+          // Invalidate re-runs the loader and resets the error boundary
+          router.invalidate()
+        }}
+      >
+        Retry
+      </button>
+    </div>
+  )
+}
+
+function PostComponent() {
+  const data = Route.useLoaderData()
+  return <h1>{data.title}</h1>
+}
+```
+
+### Router-Wide Default Error Component
+
+```tsx
+const router = createRouter({
+  routeTree,
+  defaultErrorComponent: ({ error }) => {
+    const router = useRouter()
+    return (
+      <div>
+        <p>Something went wrong: {error.message}</p>
+        <button
+          onClick={() => {
+            router.invalidate()
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    )
+  },
+})
+```
+
+## Data in `notFoundComponent`
+
+`notFoundComponent` cannot reliably use `useLoaderData` because the loader may not have completed. Safe hooks:
+
+```tsx
+notFoundComponent: ({ data }) => {
+  // SAFE — always available:
+  const params = Route.useParams()
+  const search = Route.useSearch()
+  const context = Route.useRouteContext()
+
+  // UNSAFE — may be undefined:
+  // const loaderData = Route.useLoaderData()
+
+  return <p>Item {params.id} not found</p>
+}
+```
+
+To forward partial data, use the `data` option on `notFound()`:
+
+```tsx
+loader: async ({ params }) => {
+  const partialData = await getPartialData(params.id)
+  if (!partialData.fullResource) {
+    throw notFound({ data: { name: partialData.name } })
+  }
+  return partialData
+},
+notFoundComponent: ({ data }) => {
+  // data is typed as unknown — validate it
+  const info = data as { name: string } | undefined
+  return <p>{info?.name ?? 'Resource'} not found</p>
+},
+```
+
+## Route Masking
+
+Route masking shows a different URL in the browser bar than the actual route being rendered. Masking data is stored in `location.state` and is lost when the URL is shared or opened in a new tab.
+
+### Imperative Masking on `<Link>`
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+function PhotoGrid({ photoId }: { photoId: string }) {
+  return (
+    <Link
+      to="/photos/$photoId/modal"
+      params={{ photoId }}
+      mask={{
+        to: '/photos/$photoId',
+        params: { photoId },
+      }}
+    >
+      Open Photo
+    </Link>
+  )
+}
+```
+
+### Imperative Masking with `useNavigate`
+
+```tsx
+import { useNavigate } from '@tanstack/react-router'
+
+function OpenPhotoButton({ photoId }: { photoId: string }) {
+  const navigate = useNavigate()
+
+  return (
+    <button
+      onClick={() =>
+        navigate({
+          to: '/photos/$photoId/modal',
+          params: { photoId },
+          mask: {
+            to: '/photos/$photoId',
+            params: { photoId },
+          },
+        })
+      }
+    >
+      Open Photo
+    </button>
+  )
+}
+```
+
+### Declarative Masking with `createRouteMask`
+
+```tsx
+import { createRouter, createRouteMask } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+const photoModalMask = createRouteMask({
+  routeTree,
+  from: '/photos/$photoId/modal',
+  to: '/photos/$photoId',
+  params: (prev) => ({ photoId: prev.photoId }),
+})
+
+const router = createRouter({
+  routeTree,
+  routeMasks: [photoModalMask],
+})
+```
+
+### Unmasking on Reload
+
+By default, masks survive local page reloads. To unmask on reload:
+
+```tsx
+// Per-mask
+const mask = createRouteMask({
+  routeTree,
+  from: '/photos/$photoId/modal',
+  to: '/photos/$photoId',
+  params: (prev) => ({ photoId: prev.photoId }),
+  unmaskOnReload: true,
+})
+
+// Per-link
+<Link
+  to="/photos/$photoId/modal"
+  params={{ photoId }}
+  mask={{ to: '/photos/$photoId', params: { photoId } }}
+  unmaskOnReload
+>
+  Open Photo
+</Link>
+
+// Router-wide default
+const router = createRouter({
+  routeTree,
+  unmaskOnReload: true,
+})
+```
+
+## Common Mistakes
+
+### 1. HIGH: Using deprecated `NotFoundRoute`
+
+```tsx
+// WRONG — NotFoundRoute blocks notFound() and notFoundComponent from working
+import { NotFoundRoute } from '@tanstack/react-router'
+const notFoundRoute = new NotFoundRoute({ component: () => <p>404</p> })
+const router = createRouter({ routeTree, notFoundRoute })
+
+// CORRECT — use notFoundComponent on root route
+export const Route = createRootRoute({
+  component: () => <Outlet />,
+  notFoundComponent: () => <p>404</p>,
+})
+```
+
+### 2. MEDIUM: Expecting `useLoaderData` in `notFoundComponent`
+
+```tsx
+// WRONG — loader may not have completed
+notFoundComponent: () => {
+  const data = Route.useLoaderData() // may be undefined!
+  return <p>{data.title} not found</p>
+}
+
+// CORRECT — use safe hooks
+notFoundComponent: () => {
+  const { postId } = Route.useParams()
+  return <p>Post {postId} not found</p>
+}
+```
+
+### 3. MEDIUM: Leaf routes cannot handle not-found errors
+
+Only routes with children (and therefore an `<Outlet>`) can render `notFoundComponent`. Leaf routes (routes without children) will never catch not-found errors — the error bubbles up to the nearest parent with children.
+
+```tsx
+// This route has NO children — notFoundComponent here will not catch
+// unmatched child paths (there are no child paths to unmatch)
+export const Route = createFileRoute('/posts/$postId')({
+  // notFoundComponent here only works for notFound() thrown in THIS route's loader
+  // It does NOT catch path-based not-founds
+  notFoundComponent: () => <p>Not found</p>,
+})
+```
+
+### 4. MEDIUM: Expecting masked URLs to survive sharing
+
+Masking data lives in `location.state` (browser history). When a masked URL is copied, shared, or opened in a new tab, the masking data is lost. The browser navigates to the visible (masked) URL directly.
+
+### 5. HIGH (cross-skill): Using `reset()` alone instead of `router.invalidate()`
+
+```tsx
+// WRONG — reset() clears the error boundary but does NOT re-run the loader
+function ErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+  return <button onClick={reset}>Retry</button>
+}
+
+// CORRECT — invalidate re-runs loaders and resets the error boundary
+function ErrorFallback({ error }: { error: Error; reset: () => void }) {
+  const router = useRouter()
+  return (
+    <button
+      onClick={() => {
+        router.invalidate()
+      }}
+    >
+      Retry
+    </button>
+  )
+}
+```
+
+## Cross-References
+
+- **router-core/data-loading** — `notFound()` thrown in loaders interacts with error boundaries and loader data availability. `errorComponent` retry requires `router.invalidate()`.
+- **router-core/type-safety** — `notFoundComponent` data is typed as `unknown`; validate before use.

--- a/.agents/skills/tanstack-router-path-params/SKILL.md
+++ b/.agents/skills/tanstack-router-path-params/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: router-core/path-params
+description: >-
+  Dynamic path segments ($paramName), splat routes ($ / _splat),
+  optional params ({-$paramName}), prefix/suffix patterns ({$param}.ext),
+  useParams, params.parse/stringify, pathParamsAllowedCharacters,
+  i18n locale patterns.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/path-params.md
+  - TanStack/router:docs/router/routing/routing-concepts.md
+  - TanStack/router:docs/router/guide/internationalization-i18n.md
+---
+
+# Path Params
+
+Path params capture dynamic URL segments into named variables. They are defined with a `$` prefix in the route path.
+
+> **CRITICAL**: Never interpolate params into the `to` string. Always use the `params` prop. This is the most common agent mistake for path params.
+
+> **CRITICAL**: Types are fully inferred. Never annotate the return of `useParams()`.
+
+## Dynamic Segments
+
+A segment prefixed with `$` captures text until the next `/`.
+
+```tsx
+// src/routes/posts.$postId.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => {
+    // params.postId is string — fully inferred, do not annotate
+    return fetchPost(params.postId)
+  },
+  component: PostComponent,
+})
+
+function PostComponent() {
+  const { postId } = Route.useParams()
+  const data = Route.useLoaderData()
+  return (
+    <h1>
+      Post {postId}: {data.title}
+    </h1>
+  )
+}
+```
+
+Multiple dynamic segments work across path levels:
+
+```tsx
+// src/routes/teams.$teamId.members.$memberId.tsx
+export const Route = createFileRoute('/teams/$teamId/members/$memberId')({
+  component: MemberComponent,
+})
+
+function MemberComponent() {
+  const { teamId, memberId } = Route.useParams()
+  return (
+    <div>
+      Team {teamId}, Member {memberId}
+    </div>
+  )
+}
+```
+
+## Splat / Catch-All Routes
+
+A route with a path ending in `$` (bare dollar sign) captures everything after it. The value is available under the `_splat` key.
+
+```tsx
+// src/routes/files.$.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/files/$')({
+  component: FileViewer,
+})
+
+function FileViewer() {
+  const { _splat } = Route.useParams()
+  // URL: /files/documents/report.pdf → _splat = "documents/report.pdf"
+  return <div>File path: {_splat}</div>
+}
+```
+
+## Optional Params
+
+Optional params use `{-$paramName}` syntax. The segment may or may not be present. When absent, the value is `undefined`.
+
+```tsx
+// src/routes/posts.{-$category}.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/{-$category}')({
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  const { category } = Route.useParams()
+  // URL: /posts → category is undefined
+  // URL: /posts/tech → category is "tech"
+  return <div>{category ? `Posts in ${category}` : 'All Posts'}</div>
+}
+```
+
+Multiple optional params:
+
+```tsx
+// Matches: /posts, /posts/tech, /posts/tech/hello-world
+export const Route = createFileRoute('/posts/{-$category}/{-$slug}')({
+  component: PostComponent,
+})
+```
+
+### i18n with Optional Locale
+
+```tsx
+// src/routes/{-$locale}/about.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/{-$locale}/about')({
+  component: AboutComponent,
+})
+
+function AboutComponent() {
+  const { locale } = Route.useParams()
+  const currentLocale = locale || 'en'
+  return <h1>{currentLocale === 'fr' ? 'À Propos' : 'About Us'}</h1>
+}
+// Matches: /about, /en/about, /fr/about
+```
+
+## Prefix and Suffix Patterns
+
+Curly braces `{}` around `$paramName` allow text before or after the dynamic part within a single segment.
+
+### Prefix
+
+```tsx
+// src/routes/posts/post-{$postId}.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/post-{$postId}')({
+  component: PostComponent,
+})
+
+function PostComponent() {
+  const { postId } = Route.useParams()
+  // URL: /posts/post-123 → postId = "123"
+  return <div>Post ID: {postId}</div>
+}
+```
+
+### Suffix
+
+```tsx
+// src/routes/files/{$fileName}[.]txt.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/files/{$fileName}.txt')({
+  component: FileComponent,
+})
+
+function FileComponent() {
+  const { fileName } = Route.useParams()
+  // URL: /files/readme.txt → fileName = "readme"
+  return <div>File: {fileName}.txt</div>
+}
+```
+
+### Combined Prefix + Suffix
+
+```tsx
+// URL: /users/user-456.json → userId = "456"
+export const Route = createFileRoute('/users/user-{$userId}.json')({
+  component: UserComponent,
+})
+
+function UserComponent() {
+  const { userId } = Route.useParams()
+  return <div>User: {userId}</div>
+}
+```
+
+## Navigating with Path Params
+
+### Object Form
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+function PostLink({ postId }: { postId: string }) {
+  return (
+    <Link to="/posts/$postId" params={{ postId }}>
+      View Post
+    </Link>
+  )
+}
+```
+
+### Function Form (Preserves Other Params)
+
+```tsx
+function PostLink({ postId }: { postId: string }) {
+  return (
+    <Link to="/posts/$postId" params={(prev) => ({ ...prev, postId })}>
+      View Post
+    </Link>
+  )
+}
+```
+
+### Programmatic Navigation
+
+```tsx
+import { useNavigate } from '@tanstack/react-router'
+
+function GoToPost({ postId }: { postId: string }) {
+  const navigate = useNavigate()
+
+  return (
+    <button
+      onClick={() => {
+        navigate({ to: '/posts/$postId', params: { postId } })
+      }}
+    >
+      Go to Post
+    </button>
+  )
+}
+```
+
+### Navigating with Optional Params
+
+```tsx
+// Include the optional param
+<Link to="/posts/{-$category}" params={{ category: 'tech' }}>
+  Tech Posts
+</Link>
+
+// Omit the optional param (renders /posts)
+<Link to="/posts/{-$category}" params={{ category: undefined }}>
+  All Posts
+</Link>
+```
+
+## Reading Params Outside Route Components
+
+### `useParams` with `from`
+
+```tsx
+import { useParams } from '@tanstack/react-router'
+
+function PostHeader() {
+  const { postId } = useParams({ from: '/posts/$postId' })
+  return <h2>Post {postId}</h2>
+}
+```
+
+### `useParams` with `strict: false`
+
+```tsx
+function GenericBreadcrumb() {
+  const params = useParams({ strict: false })
+  // params is a union of all possible route params
+  return <span>{params.postId ?? 'Home'}</span>
+}
+```
+
+## Params in Loaders and `beforeLoad`
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  beforeLoad: async ({ params }) => {
+    // params.postId available here
+    const canView = await checkPermission(params.postId)
+    if (!canView) throw redirect({ to: '/unauthorized' })
+  },
+  loader: async ({ params }) => {
+    return fetchPost(params.postId)
+  },
+})
+```
+
+## Allowed Characters
+
+By default, params are encoded with `encodeURIComponent`. Allow extra characters via router config:
+
+```tsx
+import { createRouter } from '@tanstack/react-router'
+
+const router = createRouter({
+  routeTree,
+  pathParamsAllowedCharacters: ['@', '+'],
+})
+```
+
+Allowed characters: `;`, `:`, `@`, `&`, `=`, `+`, `$`, `,`.
+
+## Common Mistakes
+
+### 1. CRITICAL (cross-skill): Interpolating path params into `to` string
+
+```tsx
+// WRONG — breaks type safety and param encoding
+<Link to={`/posts/${postId}`}>Post</Link>
+
+// CORRECT — use params prop
+<Link to="/posts/$postId" params={{ postId }}>Post</Link>
+```
+
+### 2. MEDIUM: Using `*` for splat routes instead of `$`
+
+TanStack Router uses `$` for splat routes. The captured value is under `_splat`, not `*`.
+
+```tsx
+// WRONG (React Router / other frameworks)
+// <Route path="/files/*" />
+
+// CORRECT (TanStack Router)
+// File: src/routes/files.$.tsx
+export const Route = createFileRoute('/files/$')({
+  component: () => {
+    const { _splat } = Route.useParams()
+    return <div>{_splat}</div>
+  },
+})
+```
+
+> Note: `*` works in v1 for backwards compatibility but will be removed in v2. Always use `_splat`.
+
+### 3. MEDIUM: Using curly braces for basic dynamic segments
+
+Curly braces are ONLY for prefix/suffix patterns and optional params. Basic dynamic segments use bare `$`.
+
+```tsx
+// WRONG — braces not needed for basic params
+createFileRoute('/posts/{$postId}')
+
+// CORRECT — bare $ for basic dynamic segments
+createFileRoute('/posts/$postId')
+
+// CORRECT — braces for prefix pattern
+createFileRoute('/posts/post-{$postId}')
+
+// CORRECT — braces for optional param
+createFileRoute('/posts/{-$category}')
+```
+
+### 4. Params are always strings
+
+Path params are always parsed as strings. If you need a number, parse in the loader or component:
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => {
+    const id = parseInt(params.postId, 10)
+    if (isNaN(id)) throw notFound()
+    return fetchPost(id)
+  },
+})
+```
+
+You can also use `params.parse` and `params.stringify` on the route for bidirectional transformation:
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  params: {
+    parse: (raw) => ({ postId: parseInt(raw.postId, 10) }),
+    stringify: (parsed) => ({ postId: String(parsed.postId) }),
+  },
+  loader: async ({ params }) => {
+    // params.postId is now number
+    return fetchPost(params.postId)
+  },
+})
+```

--- a/.agents/skills/tanstack-router-plugin/SKILL.md
+++ b/.agents/skills/tanstack-router-plugin/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: router-plugin
+description: >-
+  TanStack Router bundler plugin for route generation and automatic
+  code splitting. Supports Vite, Webpack, Rspack, and esbuild.
+  Configures autoCodeSplitting, routesDirectory, target framework,
+  and code split groupings.
+type: core
+library: tanstack-router
+library_version: '1.166.2'
+sources:
+  - TanStack/router:packages/router-plugin/src
+  - TanStack/router:docs/router/routing/file-based-routing.md
+  - TanStack/router:docs/router/guide/code-splitting.md
+---
+
+# Router Plugin (`@tanstack/router-plugin`)
+
+Bundler plugin that powers TanStack Router's file-based routing and automatic code splitting. Works with Vite, Webpack, Rspack, and esbuild via unplugin.
+
+> **CRITICAL**: The router plugin MUST come before the framework plugin (React, Solid, Vue) in the Vite config. Wrong order causes route generation and code splitting to fail silently.
+
+## Install
+
+```bash
+npm install -D @tanstack/router-plugin
+```
+
+## Bundler Setup
+
+### Vite (most common)
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { tanstackRouter } from '@tanstack/router-plugin/vite'
+
+export default defineConfig({
+  plugins: [
+    // MUST come before react()
+    tanstackRouter({
+      target: 'react',
+      autoCodeSplitting: true,
+    }),
+    react(),
+  ],
+})
+```
+
+### Webpack
+
+```ts
+// webpack.config.js
+const { tanstackRouter } = require('@tanstack/router-plugin/webpack')
+
+module.exports = {
+  plugins: [
+    tanstackRouter({
+      target: 'react',
+      autoCodeSplitting: true,
+    }),
+  ],
+}
+```
+
+### Rspack
+
+```ts
+// rspack.config.js
+const { tanstackRouter } = require('@tanstack/router-plugin/rspack')
+
+module.exports = {
+  plugins: [
+    tanstackRouter({
+      target: 'react',
+      autoCodeSplitting: true,
+    }),
+  ],
+}
+```
+
+### esbuild
+
+```ts
+import { tanstackRouter } from '@tanstack/router-plugin/esbuild'
+import esbuild from 'esbuild'
+
+esbuild.build({
+  plugins: [
+    tanstackRouter({
+      target: 'react',
+      autoCodeSplitting: true,
+    }),
+  ],
+})
+```
+
+## Configuration Options
+
+### Core Options
+
+| Option                  | Type                          | Default                    | Description                                |
+| ----------------------- | ----------------------------- | -------------------------- | ------------------------------------------ |
+| `target`                | `'react' \| 'solid' \| 'vue'` | `'react'`                  | Target framework                           |
+| `routesDirectory`       | `string`                      | `'./src/routes'`           | Directory containing route files           |
+| `generatedRouteTree`    | `string`                      | `'./src/routeTree.gen.ts'` | Path for generated route tree              |
+| `autoCodeSplitting`     | `boolean`                     | `undefined`                | Enable automatic code splitting            |
+| `enableRouteGeneration` | `boolean`                     | `true`                     | Set to `false` to disable route generation |
+
+### File Convention Options
+
+| Option                   | Type                                                    | Default     | Description                          |
+| ------------------------ | ------------------------------------------------------- | ----------- | ------------------------------------ |
+| `routeFilePrefix`        | `string`                                                | `undefined` | Prefix filter for route files        |
+| `routeFileIgnorePrefix`  | `string`                                                | `'-'`       | Prefix to exclude files from routing |
+| `routeFileIgnorePattern` | `string`                                                | `undefined` | Pattern to exclude from routing      |
+| `indexToken`             | `string \| RegExp \| { regex: string; flags?: string }` | `'index'`   | Token identifying index routes       |
+| `routeToken`             | `string \| RegExp \| { regex: string; flags?: string }` | `'route'`   | Token identifying route config files |
+
+### Code Splitting Options
+
+```ts
+tanstackRouter({
+  target: 'react',
+  autoCodeSplitting: true,
+  codeSplittingOptions: {
+    // Default groupings for all routes
+    defaultBehavior: [['component'], ['errorComponent'], ['notFoundComponent']],
+
+    // Per-route custom splitting
+    splitBehavior: ({ routeId }) => {
+      if (routeId === '/dashboard') {
+        // Keep loader and component together for dashboard
+        return [['loader', 'component'], ['errorComponent']]
+      }
+      // Return undefined to use defaultBehavior
+    },
+  },
+})
+```
+
+### Output Options
+
+| Option                      | Type                   | Default     | Description                                  |
+| --------------------------- | ---------------------- | ----------- | -------------------------------------------- |
+| `quoteStyle`                | `'single' \| 'double'` | `'single'`  | Quote style in generated code                |
+| `semicolons`                | `boolean`              | `false`     | Use semicolons in generated code             |
+| `disableTypes`              | `boolean`              | `false`     | Disable TypeScript types                     |
+| `disableLogging`            | `boolean`              | `false`     | Suppress plugin logs                         |
+| `addExtensions`             | `boolean \| string`    | `false`     | Add file extensions to imports               |
+| `enableRouteTreeFormatting` | `boolean`              | `true`      | Format generated route tree                  |
+| `verboseFileRoutes`         | `boolean`              | `undefined` | When `false`, auto-imports `createFileRoute` |
+
+### Virtual Route Config
+
+```ts
+import { routes } from './routes'
+
+tanstackRouter({
+  target: 'react',
+  virtualRouteConfig: routes, // or './routes.ts'
+})
+```
+
+## How It Works
+
+The composed plugin assembles up to 4 sub-plugins:
+
+1. **Route Generator** (always) — Watches route files and generates `routeTree.gen.ts`
+2. **Code Splitter** (when `autoCodeSplitting: true`) — Splits route files into lazy-loaded chunks using virtual modules
+3. **Auto-Import** (when `verboseFileRoutes: false`) — Auto-injects `createFileRoute` imports
+4. **HMR** (dev mode, when code splitter is off) — Hot-reloads route changes without full refresh
+
+## Individual Plugin Exports
+
+For advanced use, each sub-plugin is exported separately from the Vite entry:
+
+```ts
+import {
+  tanstackRouter, // Composed (default)
+  tanstackRouterGenerator, // Generator only
+  tanStackRouterCodeSplitter, // Code splitter only
+  tanstackRouterAutoImport, // Auto-import only
+} from '@tanstack/router-plugin/vite'
+```
+
+## Common Mistakes
+
+### 1. CRITICAL: Wrong plugin order in Vite config
+
+The router plugin must come before the framework plugin. Otherwise, route generation and code splitting fail silently.
+
+```ts
+// WRONG — react() before tanstackRouter()
+plugins: [react(), tanstackRouter({ target: 'react' })]
+
+// CORRECT — tanstackRouter() first
+plugins: [tanstackRouter({ target: 'react' }), react()]
+```
+
+### 2. HIGH: Missing target option for non-React frameworks
+
+The `target` defaults to `'react'`. For Solid or Vue, you must set it explicitly.
+
+```ts
+// WRONG for Solid — generates React imports
+tanstackRouter({ autoCodeSplitting: true })
+
+// CORRECT for Solid
+tanstackRouter({ target: 'solid', autoCodeSplitting: true })
+```
+
+### 3. MEDIUM: Confusing autoCodeSplitting with manual lazy routes
+
+When `autoCodeSplitting` is enabled, the plugin handles splitting automatically. You do NOT need manual `createLazyRoute` or `lazyRouteComponent` calls — the plugin transforms your route files at build time.
+
+```tsx
+// WRONG — manual lazy loading with autoCodeSplitting enabled
+const LazyAbout = lazyRouteComponent(() => import('./about'))
+
+// CORRECT — just write normal route files, plugin handles splitting
+// src/routes/about.tsx
+export const Route = createFileRoute('/about')({
+  component: AboutPage,
+})
+
+function AboutPage() {
+  return <h1>About</h1>
+}
+```
+
+## Cross-References
+
+- [router-core/code-splitting](../../../router-core/skills/router-core/code-splitting/SKILL.md) — manual code splitting concepts
+- [virtual-file-routes](../../../virtual-file-routes/skills/virtual-file-routes/SKILL.md) — programmatic route trees

--- a/.agents/skills/tanstack-router-search-params/SKILL.md
+++ b/.agents/skills/tanstack-router-search-params/SKILL.md
@@ -1,0 +1,349 @@
+---
+name: router-core/search-params
+description: >-
+  validateSearch, search param validation with Zod/Valibot/ArkType adapters,
+  fallback(), search middlewares (retainSearchParams, stripSearchParams),
+  custom serialization (parseSearch, stringifySearch), search param
+  inheritance, loaderDeps for cache keys, reading and writing search params.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/search-params.md
+  - TanStack/router:docs/router/how-to/setup-basic-search-params.md
+  - TanStack/router:docs/router/how-to/validate-search-params.md
+  - TanStack/router:docs/router/how-to/navigate-with-search-params.md
+  - TanStack/router:docs/router/how-to/share-search-params-across-routes.md
+  - TanStack/router:docs/router/guide/custom-search-param-serialization.md
+---
+
+# Search Params
+
+TanStack Router treats search params as JSON-first application state. They are automatically parsed from the URL into structured objects (numbers, booleans, arrays, nested objects) and validated via `validateSearch` on each route.
+
+> **CRITICAL**: When using `zodValidator()` and Zod v3, use `fallback()` from `@tanstack/zod-adapter`, NOT zod's `.catch()`. Using `.catch()` with the zod adapter makes the output type `unknown`, destroying type safety. This does not apply to Valibot or ArkType (which use their own fallback mechanisms). It also does not apply to Zod v4, which should use `.catch()` and not use the `zodValidator()`.
+> **CRITICAL**: Types are fully inferred. Never annotate the return of `useSearch()`.
+
+## Setup: Zod Adapter (Recommended)
+
+```bash
+npm install zod @tanstack/zod-adapter
+```
+
+```tsx
+// src/routes/products.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const productSearchSchema = z.object({
+  page: z.number().default(1).catch(1),
+  filter: z.string().default(''),
+  sort: z.enum(['newest', 'oldest', 'price']).default('newest').catch('newest'),
+})
+
+export const Route = createFileRoute('/products')({
+  validateSearch: productSearchSchema,
+  component: ProductsPage,
+})
+
+function ProductsPage() {
+  // page: number, filter: string, sort: 'newest' | 'oldest' | 'price'
+  // ALL INFERRED — do not annotate
+  const { page, filter, sort } = Route.useSearch()
+
+  return (
+    <div>
+      <p>
+        Page {page}, filter: {filter}, sort: {sort}
+      </p>
+    </div>
+  )
+}
+```
+
+## Reading Search Params
+
+### In Route Components: `Route.useSearch()`
+
+```tsx
+function ProductsPage() {
+  const { page, sort } = Route.useSearch()
+  return <div>Page {page}</div>
+}
+```
+
+### In Code-Split Components: `getRouteApi()`
+
+```tsx
+import { getRouteApi } from '@tanstack/react-router'
+
+const routeApi = getRouteApi('/products')
+
+function ProductFilters() {
+  const { sort } = routeApi.useSearch()
+  return <select value={sort}>{/* options */}</select>
+}
+```
+
+### From Any Component: `useSearch({ from })`
+
+```tsx
+import { useSearch } from '@tanstack/react-router'
+
+function SortIndicator() {
+  const { sort } = useSearch({ from: '/products' })
+  return <span>Sorted by: {sort}</span>
+}
+```
+
+### Loose Access: `useSearch({ strict: false })`
+
+```tsx
+function GenericPaginator() {
+  const search = useSearch({ strict: false })
+  // search.page is number | undefined (union of all routes)
+  return <span>Page: {search.page ?? 1}</span>
+}
+```
+
+## Writing Search Params
+
+### Link with Function Form (Preserves Existing Params)
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+function Pagination() {
+  return (
+    <Link
+      from="/products"
+      search={(prev) => ({ ...prev, page: prev.page + 1 })}
+    >
+      Next Page
+    </Link>
+  )
+}
+```
+
+### Link with Object Form (Replaces All Params)
+
+```tsx
+<Link to="/products" search={{ page: 1, filter: '', sort: 'newest' }}>
+  Reset
+</Link>
+```
+
+### Programmatic: `useNavigate()`
+
+```tsx
+import { useNavigate } from '@tanstack/react-router'
+
+function SortDropdown() {
+  const navigate = useNavigate({ from: '/products' })
+
+  return (
+    <select
+      onChange={(e) => {
+        navigate({
+          search: (prev) => ({ ...prev, sort: e.target.value, page: 1 }),
+        })
+      }}
+    >
+      <option value="newest">Newest</option>
+      <option value="price">Price</option>
+    </select>
+  )
+}
+```
+
+## Search Param Inheritance
+
+Parent route search params are automatically merged into child routes:
+
+```tsx
+// src/routes/shop.tsx — parent defines shared params
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const shopSearchSchema = z.object({
+  currency: z.enum(['USD', 'EUR']).default('USD').catch('USD'),
+})
+
+export const Route = createFileRoute('/shop')({
+  validateSearch: shopSearchSchema,
+})
+```
+
+```tsx
+// src/routes/shop/products.tsx — child inherits currency
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/shop/products')({
+  component: ShopProducts,
+})
+
+function ShopProducts() {
+  // currency is available here from parent — fully typed
+  const { currency } = Route.useSearch()
+  return <div>Currency: {currency}</div>
+}
+```
+
+## Search Middlewares
+
+### `retainSearchParams` — Keep Params Across Navigation
+
+```tsx
+import { createRootRoute, retainSearchParams } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const rootSearchSchema = z.object({
+  debug: z.boolean().optional(),
+})
+
+export const Route = createRootRoute({
+  validateSearch: rootSearchSchema,
+  search: {
+    middlewares: [retainSearchParams(['debug'])],
+  },
+})
+```
+
+### `stripSearchParams` — Remove Default Values from URL
+
+```tsx
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const defaults = { sort: 'newest', page: 1 }
+
+const searchSchema = z.object({
+  sort: z.string().default(defaults.sort),
+  page: z.number().default(defaults.page),
+})
+
+export const Route = createFileRoute('/items')({
+  validateSearch: searchSchema,
+  search: {
+    middlewares: [stripSearchParams(defaults)],
+  },
+})
+```
+
+### Chaining Middlewares
+
+```tsx
+export const Route = createFileRoute('/search')({
+  validateSearch: z.object({
+    retainMe: z.string().optional(),
+    arrayWithDefaults: z.string().array().default(['foo', 'bar']),
+    required: z.string(),
+  }),
+  search: {
+    middlewares: [
+      retainSearchParams(['retainMe']),
+      stripSearchParams({ arrayWithDefaults: ['foo', 'bar'] }),
+    ],
+  },
+})
+```
+
+## Custom Serialization
+
+Override the default JSON serialization at the router level:
+
+```tsx
+import {
+  createRouter,
+  parseSearchWith,
+  stringifySearchWith,
+} from '@tanstack/react-router'
+
+const router = createRouter({
+  routeTree,
+  // Example: use JSURL2 for compact, human-readable URLs
+  parseSearch: parseSearchWith(parse),
+  stringifySearch: stringifySearchWith(stringify),
+})
+```
+
+## Using Search Params in Loaders via `loaderDeps`
+
+```tsx
+export const Route = createFileRoute('/products')({
+  validateSearch: productSearchSchema,
+  // Pick ONLY the params the loader needs — not the entire search object
+  loaderDeps: ({ search }) => ({ page: search.page }),
+  loader: async ({ deps }) => {
+    return fetchProducts({ page: deps.page })
+  },
+})
+```
+
+## Common Mistakes
+
+### 1. HIGH: Using zod v3's `.catch()` with `zodValidator()` instead of adapter `fallback()`
+
+```tsx
+// WRONG — .catch() with zodValidator makes the type unknown
+const schema = z.object({ page: z.number().catch(1) })
+validateSearch: zodValidator(schema) // page is typed as unknown!
+
+// CORRECT — fallback() preserves the inferred type
+import { fallback } from '@tanstack/zod-adapter'
+const schema = z.object({ page: fallback(z.number(), 1) })
+```
+
+**Important:** This only applies when using Zod v3, not when using Zod v4. For v4, using `.catch()` is correct.
+
+### 2. HIGH: Returning entire search object from `loaderDeps`
+
+```tsx
+// WRONG — loader re-runs on ANY search param change
+loaderDeps: ({ search }) => search
+
+// CORRECT — loader only re-runs when page changes
+loaderDeps: ({ search }) => ({ page: search.page })
+```
+
+### 3. HIGH: Passing Date objects in search params
+
+```tsx
+// WRONG — Date does not serialize correctly to JSON in URLs
+<Link search={{ startDate: new Date() }}>
+
+// CORRECT — convert to ISO string
+<Link search={{ startDate: new Date().toISOString() }}>
+```
+
+### 4. MEDIUM: Parent route missing `validateSearch` blocks inheritance
+
+```tsx
+// WRONG — child cannot access shared params
+export const Route = createRootRoute({
+  component: RootComponent,
+  // no validateSearch!
+})
+
+// CORRECT — parent must define validateSearch for children to inherit
+export const Route = createRootRoute({
+  validateSearch: globalSearchSchema,
+  component: RootComponent,
+})
+```
+
+### 5. HIGH (cross-skill): Using search as object instead of function loses params
+
+```tsx
+// WRONG — replaces ALL search params, losing any existing ones
+<Link to="." search={{ page: 2 }}>Page 2</Link>
+
+// CORRECT — preserves existing params, updates only page
+<Link to="." search={(prev) => ({ ...prev, page: 2 })}>Page 2</Link>
+```
+
+## References
+
+- [Validation Patterns Reference](./references/validation-patterns.md) — comprehensive patterns for all validation libraries

--- a/.agents/skills/tanstack-router-ssr/SKILL.md
+++ b/.agents/skills/tanstack-router-ssr/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: router-core/ssr
+description: >-
+  Non-streaming and streaming SSR, RouterClient/RouterServer,
+  renderRouterToString/renderRouterToStream, createRequestHandler,
+  defaultRenderHandler/defaultStreamHandler, HeadContent/Scripts
+  components, head route option (meta/links/styles/scripts),
+  ScriptOnce, automatic loader dehydration/hydration, memory
+  history on server, data serialization, document head management.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+  - router-core/data-loading
+sources:
+  - TanStack/router:docs/router/guide/ssr.md
+  - TanStack/router:docs/router/guide/document-head-management.md
+  - TanStack/router:docs/router/how-to/setup-ssr.md
+---
+
+# SSR (Server-Side Rendering)
+
+> **WARNING**: SSR APIs are experimental. They share internal implementations with TanStack Start and may change. **TanStack Start is the recommended way to do SSR in production** — use manual SSR setup only when integrating with an existing server.
+
+> **CRITICAL**: TanStack Router is CLIENT-FIRST. Loaders run on the client by default. With SSR enabled, loaders run on BOTH client AND server. They are NOT server-only like Remix/Next.js loaders. See [router-core/data-loading](../data-loading/SKILL.md).
+
+> **CRITICAL**: Do not generate Next.js patterns (`getServerSideProps`, App Router, server components) or Remix patterns (server-only loader exports). TanStack Router has its own SSR API.
+
+## Concepts
+
+There are two SSR flavors:
+
+- **Non-streaming**: Full page rendered on server, sent as one HTML response, then hydrated on client.
+- **Streaming**: Critical first paint sent immediately; remaining content streamed incrementally as it resolves.
+
+Key behaviors:
+
+- Memory history is used automatically on the server (no `window`).
+- Loader data is automatically dehydrated on the server and hydrated on the client.
+- Data serialization supports `Date`, `Error`, `FormData`, and `undefined` out of the box.
+
+## Setup: Shared Router Factory
+
+The router must be created identically on server and client. Export a factory function from a shared file:
+
+```tsx
+// src/router.tsx
+import { createRouter as createTanstackRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+export function createRouter() {
+  return createTanstackRouter({ routeTree })
+}
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: ReturnType<typeof createRouter>
+  }
+}
+```
+
+## Non-Streaming SSR
+
+### Server Entry (using `defaultRenderHandler`)
+
+```tsx
+// src/entry-server.tsx
+import {
+  createRequestHandler,
+  defaultRenderHandler,
+} from '@tanstack/react-router/ssr/server'
+import { createRouter } from './router'
+
+export async function render({ request }: { request: Request }) {
+  const handler = createRequestHandler({ request, createRouter })
+  return await handler(defaultRenderHandler)
+}
+```
+
+### Server Entry (using `renderRouterToString` for custom wrappers)
+
+```tsx
+// src/entry-server.tsx
+import {
+  createRequestHandler,
+  renderRouterToString,
+  RouterServer,
+} from '@tanstack/react-router/ssr/server'
+import { createRouter } from './router'
+
+export function render({ request }: { request: Request }) {
+  const handler = createRequestHandler({ request, createRouter })
+
+  return handler(({ responseHeaders, router }) =>
+    renderRouterToString({
+      responseHeaders,
+      router,
+      children: <RouterServer router={router} />,
+    }),
+  )
+}
+```
+
+### Client Entry
+
+```tsx
+// src/entry-client.tsx
+import { hydrateRoot } from 'react-dom/client'
+import { RouterClient } from '@tanstack/react-router/ssr/client'
+import { createRouter } from './router'
+
+const router = createRouter()
+
+hydrateRoot(document, <RouterClient router={router} />)
+```
+
+## Streaming SSR
+
+### Server Entry (using `defaultStreamHandler`)
+
+```tsx
+// src/entry-server.tsx
+import {
+  createRequestHandler,
+  defaultStreamHandler,
+} from '@tanstack/react-router/ssr/server'
+import { createRouter } from './router'
+
+export async function render({ request }: { request: Request }) {
+  const handler = createRequestHandler({ request, createRouter })
+  return await handler(defaultStreamHandler)
+}
+```
+
+### Server Entry (using `renderRouterToStream` for custom wrappers)
+
+```tsx
+// src/entry-server.tsx
+import {
+  createRequestHandler,
+  renderRouterToStream,
+  RouterServer,
+} from '@tanstack/react-router/ssr/server'
+import { createRouter } from './router'
+
+export function render({ request }: { request: Request }) {
+  const handler = createRequestHandler({ request, createRouter })
+
+  return handler(({ request, responseHeaders, router }) =>
+    renderRouterToStream({
+      request,
+      responseHeaders,
+      router,
+      children: <RouterServer router={router} />,
+    }),
+  )
+}
+```
+
+Streaming is automatic — deferred data (unawaited promises from loaders) and streamed markup just work when using `defaultStreamHandler` or `renderRouterToStream`.
+
+## Document Head Management
+
+Use the `head` route option to manage `<title>`, `<meta>`, `<link>`, and `<style>` tags. Render `<HeadContent />` in `<head>` and `<Scripts />` in `<body>`.
+
+### Root Route with Head
+
+```tsx
+// src/routes/__root.tsx
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  head: () => ({
+    meta: [
+      { charSet: 'UTF-8' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1.0' },
+      { title: 'My App' },
+    ],
+    links: [{ rel: 'icon', href: '/favicon.ico' }],
+  }),
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html lang="en">
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+### Per-Route Head (Nested Deduplication)
+
+Child route `title` and `meta` tags override parent tags with the same `name`/`property`:
+
+```tsx
+// src/routes/posts/$postId.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => {
+    const post = await fetchPost(params.postId)
+    return { post }
+  },
+  head: ({ loaderData }) => ({
+    meta: [
+      { title: loaderData.post.title },
+      { name: 'description', content: loaderData.post.excerpt },
+    ],
+  }),
+  component: PostPage,
+})
+
+function PostPage() {
+  const { post } = Route.useLoaderData()
+  return <article>{post.content}</article>
+}
+```
+
+### SPA Head (No Full HTML Control)
+
+For SPAs without server-rendered HTML, render `<HeadContent />` at the top of the component tree:
+
+```tsx
+import { createRootRoute, HeadContent, Outlet } from '@tanstack/react-router'
+
+const rootRoute = createRootRoute({
+  head: () => ({
+    meta: [{ title: 'My SPA' }],
+  }),
+  component: () => (
+    <>
+      <HeadContent />
+      <Outlet />
+    </>
+  ),
+})
+```
+
+## Body Scripts
+
+Use `scripts` (separate from `head.scripts`) to inject scripts into `<body>` before the app entry point:
+
+```tsx
+export const Route = createRootRoute({
+  scripts: () => [{ children: 'console.log("runs before hydration")' }],
+})
+```
+
+The `<Scripts />` component renders these. Place it at the end of `<body>`.
+
+## ScriptOnce for Pre-Hydration Scripts
+
+`ScriptOnce` renders a `<script>` during SSR that executes immediately and self-removes. On client navigation, it does nothing (no duplicate execution).
+
+```tsx
+import { ScriptOnce } from '@tanstack/react-router'
+
+const themeScript = `(function() {
+  try {
+    const theme = localStorage.getItem('theme') || 'auto';
+    const resolved = theme === 'auto'
+      ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+      : theme;
+    document.documentElement.classList.add(resolved);
+  } catch (e) {}
+})();`
+
+function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <ScriptOnce children={themeScript} />
+      {children}
+    </>
+  )
+}
+```
+
+If the script modifies the DOM (e.g., adds a class to `<html>`), use `suppressHydrationWarning` on the element:
+
+```tsx
+<html lang="en" suppressHydrationWarning>
+```
+
+## Express Integration Example
+
+`createRequestHandler` expects a Web API `Request` and returns a Web API `Response`. For Express, convert between formats:
+
+```tsx
+// src/entry-server.tsx
+import { pipeline } from 'node:stream/promises'
+import {
+  RouterServer,
+  createRequestHandler,
+  renderRouterToString,
+} from '@tanstack/react-router/ssr/server'
+import { createRouter } from './router'
+import type express from 'express'
+
+export async function render({
+  req,
+  res,
+}: {
+  req: express.Request
+  res: express.Response
+}) {
+  const protocol = req.get('x-forwarded-proto') ?? req.protocol
+  const host = req.get('x-forwarded-host') ?? req.get('host')
+  const url = new URL(req.originalUrl || req.url, `${protocol}://${host}`).href
+
+  const request = new Request(url, {
+    method: req.method,
+    headers: (() => {
+      const headers = new Headers()
+      for (const [key, value] of Object.entries(req.headers)) {
+        headers.set(key, value as any)
+      }
+      return headers
+    })(),
+  })
+
+  const handler = createRequestHandler({ request, createRouter })
+
+  const response = await handler(({ responseHeaders, router }) =>
+    renderRouterToString({
+      responseHeaders,
+      router,
+      children: <RouterServer router={router} />,
+    }),
+  )
+
+  res.status(response.status)
+  response.headers.forEach((value, name) => {
+    res.setHeader(name, value)
+  })
+
+  return pipeline(response.body as any, res)
+}
+```
+
+## Common Mistakes
+
+### 1. HIGH: Using browser APIs in loaders without environment check
+
+Loaders run on BOTH client and server with SSR. Browser-only APIs (`window`, `document`, `localStorage`) throw on the server.
+
+```tsx
+// WRONG — crashes on server
+loader: async () => {
+  const token = localStorage.getItem('token')
+  return fetchData(token)
+}
+
+// CORRECT — guard with environment check
+loader: async () => {
+  const token =
+    typeof window !== 'undefined' ? localStorage.getItem('token') : null
+  return fetchData(token)
+}
+```
+
+### 2. MEDIUM: Using hash fragments for server-rendered content
+
+Hash fragments (`#section`) are never sent to the server. Conditional rendering based on hash causes hydration mismatches.
+
+```tsx
+// WRONG — server has no hash, client does → mismatch
+component: () => {
+  const hash = window.location.hash
+  return hash === '#admin' ? <AdminPanel /> : <UserPanel />
+}
+
+// CORRECT — use search params for server-visible state
+validateSearch: z.object({ view: fallback(z.enum(['admin', 'user']), 'user') }),
+component: () => {
+  const { view } = Route.useSearch()
+  return view === 'admin' ? <AdminPanel /> : <UserPanel />
+}
+```
+
+### 3. CRITICAL: Generating Next.js or Remix SSR patterns
+
+TanStack Router does NOT use `getServerSideProps`, `getStaticProps`, App Router `page.tsx`, or Remix-style server-only `loader` exports.
+
+```tsx
+// WRONG — Next.js patterns
+export async function getServerSideProps() {
+  return { props: { data: await fetchData() } }
+}
+
+// WRONG — Remix patterns
+export async function loader({ request }: LoaderFunctionArgs) {
+  return json({ data: await fetchData() })
+}
+
+// CORRECT — TanStack Router pattern
+export const Route = createFileRoute('/data')({
+  loader: async () => {
+    const data = await fetchData()
+    return { data }
+  },
+  component: DataPage,
+})
+
+function DataPage() {
+  const { data } = Route.useLoaderData()
+  return <div>{data}</div>
+}
+```
+
+## Tension: Client-First Loaders vs SSR
+
+TanStack Router loaders are client-first by design. When SSR is enabled, they run in both environments. This means:
+
+- Browser APIs work by default (client-only) but break under SSR
+- Database access does NOT belong in loaders (unlike Remix/Next) — use API routes
+- For server-only data logic with SSR, use TanStack Start's server functions
+
+See [router-core/data-loading](../data-loading/SKILL.md) for loader fundamentals.
+
+## Cross-References
+
+- [router-core/data-loading](../data-loading/SKILL.md) — SSR changes where loaders execute
+- [compositions/router-query](../../../../react-router/skills/compositions/router-query/SKILL.md) — SSR dehydration/hydration with TanStack Query

--- a/.agents/skills/tanstack-router-type-safety/SKILL.md
+++ b/.agents/skills/tanstack-router-type-safety/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: router-core/type-safety
+description: >-
+  Full type inference philosophy (never cast, never annotate inferred
+  values), Register module declaration, from narrowing on hooks and
+  Link, strict:false for shared components, getRouteApi for code-split
+  typed access, addChildren with object syntax for TS perf, LinkProps
+  and ValidateLinkOptions type utilities, as const satisfies pattern.
+type: sub-skill
+library: tanstack-router
+library_version: '1.166.2'
+requires:
+  - router-core
+sources:
+  - TanStack/router:docs/router/guide/type-safety.md
+  - TanStack/router:docs/router/guide/type-utilities.md
+  - TanStack/router:docs/router/guide/render-optimizations.md
+---
+
+# Type Safety
+
+TanStack Router is FULLY type-inferred. Params, search params, context, and loader data all flow through the route tree automatically. The **#1 AI agent mistake** is adding type annotations, casts, or generic parameters to values that are already inferred.
+
+> **CRITICAL**: NEVER use `as Type`, explicit generic params, `satisfies` on hook returns, or type annotations on inferred values. Every cast masks real type errors and breaks the inference chain.
+> **CRITICAL**: Do NOT confuse TanStack Router with Next.js or React Router. There is no `getServerSideProps`, no `useSearchParams()`, no `useLoaderData()` from `react-router-dom`.
+
+## The ONE Required Type Annotation: Register
+
+Without this, top-level exports like `Link`, `useNavigate`, `useSearch` have no type safety.
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+const router = createRouter({ routeTree })
+
+// THIS IS REQUIRED — the single type registration for the entire app
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+
+export default router
+```
+
+After registration, every `Link`, `useNavigate`, `useSearch`, `useParams` across the app is fully typed.
+
+## Types Flow Automatically
+
+### Route Hooks — No Annotation Needed
+
+```tsx
+// src/routes/posts.$postId.tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$postId')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    page: Number(search.page ?? 1),
+  }),
+  loader: async ({ params }) => {
+    // params.postId is already typed as string — do not annotate
+    const post = await fetchPost(params.postId)
+    return { post }
+  },
+  component: PostComponent,
+})
+
+function PostComponent() {
+  // ALL of these are fully inferred — do NOT add type annotations
+  const { postId } = Route.useParams()
+  //      ^? string
+
+  const { page } = Route.useSearch()
+  //      ^? number
+
+  const { post } = Route.useLoaderData()
+  //      ^? { id: string; title: string; body: string }
+
+  return (
+    <div>
+      <h1>{post.title}</h1>
+      <p>Page {page}</p>
+    </div>
+  )
+}
+```
+
+### Context Flows Through the Tree
+
+```tsx
+// src/routes/__root.tsx
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
+
+interface RouterContext {
+  auth: { userId: string; role: 'admin' | 'user' } | null
+}
+
+// Note: createRootRouteWithContext is a FACTORY — call it TWICE: ()()
+export const Route = createRootRouteWithContext<RouterContext>()({
+  component: () => <Outlet />,
+})
+```
+
+```tsx
+// src/routes/dashboard.tsx
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/dashboard')({
+  beforeLoad: ({ context }) => {
+    // context.auth is already typed as { userId: string; role: 'admin' | 'user' } | null
+    // NO annotation needed
+    if (!context.auth) throw redirect({ to: '/login' })
+    return { user: context.auth }
+  },
+  loader: ({ context }) => {
+    // context.user is typed as { userId: string; role: 'admin' | 'user' }
+    // This was added by beforeLoad above — fully inferred
+    return fetchDashboard(context.user.userId)
+  },
+  component: DashboardComponent,
+})
+
+function DashboardComponent() {
+  const data = Route.useLoaderData()
+  const { user } = Route.useRouteContext()
+  return <h1>Welcome {user.userId}</h1>
+}
+```
+
+## Narrowing with `from`
+
+Without `from`, hooks return a union of ALL routes' types — slow for TypeScript and imprecise.
+
+### On Hooks
+
+```tsx
+import { useSearch, useParams, useNavigate } from '@tanstack/react-router'
+
+function PostSidebar() {
+  // WRONG — search is a union of ALL routes' search params
+  const search = useSearch()
+
+  // CORRECT — search is narrowed to /posts/$postId's search params
+  const search = useSearch({ from: '/posts/$postId' })
+  //    ^? { page: number }
+
+  // CORRECT — params narrowed to this route
+  const { postId } = useParams({ from: '/posts/$postId' })
+
+  // CORRECT — navigate narrowed for relative paths
+  const navigate = useNavigate({ from: '/posts/$postId' })
+}
+```
+
+### On `Link`
+
+```tsx
+import { Link } from '@tanstack/react-router'
+
+// WRONG — search resolves to union of ALL routes' search params, slow TS check
+<Link to=".." search={{ page: 0 }} />
+
+// CORRECT — narrowed, fast TS check
+<Link from="/posts/$postId" to=".." search={{ page: 0 }} />
+
+// Also correct — Route.fullPath in route components
+<Link from={Route.fullPath} to=".." search={{ page: 0 }} />
+```
+
+## Shared Components: `strict: false`
+
+When a component is used across multiple routes, use `strict: false` instead of `from`:
+
+```tsx
+import { useSearch } from '@tanstack/react-router'
+
+function GlobalSearch() {
+  // Returns union of all routes' search params — no runtime error if route doesn't match
+  const search = useSearch({ strict: false })
+  return <span>Query: {search.q ?? ''}</span>
+}
+```
+
+## Code-Split Files: `getRouteApi`
+
+Use `getRouteApi` instead of importing `Route` to avoid pulling route config into the lazy chunk:
+
+```tsx
+// src/routes/posts.lazy.tsx
+import { createLazyFileRoute, getRouteApi } from '@tanstack/react-router'
+
+const routeApi = getRouteApi('/posts')
+
+export const Route = createLazyFileRoute('/posts')({
+  component: PostsComponent,
+})
+
+function PostsComponent() {
+  const data = routeApi.useLoaderData()
+  const { page } = routeApi.useSearch()
+  return <div>Page {page}</div>
+}
+```
+
+## TypeScript Performance
+
+### Use Object Syntax for `addChildren` in Large Route Trees
+
+```tsx
+// SLOWER — tuple syntax
+const routeTree = rootRoute.addChildren([
+  postsRoute.addChildren([postRoute, postsIndexRoute]),
+  indexRoute,
+])
+
+// FASTER — object syntax (TS checks objects faster than large tuples)
+const routeTree = rootRoute.addChildren({
+  postsRoute: postsRoute.addChildren({ postRoute, postsIndexRoute }),
+  indexRoute,
+})
+```
+
+With file-based routing the route tree is generated, so this is handled for you.
+
+### Avoid Returning Unused Inferred Types from Loaders
+
+When using external caches like TanStack Query, don't let the router infer complex return types you never consume:
+
+```tsx
+// SLOWER — TS infers the full ensureQueryData return type into the route tree
+export const Route = createFileRoute('/posts/$postId')({
+  loader: ({ context: { queryClient }, params: { postId } }) =>
+    queryClient.ensureQueryData(postQueryOptions(postId)),
+  component: PostComponent,
+})
+
+// FASTER — void return, inference stays out of the route tree
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ context: { queryClient }, params: { postId } }) => {
+    await queryClient.ensureQueryData(postQueryOptions(postId))
+  },
+  component: PostComponent,
+})
+```
+
+### `as const satisfies` for Link Option Objects
+
+Never use `LinkProps` as a variable type — it's an enormous union:
+
+```tsx
+import type { LinkProps, RegisteredRouter } from '@tanstack/react-router'
+
+// WRONG — LinkProps is a massive union, extremely slow TS check
+const wrongProps: LinkProps = { to: '/posts' }
+
+// CORRECT — infer a precise type, validate against LinkProps
+const goodProps = { to: '/posts' } as const satisfies LinkProps
+
+// EVEN BETTER — narrow LinkProps with generic params
+const narrowedProps = {
+  to: '/posts',
+} as const satisfies LinkProps<RegisteredRouter, string, '/posts'>
+```
+
+### Type-Safe Link Option Arrays
+
+```tsx
+import type { LinkProps } from '@tanstack/react-router'
+
+export const navLinks = [
+  { to: '/posts' },
+  { to: '/posts/$postId', params: { postId: '1' } },
+] as const satisfies ReadonlyArray<LinkProps>
+
+// Use the precise inferred type, not LinkProps directly
+export type NavLink = (typeof navLinks)[number]
+```
+
+## Type Utilities for Generic Components
+
+### `ValidateLinkOptions` — Type-Safe Link Props in Custom Components
+
+```tsx
+import {
+  Link,
+  type RegisteredRouter,
+  type ValidateLinkOptions,
+} from '@tanstack/react-router'
+
+interface NavItemProps<
+  TRouter extends RegisteredRouter = RegisteredRouter,
+  TOptions = unknown,
+> {
+  label: string
+  linkOptions: ValidateLinkOptions<TRouter, TOptions>
+}
+
+export function NavItem<TRouter extends RegisteredRouter, TOptions>(
+  props: NavItemProps<TRouter, TOptions>,
+): React.ReactNode
+export function NavItem(props: NavItemProps): React.ReactNode {
+  return (
+    <li>
+      <Link {...props.linkOptions}>{props.label}</Link>
+    </li>
+  )
+}
+
+// Usage — fully type-safe
+<NavItem label="Posts" linkOptions={{ to: '/posts' }} />
+<NavItem label="Post" linkOptions={{ to: '/posts/$postId', params: { postId: '1' } }} />
+```
+
+### `ValidateNavigateOptions` — Type-Safe Navigate in Utilities
+
+```tsx
+import {
+  useNavigate,
+  type RegisteredRouter,
+  type ValidateNavigateOptions,
+} from '@tanstack/react-router'
+
+export function useDelayedNavigate<
+  TRouter extends RegisteredRouter = RegisteredRouter,
+  TOptions = unknown,
+>(
+  options: ValidateNavigateOptions<TRouter, TOptions>,
+  delayMs: number,
+): () => void
+export function useDelayedNavigate(
+  options: ValidateNavigateOptions,
+  delayMs: number,
+): () => void {
+  const navigate = useNavigate()
+  return () => {
+    setTimeout(() => navigate(options), delayMs)
+  }
+}
+
+// Usage — type-safe
+const go = useDelayedNavigate(
+  { to: '/posts/$postId', params: { postId: '1' } },
+  500,
+)
+```
+
+### `ValidateRedirectOptions` — Type-Safe Redirect in Utilities
+
+```tsx
+import {
+  redirect,
+  type RegisteredRouter,
+  type ValidateRedirectOptions,
+} from '@tanstack/react-router'
+
+export async function fetchOrRedirect<
+  TRouter extends RegisteredRouter = RegisteredRouter,
+  TOptions = unknown,
+>(
+  url: string,
+  redirectOptions: ValidateRedirectOptions<TRouter, TOptions>,
+): Promise<unknown>
+export async function fetchOrRedirect(
+  url: string,
+  redirectOptions: ValidateRedirectOptions,
+): Promise<unknown> {
+  const response = await fetch(url)
+  if (!response.ok && response.status === 401) throw redirect(redirectOptions)
+  return response.json()
+}
+```
+
+### Render Props for Maximum Performance
+
+Instead of accepting `LinkProps`, invert control so `Link` is narrowed at the call site:
+
+```tsx
+function Card(props: { title: string; renderLink: () => React.ReactNode }) {
+  return (
+    <div>
+      <h2>{props.title}</h2>
+      {props.renderLink()}
+    </div>
+  )
+}
+
+// Link narrowed to exactly /posts — no union check
+;<Card title="All Posts" renderLink={() => <Link to="/posts">View</Link>} />
+```
+
+## Render Optimizations
+
+### Fine-Grained Selectors with `select`
+
+```tsx
+function PostTitle() {
+  // Only re-renders when page changes, not when other search params change
+  const page = Route.useSearch({ select: ({ page }) => page })
+  return <span>Page {page}</span>
+}
+```
+
+### Structural Sharing
+
+Preserve referential identity across re-renders for search params:
+
+```tsx
+const router = createRouter({
+  routeTree,
+  defaultStructuralSharing: true, // Enable globally
+})
+
+// Or per-hook
+const result = Route.useSearch({
+  select: (search) => ({ foo: search.foo, label: `Page ${search.foo}` }),
+  structuralSharing: true,
+})
+```
+
+Structural sharing only works with JSON-compatible data. TypeScript will error if you return class instances with `structuralSharing: true`.
+
+## Common Mistakes
+
+### 1. CRITICAL: Adding type annotations or casts to inferred values
+
+```tsx
+// WRONG — casting masks real type errors
+const search = useSearch({ from: '/posts' }) as { page: number }
+
+// WRONG — unnecessary annotation
+const params: { postId: string } = useParams({ from: '/posts/$postId' })
+
+// WRONG — generic param on hook
+const data = useLoaderData<{ posts: Post[] }>({ from: '/posts' })
+
+// CORRECT — let inference work
+const search = useSearch({ from: '/posts' })
+const params = useParams({ from: '/posts/$postId' })
+const data = useLoaderData({ from: '/posts' })
+```
+
+### 2. HIGH: Using un-narrowed `LinkProps` type
+
+```tsx
+// WRONG — LinkProps is a massive union, causes severe TS slowdown
+const myProps: LinkProps = { to: '/posts' }
+
+// CORRECT — use as const satisfies for precise inference
+const myProps = { to: '/posts' } as const satisfies LinkProps
+```
+
+### 3. HIGH: Not narrowing `Link`/`useNavigate` with `from`
+
+```tsx
+// WRONG — search is a union of ALL routes, TS check grows with route count
+<Link to=".." search={{ page: 0 }} />
+
+// CORRECT — narrowed, fast check
+<Link from={Route.fullPath} to=".." search={{ page: 0 }} />
+```
+
+### 4. CRITICAL (cross-skill): Missing router type registration
+
+```tsx
+// WRONG — Link/useNavigate have no autocomplete, all paths are untyped strings
+const router = createRouter({ routeTree })
+// (no declare module)
+
+// CORRECT — always register
+const router = createRouter({ routeTree })
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+```
+
+### 5. CRITICAL (cross-skill): Generating Next.js or Remix patterns
+
+```tsx
+// WRONG — these are NOT TanStack Router APIs
+export async function getServerSideProps() { ... }
+export async function loader({ request }) { ... } // Remix-style
+const [searchParams, setSearchParams] = useSearchParams() // React Router
+
+// CORRECT — TanStack Router APIs
+export const Route = createFileRoute('/posts')({
+  loader: async () => { ... },           // TanStack loader
+  validateSearch: zodValidator(schema),   // TanStack search validation
+  component: PostsComponent,
+})
+const search = Route.useSearch()          // TanStack hook
+```
+
+See also: router-core (Register setup), router-core/navigation (from narrowing), router-core/code-splitting (getRouteApi).

--- a/.agents/skills/tanstack-start-core/SKILL.md
+++ b/.agents/skills/tanstack-start-core/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: start-core
+description: >-
+  Core overview for TanStack Start: tanstackStart() Vite plugin,
+  getRouter() factory, root route document shell (HeadContent,
+  Scripts, Outlet), client/server entry points, routeTree.gen.ts,
+  tsconfig configuration. Entry point for all Start skills.
+type: core
+library: tanstack-start
+library_version: '1.166.2'
+sources:
+  - TanStack/router:docs/start/framework/react/build-from-scratch.md
+  - TanStack/router:docs/start/framework/react/quick-start.md
+  - TanStack/router:docs/start/framework/react/guide/routing.md
+---
+
+# TanStack Start Core
+
+TanStack Start is a full-stack React framework built on TanStack Router and Vite. It adds SSR, streaming, server functions (type-safe RPCs), middleware, server routes, and universal deployment.
+
+> **CRITICAL**: All code in TanStack Start is ISOMORPHIC by default — it runs in BOTH server and client environments. Loaders run on both server AND client. To run code exclusively on the server, use `createServerFn`. This is the #1 AI agent mistake.
+> **CRITICAL**: TanStack Start is NOT Next.js. Do not generate `getServerSideProps`, `"use server"` directives, `app/layout.tsx`, or any Next.js/Remix patterns. Use `createServerFn` for server-only code.
+> **CRITICAL**: Types are FULLY INFERRED. Never cast, never annotate inferred values.
+
+## Sub-Skills
+
+| Task                                         | Sub-Skill                                                           |
+| -------------------------------------------- | ------------------------------------------------------------------- |
+| Type-safe RPCs, data fetching, mutations     | [start-core/server-functions/SKILL.md](./server-functions/SKILL.md) |
+| Request/function middleware, context, auth   | [start-core/middleware/SKILL.md](./middleware/SKILL.md)             |
+| Isomorphic execution, environment boundaries | [start-core/execution-model/SKILL.md](./execution-model/SKILL.md)   |
+| REST API endpoints alongside app routes      | [start-core/server-routes/SKILL.md](./server-routes/SKILL.md)       |
+| Hosting, SSR modes, prerendering, SEO        | [start-core/deployment/SKILL.md](./deployment/SKILL.md)             |
+
+## Quick Decision Tree
+
+```text
+Need to run code exclusively on the server (DB, secrets)?
+  → start-core/server-functions
+
+Need auth checks, logging, or shared logic across server functions?
+  → start-core/middleware
+
+Need to understand where code runs (server vs client)?
+  → start-core/execution-model
+
+Need a REST API endpoint (GET/POST/PUT/DELETE)?
+  → start-core/server-routes
+
+Need to deploy, configure SSR, or prerender?
+  → start-core/deployment
+```
+
+## Project Setup
+
+### 1. Install Dependencies
+
+```bash
+npm i @tanstack/react-start @tanstack/react-router react react-dom
+npm i -D vite @vitejs/plugin-react typescript
+```
+
+### 2. Configure Vite
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import viteReact from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [
+    // MUST come before react()
+    tanstackStart(),
+    viteReact(),
+  ],
+})
+```
+
+### 3. Create Router Factory
+
+```tsx
+// src/router.tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+export function getRouter() {
+  const router = createRouter({
+    routeTree,
+    scrollRestoration: true,
+  })
+
+  return router
+}
+```
+
+### 4. Create Root Route with Document Shell
+
+```tsx
+// src/routes/__root.tsx
+import type { ReactNode } from 'react'
+import {
+  Outlet,
+  createRootRoute,
+  HeadContent,
+  Scripts,
+} from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  head: () => ({
+    meta: [
+      { charSet: 'utf-8' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      { title: 'My App' },
+    ],
+  }),
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+### 5. Create Index Route with Server Function
+
+```tsx
+// src/routes/index.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+
+const getGreeting = createServerFn({ method: 'GET' }).handler(async () => {
+  return { message: 'Hello from the server!' }
+})
+
+export const Route = createFileRoute('/')({
+  loader: () => getGreeting(),
+  component: HomePage,
+})
+
+function HomePage() {
+  const data = Route.useLoaderData()
+  return <h1>{data.message}</h1>
+}
+```
+
+## Common Mistakes
+
+### 1. CRITICAL: React plugin before Start plugin in Vite config
+
+```ts
+// WRONG — route generation and server function compilation fail
+plugins: [react(), tanstackStart()]
+
+// CORRECT — Start plugin must come first
+plugins: [tanstackStart(), react()]
+```
+
+### 2. HIGH: Enabling verbatimModuleSyntax in tsconfig
+
+`verbatimModuleSyntax` causes server bundles to leak into client bundles. Keep it disabled.
+
+### 3. HIGH: Missing Scripts component in root route
+
+The `<Scripts />` component must be rendered in the `<body>` of the root route. Without it, client-side JavaScript does not load and hydration fails.
+
+```tsx
+// WRONG — no Scripts
+function RootComponent() {
+  return (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+      </body>
+    </html>
+  )
+}
+
+// CORRECT — Scripts in body
+function RootComponent() {
+  return (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        <Outlet />
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+## Version Note
+
+This skill targets `@tanstack/react-start` v1.166.2 and `@tanstack/start-client-core` v1.166.2.

--- a/.agents/skills/tanstack-start-deployment/SKILL.md
+++ b/.agents/skills/tanstack-start-deployment/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: start-core/deployment
+description: >-
+  Deploy to Cloudflare Workers, Netlify, Vercel, Node.js/Docker,
+  Bun, Railway. Selective SSR (ssr option per route), SPA mode,
+  static prerendering, ISR with Cache-Control headers, SEO and
+  head management.
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+sources:
+  - TanStack/router:docs/start/framework/react/guide/hosting.md
+  - TanStack/router:docs/start/framework/react/guide/selective-ssr.md
+  - TanStack/router:docs/start/framework/react/guide/static-prerendering.md
+  - TanStack/router:docs/start/framework/react/guide/seo.md
+---
+
+# Deployment and Rendering
+
+TanStack Start deploys to any hosting provider via Vite and Nitro. This skill covers hosting setup, SSR configuration, prerendering, and SEO.
+
+## Hosting Providers
+
+### Cloudflare Workers
+
+```bash
+pnpm add -D @cloudflare/vite-plugin wrangler
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import { cloudflare } from '@cloudflare/vite-plugin'
+import viteReact from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [
+    cloudflare({ viteEnvironment: { name: 'ssr' } }),
+    tanstackStart(),
+    viteReact(),
+  ],
+})
+```
+
+```jsonc
+// wrangler.jsonc
+{
+  "name": "my-app",
+  "compatibility_date": "2025-09-02",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "@tanstack/react-start/server-entry",
+}
+```
+
+Deploy: `npx wrangler login && pnpm run deploy`
+
+### Netlify
+
+```bash
+pnpm add -D @netlify/vite-plugin-tanstack-start
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import netlify from '@netlify/vite-plugin-tanstack-start'
+import viteReact from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [tanstackStart(), netlify(), viteReact()],
+})
+```
+
+Deploy: `npx netlify deploy`
+
+### Nitro (Vercel, Railway, Node.js, Docker)
+
+```bash
+npm install nitro@npm:nitro-nightly@latest
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import { nitro } from 'nitro/vite'
+import viteReact from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [tanstackStart(), nitro(), viteReact()],
+})
+```
+
+Build and start: `npm run build && node .output/server/index.mjs`
+
+### Bun
+
+Bun deployment requires React 19. For React 18, use Node.js deployment.
+
+```ts
+// vite.config.ts — add bun preset to nitro
+plugins: [tanstackStart(), nitro({ preset: 'bun' }), viteReact()]
+```
+
+## Selective SSR
+
+Control SSR per route with the `ssr` property.
+
+### `ssr: true` (default)
+
+Runs `beforeLoad` and `loader` on server, renders component on server:
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  ssr: true, // default
+  loader: () => fetchPost(), // runs on server during SSR
+  component: PostPage, // rendered on server
+})
+```
+
+### `ssr: false`
+
+Disables server execution of `beforeLoad`/`loader` and server rendering:
+
+```tsx
+export const Route = createFileRoute('/dashboard')({
+  ssr: false,
+  loader: () => fetchDashboard(), // runs on client only
+  component: DashboardPage, // rendered on client only
+})
+```
+
+### `ssr: 'data-only'`
+
+Runs `beforeLoad`/`loader` on server but renders component on client only:
+
+```tsx
+export const Route = createFileRoute('/canvas')({
+  ssr: 'data-only',
+  loader: () => fetchCanvasData(), // runs on server
+  component: CanvasPage, // rendered on client only
+})
+```
+
+### Functional Form
+
+Decide SSR at runtime based on params/search:
+
+```tsx
+export const Route = createFileRoute('/docs/$docType/$docId')({
+  ssr: ({ params }) => {
+    if (params.status === 'success' && params.value.docType === 'sheet') {
+      return false
+    }
+  },
+})
+```
+
+### SSR Inheritance
+
+Children inherit parent SSR config and can only be MORE restrictive:
+
+- `true` → `data-only` or `false` (allowed)
+- `false` → `true` (NOT allowed — parent `false` wins)
+
+### Default SSR
+
+Change the default for all routes in `src/start.ts`:
+
+```tsx
+import { createStart } from '@tanstack/react-start'
+
+export const startInstance = createStart(() => ({
+  defaultSsr: false,
+}))
+```
+
+## Static Prerendering
+
+Generate static HTML at build time:
+
+```ts
+// vite.config.ts
+tanstackStart({
+  prerender: {
+    enabled: true,
+    crawlLinks: true,
+    concurrency: 14,
+    failOnError: true,
+  },
+})
+```
+
+Static routes are auto-discovered. Dynamic routes (e.g. `/users/$userId`) require `crawlLinks` or explicit `pages` config.
+
+## SEO and Head Management
+
+### Basic Meta Tags
+
+```tsx
+export const Route = createFileRoute('/')({
+  head: () => ({
+    meta: [
+      { title: 'My App - Home' },
+      { name: 'description', content: 'Welcome to My App' },
+    ],
+  }),
+})
+```
+
+### Dynamic Meta from Loader Data
+
+```tsx
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => fetchPost(params.postId),
+  head: ({ loaderData }) => ({
+    meta: [
+      { title: loaderData.title },
+      { name: 'description', content: loaderData.excerpt },
+      { property: 'og:title', content: loaderData.title },
+      { property: 'og:image', content: loaderData.coverImage },
+    ],
+  }),
+})
+```
+
+### Structured Data (JSON-LD)
+
+```tsx
+head: ({ loaderData }) => ({
+  scripts: [
+    {
+      type: 'application/ld+json',
+      children: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: loaderData.title,
+      }),
+    },
+  ],
+})
+```
+
+### Dynamic Sitemap via Server Route
+
+```ts
+// src/routes/sitemap[.]xml.ts
+export const Route = createFileRoute('/sitemap.xml')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const posts = await fetchAllPosts()
+        const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  ${posts.map((p) => `<url><loc>https://myapp.com/posts/${p.id}</loc></url>`).join('')}
+</urlset>`
+        return new Response(sitemap, {
+          headers: { 'Content-Type': 'application/xml' },
+        })
+      },
+    },
+  },
+})
+```
+
+## Common Mistakes
+
+### 1. HIGH: Missing nodejs_compat flag for Cloudflare Workers
+
+```jsonc
+// WRONG — Node.js APIs fail at runtime
+{ "compatibility_flags": [] }
+
+// CORRECT
+{ "compatibility_flags": ["nodejs_compat"] }
+```
+
+### 2. MEDIUM: Bun deployment with React 18
+
+Bun-specific deployment only works with React 19. Use Node.js deployment for React 18.
+
+### 3. MEDIUM: Child route loosening parent SSR config
+
+```tsx
+// Parent sets ssr: false
+// WRONG — child cannot upgrade to ssr: true
+const parentRoute = createFileRoute('/dashboard')({ ssr: false })
+const childRoute = createFileRoute('/dashboard/stats')({
+  ssr: true, // IGNORED — parent false wins
+})
+
+// CORRECT — children can only be MORE restrictive
+const parentRoute = createFileRoute('/dashboard')({ ssr: 'data-only' })
+const childRoute = createFileRoute('/dashboard/stats')({
+  ssr: false, // OK — more restrictive than parent
+})
+```
+
+## Cross-References
+
+- [start-core/server-routes](../server-routes/SKILL.md) — API endpoints for sitemaps, robots.txt
+- [start-core/execution-model](../execution-model/SKILL.md) — SSR affects where code runs

--- a/.agents/skills/tanstack-start-execution-model/SKILL.md
+++ b/.agents/skills/tanstack-start-execution-model/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: start-core/execution-model
+description: >-
+  Isomorphic-by-default principle, environment boundary functions
+  (createServerFn, createServerOnlyFn, createClientOnlyFn,
+  createIsomorphicFn), ClientOnly component, useHydrated hook,
+  import protection, dead code elimination, environment variable
+  safety (VITE_ prefix, process.env).
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+sources:
+  - TanStack/router:docs/start/framework/react/guide/execution-model.md
+  - TanStack/router:docs/start/framework/react/guide/environment-variables.md
+---
+
+# Execution Model
+
+Understanding where code runs is fundamental to TanStack Start. This skill covers the isomorphic execution model and how to control environment boundaries.
+
+> **CRITICAL**: ALL code in TanStack Start is isomorphic by default — it runs in BOTH server and client bundles. Route loaders run on BOTH server (during SSR) AND client (during navigation). Server-only operations MUST use `createServerFn`.
+> **CRITICAL**: Module-level `process.env` access runs in both environments. Secret values leak into the client bundle. Access secrets ONLY inside `createServerFn` or `createServerOnlyFn`.
+> **CRITICAL**: `VITE_` prefixed environment variables are exposed to the client bundle. Server secrets must NOT have the `VITE_` prefix.
+
+## Execution Control APIs
+
+| API                      | Use Case                  | Client Behavior           | Server Behavior       |
+| ------------------------ | ------------------------- | ------------------------- | --------------------- |
+| `createServerFn()`       | RPC calls, data mutations | Network request to server | Direct execution      |
+| `createServerOnlyFn(fn)` | Utility functions         | Throws error              | Direct execution      |
+| `createClientOnlyFn(fn)` | Browser utilities         | Direct execution          | Throws error          |
+| `createIsomorphicFn()`   | Different impl per env    | Uses `.client()` impl     | Uses `.server()` impl |
+| `<ClientOnly>`           | Browser-only components   | Renders children          | Renders fallback      |
+| `useHydrated()`          | Hydration-dependent logic | `true` after hydration    | `false`               |
+
+## Server-Only Execution
+
+### createServerFn (RPC pattern)
+
+The primary way to run server-only code. On the client, calls become fetch requests:
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createServerFn } from '@tanstack/react-start'
+
+const fetchUser = createServerFn().handler(async () => {
+  const secret = process.env.API_SECRET // safe — server only
+  return await db.users.find()
+})
+
+// Client calls this via network request
+const user = await fetchUser()
+```
+
+### createServerOnlyFn (throws on client)
+
+For utility functions that must never run on client:
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createServerOnlyFn } from '@tanstack/react-start'
+
+const getSecret = createServerOnlyFn(() => process.env.DATABASE_URL)
+
+// Server: returns the value
+// Client: THROWS an error
+```
+
+## Client-Only Execution
+
+### createClientOnlyFn
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createClientOnlyFn } from '@tanstack/react-start'
+
+const saveToStorage = createClientOnlyFn((key: string, value: string) => {
+  localStorage.setItem(key, value)
+})
+```
+
+### ClientOnly Component
+
+```tsx
+// Use @tanstack/<framework>-router for your framework (react, solid, vue)
+import { ClientOnly } from '@tanstack/react-router'
+
+function Analytics() {
+  return (
+    <ClientOnly fallback={null}>
+      <GoogleAnalyticsScript />
+    </ClientOnly>
+  )
+}
+```
+
+### useHydrated Hook
+
+```tsx
+// Use @tanstack/<framework>-router for your framework (react, solid, vue)
+import { useHydrated } from '@tanstack/react-router'
+
+function TimeZoneDisplay() {
+  const hydrated = useHydrated()
+  const timeZone = hydrated
+    ? Intl.DateTimeFormat().resolvedOptions().timeZone
+    : 'UTC'
+
+  return <div>Your timezone: {timeZone}</div>
+}
+```
+
+Behavior: SSR → `false`, first client render → `false`, after hydration → `true` (stays `true`).
+
+## Environment-Specific Implementations
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createIsomorphicFn } from '@tanstack/react-start'
+
+const getDeviceInfo = createIsomorphicFn()
+  .server(() => ({ type: 'server', platform: process.platform }))
+  .client(() => ({ type: 'client', userAgent: navigator.userAgent }))
+```
+
+## Environment Variables
+
+### Server-Side (inside createServerFn)
+
+Access any variable via `process.env`:
+
+```tsx
+const connectDb = createServerFn().handler(async () => {
+  const url = process.env.DATABASE_URL // no prefix needed
+  return createConnection(url)
+})
+```
+
+### Client-Side (components)
+
+Only `VITE_` prefixed variables are available:
+
+```tsx
+// Framework-specific component type (React.ReactNode, JSX.Element, etc.)
+function ApiProvider({ children }: { children: React.ReactNode }) {
+  const apiUrl = import.meta.env.VITE_API_URL // available
+  // import.meta.env.DATABASE_URL → undefined (security)
+  return (
+    <ApiContext.Provider value={{ apiUrl }}>{children}</ApiContext.Provider>
+  )
+}
+```
+
+### Runtime Client Variables
+
+If you need server-side variables on the client without `VITE_` prefix, pass them through a server function:
+
+```tsx
+const getRuntimeVar = createServerFn({ method: 'GET' }).handler(() => {
+  return process.env.MY_RUNTIME_VAR
+})
+
+export const Route = createFileRoute('/')({
+  loader: async () => {
+    const foo = await getRuntimeVar()
+    return { foo }
+  },
+  component: () => {
+    const { foo } = Route.useLoaderData()
+    return <div>{foo}</div>
+  },
+})
+```
+
+### Type Safety for Environment Variables
+
+```tsx
+// src/env.d.ts
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_NAME: string
+  readonly VITE_API_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      readonly DATABASE_URL: string
+      readonly JWT_SECRET: string
+    }
+  }
+}
+
+export {}
+```
+
+## Common Mistakes
+
+### 1. CRITICAL: Assuming loaders are server-only
+
+```tsx
+// WRONG — loader runs on BOTH server and client
+export const Route = createFileRoute('/dashboard')({
+  loader: async () => {
+    const secret = process.env.API_SECRET // LEAKED to client
+    return fetch(`https://api.example.com/data`, {
+      headers: { Authorization: secret },
+    })
+  },
+})
+
+// CORRECT — use createServerFn
+const getData = createServerFn({ method: 'GET' }).handler(async () => {
+  const secret = process.env.API_SECRET
+  return fetch(`https://api.example.com/data`, {
+    headers: { Authorization: secret },
+  })
+})
+
+export const Route = createFileRoute('/dashboard')({
+  loader: () => getData(),
+})
+```
+
+### 2. CRITICAL: Exposing secrets via module-level process.env
+
+```tsx
+// WRONG — runs in both environments, value in client bundle
+const apiKey = process.env.SECRET_KEY
+export function fetchData() {
+  /* uses apiKey */
+}
+
+// CORRECT — access inside server function only
+const fetchData = createServerFn({ method: 'GET' }).handler(async () => {
+  const apiKey = process.env.SECRET_KEY
+  return fetch(url, { headers: { Authorization: apiKey } })
+})
+```
+
+### 3. CRITICAL: Using VITE\_ prefix for server secrets
+
+```bash
+# WRONG — exposed to client bundle
+VITE_SECRET_API_KEY=sk_live_xxx
+
+# CORRECT — no prefix for server secrets
+SECRET_API_KEY=sk_live_xxx
+
+# CORRECT — VITE_ only for public client values
+VITE_APP_NAME=My App
+```
+
+### 4. HIGH: Hydration mismatches
+
+```tsx
+// WRONG — different content server vs client
+function CurrentTime() {
+  return <div>{new Date().toLocaleString()}</div>
+}
+
+// CORRECT — consistent rendering
+function CurrentTime() {
+  const [time, setTime] = useState<string>()
+  useEffect(() => {
+    setTime(new Date().toLocaleString())
+  }, [])
+  return <div>{time || 'Loading...'}</div>
+}
+```
+
+## Architecture Decision Framework
+
+**Server-Only** (`createServerFn` / `createServerOnlyFn`):
+
+- Sensitive data (env vars, secrets)
+- Database connections, file system
+- External API keys
+
+**Client-Only** (`createClientOnlyFn` / `<ClientOnly>`):
+
+- DOM manipulation, browser APIs
+- localStorage, geolocation
+- Analytics/tracking
+
+**Isomorphic** (default / `createIsomorphicFn`):
+
+- Data formatting, business logic
+- Shared utilities
+- Route loaders (they're isomorphic by nature)
+
+## Cross-References
+
+- [start-core/server-functions](../server-functions/SKILL.md) — the primary server boundary
+- [start-core/deployment](../deployment/SKILL.md) — deployment target affects execution

--- a/.agents/skills/tanstack-start-middleware/SKILL.md
+++ b/.agents/skills/tanstack-start-middleware/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: start-core/middleware
+description: >-
+  createMiddleware, request middleware (.server only), server function
+  middleware (.client + .server), context passing via next({ context }),
+  sendContext for client-server transfer, global middleware via
+  createStart in src/start.ts, middleware factories, method order
+  enforcement, fetch override precedence.
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+  - start-core/server-functions
+sources:
+  - TanStack/router:docs/start/framework/react/guide/middleware.md
+---
+
+# Middleware
+
+Middleware customizes the behavior of server functions and server routes. It is composable — middleware can depend on other middleware to form a chain.
+
+> **CRITICAL**: TypeScript enforces method order: `middleware()` → `inputValidator()` → `client()` → `server()`. Wrong order causes type errors.
+> **CRITICAL**: Client context sent via `sendContext` is NOT validated by default. If you send dynamic user-generated data, validate it in server-side middleware before use.
+
+## Two Types of Middleware
+
+| Feature           | Request Middleware                           | Server Function Middleware               |
+| ----------------- | -------------------------------------------- | ---------------------------------------- |
+| Scope             | All server requests (SSR, routes, functions) | Server functions only                    |
+| Methods           | `.server()`                                  | `.client()`, `.server()`                 |
+| Input validation  | No                                           | Yes (`.inputValidator()`)                |
+| Client-side logic | No                                           | Yes                                      |
+| Created with      | `createMiddleware()`                         | `createMiddleware({ type: 'function' })` |
+
+Request middleware cannot depend on server function middleware. Server function middleware can depend on both types.
+
+## Request Middleware
+
+Runs on ALL server requests (SSR, server routes, server functions):
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createMiddleware } from '@tanstack/react-start'
+
+const loggingMiddleware = createMiddleware().server(
+  async ({ next, context, request }) => {
+    console.log('Request:', request.url)
+    const result = await next()
+    return result
+  },
+)
+```
+
+## Server Function Middleware
+
+Has both client and server phases:
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createMiddleware } from '@tanstack/react-start'
+
+const authMiddleware = createMiddleware({ type: 'function' })
+  .client(async ({ next }) => {
+    // Runs on client BEFORE the RPC call
+    const result = await next()
+    // Runs on client AFTER the RPC response
+    return result
+  })
+  .server(async ({ next, context }) => {
+    // Runs on server BEFORE the handler
+    const result = await next()
+    // Runs on server AFTER the handler
+    return result
+  })
+```
+
+## Attaching Middleware to Server Functions
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createServerFn } from '@tanstack/react-start'
+
+const fn = createServerFn()
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    // context contains data from middleware
+    return { user: context.user }
+  })
+```
+
+## Context Passing via next()
+
+Pass context down the middleware chain:
+
+```tsx
+const authMiddleware = createMiddleware().server(async ({ next, request }) => {
+  const session = await getSession(request.headers)
+  if (!session) throw new Error('Unauthorized')
+
+  return next({
+    context: { session },
+  })
+})
+
+const roleMiddleware = createMiddleware()
+  .middleware([authMiddleware])
+  .server(async ({ next, context }) => {
+    console.log('Session:', context.session) // typed!
+    return next()
+  })
+```
+
+## Sending Context Between Client and Server
+
+### Client → Server (sendContext)
+
+```tsx
+const workspaceMiddleware = createMiddleware({ type: 'function' })
+  .client(async ({ next, context }) => {
+    return next({
+      sendContext: {
+        workspaceId: context.workspaceId,
+      },
+    })
+  })
+  .server(async ({ next, context }) => {
+    // workspaceId available here, but VALIDATE IT
+    console.log('Workspace:', context.workspaceId)
+    return next()
+  })
+```
+
+### Server → Client (sendContext in server)
+
+```tsx
+const serverTimer = createMiddleware({ type: 'function' }).server(
+  async ({ next }) => {
+    return next({
+      sendContext: {
+        timeFromServer: new Date(),
+      },
+    })
+  },
+)
+
+const clientLogger = createMiddleware({ type: 'function' })
+  .middleware([serverTimer])
+  .client(async ({ next }) => {
+    const result = await next()
+    console.log('Server time:', result.context.timeFromServer)
+    return result
+  })
+```
+
+## Input Validation in Middleware
+
+```tsx
+import { z } from 'zod'
+import { zodValidator } from '@tanstack/zod-adapter'
+
+const workspaceMiddleware = createMiddleware({ type: 'function' })
+  .inputValidator(zodValidator(z.object({ workspaceId: z.string() })))
+  .server(async ({ next, data }) => {
+    console.log('Workspace:', data.workspaceId)
+    return next()
+  })
+```
+
+## Global Middleware
+
+Create `src/start.ts` to configure global middleware:
+
+```tsx
+// src/start.ts
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import { createStart, createMiddleware } from '@tanstack/react-start'
+
+const requestLogger = createMiddleware().server(async ({ next, request }) => {
+  console.log(`${request.method} ${request.url}`)
+  return next()
+})
+
+const functionAuth = createMiddleware({ type: 'function' }).server(
+  async ({ next }) => {
+    // runs for every server function
+    return next()
+  },
+)
+
+export const startInstance = createStart(() => ({
+  requestMiddleware: [requestLogger],
+  functionMiddleware: [functionAuth],
+}))
+```
+
+## Using Middleware with Server Routes
+
+### All handlers in a route
+
+```tsx
+export const Route = createFileRoute('/api/users')({
+  server: {
+    middleware: [authMiddleware],
+    handlers: {
+      GET: async ({ context }) => Response.json(context.user),
+      POST: async ({ request }) => {
+        /* ... */
+      },
+    },
+  },
+})
+```
+
+### Specific handlers only
+
+```tsx
+export const Route = createFileRoute('/api/users')({
+  server: {
+    handlers: ({ createHandlers }) =>
+      createHandlers({
+        GET: async () => Response.json({ public: true }),
+        POST: {
+          middleware: [authMiddleware],
+          handler: async ({ context }) => {
+            return Response.json({ user: context.session.user })
+          },
+        },
+      }),
+  },
+})
+```
+
+## Middleware Factories
+
+Create parameterized middleware for reusable patterns like authorization:
+
+```tsx
+const authMiddleware = createMiddleware().server(async ({ next, request }) => {
+  const session = await auth.getSession({ headers: request.headers })
+  if (!session) throw new Error('Unauthorized')
+  return next({ context: { session } })
+})
+
+type Permissions = Record<string, string[]>
+
+function authorizationMiddleware(permissions: Permissions) {
+  return createMiddleware({ type: 'function' })
+    .middleware([authMiddleware])
+    .server(async ({ next, context }) => {
+      const granted = await auth.hasPermission(context.session, permissions)
+      if (!granted) throw new Error('Forbidden')
+      return next()
+    })
+}
+
+// Usage
+const getClients = createServerFn()
+  .middleware([authorizationMiddleware({ client: ['read'] })])
+  .handler(async () => {
+    return { message: 'The user can read clients.' }
+  })
+```
+
+## Custom Headers and Fetch
+
+### Setting headers from client middleware
+
+```tsx
+const authMiddleware = createMiddleware({ type: 'function' }).client(
+  async ({ next }) => {
+    return next({
+      headers: { Authorization: `Bearer ${getToken()}` },
+    })
+  },
+)
+```
+
+Headers merge across middleware. Later middleware overrides earlier. Call-site headers override all middleware headers.
+
+### Custom fetch
+
+```tsx
+// Use @tanstack/<framework>-start for your framework (react, solid, vue)
+import type { CustomFetch } from '@tanstack/react-start'
+
+const loggingMiddleware = createMiddleware({ type: 'function' }).client(
+  async ({ next }) => {
+    const customFetch: CustomFetch = async (url, init) => {
+      console.log('Request:', url)
+      return fetch(url, init)
+    }
+    return next({ fetch: customFetch })
+  },
+)
+```
+
+Fetch precedence (highest to lowest): call site → later middleware → earlier middleware → createStart global → default fetch.
+
+## Common Mistakes
+
+### 1. HIGH: Trusting client sendContext without validation
+
+```tsx
+// WRONG — client can send arbitrary data
+.server(async ({ next, context }) => {
+  await db.query(`SELECT * FROM workspace_${context.workspaceId}`)
+  return next()
+})
+
+// CORRECT — validate before use
+.server(async ({ next, context }) => {
+  const workspaceId = z.string().uuid().parse(context.workspaceId)
+  await db.query('SELECT * FROM workspaces WHERE id = $1', [workspaceId])
+  return next()
+})
+```
+
+### 2. MEDIUM: Confusing request vs server function middleware
+
+Request middleware runs on ALL requests (SSR, routes, functions). Server function middleware runs only for `createServerFn` calls and has `.client()` method.
+
+### 3. HIGH: Browser APIs in .client() crash during SSR
+
+During SSR, `.client()` callbacks run on the server. Browser-only APIs like `localStorage` or `window` will throw `ReferenceError`:
+
+```tsx
+// WRONG — localStorage doesn't exist on the server during SSR
+const middleware = createMiddleware({ type: 'function' }).client(
+  async ({ next }) => {
+    const token = localStorage.getItem('token')
+    return next({ sendContext: { token } })
+  },
+)
+
+// CORRECT — use cookies/headers or guard with typeof window check
+const middleware = createMiddleware({ type: 'function' }).client(
+  async ({ next }) => {
+    const token =
+      typeof window !== 'undefined' ? localStorage.getItem('token') : null
+    return next({ sendContext: { token } })
+  },
+)
+```
+
+### 4. MEDIUM: Wrong method order
+
+```tsx
+// WRONG — type error
+createMiddleware({ type: 'function' })
+  .server(() => { ... })
+  .client(() => { ... })
+
+// CORRECT — middleware → inputValidator → client → server
+createMiddleware({ type: 'function' })
+  .middleware([dep])
+  .inputValidator(schema)
+  .client(({ next }) => next())
+  .server(({ next }) => next())
+```
+
+## Cross-References
+
+- [start-core/server-functions](../server-functions/SKILL.md) — what middleware wraps
+- [start-core/server-routes](../server-routes/SKILL.md) — middleware on API endpoints

--- a/.agents/skills/tanstack-start-server-functions/SKILL.md
+++ b/.agents/skills/tanstack-start-server-functions/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: start-core/server-functions
+description: >-
+  createServerFn (GET/POST), inputValidator (Zod or function),
+  useServerFn hook, server context utilities (getRequest,
+  getRequestHeader, setResponseHeader, setResponseStatus), error
+  handling (throw errors, redirect, notFound), streaming, FormData
+  handling, file organization (.functions.ts, .server.ts).
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+sources:
+  - TanStack/router:docs/start/framework/react/guide/server-functions.md
+---
+
+# Server Functions
+
+Server functions are type-safe RPCs created with `createServerFn`. They run exclusively on the server but can be called from anywhere — loaders, components, hooks, event handlers, or other server functions.
+
+> **CRITICAL**: Loaders are ISOMORPHIC — they run on BOTH client and server. Database queries, file system access, and secret API keys MUST go inside `createServerFn`, NOT in loaders directly.
+> **CRITICAL**: Do not use `"use server"` directives, `getServerSideProps`, or any Next.js/Remix server patterns. TanStack Start uses `createServerFn` exclusively.
+
+## Basic Usage
+
+```tsx
+import { createServerFn } from '@tanstack/react-start'
+
+// GET (default)
+const getData = createServerFn().handler(async () => {
+  return { message: 'Hello from server!' }
+})
+
+// POST
+const saveData = createServerFn({ method: 'POST' }).handler(async () => {
+  return { success: true }
+})
+```
+
+## Calling from Loaders
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+
+const getPosts = createServerFn({ method: 'GET' }).handler(async () => {
+  const posts = await db.query('SELECT * FROM posts')
+  return { posts }
+})
+
+export const Route = createFileRoute('/posts')({
+  loader: () => getPosts(),
+  component: PostList,
+})
+
+function PostList() {
+  const { posts } = Route.useLoaderData()
+  return (
+    <ul>
+      {posts.map((p) => (
+        <li key={p.id}>{p.title}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+## Calling from Components
+
+Use the `useServerFn` hook to call server functions from event handlers:
+
+```tsx
+import { useServerFn } from '@tanstack/react-start'
+
+const deletePost = createServerFn({ method: 'POST' })
+  .inputValidator((data: { id: string }) => data)
+  .handler(async ({ data }) => {
+    await db.delete('posts').where({ id: data.id })
+    return { success: true }
+  })
+
+function DeleteButton({ postId }: { postId: string }) {
+  const deletePostFn = useServerFn(deletePost)
+
+  return (
+    <button onClick={() => deletePostFn({ data: { id: postId } })}>
+      Delete
+    </button>
+  )
+}
+```
+
+## Input Validation
+
+### Basic Validator
+
+```tsx
+const greetUser = createServerFn({ method: 'GET' })
+  .inputValidator((data: { name: string }) => data)
+  .handler(async ({ data }) => {
+    return `Hello, ${data.name}!`
+  })
+
+await greetUser({ data: { name: 'John' } })
+```
+
+### Zod Validator
+
+```tsx
+import { z } from 'zod'
+
+const createUser = createServerFn({ method: 'POST' })
+  .inputValidator(
+    z.object({
+      name: z.string().min(1),
+      age: z.number().min(0),
+    }),
+  )
+  .handler(async ({ data }) => {
+    return `Created user: ${data.name}, age ${data.age}`
+  })
+```
+
+### FormData
+
+```tsx
+const submitForm = createServerFn({ method: 'POST' })
+  .inputValidator((data) => {
+    if (!(data instanceof FormData)) {
+      throw new Error('Expected FormData')
+    }
+    return {
+      name: data.get('name')?.toString() || '',
+      email: data.get('email')?.toString() || '',
+    }
+  })
+  .handler(async ({ data }) => {
+    return { success: true }
+  })
+```
+
+## Error Handling
+
+### Errors
+
+```tsx
+const riskyFunction = createServerFn().handler(async () => {
+  throw new Error('Something went wrong!')
+})
+
+try {
+  await riskyFunction()
+} catch (error) {
+  console.log(error.message) // "Something went wrong!"
+}
+```
+
+### Redirects
+
+```tsx
+import { redirect } from '@tanstack/react-router'
+
+const requireAuth = createServerFn().handler(async () => {
+  const user = await getCurrentUser()
+  if (!user) {
+    throw redirect({ to: '/login' })
+  }
+  return user
+})
+```
+
+### Not Found
+
+```tsx
+import { notFound } from '@tanstack/react-router'
+
+const getPost = createServerFn()
+  .inputValidator((data: { id: string }) => data)
+  .handler(async ({ data }) => {
+    const post = await db.findPost(data.id)
+    if (!post) {
+      throw notFound()
+    }
+    return post
+  })
+```
+
+## Server Context Utilities
+
+Access request/response details inside server function handlers:
+
+```tsx
+import { createServerFn } from '@tanstack/react-start'
+import {
+  getRequest,
+  getRequestHeader,
+  setResponseHeaders,
+  setResponseStatus,
+} from '@tanstack/react-start/server'
+
+const getCachedData = createServerFn({ method: 'GET' }).handler(async () => {
+  const request = getRequest()
+  const authHeader = getRequestHeader('Authorization')
+
+  setResponseHeaders({
+    'Cache-Control': 'public, max-age=300',
+  })
+  setResponseStatus(200)
+
+  return fetchData()
+})
+```
+
+Available utilities:
+
+- `getRequest()` — full Request object
+- `getRequestHeader(name)` — single request header
+- `setResponseHeader(name, value)` — single response header
+- `setResponseHeaders(headers)` — multiple response headers
+- `setResponseStatus(code)` — HTTP status code
+
+## File Organization
+
+```text
+src/utils/
+├── users.functions.ts   # createServerFn wrappers (safe to import anywhere)
+├── users.server.ts      # Server-only helpers (DB queries, internal logic)
+└── schemas.ts           # Shared validation schemas (client-safe)
+```
+
+```tsx
+// users.server.ts — server-only helpers
+import { db } from '~/db'
+
+export async function findUserById(id: string) {
+  return db.query.users.findFirst({ where: eq(users.id, id) })
+}
+```
+
+```tsx
+// users.functions.ts — server functions
+import { createServerFn } from '@tanstack/react-start'
+import { findUserById } from './users.server'
+
+export const getUser = createServerFn({ method: 'GET' })
+  .inputValidator((data: { id: string }) => data)
+  .handler(async ({ data }) => {
+    return findUserById(data.id)
+  })
+```
+
+Static imports of server functions are safe — the build replaces implementations with RPC stubs in client bundles.
+
+## Common Mistakes
+
+### 1. CRITICAL: Putting server-only code in loaders
+
+```tsx
+// WRONG — loader is ISOMORPHIC, runs on BOTH client and server
+export const Route = createFileRoute('/posts')({
+  loader: async () => {
+    const posts = await db.query('SELECT * FROM posts')
+    return { posts }
+  },
+})
+
+// CORRECT — use createServerFn for server-only logic
+const getPosts = createServerFn({ method: 'GET' }).handler(async () => {
+  const posts = await db.query('SELECT * FROM posts')
+  return { posts }
+})
+
+export const Route = createFileRoute('/posts')({
+  loader: () => getPosts(),
+})
+```
+
+### 2. CRITICAL: Using Next.js/Remix server patterns
+
+```tsx
+// WRONG — "use server" is a React directive, not used in TanStack Start
+'use server'
+export async function getUser() { ... }
+
+// WRONG — getServerSideProps is Next.js
+export async function getServerSideProps() { ... }
+
+// CORRECT — TanStack Start uses createServerFn
+const getUser = createServerFn({ method: 'GET' })
+  .handler(async () => { ... })
+```
+
+### 3. HIGH: Dynamic imports for server functions
+
+```tsx
+// WRONG — can cause bundler issues
+const { getUser } = await import('~/utils/users.functions')
+
+// CORRECT — static imports are safe, build handles environment shaking
+import { getUser } from '~/utils/users.functions'
+```
+
+### 4. HIGH: Awaiting server function without calling it
+
+`createServerFn` returns a function — it must be invoked with `()`:
+
+```tsx
+// WRONG — getItems is a function, not a Promise
+const data = await getItems
+
+// CORRECT — call the function
+const data = await getItems()
+
+// With validated input
+const data = await getItems({ data: { id: '1' } })
+```
+
+### 5. MEDIUM: Not using useServerFn for component calls
+
+When calling server functions from event handlers in components, use `useServerFn` to get proper React integration:
+
+```tsx
+// WRONG — direct call doesn't integrate with React lifecycle
+<button onClick={() => deletePost({ data: { id } })}>Delete</button>
+
+// CORRECT — useServerFn integrates with React
+const deletePostFn = useServerFn(deletePost)
+<button onClick={() => deletePostFn({ data: { id } })}>Delete</button>
+```
+
+## Cross-References
+
+- [start-core/execution-model](../execution-model/SKILL.md) — understanding where code runs
+- [start-core/middleware](../middleware/SKILL.md) — composing server functions with middleware

--- a/.agents/skills/tanstack-start-server-routes/SKILL.md
+++ b/.agents/skills/tanstack-start-server-routes/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: start-core/server-routes
+description: >-
+  Server-side API endpoints using the server property on
+  createFileRoute, HTTP method handlers (GET, POST, PUT, DELETE),
+  createHandlers for per-handler middleware, handler context
+  (request, params, context), request body parsing, response
+  helpers, file naming for API routes.
+type: sub-skill
+library: tanstack-start
+library_version: '1.166.2'
+requires:
+  - start-core
+sources:
+  - TanStack/router:docs/start/framework/react/guide/server-routes.md
+---
+
+# Server Routes
+
+Server routes are API endpoints defined alongside app routes in the `src/routes` directory. They use the `server` property on `createFileRoute` and handle raw HTTP requests.
+
+## Basic Server Route
+
+```ts
+// src/routes/api/hello.ts
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/hello')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        return new Response('Hello, World!')
+      },
+    },
+  },
+})
+```
+
+## Combining Server Route and App Route
+
+The same file can define both a server route and a UI route:
+
+```tsx
+// src/routes/hello.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+
+export const Route = createFileRoute('/hello')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const body = await request.json()
+        return Response.json({ message: `Hello, ${body.name}!` })
+      },
+    },
+  },
+  component: HelloComponent,
+})
+
+function HelloComponent() {
+  const [reply, setReply] = useState('')
+  return (
+    <button
+      onClick={() => {
+        fetch('/hello', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'Tanner' }),
+        })
+          .then((res) => res.json())
+          .then((data) => setReply(data.message))
+      }}
+    >
+      Say Hello {reply && `- ${reply}`}
+    </button>
+  )
+}
+```
+
+## File Route Conventions
+
+Server routes follow TanStack Router file-based routing conventions:
+
+| File                        | Route                         |
+| --------------------------- | ----------------------------- |
+| `routes/users.ts`           | `/users`                      |
+| `routes/users/$id.ts`       | `/users/$id`                  |
+| `routes/users/$id/posts.ts` | `/users/$id/posts`            |
+| `routes/api/file/$.ts`      | `/api/file/$` (splat)         |
+| `routes/my-script[.]js.ts`  | `/my-script.js` (escaped dot) |
+
+## Unique Route Paths
+
+Each route can only have a single handler file. These would conflict:
+
+- `routes/users.ts`
+- `routes/users.index.ts`
+- `routes/users/index.ts`
+
+## Handler Context
+
+Each handler receives:
+
+- `request` — the incoming [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object
+- `params` — dynamic path parameters
+- `context` — context from middleware
+- `pathname` — the matched pathname
+- `next` — call to fall through to SSR (returns a `Response`)
+
+## Dynamic Path Params
+
+```ts
+// routes/users/$id.ts
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/users/$id')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        return new Response(`User ID: ${params.id}`)
+      },
+    },
+  },
+})
+```
+
+## Splat/Wildcard Params
+
+```ts
+// routes/file/$.ts
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/file/$')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        return new Response(`File: ${params._splat}`)
+      },
+    },
+  },
+})
+```
+
+## Request Body Handling
+
+```ts
+export const Route = createFileRoute('/api/users')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const body = await request.json()
+        return Response.json({ created: body.name })
+      },
+    },
+  },
+})
+```
+
+Other body methods: `request.text()`, `request.formData()`.
+
+## JSON Responses
+
+```ts
+// Using Response.json helper
+handlers: {
+  GET: async () => {
+    return Response.json({ message: 'Hello!' })
+  },
+}
+```
+
+## Status Codes and Headers
+
+```ts
+handlers: {
+  GET: async ({ params }) => {
+    const user = await findUser(params.id)
+    if (!user) {
+      return new Response('Not found', { status: 404 })
+    }
+    return Response.json(user)
+  },
+}
+```
+
+```ts
+handlers: {
+  GET: async () => {
+    return new Response('Hello', {
+      headers: { 'Content-Type': 'text/plain' },
+    })
+  },
+}
+```
+
+## Middleware on Server Routes
+
+### All handlers
+
+```tsx
+export const Route = createFileRoute('/api/admin')({
+  server: {
+    middleware: [authMiddleware, loggerMiddleware],
+    handlers: {
+      GET: async ({ context }) => Response.json(context.user),
+      POST: async ({ request, context }) => {
+        /* ... */
+      },
+    },
+  },
+})
+```
+
+### Specific handlers with createHandlers
+
+```tsx
+export const Route = createFileRoute('/api/data')({
+  server: {
+    handlers: ({ createHandlers }) =>
+      createHandlers({
+        GET: async () => Response.json({ public: true }),
+        POST: {
+          middleware: [authMiddleware],
+          handler: async ({ context }) => {
+            return Response.json({ user: context.session.user })
+          },
+        },
+      }),
+  },
+})
+```
+
+### Combined route-level and handler-specific
+
+```tsx
+export const Route = createFileRoute('/api/posts')({
+  server: {
+    middleware: [authMiddleware], // runs first for all
+    handlers: ({ createHandlers }) =>
+      createHandlers({
+        GET: async () => Response.json([]),
+        POST: {
+          middleware: [validationMiddleware], // runs after auth, POST only
+          handler: async ({ request }) => {
+            const body = await request.json()
+            return Response.json({ created: true })
+          },
+        },
+      }),
+  },
+})
+```
+
+## Common Mistakes
+
+### 1. MEDIUM: Duplicate route paths
+
+```text
+# WRONG — both resolve to /users, causes error
+routes/users.ts
+routes/users/index.ts
+
+# CORRECT — pick one
+routes/users.ts
+```
+
+### 2. MEDIUM: Forgetting to await request body methods
+
+```ts
+// WRONG — body is a Promise, not the actual data
+const body = request.json()
+
+// CORRECT — await the promise
+const body = await request.json()
+```
+
+## Cross-References
+
+- [start-core/middleware](../middleware/SKILL.md) — middleware for server routes
+- [start-core/server-functions](../server-functions/SKILL.md) — alternative for RPC-style calls

--- a/.claude/skills/tanstack-devtools-app-setup
+++ b/.claude/skills/tanstack-devtools-app-setup
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-devtools-app-setup

--- a/.claude/skills/tanstack-devtools-vite-plugin
+++ b/.claude/skills/tanstack-devtools-vite-plugin
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-devtools-vite-plugin

--- a/.claude/skills/tanstack-react-start
+++ b/.claude/skills/tanstack-react-start
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-react-start

--- a/.claude/skills/tanstack-router-core
+++ b/.claude/skills/tanstack-router-core
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-router-core

--- a/.claude/skills/tanstack-router-data-loading
+++ b/.claude/skills/tanstack-router-data-loading
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-router-data-loading

--- a/.claude/skills/tanstack-router-navigation
+++ b/.claude/skills/tanstack-router-navigation
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-router-navigation

--- a/.claude/skills/tanstack-router-not-found-and-errors
+++ b/.claude/skills/tanstack-router-not-found-and-errors
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-router-not-found-and-errors

--- a/.claude/skills/tanstack-router-path-params
+++ b/.claude/skills/tanstack-router-path-params
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-router-path-params

--- a/.claude/skills/tanstack-router-plugin
+++ b/.claude/skills/tanstack-router-plugin
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-router-plugin

--- a/.claude/skills/tanstack-router-search-params
+++ b/.claude/skills/tanstack-router-search-params
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-router-search-params

--- a/.claude/skills/tanstack-router-ssr
+++ b/.claude/skills/tanstack-router-ssr
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-router-ssr

--- a/.claude/skills/tanstack-router-type-safety
+++ b/.claude/skills/tanstack-router-type-safety
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-router-type-safety

--- a/.claude/skills/tanstack-start-core
+++ b/.claude/skills/tanstack-start-core
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-start-core

--- a/.claude/skills/tanstack-start-deployment
+++ b/.claude/skills/tanstack-start-deployment
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-start-deployment

--- a/.claude/skills/tanstack-start-execution-model
+++ b/.claude/skills/tanstack-start-execution-model
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-start-execution-model

--- a/.claude/skills/tanstack-start-middleware
+++ b/.claude/skills/tanstack-start-middleware
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-start-middleware

--- a/.claude/skills/tanstack-start-server-functions
+++ b/.claude/skills/tanstack-start-server-functions
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-start-server-functions

--- a/.claude/skills/tanstack-start-server-routes
+++ b/.claude/skills/tanstack-start-server-routes
@@ -1,0 +1,1 @@
+../../.agents/skills/tanstack-start-server-routes

--- a/docs/tanstack-docs-audit.md
+++ b/docs/tanstack-docs-audit.md
@@ -1,0 +1,120 @@
+# Docs app — TanStack best-practice audit
+
+_Date: 2026-06-04 · Scope: the `www` docs site (TanStack Start, Router, and fumadocs)_
+
+## TL;DR
+
+**The docs approach is sound and largely idiomatic.** The `www` app is a TanStack
+Start and Router application that renders MDX docs through fumadocs, prerendered to
+static HTML. We audited it across **13 dimensions** against the official TanStack
+agent skills. Seven dimensions pass cleanly; the rest surfaced **12 raw findings**,
+which an adversarial verification pass narrowed to **6 confirmed issues — all LOW
+severity**. No correctness, security, or data-loss issues were found.
+
+This PR **applies the 5 safe fixes** and **defers 1** as a deliberate UX judgment
+call. The remaining raw findings were filtered out because they were either factually
+wrong against the installed package versions, or real-but-immaterial to a
+prerendered-static site.
+
+## Method
+
+1. **Vendored the TanStack skills the app uses** into `.agents/skills/` (see
+   [Vendored skills](#vendored-skills)) — these are the authoritative best-practice
+   reference, version-controlled alongside the existing `mattpocock/skills`.
+2. **Multi-agent audit.** One expert agent per dimension read the authoritative skill
+   _and_ the actual code, then reported deviations with evidence (`file:line`).
+3. **Adversarial verification.** A skeptical verifier re-checked every finding against
+   ground truth, explicitly accounting for the prerendered-static, `staticFunctionMiddleware`,
+   and fumadocs context (e.g. recommendations that only help per-request SSR or client SWR
+   caching do not apply here). Only findings that were _real_ **and** _applicable_ were actioned.
+
+## What's already idiomatic
+
+The audit confirmed these are done correctly and need no change:
+
+| Dimension                                      | Verdict                                                                                                                                                                                       |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Router config** (`router.tsx`, `__root.tsx`) | `scrollRestoration`, `defaultPreload: "intent"`, `defaultNotFoundComponent`, `<HeadContent/>`/`<Scripts/>` all per the skills. No `createRootRouteWithContext` needed (no router-context DI). |
+| **SSR / head**                                 | Root + per-route `head()` with full meta/OG/twitter + `links`; `<Scripts/>` correctly in `<body>`. Matches the SSR skill's document-shell pattern.                                            |
+| **Path params**                                | Splat (`$` → `params._splat`), optional (`{-$category}`), and suffix (`{$}.md`) routes all use the documented keys.                                                                           |
+| **Search params**                              | `validateSearch` with Zod v4 + `.catch()` fallbacks; `useSearch` for reads. Idiomatic.                                                                                                        |
+| **Code splitting**                             | Automatic code splitting is always-on under the Start plugin; no manual config needed.                                                                                                        |
+| **Server functions / middleware**              | `createServerFn({ method: "GET" })` for read-only loaders, correct middleware → validator → handler order, `notFound()` thrown inside handlers.                                               |
+| **Not-found handling**                         | Router-wide `defaultNotFoundComponent`; `NotFound` avoids the `useLoaderData` pitfall; `throw notFound()` bubbles correctly.                                                                  |
+| **Execution model**                            | The `serverLoader` (server-only fumadocs work behind `createServerFn` + `staticFunctionMiddleware`) / `clientLoader` split is the canonical fumadocs + Start pattern.                         |
+| **Deployment**                                 | nitro preset selected per-target; prerender filter correctly excludes query-string URLs; `preview/$slug` uses `ssr: false` sensibly; ISR/cache via `vercel.ts`.                               |
+| **fumadocs integration**                       | Page tree shared from the `_app` parent loader into the docs layout via `getRouteApi("/_app")` — the skill's documented cross-route typed-access pattern.                                     |
+
+## Confirmed findings & fixes
+
+All six are **LOW** severity.
+
+| ID                                      | Area           | Status      | Summary                                                                                                                                |
+| --------------------------------------- | -------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `not-found-errors-1` / `data-loading-1` | Error boundary | ✅ Fixed    | No router-wide `defaultErrorComponent` / per-route `errorComponent`; a non-`notFound` loader/render error had no scoped UI.            |
+| `data-loading-3`                        | Caching        | ✅ Fixed    | Static, prerendered docs/page-tree loaders had no `staleTime`, so client re-matches background-revalidated immutable data.             |
+| `server-routes-1`                       | Server route   | ✅ Fixed    | `r/$name` signalled 404 with `throw notFound()` inside a raw-`Response` handler instead of returning a `Response`.                     |
+| `fumadocs-integration-1`                | Efficiency     | ✅ Fixed    | The docs `$` loader serialized the full page tree into loader data that no component consumes (the `_app` parent already provides it). |
+| `data-loading-2`                        | Pending UI     | ⏸️ Deferred | No `pendingComponent` for cold client navigations — a UX judgment call (see below).                                                    |
+
+### Fixes applied in this PR
+
+- **Router-wide error boundary** — added `defaultErrorComponent: DefaultError` in
+  `www/src/router.tsx` and a new `www/src/components/default-error.tsx`. It mirrors the
+  `NotFound` chrome and retries via `router.invalidate()` (re-runs loaders), per the
+  data-loading skill's "use `router.invalidate()`, not `reset()`" guidance. Covers both
+  `data-loading-1` and `not-found-errors-1`. Render-only, so it cannot affect prerender.
+- **`staleTime: Infinity`** on the two static loaders — `www/src/routes/_app/docs/$.tsx`
+  (docs content) and `www/src/routes/_app/route.tsx` (page tree). Both are baked at build
+  time via `staticFunctionMiddleware`, so they are immutable until the next deploy;
+  background revalidation was pure waste.
+- **Proper 404 Response** — `www/src/routes/r/$name.tsx` now returns
+  `Response.json({ error: "Not found" }, { status: 404 })` (keeping the endpoint's JSON
+  content type for `shadcn add` consumers) instead of `throw notFound()`, and drops the
+  now-unused `notFound` import.
+- **Dropped dead page-tree serialization** — `www/src/routes/_app/docs/$.tsx` no longer
+  serializes `pageTree` into its loader data; the raw tree is still computed for
+  `findNeighbour`. This trims wasted prerender compute and dead bytes from every doc
+  page's dehydrated payload.
+
+All fixes were verified: format and lint clean (`oxfmt`/`oxlint`), `tsc --noEmit` passes,
+and the docs site was run in a dev preview — `/docs` renders fully (sidebar, content,
+TOC, pager) with no new console errors, the 404 endpoint returns `404 {"error":"Not found"}`,
+and a valid component (`/r/toast`) still returns `200`.
+
+### Deferred (intentional)
+
+- **`data-loading-2` — pending UI.** There is no `pendingComponent` for cold client
+  navigations (touch devices, fast clicks before intent-preload completes). This is a
+  **deliberate UX decision**, not a defect: `defaultPreload: "intent"` covers the common
+  hover path, and adding a pending affordance neither helps nor hurts prerendering. Left
+  for a design decision rather than auto-applied. If wanted, add a lightweight
+  router-level `defaultPendingComponent`.
+
+## Filtered out by verification
+
+Shown for transparency — these raw findings did **not** survive the adversarial pass:
+
+| Finding                                                     | Why dropped                                                                                                                                                                                                        |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `devtools()` not the first Vite plugin                      | Real position, but immaterial: `devtools()` already precedes `viteReact()` (the JSX transformer), so source-injection still works; the plugins before it (`mdx`/`nitro`/`tailwind`) don't transform component JSX. |
+| `devtools-vite` under Vite 8 (outside `^6 \|\| ^7`)         | Refuted — the installed package's peer range includes Vite 8.                                                                                                                                                      |
+| `getGitHubStars` is a bare async fn, not a `createServerFn` | Real stylistic inconsistency with its sibling, but it works correctly as-is; not a best-practice violation. Left as-is (out of "safe fixes" scope).                                                                |
+| `$.tsx` statically imports `docsSource`                     | Not a deviation — the import is only used inside the server handler and is tree-shaken from the client bundle.                                                                                                     |
+| Prerender without `crawlLinks`/`pages`                      | Refuted — the installed `@tanstack/start-plugin-core` version discovers the docs splat route without those options.                                                                                                |
+
+## Vendored skills
+
+The PR adds the **18 TanStack skills the app actually exercises** to `.agents/skills/`
+(+ `.claude/skills/` symlinks), following the existing `portless` precedent (these are
+not from `mattpocock/skills`, so `skills-lock.json` is intentionally untouched):
+
+`tanstack-router-core`, `-data-loading`, `-ssr`, `-navigation`, `-not-found-and-errors`,
+`-type-safety`, `-path-params`, `-search-params`, `-plugin`; `tanstack-start-core`,
+`-server-functions`, `-server-routes`, `-middleware`, `-execution-model`, `-deployment`;
+`tanstack-react-start`; `tanstack-devtools-vite-plugin`, `-app-setup`.
+
+**Intentionally excluded** (not used by this app): `tanstack-router-code-splitting`
+(automatic under Start, no config to maintain), `tanstack-router-auth-and-guards` (public
+site, no auth), `tanstack-start-server-core` (no custom server entry), and
+`tanstack-virtual-file-routes` (the app uses filesystem routing).

--- a/www/src/components/default-error.tsx
+++ b/www/src/components/default-error.tsx
@@ -1,0 +1,25 @@
+import { useRouter } from "@tanstack/react-router";
+
+// Router-wide error boundary. notFound() throws are handled by the router's
+// defaultNotFoundComponent; this catches any other loader/render error so it
+// renders scoped chrome with a retry instead of bubbling to the document root.
+// Retry uses router.invalidate() (re-runs the route loaders), per TanStack's
+// guidance for loader errors — reset() alone clears the boundary without refetching.
+export function DefaultError({ error }: { error: Error }) {
+	const router = useRouter();
+
+	return (
+		<main className="container flex flex-1 flex-col items-center justify-center py-20 text-center">
+			<h1 className="text-6xl font-bold">Error</h1>
+			<p className="mt-4 text-lg text-fg-muted">Something went wrong.</p>
+			{error?.message ? <p className="mt-2 max-w-xl text-sm text-fg-muted">{error.message}</p> : null}
+			<button
+				type="button"
+				onClick={() => router.invalidate()}
+				className="mt-8 text-sm text-fg-muted underline underline-offset-4 hover:text-fg"
+			>
+				Try again
+			</button>
+		</main>
+	);
+}

--- a/www/src/router.tsx
+++ b/www/src/router.tsx
@@ -1,5 +1,6 @@
 import { createRouter } from "@tanstack/react-router";
 
+import { DefaultError } from "@/components/default-error";
 import { NotFound } from "@/components/not-found";
 
 import { routeTree } from "./routeTree.gen";
@@ -10,6 +11,7 @@ export function getRouter() {
 		scrollRestoration: true,
 		defaultPreload: "intent",
 		defaultNotFoundComponent: NotFound,
+		defaultErrorComponent: DefaultError,
 	});
 
 	return router;

--- a/www/src/routes/_app/docs/$.tsx
+++ b/www/src/routes/_app/docs/$.tsx
@@ -17,6 +17,9 @@ import { TOC, TOCProvider } from "@/modules/docs/toc";
 
 export const Route = createFileRoute("/_app/docs/$")({
 	component: DocsPage,
+	// Docs content is immutable until the next build/deploy (prerendered via
+	// staticFunctionMiddleware), so never background-revalidate it on re-match.
+	staleTime: Infinity,
 	loader: async ({ params }) => {
 		const slugs = params._splat?.split("/") ?? [];
 		const data = await serverLoader({ data: slugs });
@@ -69,7 +72,6 @@ const serverLoader = createServerFn({ method: "GET" })
 			url: page.url,
 			title: page.data.title,
 			description: page.data.description,
-			pageTree: await docsSource.serializePageTree(pageTree),
 			rawContent,
 			neighbours: {
 				previous: previous ? { name: String(previous.name), path: previous.url.replace(/^\/docs\/?/, "") } : undefined,

--- a/www/src/routes/_app/route.tsx
+++ b/www/src/routes/_app/route.tsx
@@ -21,6 +21,9 @@ export const Route = createFileRoute("/_app")({
 		const pageTree = await getPageTree();
 		return { pageTree };
 	},
+	// The page tree is immutable until the next build/deploy (baked at build time
+	// via staticFunctionMiddleware), so never background-revalidate it on re-match.
+	staleTime: Infinity,
 });
 
 function AppLayout() {

--- a/www/src/routes/r/$name.tsx
+++ b/www/src/routes/r/$name.tsx
@@ -11,7 +11,7 @@
  * `name` must match a generated publishable. Missing names return 404.
  */
 
-import { createFileRoute, notFound } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 
 import { format } from "oxfmt";
 
@@ -35,7 +35,9 @@ export const Route = createFileRoute("/r/$name")({
 			GET: async ({ request, params }) => {
 				const name = params.name;
 				const loader = publishables[name];
-				if (!loader) throw notFound();
+				if (!loader) {
+					return Response.json({ error: "Not found" }, { status: 404 });
+				}
 
 				const url = new URL(request.url);
 				const encodedPreset = url.searchParams.get("preset") ?? undefined;


### PR DESCRIPTION
## What

`ultracode`-driven pass over the docs site (`www` — TanStack Start + Router + fumadocs):

1. **Vendored the TanStack skills the app uses** (18) into `.agents/skills/` + `.claude/skills/` symlinks, following the existing `portless` precedent — no `skills-lock.json` change (that lockfile is `mattpocock/skills`-only).
2. **Audited the docs approach** against those skills with a multi-agent pass, each finding adversarially verified against the prerendered-static + fumadocs context.
3. **Applied the safe fixes** and wrote up the audit in [`docs/tanstack-docs-audit.md`](docs/tanstack-docs-audit.md).

## Verdict

The docs approach is **sound and largely idiomatic**. 13 dimensions audited; 7 pass cleanly. 12 raw findings → **6 confirmed, all LOW** after adversarial verification → **5 applied here, 1 deferred**. No correctness or security issues.

## Fixes applied

- **Router-wide error boundary** — new `default-error.tsx` wired as `defaultErrorComponent`, retry via `router.invalidate()` (per the data-loading skill). Render-only; cannot affect prerender.
- **`staleTime: Infinity`** on the static docs + page-tree loaders (baked at build time via `staticFunctionMiddleware`) — stops needless background revalidation on client re-match.
- **`r/$name` 404** — returns `Response.json({ error: "Not found" }, { status: 404 })` instead of `throw notFound()` in a raw-`Response` handler; drops the unused import.
- **Drop dead `pageTree` serialization** from the docs `$` loader (no component reads it; the `_app` parent already provides the tree) — trims prerender compute + dehydrated payload.

## Deferred (intentional)

- **`pendingComponent`** for cold client navigations — a UX judgment call; `defaultPreload: "intent"` covers the common hover path. Left for a design decision.

## Verification

- `oxlint` + `oxfmt` clean; `tsc --noEmit` passes.
- Ran the docs site in a dev preview: `/docs` renders fully (sidebar / content / TOC / pager) with no new console errors; `/r/<missing>` → `404 {"error":"Not found"}`, `/r/toast` → `200`.

The report also lists the raw findings the adversarial pass **filtered out** (e.g. the devtools plugin-order and Vite-8 peer-range claims), for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)