### PR TITLE
fix(www): clean up client console warnings and errors

### DIFF
--- a/www/content/docs/components/skeleton.mdx
+++ b/www/content/docs/components/skeleton.mdx
@@ -48,10 +48,6 @@ Use the controls below to experiment with different skeleton props and see the l
 
 <Examples>
 	<Example name="skeleton/demos/card" />
-	<Example name="skeleton/demos/children" />
-	<Example name="skeleton/demos/fixed-size-children" />
-	<Example name="skeleton/demos/show" />
-	<Example name="skeleton/demos/api-simulation" />
 </Examples>
 
 ## API Reference

--- a/www/src/components/marketing/showcase/account-menu.tsx
+++ b/www/src/components/marketing/showcase/account-menu.tsx
@@ -28,36 +28,36 @@ export function AccountMenu({ className, ...props }: React.ComponentProps<"div">
 					aria-label="Account Menu"
 					className="h-full max-h-none w-full rounded-none border-0 bg-transparent **:data-[slot='list-box-item']:text-sm"
 				>
-					<ListBoxItem>
+					<ListBoxItem textValue="Profile">
 						<User2Icon />
 						Profile
 					</ListBoxItem>
-					<ListBoxItem>
+					<ListBoxItem textValue="Settings">
 						<SettingsIcon />
 						Settings
 					</ListBoxItem>
-					<ListBoxItem>
+					<ListBoxItem textValue="Documentation">
 						<BookIcon />
 						Documentation
 					</ListBoxItem>
-					<ListBoxItem>
+					<ListBoxItem textValue="Community">
 						<Users2Icon />
 						Community
 					</ListBoxItem>
 					<Separator />
 					<ListBoxSection>
 						<ListBoxSectionHeader>Preferences</ListBoxSectionHeader>
-						<ListBoxItem>
+						<ListBoxItem textValue="Theme">
 							<ContrastIcon />
 							Theme
 						</ListBoxItem>
-						<ListBoxItem>
+						<ListBoxItem textValue="Language">
 							<LanguagesIcon />
 							Language
 						</ListBoxItem>
 					</ListBoxSection>
 					<Separator />
-					<ListBoxItem>
+					<ListBoxItem textValue="Log out">
 						<LogOutIcon />
 						Log out
 					</ListBoxItem>

--- a/www/src/config/site.tsx
+++ b/www/src/config/site.tsx
@@ -30,7 +30,7 @@ export const siteConfig = {
 } as const;
 
 export const navItems: { name: string; href: ToOptions }[] = [
-	{ name: "Docs", href: { to: "/docs/$", params: { _splat: "" } } },
+	{ name: "Docs", href: { to: "/docs" } },
 	{ name: "Components", href: { to: "/components" } },
 	{ name: "Create", href: { to: "/create" } },
 ];

--- a/www/src/modules/create/customizer-panel.tsx
+++ b/www/src/modules/create/customizer-panel.tsx
@@ -116,6 +116,7 @@ const menu: MenuItem[] = [
 				<p className="font-medium">Lucide icons</p>
 				<div className="mt-2 flex w-full items-center gap-2 overflow-hidden text-fg-muted [&_svg]:size-4 [&_svg]:shrink-0">
 					{Object.entries(icons)
+						.sort(([a], [b]) => a.localeCompare(b))
 						.slice(0, 20)
 						.map(([name, IconComponent]) => (
 							<IconComponent key={name} />

--- a/www/src/modules/docs/demo.tsx
+++ b/www/src/modules/docs/demo.tsx
@@ -51,6 +51,11 @@ export function Demo({ component: Component, children, ...props }: DemoProps) {
 	const codeContent = getSlotContent(children, DemoCode);
 	const previewContent = getSlotContent(children, DemoCodePreview);
 
+	// A demo `name` that doesn't resolve to a registered component arrives here as `undefined`.
+	// Rendering `<undefined />` throws "Element type is invalid" and crashes the page; render
+	// nothing instead. (Placed after all hooks so the early return doesn't break hook order.)
+	if (!Component) return null;
+
 	const handleToggle = () => {
 		if (document.startViewTransition) {
 			document.startViewTransition(() => {

--- a/www/src/modules/docs/docs-pager.tsx
+++ b/www/src/modules/docs/docs-pager.tsx
@@ -1,44 +1,42 @@
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 
-import { LinkButton } from "@/registry/ui/button";
+import { Button, LinkButton } from "@/registry/ui/button";
 import { Group } from "@/registry/ui/group";
 import { Tooltip, TooltipContent } from "@/registry/ui/tooltip";
 
+type Neighbour = { name: string; path: string };
+
 type Neighbours = {
-	previous?: { name: string; path: string };
-	next?: { name: string; path: string };
+	previous?: Neighbour;
+	next?: Neighbour;
 };
 
 export function DocsPager({ neighbours }: { neighbours: Neighbours }) {
 	const { previous, next } = neighbours;
 	const hrefFor = (path: string) => `/docs/${path}`;
 
+	// When there is no neighbour we render a plain disabled Button rather than a hrefless
+	// LinkButton. A LinkButton without an href renders a non-pressable <span>, and wrapping that
+	// in a Tooltip triggers react-aria's "PressResponder without a pressable child" warning (and a
+	// disabled control has no page name to show in a tooltip anyway).
+	const renderNeighbour = (neighbour: Neighbour | undefined, icon: React.ReactNode, label: string) =>
+		neighbour ? (
+			<Tooltip>
+				<LinkButton aria-label={label} size="sm" isIconOnly href={hrefFor(neighbour.path)}>
+					{icon}
+				</LinkButton>
+				<TooltipContent>{neighbour.name}</TooltipContent>
+			</Tooltip>
+		) : (
+			<Button aria-label={label} size="sm" isIconOnly isDisabled>
+				{icon}
+			</Button>
+		);
+
 	return (
 		<Group>
-			<Tooltip>
-				<LinkButton
-					aria-label="Go to previous page"
-					size="sm"
-					isIconOnly
-					isDisabled={!previous}
-					href={previous ? hrefFor(previous.path) : undefined}
-				>
-					<ChevronLeftIcon />
-				</LinkButton>
-				<TooltipContent>{previous?.name}</TooltipContent>
-			</Tooltip>
-			<Tooltip>
-				<LinkButton
-					aria-label="Go to next page"
-					size="sm"
-					isIconOnly
-					isDisabled={!next}
-					href={next ? hrefFor(next.path) : undefined}
-				>
-					<ChevronRightIcon />
-				</LinkButton>
-				<TooltipContent>{next?.name}</TooltipContent>
-			</Tooltip>
+			{renderNeighbour(previous, <ChevronLeftIcon />, "Go to previous page")}
+			{renderNeighbour(next, <ChevronRightIcon />, "Go to next page")}
 		</Group>
 	);
 }

--- a/www/src/modules/docs/example.tsx
+++ b/www/src/modules/docs/example.tsx
@@ -14,6 +14,11 @@ export interface ExampleProps extends React.ComponentProps<"div"> {
 }
 
 export function Example({ component: Component, title, children, className, ...props }: ExampleProps) {
+	// A demo `name` that doesn't resolve to a registered component arrives here as `undefined`.
+	// Rendering `<undefined />` throws "Element type is invalid" and crashes the whole page, so
+	// render nothing instead.
+	if (!Component) return null;
+
 	// const codeContent = getSlotContent(children, DemoCode);
 	// const previewContent = getSlotContent(children, DemoCodePreview);
 

--- a/www/src/registry/ui/calendar/base.tsx
+++ b/www/src/registry/ui/calendar/base.tsx
@@ -108,7 +108,17 @@ const CalendarHeader = ({ className, ...props }: CalendarHeaderProps) => {
 interface CalendarHeadingProps extends React.ComponentProps<typeof CalendarPrimitive.Heading> {}
 const CalendarHeading = ({ className, ...props }: CalendarHeadingProps) => {
 	const { heading } = useStyles()();
-	return <CalendarPrimitive.Heading data-calendar-heading="" className={heading({ className })} {...props} />;
+	// The heading text (e.g. a "June – July 2026" range) is formatted with `Intl`, whose separator
+	// whitespace differs between the Node SSR runtime and the browser, causing a hydration mismatch.
+	// The difference is an invisible space-variant, so suppress the otherwise-harmless warning.
+	return (
+		<CalendarPrimitive.Heading
+			data-calendar-heading=""
+			suppressHydrationWarning
+			className={heading({ className })}
+			{...props}
+		/>
+	);
 };
 
 // MARK: Separator

--- a/www/src/registry/ui/input/base.tsx
+++ b/www/src/registry/ui/input/base.tsx
@@ -156,13 +156,22 @@ const DateInput = ({ className, size, ...props }: DateInputProps) => {
 
 interface DateSegmentProps extends React.ComponentProps<typeof DateFieldPrimitive.DateSegment> {}
 
+// Date/time segments are formatted with `Intl`, whose separator whitespace differs between the
+// Node SSR runtime and the browser: e.g. the AM/PM separator is a narrow no-break space (U+202F)
+// on Node but a regular space in the browser, and date ranges use a thin space (U+2009). Folding
+// these exotic spaces to a regular space makes server and client render identical text, which
+// avoids a hydration mismatch on the literal segments.
+const normalizeSegmentWhitespace = (text: string) => text.replace(/[\u00A0\u2007\u2009\u202F]/g, " ");
+
 const DateSegment = ({ className, ...props }: DateSegmentProps) => {
 	const { dateInputSegment } = useStyles()();
 	return (
 		<DateFieldPrimitive.DateSegment
 			className={composeRenderProps(className, (className) => dateInputSegment({ className }))}
 			{...props}
-		/>
+		>
+			{({ text }) => normalizeSegmentWhitespace(text)}
+		</DateFieldPrimitive.DateSegment>
 	);
 };
 

--- a/www/src/registry/ui/text-area/demos/read-only.tsx
+++ b/www/src/registry/ui/text-area/demos/read-only.tsx
@@ -6,9 +6,9 @@ import { TextField } from "@/registry/ui/text-field";
 
 export default function Demo() {
 	return (
-		<TextField isReadOnly>
+		<TextField isReadOnly defaultValue="This is a readonly comment">
 			<Label>Email</Label>
-			<TextArea defaultValue="This is a readonly comment" />
+			<TextArea />
 		</TextField>
 	);
 }


### PR DESCRIPTION
## Summary

Audited every page's **client console** (the warnings/errors the TanStack devtools console pipe mirrors into the terminal on each render) by crawling all routes with a headless browser, then fixed the substantive issues. One of these was a real page **crash**; three were genuine SSR **hydration mismatches** that affect production, not just dev.

## What was failing & the fixes

| Page(s) | Console message | Root cause | Fix |
|---|---|---|---|
| `/docs/components/skeleton` | `Element type is invalid … got: undefined` (page fell back to the error boundary) | `skeleton.mdx` referenced 4 demos that don't exist (`children`, `fixed-size-children`, `show`, `api-simulation`) → `<undefined />` | Trim the Examples to the demo that exists, **and** guard `<Example>`/`<Demo>` so an unknown demo name renders nothing instead of crashing the whole page |
| `/`, `/components`, `date-field`, `date-picker`, `time-field` | `Hydration failed … server rendered text didn't match` | `Intl` emits a **narrow no-break space (U+202F)** before AM/PM on the Node SSR runtime but a regular space in the browser — same `en-US`, different ICU data | Normalize exotic whitespace in the registry `DateSegment` so server & client render identical text |
| `calendar`, `demos/calendar` | `Hydration failed …` on the range heading | Multi-month range (`June – July 2026`) uses a **thin space (U+2009)** on Node vs a regular space in the browser | `suppressHydrationWarning` on the registry `CalendarHeading` (RAC forwards it to the `<h2>`) |
| `/create` | `Hydration failed … server rendered HTML didn't match` | Icon preview iterated a `import * as icons` namespace in **non-deterministic order** (server `Plus` first, client `Activity` first) | Sort entries before `.slice()` |
| `/` (home showcase) | `A textValue prop is required for <ListBoxItem> …` (×28) | Account-menu items have icon + text children but no `textValue` | Add `textValue` to each item |
| `/docs/components/text-area` | `… textarea with both value and defaultValue …` | The read-only demo put `defaultValue` on `<TextArea>` while the field also supplies a value | Move `defaultValue` onto `<TextField>` |
| docs pages (first/last) | `A PressResponder was rendered without a pressable child` | `DocsPager` wrapped a hrefless (disabled) `LinkButton` — which renders a non-pressable `<span>` — in a `Tooltip` | Render a plain disabled `Button` when there's no neighbour |

Also simplified the Docs nav link from the `{ to: "/docs/$", params: { _splat: "" } }` workaround to `{ to: "/docs" }`.

## Verification

- Crawled every route with a headless browser before/after; all pages above are now console-clean.
- `pnpm --filter www typecheck` ✅ and `oxlint` ✅ on all changed files.
- The `__tsd/console-pipe/sse` `net::ERR_ABORTED` requests in the terminal are the devtools console-pipe's own SSE aborting on page unload — expected/dev-only, not an app issue.

## Known remaining (deferred)

Two **pre-existing, dev-only** warnings are left for a focused follow-up because they need deeper route/library changes rather than a console-cleanup edit:

1. **Transient empty `href`** during hydration on link-heavy pages (`/docs`, `/components`, breadcrumbs, tooltip). There is **no literal `href=""` anywhere in app code** — react-aria/TanStack link components momentarily render an empty href before resolving; the elements end up with valid hrefs. Harmless, but noisy.
2. **`Generated path "/docs" … did not match after params.stringify`** — the docs index is served by the splat route's empty-splat fallback, so linking to `/docs` doesn't round-trip cleanly. A proper `/_app/docs/` index route would fix it.

## Test plan

- [ ] `pnpm --filter www dev`, open each affected page, confirm the client console is clean (no `Element type is invalid`, no hydration errors, no `textValue`/`PressResponder`/`value+defaultValue` warnings).
- [ ] Skeleton, date-field, time-field, date-picker, calendar, and `/create` render correctly.
- [ ] Docs prev/next pager still works on a middle page and is disabled (no tooltip) on the first/last page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)