### PR TITLE
fix(www): order validateSearch before ssr in preview route

### DIFF
--- a/www/src/routes/preview/$slug.tsx
+++ b/www/src/routes/preview/$slug.tsx
@@ -24,8 +24,8 @@ function getExamplesPromise(slug: string) {
 }
 
 export const Route = createFileRoute("/preview/$slug")({
-	ssr: false,
 	validateSearch: z.object({ preset: z.string().optional().catch(undefined) }),
+	ssr: false,
 	beforeLoad: ({ params }) => {
 		getExamplesPromise(params.slug);
 	},


### PR DESCRIPTION
## What

Ran [`react-doctor`](https://www.npmjs.com/package/react-doctor) (`npx react-doctor@latest -y --no-telemetry`) over the workspace (`www` + `starter-themes`, 1213 files). It reported **1 error and 381 warnings**. This PR fixes the **one error**; the warnings were triaged and deliberately left (rationale below).

### The fix

`react-doctor` flagged a single error — `tanstack-start-route-property-order` in [`www/src/routes/preview/$slug.tsx`](https://github.com/mehdibha/dotUI/blob/main/www/src/routes/preview/%24slug.tsx):

> Ordering route property `validateSearch` after `ssr` breaks type inference.

TanStack Router infers route generics positionally, so type-inference properties (`params → validateSearch → loaderDeps → context → beforeLoad → loader → head`) must precede other options like `ssr`. The fix is a two-line reorder — `validateSearch` now comes before `ssr`. **Runtime behavior is unchanged** (object property order only affects TypeScript inference).

```diff
 export const Route = createFileRoute("/preview/$slug")({
-	ssr: false,
 	validateSearch: z.object({ preset: z.string().optional().catch(undefined) }),
+	ssr: false,
 	beforeLoad: ({ params }) => {
```

## Why the 381 warnings were left

I read the strongest candidate in every category. They fall into three buckets, none of which is a real defect in this codebase:

- **False positives in context.** The 9 `no-unknown-property` hits in `og.tsx` are the `tw=` prop from `@vercel/og`/Satori (valid there, not React DOM). The 7 `heading-has-content` / `anchor-has-content` hits are MDX wrappers and render-prop spreads where children arrive via `{...props}`/`{...domProps}`. `no-initialize-state` flags the canonical SSR mount guard. The lone `loader-parallel-fetch` is a genuine waterfall (`preload(data.path)` depends on the prior `await`). 139 `unused-file` + 23 `unused-export` are registry items consumed by external users, not imported internally.
- **Already acknowledged by the maintainer.** The `no-danger` and `no-array-index-as-key` hits already carry `// oxlint-disable … --` justification comments (first-party highlighted HTML; static nav data). `react-doctor`'s own plugin rule IDs differ from the suppressed `react/*` ones, so it re-flags them.
- **Opinionated / behavior-changing refactors** (`no-cascading-set-state`, `no-derived-state`, `no-event-handler`, `no-document-start-view-transition`, `exhaustive-deps`) — not safe to apply blindly across shipped registry components.

Happy to follow up on any specific warning if you'd like it addressed.

## Verification

All CI gates pass locally:

- ✅ `pnpm lint:ws` — sherif + syncpack, no issues
- ✅ `pnpm check` — oxlint 0/0, oxfmt format correct
- ✅ `pnpm typecheck` — 3/3 successful
- ✅ `pnpm test` — 95/95 passed
- ✅ registry artifacts unchanged (no drift)
- ✅ `react-doctor --no-warnings` now reports **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)