### PR TITLE
feat(docs): redesign component playground (layouts, segmented enums) + drop legacy Button icon sizes

### DIFF
--- a/www/content/docs/components/button.mdx
+++ b/www/content/docs/components/button.mdx
@@ -12,7 +12,7 @@ links:
 	controls={[
 		{ name: "children", type: "string", defaultValue: "Button" },
 		"variant",
-		"size",
+		{ name: "size", type: "enum", options: ["xs", "sm", "md", "lg"], defaultValue: "md" },
 		"isDisabled",
 		"isPending",
 	]}

--- a/www/src/modules/docs/interactive-demo/controls.tsx
+++ b/www/src/modules/docs/interactive-demo/controls.tsx
@@ -206,13 +206,13 @@ interface EnumControlRendererProps {
 }
 
 /**
- * A small enum (few short options, e.g. `size`: sm/md/lg) renders as a segmented
- * control — quicker to scan and toggle than a dropdown, matching the playground
- * design. Larger option sets fall back to a Select to avoid overflow.
+ * A small enum (a few short options, e.g. `size`: xs/sm/md/lg) renders as a
+ * segmented control — quicker to scan and toggle than a dropdown, matching the
+ * playground design. Larger option sets fall back to a Select to avoid overflow.
  */
 function isSegmentedEnum(control: SerializableEnumControl): boolean {
 	return (
-		control.options.length > 1 && control.options.length <= 3 && control.options.every((option) => option.length <= 8)
+		control.options.length > 1 && control.options.length <= 4 && control.options.every((option) => option.length <= 8)
 	);
 }
 

--- a/www/src/modules/docs/interactive-demo/controls.tsx
+++ b/www/src/modules/docs/interactive-demo/controls.tsx
@@ -30,6 +30,8 @@ import { Popover } from "@/registry/ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger } from "@/registry/ui/select";
 import { Switch } from "@/registry/ui/switch";
 import { TextField } from "@/registry/ui/text-field";
+import { ToggleButton } from "@/registry/ui/toggle-button";
+import { ToggleButtonGroup } from "@/registry/ui/toggle-button-group";
 
 import type {
 	ControlValues,
@@ -189,7 +191,22 @@ interface EnumControlRendererProps {
 	onChange: (name: string, value: unknown) => void;
 }
 
+/**
+ * A small enum (few short options, e.g. `size`: sm/md/lg) renders as a segmented
+ * control — quicker to scan and toggle than a dropdown, matching the playground
+ * design. Larger option sets fall back to a Select to avoid overflow.
+ */
+function isSegmentedEnum(control: SerializableEnumControl): boolean {
+	return (
+		control.options.length > 1 && control.options.length <= 3 && control.options.every((option) => option.length <= 8)
+	);
+}
+
 function EnumControlRenderer({ control, value, onChange }: EnumControlRendererProps) {
+	if (isSegmentedEnum(control)) {
+		return <SegmentedEnumControlRenderer control={control} value={value} onChange={onChange} />;
+	}
+
 	return (
 		<Select selectedKey={value} onSelectionChange={(key) => onChange(control.name, key)}>
 			<div className="flex items-center gap-1">
@@ -205,6 +222,35 @@ function EnumControlRenderer({ control, value, onChange }: EnumControlRendererPr
 				))}
 			</SelectContent>
 		</Select>
+	);
+}
+
+function SegmentedEnumControlRenderer({ control, value, onChange }: EnumControlRendererProps) {
+	return (
+		<Field>
+			<div className="flex items-center gap-1">
+				<Label>{control.name}</Label>
+				<ContextualHelp name={control.name} reference={control.reference} />
+			</div>
+			<ToggleButtonGroup
+				aria-label={control.name}
+				size="sm"
+				selectionMode="single"
+				disallowEmptySelection
+				selectedKeys={value ? [value] : []}
+				onSelectionChange={(keys) => {
+					const next = keys.values().next().value;
+					if (next != null) onChange(control.name, next);
+				}}
+				className="w-full"
+			>
+				{control.options.map((option) => (
+					<ToggleButton key={option} id={option} className="flex-1">
+						{option}
+					</ToggleButton>
+				))}
+			</ToggleButtonGroup>
+		</Field>
 	);
 }
 

--- a/www/src/modules/docs/interactive-demo/controls.tsx
+++ b/www/src/modules/docs/interactive-demo/controls.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import * as ButtonPrimitives from "react-aria-components/Button";
 
+import { cn } from "@/registry/lib/utils";
 import { Button } from "@/registry/ui/button";
 import { Dialog, DialogContent } from "@/registry/ui/dialog";
 import { Field, Label } from "@/registry/ui/field";
@@ -103,16 +104,19 @@ function ContextualHelp({ name, reference }: { name: string; reference?: Seriali
  * Control components for the interactive demo.
  */
 
+type ControlsLayout = "horizontal" | "vertical";
+
 interface ControlRendererProps {
 	control: SerializableControl;
 	value: unknown;
 	onChange: (name: string, value: unknown) => void;
+	layout: ControlsLayout;
 }
 
-export function ControlRenderer({ control, value, onChange }: ControlRendererProps) {
+export function ControlRenderer({ control, value, onChange, layout }: ControlRendererProps) {
 	switch (control.type) {
 		case "boolean":
-			return <BooleanControlRenderer control={control} value={value as boolean} onChange={onChange} />;
+			return <BooleanControlRenderer control={control} value={value as boolean} onChange={onChange} layout={layout} />;
 		case "string":
 			return <StringControlRenderer control={control} value={value as string} onChange={onChange} />;
 		case "number":
@@ -130,11 +134,21 @@ interface BooleanControlRendererProps {
 	control: SerializableBooleanControl;
 	value: boolean;
 	onChange: (name: string, value: unknown) => void;
+	layout: ControlsLayout;
 }
 
-function BooleanControlRenderer({ control, value, onChange }: BooleanControlRendererProps) {
+/**
+ * In the inline-column (horizontal) layout the switch sits on one row with its
+ * label (label left, switch right); in the bottom-bar (vertical) layout it
+ * stacks under the label like the other controls.
+ */
+function BooleanControlRenderer({ control, value, onChange, layout }: BooleanControlRendererProps) {
+	const inline = layout === "horizontal";
 	return (
-		<Field>
+		<Field
+			orientation={inline ? "horizontal" : "vertical"}
+			className={inline ? "items-center justify-between gap-2" : "w-auto"}
+		>
 			<div className="flex items-center gap-1">
 				<Label>{control.name}</Label>
 				<ContextualHelp name={control.name} reference={control.reference} />
@@ -208,7 +222,7 @@ function EnumControlRenderer({ control, value, onChange }: EnumControlRendererPr
 	}
 
 	return (
-		<Select selectedKey={value} onSelectionChange={(key) => onChange(control.name, key)}>
+		<Select selectedKey={value} onSelectionChange={(key) => onChange(control.name, key)} className="w-full">
 			<div className="flex items-center gap-1">
 				<Label>{control.name}</Label>
 				<ContextualHelp name={control.name} reference={control.reference} />
@@ -299,14 +313,22 @@ interface ControlsProps {
 	controls: SerializableControl[];
 	values: ControlValues;
 	onChange: (name: string, value: unknown) => void;
+	layout: ControlsLayout;
 }
 
-export function Controls({ controls, values, onChange }: ControlsProps) {
+export function Controls({ controls, values, onChange, layout }: ControlsProps) {
 	return (
 		<>
-			{controls.map((control) => (
-				<ControlRenderer key={control.name} control={control} value={values[control.name]} onChange={onChange} />
-			))}
+			{controls.map((control) => {
+				// In the bottom-bar (vertical) layout controls sit in a row, so give text/select
+				// controls a fixed width; booleans size to content. In the inline column they fill it.
+				const wrapperWidth = layout === "vertical" ? (control.type === "boolean" ? "w-auto" : "w-44") : "w-full";
+				return (
+					<div key={control.name} className={cn("shrink-0", wrapperWidth)}>
+						<ControlRenderer control={control} value={values[control.name]} onChange={onChange} layout={layout} />
+					</div>
+				);
+			})}
 		</>
 	);
 }

--- a/www/src/modules/docs/interactive-demo/interactive-demo.tsx
+++ b/www/src/modules/docs/interactive-demo/interactive-demo.tsx
@@ -170,10 +170,11 @@ export function InteractiveDemo({
 	return (
 		<div className={cn("", className)}>
 			<div className={cn("flex flex-col", layout === "horizontal" && "flex-row")}>
-				{/* Preview frame */}
+				{/* Preview frame — dotted backdrop (theme border token, so it adapts to dark mode) */}
 				<div
 					className={cn(
 						"flex min-h-56 flex-1 items-center justify-center border bg-bg p-10",
+						"[background-image:radial-gradient(var(--color-border)_1px,transparent_1px)] [background-size:18px_18px] [background-position:center]",
 						layout === "horizontal" && "rounded-tl-lg",
 						layout === "vertical" && "rounded-t-lg",
 					)}

--- a/www/src/modules/docs/interactive-demo/interactive-demo.tsx
+++ b/www/src/modules/docs/interactive-demo/interactive-demo.tsx
@@ -168,35 +168,27 @@ export function InteractiveDemo({
 	};
 
 	return (
-		<div className={cn("", className)}>
+		<div className={cn("overflow-hidden rounded-lg border", className)}>
 			<div className={cn("flex flex-col", layout === "horizontal" && "flex-row")}>
-				{/* Preview frame — dotted backdrop (theme border token, so it adapts to dark mode) */}
-				<div
-					className={cn(
-						"flex min-h-56 flex-1 items-center justify-center border bg-bg p-10",
-						"[background-image:radial-gradient(var(--color-border)_1px,transparent_1px)] [background-size:18px_18px] [background-position:center]",
-						layout === "horizontal" && "rounded-tl-lg",
-						layout === "vertical" && "rounded-t-lg",
-					)}
-				>
-					{previewElement}
-				</div>
+				{/* Preview — borderless open space (no card, no backdrop); the demo just sits in it */}
+				<div className="flex min-h-56 flex-1 items-center justify-center p-10">{previewElement}</div>
 
-				{/* Controls panel */}
+				{/* Controls — a column beside the preview (inline column) or a row beneath it (bottom bar) */}
 				<div
 					className={cn(
-						"relative flex flex-col gap-2.5 bg-card p-4 **:data-field:gap-1 **:data-label:text-[0.8125rem] **:data-label:text-fg-muted",
-						layout === "horizontal" && "min-w-48 rounded-tr-lg border-y border-r",
-						layout === "vertical" && "border-x border-b",
+						"flex **:data-field:gap-1 **:data-label:text-[0.8125rem] **:data-label:text-fg-muted",
+						layout === "horizontal"
+							? "w-64 shrink-0 flex-col gap-4 p-5"
+							: "flex-row flex-wrap items-start gap-x-6 gap-y-4 border-t p-5",
 					)}
 				>
-					<Controls controls={controls} values={values} onChange={handleChange} />
+					<Controls controls={controls} values={values} onChange={handleChange} layout={layout} />
 				</div>
 			</div>
 
-			{/* Code block with toggle */}
+			{/* Code bar — split from the panel above by a single thin divider */}
 			<CodeBlock
-				className="rounded-t-none border-t-0"
+				className="rounded-none border-x-0 border-b-0"
 				actions={
 					<>
 						<Button variant="quiet" size="sm" className="h-7 gap-1 pr-2 pl-1 text-xs" onPress={handleToggle}>

--- a/www/src/modules/references/generated/button.json
+++ b/www/src/modules/references/generated/button.json
@@ -38,27 +38,11 @@
 			"default": "'default'"
 		},
 		"size": {
-			"type": "\"icon\" | \"icon-lg\" | \"icon-sm\" | \"icon-xs\" | \"lg\" | \"md\" | \"sm\" | \"xs\"",
-			"detailedType": "| 'icon'\n| 'icon-lg'\n| 'icon-sm'\n| 'icon-xs'\n| 'lg'\n| 'md'\n| 'sm'\n| 'xs'\n| undefined",
+			"type": "\"lg\" | \"md\" | \"sm\" | \"xs\"",
+			"detailedType": "'lg' | 'md' | 'sm' | 'xs' | undefined",
 			"typeAst": {
 				"type": "union",
 				"elements": [
-					{
-						"type": "stringLiteral",
-						"value": "icon"
-					},
-					{
-						"type": "stringLiteral",
-						"value": "icon-lg"
-					},
-					{
-						"type": "stringLiteral",
-						"value": "icon-sm"
-					},
-					{
-						"type": "stringLiteral",
-						"value": "icon-xs"
-					},
 					{
 						"type": "stringLiteral",
 						"value": "lg"
@@ -77,7 +61,7 @@
 					}
 				]
 			},
-			"description": "The size of the button.\nUse `icon-xs`, `icon-sm`, `icon`, or `icon-lg` for icon-only buttons.",
+			"description": "The size of the button.\nFor an icon-only button, set `isIconOnly` rather than a dedicated size.",
 			"default": "\"md\""
 		},
 		"onPress": {

--- a/www/src/modules/references/generated/link-button.json
+++ b/www/src/modules/references/generated/link-button.json
@@ -37,27 +37,11 @@
 			"default": "\"default\""
 		},
 		"size": {
-			"type": "\"icon\" | \"icon-lg\" | \"icon-sm\" | \"icon-xs\" | \"lg\" | \"md\" | \"sm\" | \"xs\"",
-			"detailedType": "| 'icon'\n| 'icon-lg'\n| 'icon-sm'\n| 'icon-xs'\n| 'lg'\n| 'md'\n| 'sm'\n| 'xs'\n| undefined",
+			"type": "\"lg\" | \"md\" | \"sm\" | \"xs\"",
+			"detailedType": "'lg' | 'md' | 'sm' | 'xs' | undefined",
 			"typeAst": {
 				"type": "union",
 				"elements": [
-					{
-						"type": "stringLiteral",
-						"value": "icon"
-					},
-					{
-						"type": "stringLiteral",
-						"value": "icon-lg"
-					},
-					{
-						"type": "stringLiteral",
-						"value": "icon-sm"
-					},
-					{
-						"type": "stringLiteral",
-						"value": "icon-xs"
-					},
 					{
 						"type": "stringLiteral",
 						"value": "lg"
@@ -76,7 +60,7 @@
 					}
 				]
 			},
-			"description": "The size of the button.\nUse `icon-xs`, `icon-sm`, `icon`, or `icon-lg` for icon-only buttons.",
+			"description": "The size of the button.\nFor an icon-only button, set `isIconOnly` rather than a dedicated size.",
 			"default": "\"md\""
 		},
 		"onPress": {

--- a/www/src/registry/ui/button/types.ts
+++ b/www/src/registry/ui/button/types.ts
@@ -14,10 +14,10 @@ export interface ButtonProps extends React.ComponentProps<typeof ButtonPrimitive
 
 	/**
 	 * The size of the button.
-	 * Use `icon-xs`, `icon-sm`, `icon`, or `icon-lg` for icon-only buttons.
+	 * For an icon-only button, set `isIconOnly` rather than a dedicated size.
 	 * @default "md"
 	 */
-	size?: "xs" | "sm" | "md" | "lg" | "icon-xs" | "icon-sm" | "icon" | "icon-lg";
+	size?: "xs" | "sm" | "md" | "lg";
 }
 
 export interface LinkButtonProps extends React.ComponentProps<typeof LinkPrimitives.Link> {
@@ -29,8 +29,8 @@ export interface LinkButtonProps extends React.ComponentProps<typeof LinkPrimiti
 
 	/**
 	 * The size of the button.
-	 * Use `icon-xs`, `icon-sm`, `icon`, or `icon-lg` for icon-only buttons.
+	 * For an icon-only button, set `isIconOnly` rather than a dedicated size.
 	 * @default "md"
 	 */
-	size?: "xs" | "sm" | "md" | "lg" | "icon-xs" | "icon-sm" | "icon" | "icon-lg";
+	size?: "xs" | "sm" | "md" | "lg";
 }


### PR DESCRIPTION
Redesigns the docs **component playground** (`InteractiveDemo`) to match the [Component Playground](https://claude.ai/design/p/ef1e92ad-5573-432e-9dc6-c6fbac565ba4?file=Component+Playground.html) design, plus a related Button cleanup.

## Playground

- **One unified, borderless surface.** Dropped the two-compartment boxed look (separate `bg-bg` preview box + `bg-card` controls panel). Preview and controls now share a single subtly-bordered container, with one thin divider above the code bar — matching the design's two layout tweaks.
- **Two layouts** (via the existing `layout` prop / the code-bar toggle):
  - **Inline column** (`horizontal`): preview left, controls in a right-hand column; boolean controls render **inline** (label left, switch right).
  - **Bottom bar** (`vertical`): preview on top, controls in a **horizontal row** beneath it.
- **Segmented control for small enums.** Enum controls with ≤ 4 short options (e.g. `size`: xs/sm/md/lg) render as a `ToggleButtonGroup` instead of a dropdown; larger sets (e.g. Button `variant`, 6 options) keep the `Select`.

The `layout` prop already existed (`"horizontal" | "vertical"`, authorable from MDX + a runtime toggle), so no new prop was added — it's the analogue of the design's layout tweak.

## Button: drop legacy `icon-*` sizes

`ButtonProps`/`LinkButtonProps` declared `icon`, `icon-xs`, `icon-sm`, `icon-lg` sizes "for icon-only buttons", but:
- `styles.ts` never implemented them (only `xs/sm/md/lg`) — picking one rendered an **unsized** button;
- icon-only buttons actually use the **`isIconOnly`** prop (`data-icon-only:size-*`, 130 uses);
- nothing in the repo used `size="icon*"`.

They were vestigial type-only leftovers from an older `size="icon"` API that leaked into the playground as 4 dead options. Removed them from `button/types.ts` (so the documented type matches the real component type from `base.tsx`) and updated the `button`/`link-button` references accordingly. Button `size` is now a clean `xs/sm/md/lg` segmented control.

## Notes

- Docs app (`www`, private) + a public Button type change. No new runtime deps.
- Generated references are badly drifted from the current generator (a full `build:references` rewrites 121 files / 62k lines), so I hand-edited only the `size` field in `button.json` + `link-button.json` to avoid unrelated churn.

## Verification

Ran the docs app and checked the Button + Input playgrounds in both layouts (light/dark):
- Inline column: borderless unified surface, inline switches, code bar with one divider.
- Bottom bar: preview on top, controls in a horizontal row.
- Button `size` → segmented `xs/sm/md/lg` (md default); Input `size` → `sm/md/lg`; clicking a segment updates preview + code (`<Input size="lg" />`).
- `oxlint` / `oxfmt` clean, `tsc --noEmit` passes, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)