### PR TITLE
fix: restore input focus ring (patch tailwindcss-react-aria-components not-* variants)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
 		"overrides": {
 			"@types/react": "19.2.2",
 			"@types/react-dom": "19.2.1"
+		},
+		"patchedDependencies": {
+			"tailwindcss-react-aria-components@2.1.1": "patches/tailwindcss-react-aria-components@2.1.1.patch"
 		}
 	}
 }

--- a/patches/tailwindcss-react-aria-components@2.1.1.patch
+++ b/patches/tailwindcss-react-aria-components@2.1.1.patch
@@ -1,0 +1,30 @@
+diff --git a/src/index.js b/src/index.js
+index 9c948a49d3391a7c97dfe57864703d96097aa23f..37f1ddbefa403d616d5d633d3c018caee21f78d8 100644
+--- a/src/index.js
++++ b/src/index.js
+@@ -94,12 +94,21 @@ let getSelector = (prefix, attributeName, attributeValue) => {
+     : `[data-${attributeName}]`;
+   let nativeSelector = nativeVariantSelectors.get(attributeName);
+   if (prefix === '' && nativeSelector) {
+-    let wrappedNativeSelector = `&:where(:not([data-rac]))${nativeSelector}`;
+-    let nativeSelectorGenerator = wrappedNativeSelector;
++    // Hover keeps its `@media (hover: hover)` wrapper and two-rule shape. It
++    // can't be a single selector, so its `not-hover:` negation stays
++    // unsupported (the same limitation native Tailwind has).
+     if (nativeSelector === ':hover') {
+-      nativeSelectorGenerator = wrap => `@media (hover: hover) { ${wrap(wrappedNativeSelector)} }`;
++      let wrappedNativeSelector = `&:where(:not([data-rac]))${nativeSelector}`;
++      let nativeSelectorGenerator = wrap => `@media (hover: hover) { ${wrap(wrappedNativeSelector)} }`;
++      return [`&:where([data-rac])${baseSelector}`, nativeSelectorGenerator];
+     }
+-    return [`&:where([data-rac])${baseSelector}`, nativeSelectorGenerator];
++    // Combine the RAC data-attribute selector and the native pseudo-class into
++    // a SINGLE `:is()` selector. Emitting them as two sibling rules (the old
++    // behavior) makes Tailwind's `not-*` compound walker bail out and silently
++    // drop utilities like `not-invalid:`, so the focus ring on valid inputs
++    // disappeared. `:where()` keeps specificity at (0,1,0), so the cascade is
++    // unchanged. See adobe/react-spectrum#9974.
++    return `&:is(:where([data-rac])${baseSelector}, :where(:not([data-rac]))${nativeSelector})`;
+   } else if (prefix === '' && nativeMergeSelectors.has(attributeName)) {
+     return [`&${baseSelector}`, `&${nativeMergeSelectors.get(attributeName)}`];
+   } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,11 @@ overrides:
   '@types/react': 19.2.2
   '@types/react-dom': 19.2.1
 
+patchedDependencies:
+  tailwindcss-react-aria-components@2.1.1:
+    hash: 6cb95f5dd03b6c25e64129ef62ed9c9fad8d1197854d490055d6a8f7e5a68003
+    path: patches/tailwindcss-react-aria-components@2.1.1.patch
+
 importers:
 
   .:
@@ -264,7 +269,7 @@ importers:
         version: link:../packages/tailwindcss-autocontrast
       tailwindcss-react-aria-components:
         specifier: ^2.1.1
-        version: 2.1.1(tailwindcss@4.3.0)
+        version: 2.1.1(patch_hash=6cb95f5dd03b6c25e64129ef62ed9c9fad8d1197854d490055d6a8f7e5a68003)(tailwindcss@4.3.0)
       tailwindcss-with:
         specifier: workspace:*
         version: link:../packages/tailwindcss-with
@@ -12472,7 +12477,7 @@ snapshots:
     optionalDependencies:
       tailwind-merge: 3.4.0
 
-  tailwindcss-react-aria-components@2.1.1(tailwindcss@4.3.0):
+  tailwindcss-react-aria-components@2.1.1(patch_hash=6cb95f5dd03b6c25e64129ef62ed9c9fad8d1197854d490055d6a8f7e5a68003)(tailwindcss@4.3.0):
     dependencies:
       tailwindcss: 4.3.0
 

--- a/www/src/registry/ui/input/styles.ts
+++ b/www/src/registry/ui/input/styles.ts
@@ -32,9 +32,9 @@ const outlineField = tv({
 	base: "rounded-(--input-radius) border border-border-field bg-field px-(--edge-to-text) transition-[box-shadow,border-color,color] invalid:border-border-danger invalid:ring-danger-muted disabled:border-border-disabled disabled:bg-disabled",
 	variants: {
 		focus: {
-			self: "focus:not-invalid:border-border-focus focus:not-invalid:ring-border-focus-muted focus:ring-2",
+			self: "focus:ring-2 focus:not-invalid:border-border-focus focus:not-invalid:ring-border-focus-muted",
 			group:
-				"group-focus/combobox:not-invalid:border-border-focus group-focus/combobox:not-invalid:ring-border-focus-muted has-[[data-input-control][data-focused]]:not-invalid:border-border-focus has-[[data-input-control][data-focused]]:not-invalid:ring-border-focus-muted group-focus/combobox:ring-2 has-[[data-input-control][data-focused]]:ring-2",
+				"group-focus/combobox:ring-2 group-focus/combobox:not-invalid:border-border-focus group-focus/combobox:not-invalid:ring-border-focus-muted has-[[data-input-control][data-focused]]:ring-2 has-[[data-input-control][data-focused]]:not-invalid:border-border-focus has-[[data-input-control][data-focused]]:not-invalid:ring-border-focus-muted",
 		},
 	},
 });
@@ -45,7 +45,7 @@ const lineField = tv({
 		focus: {
 			self: "focus:not-invalid:border-border-focus invalid:focus:border-fg-danger",
 			group:
-				"group-focus/combobox:not-invalid:border-border-focus has-[[data-input-control][data-focused]]:not-invalid:border-border-focus invalid:group-focus/combobox:border-fg-danger invalid:has-[[data-input-control][data-focused]]:border-fg-danger",
+				"group-focus/combobox:not-invalid:border-border-focus invalid:group-focus/combobox:border-fg-danger has-[[data-input-control][data-focused]]:not-invalid:border-border-focus invalid:has-[[data-input-control][data-focused]]:border-fg-danger",
 		},
 	},
 });
@@ -65,9 +65,9 @@ const filledField = tv({
 	base: "rounded-(--input-radius) border border-transparent bg-field px-(--edge-to-text) transition-[box-shadow,border-color,color] invalid:border-border-danger invalid:ring-danger-muted disabled:bg-disabled",
 	variants: {
 		focus: {
-			self: "focus:not-invalid:border-border-focus focus:not-invalid:ring-border-focus-muted focus:ring-2",
+			self: "focus:ring-2 focus:not-invalid:border-border-focus focus:not-invalid:ring-border-focus-muted",
 			group:
-				"group-focus/combobox:not-invalid:border-border-focus group-focus/combobox:not-invalid:ring-border-focus-muted has-[[data-input-control][data-focused]]:not-invalid:border-border-focus has-[[data-input-control][data-focused]]:not-invalid:ring-border-focus-muted group-focus/combobox:ring-2 has-[[data-input-control][data-focused]]:ring-2",
+				"group-focus/combobox:ring-2 group-focus/combobox:not-invalid:border-border-focus group-focus/combobox:not-invalid:ring-border-focus-muted has-[[data-input-control][data-focused]]:ring-2 has-[[data-input-control][data-focused]]:not-invalid:border-border-focus has-[[data-input-control][data-focused]]:not-invalid:ring-border-focus-muted",
 		},
 	},
 });


### PR DESCRIPTION
## The regression

Focused text inputs stopped showing the blue focus ring (and the blue focus border). This regressed when the vendored react-aria was swapped for the official packages, which brought a newer `tailwindcss-react-aria-components` plugin.

## Root cause

The input's focus styles depend on the `not-invalid:` variant:

```
focus:not-invalid:border-border-focus   // blue focus border
focus:not-invalid:ring-border-focus-muted // blue ring color
```

The `tailwindcss-react-aria-components` plugin emits each native state variant (`invalid`, `focus`, `disabled`, …) as **two sibling rules** — one for React-Aria elements and one for the native pseudo-class:

```css
.invalid\:… {
  &:where([data-rac])[data-invalid] { … }
  &:where(:not([data-rac])):invalid  { … }
}
```

Tailwind's `not-*` compound walker **bails out on variants that produce more than one rule**, so every `not-invalid:` utility **silently emitted no CSS**. Confirmed against the live stylesheet: `invalid:` → 10 rules, `not-invalid:` → **0 rules**. With no `focus:not-invalid:*` rules, the focused input had no focus border and `--tw-ring-color` was never set → no ring.

## The fix

Patch the plugin (`pnpm patch`) to collapse the two branches into a **single `:is()` selector**, so `not-*` negation works again:

```js
return `&:is(:where([data-rac])${baseSelector}, :where(:not([data-rac]))${nativeSelector})`;
```

`:where()` keeps specificity at `(0,1,0)`, so the cascade is unchanged. Hover keeps its `@media (hover: hover)` wrapper (its `not-hover:` stays unsupported, matching native Tailwind). This backports [adobe/react-spectrum#9974](https://github.com/adobe/react-spectrum/pull/9974).

## Verification

After patching, with **real keyboard focus** (foreground browser, since a backgrounded tab drops react-aria focus state):

| state | border-color | box-shadow |
|---|---|---|
| unfocused | `rgb(55,55,62)` (grey field) | `none` |
| **focused** | **`rgb(59,122,186)`** (focus blue) | **`rgb(35,74,112) 0 0 0 2px`** (2px blue ring) |

`not-invalid:` rules in the compiled CSS: **0 → 6**.

### CI (all green locally)
- ✅ `pnpm lint:ws` · ✅ `pnpm check` · ✅ `pnpm typecheck` · ✅ `pnpm test` · ✅ `pnpm build:registry` (no drift)

## Notes
- `www/src/registry/ui/input/styles.ts` has a second commit applying oxfmt's class ordering — pre-existing formatting drift on `main` that `oxfmt --check` flags. Reordering Tailwind classes in the source string is behavior-neutral (Tailwind decides precedence by its own internal sort). Split out so it's easy to see it's unrelated to the fix.
- Consumers of the published registry will need the same upstream fix (or this patch) for `not-invalid:` to work in their own Tailwind build, until `tailwindcss-react-aria-components` ships the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
