### PR TITLE
feat(publisher): reproduce a customized palette via shadcn add (Phase 2)

### DIFF
--- a/www/src/publisher/emit-theme.spec.ts
+++ b/www/src/publisher/emit-theme.spec.ts
@@ -88,4 +88,30 @@ describe("emitInitItem", () => {
 		expect(item.css?.[":root"]).toMatchObject({ "--dotui-density": "default" });
 		expect(baseRegistryCss.css[":root"]).not.toHaveProperty("--dotui-density");
 	});
+
+	test("a custom color recipe regenerates the :root + .dark palette ramps", () => {
+		const item = emitInitItem({
+			baseRegistryCss,
+			preset: {
+				density: "compact",
+				componentParams: {},
+				color: {
+					algorithm: "oklch",
+					seeds: { neutral: "#808080", accent: "#ef4444", success: "#22c55e", warning: "#eab308", danger: "#ef4444" },
+				},
+			},
+			registryRoot: "https://dotui.com",
+		});
+
+		const root = (item.css?.[":root"] ?? {}) as Record<string, string>;
+		const dark = (item.css?.[".dark"] ?? {}) as Record<string, string>;
+		expect(root["--accent-500"]).toMatch(/^oklch\(/);
+		expect(root["--neutral-50"]).not.toBe("hsl(0, 0%, 98%)");
+		// #ef4444 is red — hue far from the default blue (~250).
+		const hue = Number(root["--accent-500"]?.match(/oklch\([\d.]+ [\d.]+ ([\d.]+)\)/)?.[1]);
+		expect(hue).toBeGreaterThan(0);
+		expect(hue).toBeLessThan(60);
+		expect(dark["--accent-50"]).toMatch(/^oklch\(/);
+		expect(dark["--neutral-950"]).toMatch(/^oklch\(/);
+	});
 });

--- a/www/src/publisher/emit-theme.ts
+++ b/www/src/publisher/emit-theme.ts
@@ -9,6 +9,8 @@
  * Pure JS — no `ts-morph`, no React. Safe to import in route handlers.
  */
 
+import { resolveColorConfig } from "@/registry/theme";
+
 import type { Density, RegistryItem } from "@/registry/types";
 
 import type { PublishPreset } from "./types";
@@ -132,12 +134,33 @@ function registryConfigUrl(registryRoot: string, encodedPreset: string | undefin
 	return `${registryRoot}/r/{name}?preset=${encodedPreset ?? ""}`;
 }
 
+/** Flatten resolved per-palette ramps into `--<palette>-<step>` CSS var entries. */
+function rampsToVars(palettes: Record<string, Record<string, string>>): Record<string, string> {
+	const vars: Record<string, string> = {};
+	for (const [palette, scale] of Object.entries(palettes)) {
+		for (const [step, value] of Object.entries(scale)) {
+			vars[`--${palette}-${step}`] = value;
+		}
+	}
+	return vars;
+}
+
 function mergePresetCssFields(base: RegistryCssFields, preset: PublishPreset): RegistryCssFields {
 	const css = cloneRecord(base.css) ?? {};
 	mergeCssVarsIntoCssRule(css, ":root", base.cssVars?.light);
 	mergeCssVarsIntoCssRule(css, ".dark", base.cssVars?.dark);
 
 	const cssVars = cloneThemeCssVars(base.cssVars);
+
+	// A custom color recipe regenerates the primitive ramps, overriding the static
+	// base palette in :root (light) and .dark (reversed). The consumer's
+	// tailwindcss-autocontrast plugin re-derives --on-* from these shipped ramps.
+	if (preset.color) {
+		const resolved = resolveColorConfig(preset.color);
+		css[":root"] = { ...(isPlainCssObject(css[":root"]) ? css[":root"] : {}), ...rampsToVars(resolved.light) };
+		css[".dark"] = { ...(isPlainCssObject(css[".dark"]) ? css[".dark"] : {}), ...rampsToVars(resolved.dark) };
+	}
+
 	const lightVars = emitPresetLightVars(preset);
 	if (Object.keys(lightVars).length > 0) {
 		css[":root"] = { ...(isPlainCssObject(css[":root"]) ? css[":root"] : {}), ...lightVars };

--- a/www/src/publisher/types.ts
+++ b/www/src/publisher/types.ts
@@ -7,6 +7,7 @@
  * a flat `tv` config, then serialized.
  */
 
+import type { ColorConfig } from "@/registry/theme";
 import type { Density, RegistryItem, RegistryItemFile } from "@/registry/types";
 
 /**
@@ -79,6 +80,8 @@ export interface PublishPreset {
 	density: Density;
 	/** Per-component param selections: { button: { variant: "primary", ... } } */
 	componentParams: Record<string, Record<string, string>>;
+	/** Generative color recipe; when present, its ramps override the static base palette. */
+	color?: ColorConfig;
 }
 
 /** Subset of `RegistryItemFile` we emit. */

--- a/www/src/routes/r/init.tsx
+++ b/www/src/routes/r/init.tsx
@@ -49,6 +49,7 @@ async function decodePresetForRoute(encoded: string): Promise<PublishPreset> {
 		const { decodePreset } = await import("@/modules/create/preset/codec");
 		const ds = decodePreset(encoded);
 		return {
+			color: ds.color,
 			density: ds.density,
 			componentParams: ds.componentParams,
 		};


### PR DESCRIPTION
## What
Threads the generative `ColorConfig` through the publisher so a color system customized in `/create` **reproduces when installed** via `shadcn init/add ?preset=` — closing the "connected with our registry" loop.

- **`PublishPreset`** gains an optional `color: ColorConfig`.
- **`emit-theme`**: when a recipe is present, `resolveColorConfig` regenerates the primitive ramps and **overrides the static base palette** in `:root` (light) + `.dark` (reversed). The consumer's `tailwindcss-autocontrast` plugin (shipped in the base item) re-derives `--on-*` from these ramps.
- **`/r/init`**: threads the decoded `ds.color` into the preset. (Per-component items don't carry the base palette, so `/r/[name]` is unchanged.)

## Verification
- ✅ New publisher test: `emitInitItem` with a custom **red** color recipe emits oklch `:root`/`.dark` accent ramps (hue ~25, not the default blue ~250); base `hsl` neutral overridden.
- ✅ 33 publisher tests green; `tsc` clean, oxlint 0/0, oxfmt clean.
- ✅ `build:registry` → **no base-artifact changes** (this is request-time only).

This completes the core color-system rewrite: generate → customize (seeds + modes) → preview → **install reproduces**. Follow-up polish: customizer algorithm picker + live swatch strip + per-pairing contrast readout; the preview/starter-themes mode-ownership edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)