### PR TITLE
feat(create): live generated-ramp swatch strip + harden status ramps (Phase 1d)

### DIFF
--- a/www/src/modules/create/colors-config.tsx
+++ b/www/src/modules/create/colors-config.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { DEFAULT_COLOR_CONFIG } from "@/registry/theme";
+import { useMemo } from "react";
+
+import { DEFAULT_COLOR_CONFIG, resolveColorConfig } from "@/registry/theme";
 import { Button } from "@/registry/ui/button";
 import { ColorEditor } from "@/registry/ui/color-editor";
 import { ColorPicker } from "@/registry/ui/color-picker";
@@ -21,13 +23,18 @@ const SEED_FIELDS: ReadonlyArray<{ label: string; key: keyof PaletteSeeds }> = [
 	{ label: "Danger", key: "danger" },
 ];
 
+const RAMP_ORDER = ["neutral", "accent", "success", "warning", "danger", "info"] as const;
+
 export function ColorsConfig() {
 	const { designSystem, setColorSeed } = useDesignSystem();
-	const seeds = designSystem.color?.seeds ?? DEFAULT_COLOR_CONFIG.seeds;
+	const config = designSystem.color ?? DEFAULT_COLOR_CONFIG;
+	const seeds = config.seeds;
+	const resolved = useMemo(() => resolveColorConfig(config), [config]);
 
 	return (
 		<div className="-mt-6 flex flex-col gap-4">
 			<p className="text-xs text-fg-muted">Pick brand + status seeds — the ramps regenerate live.</p>
+
 			<div className="grid grid-cols-2 gap-4">
 				{SEED_FIELDS.map(({ label, key }) => (
 					<ColorPicker
@@ -53,6 +60,26 @@ export function ColorsConfig() {
 						)}
 					</ColorPicker>
 				))}
+			</div>
+
+			<div className="flex flex-col gap-1.5">
+				<span className="pl-1 text-xs font-medium text-fg-muted">Generated ramps</span>
+				{RAMP_ORDER.map((palette) => {
+					const ramp = resolved.light[palette];
+					if (!ramp) return null;
+					return (
+						<div key={palette} className="flex overflow-hidden rounded-md" title={palette}>
+							{Object.entries(ramp).map(([step, value]) => (
+								<div
+									key={step}
+									className="h-5 flex-1"
+									style={{ backgroundColor: value }}
+									title={`--${palette}-${step}: ${value}`}
+								/>
+							))}
+						</div>
+					);
+				})}
 			</div>
 		</div>
 	);

--- a/www/src/registry/theme/primitives.ts
+++ b/www/src/registry/theme/primitives.ts
@@ -70,10 +70,11 @@ export function resolveColorConfig(config: ColorConfig): ResolvedPalettes {
 	const { seeds, algorithm, steps } = config;
 
 	// The kernel requires a `primary` palette (the brand); dotUI names it `accent`.
-	const palettes: Record<string, string> = { primary: seeds.accent, neutral: seeds.neutral };
+	// Always generate every status palette (a missing seed falls back to the kernel's
+	// built-in) so a partial config never leaves a stale base ramp downstream.
+	const palettes: Record<string, string | boolean> = { primary: seeds.accent, neutral: seeds.neutral };
 	for (const name of ["success", "warning", "danger", "info"] as const) {
-		const seed = seeds[name];
-		if (seed) palettes[name] = seed;
+		palettes[name] = seeds[name] ?? true;
 	}
 
 	// algorithm is a runtime-validated discriminant the kernel's zod schema checks.


### PR DESCRIPTION
## What
Rounds out the customizer so the **generated palette is visible** as you build it.

- **`colors-config`**: a live **swatch strip** under the seed pickers, rendering the resolved per-palette ramps (neutral / accent / success / warning / danger / info, 11 steps each via `resolveColorConfig`). Regenerates as you change any seed.
- **`primitives`**: `resolveColorConfig` now **always generates every status palette** — a missing seed falls back to the kernel's built-in — so a partial `ColorConfig` never leaves a stale base ramp downstream (hardening the publisher review nit).

## Verification
- ✅ Live in browser: the Colors panel shows all six ramps as smooth gradients; updates on seed change; zero console errors.
- ✅ 20 theme tests green; `tsc` clean, oxlint 0/0.
- ✅ `build:registry` → **default palette + base artifacts unchanged** (the default config seeds every palette, so the `?? true` fallback never fires for it).

Completes the core "flexible working color system" customizer UX (seeds + live ramps + display-mode toggle). Optional follow-ups: algorithm picker, per-pairing contrast readout, the preview/starter-themes mode-ownership edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)