### PR TITLE
feat(create): preview display-mode toggle (light / dark) (Phase 1d)

### DIFF
--- a/www/src/modules/create/customizer-panel.tsx
+++ b/www/src/modules/create/customizer-panel.tsx
@@ -2,7 +2,15 @@ import { type ReactNode, useMemo } from "react";
 
 import { getRouteApi } from "@tanstack/react-router";
 
-import { ChevronDownIcon, ChevronLeftIcon, MoonIcon, MousePointer2Icon, ShuffleIcon, Undo2Icon } from "lucide-react";
+import {
+	ChevronDownIcon,
+	ChevronLeftIcon,
+	MoonIcon,
+	MousePointer2Icon,
+	ShuffleIcon,
+	SunIcon,
+	Undo2Icon,
+} from "lucide-react";
 import { AnimatePresence, motion, type Transition } from "motion/react";
 import * as ButtonPrimitives from "react-aria-components/Button";
 
@@ -37,6 +45,8 @@ import { InstallCommand } from "./install-command";
 import { DEFAULT_RADIUS_FACTOR, DensityConfig, RADIUS_FACTOR_VAR, RadiusConfig } from "./layout-config";
 import { useDesignSystem } from "./preset";
 import { TypographyConfig } from "./typography-config";
+
+import type { PreviewMode } from "./preset";
 
 /* -------------------------------- Types -------------------------------- */
 
@@ -152,7 +162,13 @@ const menuIds = MENU_IDS;
 
 const routeApi = getRouteApi("/_app/create");
 
-export function CustomizerPanel() {
+export function CustomizerPanel({
+	previewMode = "light",
+	onTogglePreviewMode,
+}: {
+	previewMode?: PreviewMode;
+	onTogglePreviewMode?: () => void;
+}) {
 	const { panel, preview } = routeApi.useSearch();
 	const navigate = routeApi.useNavigate();
 	const { designSystem, setComponentParam, setToken, setDensity } = useDesignSystem();
@@ -327,8 +343,8 @@ export function CustomizerPanel() {
 					<Button size="sm" isIconOnly>
 						<ShuffleIcon />
 					</Button>
-					<Button size="sm" isIconOnly>
-						<MoonIcon />
+					<Button size="sm" isIconOnly onPress={onTogglePreviewMode} aria-label="Toggle preview mode">
+						{previewMode === "dark" ? <SunIcon /> : <MoonIcon />}
 					</Button>
 					<Button size="sm" isIconOnly>
 						<Undo2Icon />

--- a/www/src/modules/create/preset/iframe-sync.ts
+++ b/www/src/modules/create/preset/iframe-sync.ts
@@ -6,16 +6,22 @@ import type { DesignSystem } from "./types";
 
 /* --------------------------------- Types --------------------------------- */
 
-type ParentToIframeMessage = {
-	type: "design-system";
-	data: DesignSystem;
-};
+export type PreviewMode = "light" | "dark";
+
+type ParentToIframeMessage =
+	| { type: "design-system"; data: DesignSystem }
+	| { type: "preview-mode"; mode: PreviewMode };
 
 /* ------------------------------ Send (parent) ------------------------------ */
 
 export function sendToIframe(iframe: HTMLIFrameElement | null, data: DesignSystem) {
 	if (!iframe?.contentWindow) return;
 	iframe.contentWindow.postMessage({ type: "design-system", data } satisfies ParentToIframeMessage, "*");
+}
+
+export function sendPreviewMode(iframe: HTMLIFrameElement | null, mode: PreviewMode) {
+	if (!iframe?.contentWindow) return;
+	iframe.contentWindow.postMessage({ type: "preview-mode", mode } satisfies ParentToIframeMessage, "*");
 }
 
 /* ----------------------------- Listen (iframe) ----------------------------- */
@@ -45,6 +51,32 @@ export function useIframeMessageListener(onMessage: (data: DesignSystem) => void
 		};
 
 		window.addEventListener("message", handleMessage);
+		return () => window.removeEventListener("message", handleMessage);
+	}, []);
+}
+
+/**
+ * Inside the preview iframe: apply display-mode messages from the customizer by
+ * toggling the `.dark` class (the customizer owns the previewed mode, overriding
+ * the iframe's own theme state).
+ */
+export function useIframePreviewModeListener() {
+	React.useEffect(() => {
+		if (!isInIframe()) return;
+
+		const handleMessage = (event: MessageEvent) => {
+			if (event.data?.type === "preview-mode") {
+				const mode: PreviewMode = event.data.mode === "dark" ? "dark" : "light";
+				const root = document.documentElement;
+				root.classList.toggle("dark", mode === "dark");
+				root.style.colorScheme = mode;
+			}
+		};
+
+		window.addEventListener("message", handleMessage);
+		// Signal readiness so the parent can push the current mode — its load-event
+		// send can race ahead of this listener mounting.
+		window.parent.postMessage({ type: "preview-ready" }, "*");
 		return () => window.removeEventListener("message", handleMessage);
 	}, []);
 }

--- a/www/src/modules/create/preset/index.ts
+++ b/www/src/modules/create/preset/index.ts
@@ -1,5 +1,11 @@
 export { decodePreset, encodePreset } from "./codec";
 export { DEFAULTS } from "./defaults";
-export { sendToIframe, useIframeMessageListener } from "./iframe-sync";
+export {
+	type PreviewMode,
+	sendPreviewMode,
+	sendToIframe,
+	useIframeMessageListener,
+	useIframePreviewModeListener,
+} from "./iframe-sync";
 export { useDesignSystem } from "./use-design-system";
 export type { Density, DesignSystem, DesignSystemState } from "./types";

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
 
 import { z } from "zod";
 
 import { CustomizerPanel } from "@/modules/create/customizer-panel";
-import { sendToIframe, useDesignSystem } from "@/modules/create/preset";
+import { sendPreviewMode, sendToIframe, useDesignSystem } from "@/modules/create/preset";
+
+import type { PreviewMode } from "@/modules/create/preset";
 
 export const createSearchSchema = z.object({
 	panel: z.string().optional().catch(undefined),
@@ -27,6 +29,7 @@ function CreatePage() {
 	const { preview, preset } = Route.useSearch();
 	const { designSystem } = useDesignSystem();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const [previewMode, setPreviewMode] = useState<PreviewMode>("light");
 
 	const effectivePreview = preview;
 
@@ -52,9 +55,30 @@ function CreatePage() {
 		return () => iframe.removeEventListener("load", send);
 	}, [designSystem]);
 
+	// Forward the previewed display mode (light / dark) to the iframe — on change,
+	// on load, and when the iframe signals it's ready (its listener can mount after load).
+	useEffect(() => {
+		const iframe = iframeRef.current;
+		if (!iframe) return;
+		const send = () => sendPreviewMode(iframe, previewMode);
+		if (iframe.contentWindow) send();
+		iframe.addEventListener("load", send);
+		const onReady = (event: MessageEvent) => {
+			if (event.data?.type === "preview-ready") send();
+		};
+		window.addEventListener("message", onReady);
+		return () => {
+			iframe.removeEventListener("load", send);
+			window.removeEventListener("message", onReady);
+		};
+	}, [previewMode]);
+
 	return (
 		<div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-row gap-6 p-6 pt-2">
-			<CustomizerPanel />
+			<CustomizerPanel
+				previewMode={previewMode}
+				onTogglePreviewMode={() => setPreviewMode((m) => (m === "dark" ? "light" : "dark"))}
+			/>
 			<iframe
 				ref={iframeRef}
 				key={effectivePreview}

--- a/www/src/routes/preview/$slug.tsx
+++ b/www/src/routes/preview/$slug.tsx
@@ -5,7 +5,12 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { DesignSystemProvider } from "@/modules/core/styles";
-import { DEFAULTS, decodePreset, useIframeMessageListener } from "@/modules/create/preset";
+import {
+	DEFAULTS,
+	decodePreset,
+	useIframeMessageListener,
+	useIframePreviewModeListener,
+} from "@/modules/create/preset";
 import { ExamplesIndex, GroupExamplesIndex } from "@/registry/__generated__/examples";
 
 import type { DesignSystem } from "@/modules/create/preset";
@@ -38,6 +43,7 @@ function PreviewPage() {
 	const [designSystem, setDesignSystem] = useState<DesignSystem>(() => (preset ? decodePreset(preset) : DEFAULTS));
 
 	useIframeMessageListener(useCallback((ds: DesignSystem) => setDesignSystem(ds), []));
+	useIframePreviewModeListener();
 
 	const promise = getExamplesPromise(slug);
 


### PR DESCRIPTION
## What
Wires the customizer's **Moon/Sun button** to flip the preview between light and dark — **independently of the app theme** — so you can build/preview a system in either display mode.

- **iframe-sync**: `sendPreviewMode` + `useIframePreviewModeListener` (toggles `.dark` + `colorScheme` inside the preview iframe), plus a **preview-ready handshake** so the initial mode reliably lands (the iframe's listener mounts after the `load` event, which would otherwise race the parent's send).
- **create.tsx**: `previewMode` state, forwarded to the iframe on change / load / ready; passes the toggle to the panel.
- **customizer-panel**: the Moon/Sun button is wired (`onPress` + icon reflects the current mode).

## Verified live (browser)
- Fresh `/create`: preview starts in the default (light) via the handshake, even with the app in dark. ✓
- Click the toggle → preview flips to near-black dark (`bodyBg oklch(0.13)`); click again → light. ✓
- Direct message-path + full button-click chain both confirmed; **zero console errors**.

## Gates
- ✅ `tsc` clean, oxlint 0/0, oxfmt clean, `lint:ws` clean, 23 tests green

Part of the color rewrite (Phase 1d). Follow-ups: customizer algorithm picker + live swatch strip + contrast readout; publisher parity so `shadcn add` reproduces a customized system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)