### PR TITLE
feat(create): emit live --on-* foregrounds (fix the freeze + preview≠shipped)

### DIFF
--- a/.changeset/autocontrast-expose-pick.md
+++ b/.changeset/autocontrast-expose-pick.md
@@ -1,0 +1,5 @@
+---
+"tailwindcss-autocontrast": patch
+---
+
+Expose `getContrastColor` so consumers can parity-test their runtime foreground pick against the plugin's compile-time output.

--- a/packages/colors/src/index.ts
+++ b/packages/colors/src/index.ts
@@ -37,6 +37,6 @@ export { registerBuiltins } from "./producers";
 
 // Shared kernel ops + types
 export { apca, type ContrastFormula, gamutMap, type Oklch, oklchCss, toOklch, wcag2 } from "./shared/color";
-export { onColor } from "./shared/on-color";
+export { onBlackWhite, onColor } from "./shared/on-color";
 export { SEMANTIC_COLORS } from "./shared/constants";
 export type { ColorScale, Theme, ThemeMode } from "./shared/types";

--- a/packages/colors/src/shared/on-color.ts
+++ b/packages/colors/src/shared/on-color.ts
@@ -8,7 +8,7 @@
  * mid-light bg (the floor is genuinely unreachable there), surfaced rather than faked.
  */
 
-import { type ContrastFormula, gamutMap, makeContrast, type Oklch, oklchCss, toOklch } from "./color";
+import { type ContrastFormula, gamutMap, makeContrast, type Oklch, oklchCss, toOklch, toSrgb } from "./color";
 
 import type { ColorScale } from "./types";
 
@@ -75,4 +75,23 @@ export function computeOnColors(scale: ColorScale, formula: ContrastFormula = "w
 		on[step] = onColor(value, formula).value;
 	}
 	return on;
+}
+
+/**
+ * Pure black/white foreground pick — replicates `tailwindcss-autocontrast`'s
+ * `getContrastColor`, the plugin that bakes dotUI's `--on-*` at Tailwind-compile time:
+ * WCAG relative luminance of the sRGB color (rounded to 8-bit, as the plugin does), then
+ * whichever of black/white has the higher contrast. dotUI's live preview emits `--on-*`
+ * with this so the in-browser palette matches what `shadcn add` ships — kept in lockstep by
+ * a parity test. Distinct from {@link onColor}, which returns AA-verified hue-tinted poles.
+ */
+export function onBlackWhite(background: string): "black" | "white" {
+	const { r, g, b } = toSrgb(background);
+	const lin = (channel: number): number => {
+		const s = Math.round(channel * 255) / 255;
+		return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+	};
+	const luminance = 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+	// contrast-with-black = (L+0.05)/0.05 ; contrast-with-white = 1.05/(L+0.05)
+	return (luminance + 0.05) / 0.05 > 1.05 / (luminance + 0.05) ? "black" : "white";
 }

--- a/packages/tailwindcss-autocontrast/src/index.js
+++ b/packages/tailwindcss-autocontrast/src/index.js
@@ -501,3 +501,5 @@ const autoContrast = plugin.withOptions((options = {}) => {
 });
 
 module.exports = autoContrast;
+// Exposed so dotUI can parity-test its runtime `onBlackWhite` against this baked-at-compile pick.
+module.exports.getContrastColor = getContrastColor;

--- a/www/src/modules/core/styles.tsx
+++ b/www/src/modules/core/styles.tsx
@@ -118,7 +118,10 @@ function DesignSystemProvider({
 
 	// Generative palette: inject the resolved per-mode primitive ramps as a <style>
 	// (the flat-token path above only writes :root; this carries :root + .dark).
-	const colorCss = React.useMemo(() => (color ? emitPrimitivesCss(resolveColorConfig(color)) : null), [color]);
+	const colorCss = React.useMemo(
+		() => (color ? emitPrimitivesCss(resolveColorConfig(color), { onColors: true }) : null),
+		[color],
+	);
 
 	React.useLayoutEffect(() => {
 		if (!colorCss) return;

--- a/www/src/registry/theme/on-color-parity.spec.ts
+++ b/www/src/registry/theme/on-color-parity.spec.ts
@@ -1,0 +1,53 @@
+import autoContrastPlugin from "tailwindcss-autocontrast";
+import { describe, expect, it } from "vitest";
+
+import { onBlackWhite, wcag2 } from "@dotui/colors";
+
+import { DEFAULT_COLOR_CONFIG } from "./color-config";
+import { emitPrimitivesCss, resolveColorConfig } from "./primitives";
+
+// The plugin exposes its compile-time foreground pick for parity testing (absent from its plugin type).
+type PluginWithPick = { getContrastColor: (value: string) => "black" | "white" };
+const { getContrastColor } = autoContrastPlugin as unknown as PluginWithPick;
+
+const resolved = resolveColorConfig(DEFAULT_COLOR_CONFIG);
+const allRampValues = [...Object.values(resolved.light), ...Object.values(resolved.dark)].flatMap((ramp) =>
+	Object.values(ramp),
+);
+
+describe("onBlackWhite (preview --on-* foreground pick)", () => {
+	it("picks black on light backgrounds and white on dark", () => {
+		expect(onBlackWhite("#ffffff")).toBe("black");
+		expect(onBlackWhite("#000000")).toBe("white");
+		expect(onBlackWhite("oklch(0.985 0 0)")).toBe("black");
+		expect(onBlackWhite("oklch(0.13 0 0)")).toBe("white");
+	});
+
+	it("every step's on-* clears WCAG AA against its own background (the pure-pole minimum is ~4.58)", () => {
+		for (const value of allRampValues) {
+			expect(wcag2(onBlackWhite(value), value)).toBeGreaterThanOrEqual(4.5);
+		}
+	});
+
+	it("matches tailwindcss-autocontrast's getContrastColor for every generated step (preview == shipped)", () => {
+		expect(allRampValues.length).toBeGreaterThan(60);
+		for (const value of allRampValues) {
+			expect(onBlackWhite(value)).toBe(getContrastColor(value));
+		}
+	});
+});
+
+describe("emitPrimitivesCss — on-* emission", () => {
+	it("omits --on-* by default (base/colors.css stays ramps-only; the plugin derives them)", () => {
+		expect(emitPrimitivesCss(resolved)).not.toContain("--on-accent-500");
+	});
+
+	it("emits black/white --on-<palette>-<step> for :root and .dark when onColors is set", () => {
+		const css = emitPrimitivesCss(resolved, { onColors: true });
+		expect(css).toMatch(/--on-accent-500:\s*(black|white);/);
+		expect(css).toMatch(/--on-neutral-950:\s*(black|white);/);
+		// one --on-* per ramp step, per mode (light + dark)
+		const count = (css.match(/--on-[a-z]+-\d+:/g) ?? []).length;
+		expect(count).toBe(allRampValues.length);
+	});
+});

--- a/www/src/registry/theme/primitives.ts
+++ b/www/src/registry/theme/primitives.ts
@@ -11,7 +11,7 @@
  * the `tailwindcss-autocontrast` plugin at Tailwind-compile.
  */
 
-import { createTheme, oklchCss, toOklch } from "@dotui/colors";
+import { createTheme, oklchCss, onBlackWhite, toOklch } from "@dotui/colors";
 
 import { GENERATIVE_ALGORITHMS, type ColorConfig } from "./color-config";
 import { ACCENT_KERNEL_NAME, fromKernelPaletteName, PALETTE_ORDER, STATUS_PALETTES } from "./palettes";
@@ -125,8 +125,29 @@ function emitBlock(out: string[], palettes: Record<string, Ramp>, names: string[
 	});
 }
 
+/** Append `--on-<palette>-<step>: black|white` per ramp step (matches the autocontrast plugin). */
+function emitOnBlock(out: string[], palettes: Record<string, Ramp>, names: string[]): void {
+	for (const name of names) {
+		const ramp = palettes[name];
+		if (!ramp) continue;
+		for (const [step, value] of Object.entries(ramp)) {
+			out.push(`\t--on-${name}-${step}: ${onBlackWhite(value)};`);
+		}
+	}
+}
+
+export interface EmitPrimitivesOptions {
+	/**
+	 * Also emit `--on-<palette>-<step>` foregrounds (black/white). OFF for the generated
+	 * `base/colors.css` — the `tailwindcss-autocontrast` plugin derives `--on-*` at
+	 * Tailwind-compile from the static ramps. ON for the live-preview `<style>`, whose runtime
+	 * ramp overrides would otherwise leave the baked `--on-*` stale (unreadable text-on-color).
+	 */
+	onColors?: boolean;
+}
+
 /** Render resolved ramps as the `base/colors.css` content (`:root` light + `.dark` reversed). */
-export function emitPrimitivesCss(resolved: ResolvedPalettes): string {
+export function emitPrimitivesCss(resolved: ResolvedPalettes, options: EmitPrimitivesOptions = {}): string {
 	const names = orderedNames(resolved.light);
 	const out: string[] = [
 		"/* AUTO-GENERATED — do not edit. Run `pnpm build:registry`. */",
@@ -137,8 +158,16 @@ export function emitPrimitivesCss(resolved: ResolvedPalettes): string {
 		"",
 	];
 	emitBlock(out, resolved.light, names);
+	if (options.onColors) {
+		out.push("");
+		emitOnBlock(out, resolved.light, names);
+	}
 	out.push("}", "", ".dark {");
 	emitBlock(out, resolved.dark, names);
+	if (options.onColors) {
+		out.push("");
+		emitOnBlock(out, resolved.dark, names);
+	}
 	out.push("}");
 	return `${out.join("\n")}\n`;
 }


### PR DESCRIPTION
The third audit-flagged bug: the injected preview `<style>` rewrote ramps but **never** the `--on-*` text-on-color foregrounds. Those are baked by `tailwindcss-autocontrast` at Tailwind-compile from the static `colors.css`, so changing a seed in `/create` moved backgrounds live while foregrounds stayed locked to the default palette (**unreadable text**) — and the live preview **diverged from what `shadcn add` ships**.

## How
- **`@dotui/colors`**: new `onBlackWhite` — a pure black/white pick that replicates the plugin's WCAG-luminance `getContrastColor`, kept in lockstep by a **cross-library parity test** (colorjs.io vs the plugin's culori path).
- **`primitives.ts`**: `emitPrimitivesCss(resolved, { onColors })` appends `--on-<palette>-<step>` for `:root` + `.dark`. **Off by default** — `base/colors.css` stays ramps-only (the plugin owns `--on-*` for the static build, so **no drift**); **on** for the runtime `<style>`.
- **`styles.tsx`** opts in. The unlayered `<style>` overrides the plugin's `@layer base` `--on-*`.
- **Publisher unchanged** (ships ramps-only; the consumer's autocontrast re-derives) — the preview now produces the **same** `--on-*` the consumer will.

## Verification
- `tsc` + **144 vitest** (incl. the parity test `onBlackWhite === getContrastColor` over every generated step, and an on-* clears-AA invariant) + oxlint/oxfmt green.
- `base/colors.css` **byte-unchanged** (gated default).
- **In-browser** (yellow-accent preset): the iframe's injected `<style>` carries `--on-*`; a sentinel value proved the unlayered `<style>` **overrides** the `@layer base` baked value (`--color-fg-on-accent` followed the injected value). Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)