### PR TITLE
feat(create): per-producer knobs + Info seed + live Colors summary

### DIFF
--- a/www/src/modules/create/color-knobs.tsx
+++ b/www/src/modules/create/color-knobs.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { ChevronDownIcon } from "lucide-react";
+
+import { Button } from "@/registry/ui/button";
+import { Label } from "@/registry/ui/field";
+import { ListBox, ListBoxItem } from "@/registry/ui/list-box";
+import { Popover } from "@/registry/ui/popover";
+import { Select, SelectValue } from "@/registry/ui/select";
+import { Slider, SliderControl, SliderOutput } from "@/registry/ui/slider";
+
+import type { AlgorithmId, ColorKnobs } from "@/registry/theme";
+
+type SetKnob = <K extends keyof ColorKnobs>(key: K, value: ColorKnobs[K]) => void;
+
+const PRESERVE_OFF = "off";
+
+interface OklchSliderDef {
+	key: "chromaMult" | "minChroma" | "hueTorsion";
+	label: string;
+	minValue: number;
+	maxValue: number;
+	step: number;
+	/** Mirrors the kernel oklch producer's default for this knob. */
+	fallback: number;
+}
+
+const OKLCH_SLIDERS: ReadonlyArray<OklchSliderDef> = [
+	{ key: "chromaMult", label: "Chroma", minValue: 0, maxValue: 2, step: 0.05, fallback: 1 },
+	{ key: "minChroma", label: "Min chroma", minValue: 0, maxValue: 0.2, step: 0.005, fallback: 0.11 },
+	{ key: "hueTorsion", label: "Hue shift", minValue: -40, maxValue: 40, step: 1, fallback: 0 },
+];
+
+function KnobSlider({
+	label,
+	value,
+	minValue,
+	maxValue,
+	step,
+	onChange,
+}: {
+	label: string;
+	value: number;
+	minValue: number;
+	maxValue: number;
+	step: number;
+	onChange: (value: number) => void;
+}) {
+	return (
+		<Slider
+			aria-label={label}
+			value={value}
+			minValue={minValue}
+			maxValue={maxValue}
+			step={step}
+			onChange={(v) => onChange(typeof v === "number" ? v : (v[0] ?? minValue))}
+		>
+			<div className="flex items-center justify-between text-xs">
+				<Label>{label}</Label>
+				<SliderOutput className="text-fg-muted" />
+			</div>
+			<SliderControl />
+		</Slider>
+	);
+}
+
+function KnobSelect({
+	label,
+	value,
+	options,
+	onChange,
+}: {
+	label: string;
+	value: string;
+	options: ReadonlyArray<{ id: string; label: string }>;
+	onChange: (value: string) => void;
+}) {
+	return (
+		<Select className="w-full" selectedKey={value} onSelectionChange={(key) => onChange(key as string)}>
+			<Label className="text-xs">{label}</Label>
+			<Button size="sm" className="w-full justify-between">
+				<SelectValue className="truncate" />
+				<ChevronDownIcon data-icon-end="" />
+			</Button>
+			<Popover>
+				<ListBox>
+					{options.map((option) => (
+						<ListBoxItem key={option.id} id={option.id}>
+							{option.label}
+						</ListBoxItem>
+					))}
+				</ListBox>
+			</Popover>
+		</Select>
+	);
+}
+
+/** Algorithm-gated tuning knobs for the active producer. Array knobs (ratios/tones) land later. */
+export function ColorKnobsControls({
+	algorithm,
+	knobs,
+	steps,
+	onChange,
+}: {
+	algorithm: AlgorithmId;
+	knobs: ColorKnobs;
+	steps: string[];
+	onChange: SetKnob;
+}) {
+	if (algorithm === "oklch" || algorithm === "tailwind") {
+		return (
+			<div className="flex flex-col gap-3">
+				{OKLCH_SLIDERS.map((def) => (
+					<KnobSlider
+						key={def.key}
+						label={def.label}
+						value={knobs[def.key] ?? def.fallback}
+						minValue={def.minValue}
+						maxValue={def.maxValue}
+						step={def.step}
+						onChange={(value) => onChange(def.key, value)}
+					/>
+				))}
+				<KnobSelect
+					label="Chroma mode"
+					value={knobs.chromaMode ?? "consistent"}
+					options={[
+						{ id: "consistent", label: "Consistent" },
+						{ id: "max", label: "Vivid (gamut cusp)" },
+					]}
+					onChange={(value) => onChange("chromaMode", value as "consistent" | "max")}
+				/>
+				<KnobSelect
+					label="Pin seed lightness at"
+					value={knobs.preserveSeedAt ?? PRESERVE_OFF}
+					options={[{ id: PRESERVE_OFF, label: "Off (array-driven)" }, ...steps.map((s) => ({ id: s, label: s }))]}
+					onChange={(value) => onChange("preserveSeedAt", value === PRESERVE_OFF ? undefined : value)}
+				/>
+			</div>
+		);
+	}
+
+	if (algorithm === "contrast") {
+		return (
+			<div className="flex flex-col gap-3">
+				<KnobSelect
+					label="Contrast formula"
+					value={knobs.formula ?? "wcag2"}
+					options={[
+						{ id: "wcag2", label: "WCAG 2" },
+						{ id: "apca", label: "APCA" },
+					]}
+					onChange={(value) => onChange("formula", value as "wcag2" | "apca")}
+				/>
+				<KnobSlider
+					label="Saturation"
+					value={knobs.saturation ?? 100}
+					minValue={0}
+					maxValue={100}
+					step={1}
+					onChange={(value) => onChange("saturation", value)}
+				/>
+			</div>
+		);
+	}
+
+	// material: a per-step tone-array editor lands in a later pass.
+	return null;
+}

--- a/www/src/modules/create/colors-config.tsx
+++ b/www/src/modules/create/colors-config.tsx
@@ -17,6 +17,7 @@ import { Select, SelectValue } from "@/registry/ui/select";
 
 import type { AlgorithmId, PaletteSeeds } from "@/registry/theme";
 
+import { ColorKnobsControls } from "./color-knobs";
 import { useDesignSystem } from "./preset";
 
 const ALGORITHMS: ReadonlyArray<{ id: AlgorithmId; label: string }> = [
@@ -32,17 +33,46 @@ const SEED_FIELDS: ReadonlyArray<{ label: string; key: keyof PaletteSeeds }> = [
 	{ label: "Success", key: "success" },
 	{ label: "Warning", key: "warning" },
 	{ label: "Danger", key: "danger" },
+	{ label: "Info", key: "info" },
 ];
 
+/** Collapsed-card summary of the live color recipe (replaces the old hardcoded mock). */
+export function ColorsSummary() {
+	const { designSystem } = useDesignSystem();
+	const config = designSystem.color ?? DEFAULT_COLOR_CONFIG;
+	const algorithmLabel = ALGORITHMS.find((a) => a.id === config.algorithm)?.label ?? config.algorithm;
+	const rows = [
+		{ name: "Base color", value: config.seeds.neutral },
+		{ name: "Accent", value: config.seeds.accent },
+	];
+	return (
+		<div className="flex flex-col gap-1.5">
+			{rows.map((row) => (
+				<div key={row.name} className="flex items-center justify-between">
+					<div className="flex min-w-0 flex-col items-start gap-1">
+						<span className="text-[10px] tracking-widest text-fg-muted uppercase">{row.name}</span>
+						<p className="truncate font-medium">{row.value}</p>
+					</div>
+					<div className="size-7 shrink-0 rounded-md border" style={{ backgroundColor: row.value }} />
+				</div>
+			))}
+			<div className="flex items-center justify-between">
+				<span className="text-[10px] tracking-widest text-fg-muted uppercase">Algorithm</span>
+				<p className="font-medium">{algorithmLabel}</p>
+			</div>
+		</div>
+	);
+}
+
 export function ColorsConfig() {
-	const { designSystem, setColorSeed, setColorAlgorithm } = useDesignSystem();
+	const { designSystem, setColorSeed, setColorAlgorithm, setColorKnob } = useDesignSystem();
 	const config = designSystem.color ?? DEFAULT_COLOR_CONFIG;
 	const seeds = config.seeds;
 	const resolved = useMemo(() => resolveColorConfig(config), [config]);
 
 	return (
 		<div className="-mt-6 flex flex-col gap-4">
-			<p className="text-xs text-fg-muted">Pick brand + status seeds — the ramps regenerate live.</p>
+			<p className="text-xs text-fg-muted">Pick seeds, switch the algorithm, and fine-tune — ramps regenerate live.</p>
 
 			<Select
 				className="w-full"
@@ -91,6 +121,13 @@ export function ColorsConfig() {
 					</ColorPicker>
 				))}
 			</div>
+
+			<ColorKnobsControls
+				algorithm={config.algorithm}
+				knobs={config.knobs ?? {}}
+				steps={resolved.steps}
+				onChange={setColorKnob}
+			/>
 
 			<div className="flex flex-col gap-1.5">
 				<span className="pl-1 text-xs font-medium text-fg-muted">Generated ramps</span>

--- a/www/src/modules/create/customizer-panel.tsx
+++ b/www/src/modules/create/customizer-panel.tsx
@@ -24,7 +24,7 @@ import { Popover } from "@/registry/ui/popover";
 import { SearchField } from "@/registry/ui/search-field";
 import { Select, SelectValue } from "@/registry/ui/select";
 
-import { ColorsConfig } from "./colors-config";
+import { ColorsConfig, ColorsSummary } from "./colors-config";
 import {
 	AllComponentsView,
 	ComponentDetailView,
@@ -69,30 +69,7 @@ const menu: MenuItem[] = [
 	{
 		id: "colors",
 		title: "Colors",
-		preview: (
-			<div className="flex flex-col gap-1.5">
-				{[
-					{
-						name: "Base color",
-						value: "neutral",
-						className: "bg-neutral",
-					},
-					{
-						name: "Theme",
-						value: "blue",
-						className: "bg-blue-500",
-					},
-				].map((item) => (
-					<div key={item.name} className="flex items-center justify-between">
-						<div className="flex flex-col items-start gap-1">
-							<span className="text-[10px] tracking-widest text-fg-muted uppercase">{item.name}</span>
-							<p className="font-medium">{item.value}</p>
-						</div>
-						<div className={`size-7 rounded-md border ${item.className}`} />
-					</div>
-				))}
-			</div>
-		),
+		preview: <ColorsSummary />,
 		config: <ColorsConfig />,
 	},
 	{

--- a/www/src/modules/create/preset/codec.spec.ts
+++ b/www/src/modules/create/preset/codec.spec.ts
@@ -32,4 +32,11 @@ describe("preset codec — color recipe", () => {
 		expect(() => decodePreset(encoded ?? "")).not.toThrow();
 		expect(decodePreset(encoded ?? "").color).toBeUndefined();
 	});
+
+	it("round-trips a config with per-producer knobs", () => {
+		const custom = { ...DEFAULT_COLOR_CONFIG, knobs: { hueTorsion: 30, chromaMode: "max" as const } };
+		const encoded = encodePreset({ ...DEFAULTS, color: custom });
+		expect(encoded).toBeTypeOf("string");
+		expect(decodePreset(encoded ?? "").color).toEqual(custom);
+	});
 });

--- a/www/src/modules/create/preset/use-design-system.ts
+++ b/www/src/modules/create/preset/use-design-system.ts
@@ -6,7 +6,7 @@ import { getRouteApi } from "@tanstack/react-router";
 
 import { DEFAULT_COLOR_CONFIG } from "@/registry/theme";
 
-import type { AlgorithmId, PaletteSeeds } from "@/registry/theme";
+import type { AlgorithmId, ColorKnobs, PaletteSeeds } from "@/registry/theme";
 
 import { decodePreset, encodePreset } from "./codec";
 import { DEFAULTS } from "./defaults";
@@ -88,6 +88,17 @@ export function useDesignSystem() {
 		[setDesignSystem],
 	);
 
+	/** Set one per-producer tuning knob of the color recipe. */
+	const setColorKnob = useCallback(
+		<K extends keyof ColorKnobs>(key: K, value: ColorKnobs[K]) => {
+			setDesignSystem((prev) => {
+				const base = prev.color ?? DEFAULT_COLOR_CONFIG;
+				return { ...prev, color: { ...base, knobs: { ...base.knobs, [key]: value } } };
+			});
+		},
+		[setDesignSystem],
+	);
+
 	return {
 		designSystem,
 		setDesignSystem,
@@ -96,5 +107,6 @@ export function useDesignSystem() {
 		setDensity,
 		setColorSeed,
 		setColorAlgorithm,
+		setColorKnob,
 	};
 }

--- a/www/src/registry/theme/color-config.ts
+++ b/www/src/registry/theme/color-config.ts
@@ -28,11 +28,40 @@ export interface PaletteSeeds {
 	info?: string;
 }
 
+/**
+ * Per-producer tuning knobs, all optional. `resolveColorConfig` spreads them into the
+ * kernel's `createTheme`; each producer's schema keeps only the knobs it understands.
+ * Kept ABSENT from {@link DEFAULT_COLOR_CONFIG} so an untouched palette still encodes to
+ * `undefined` (the codec diffs the whole recipe against the default).
+ */
+export interface ColorKnobs {
+	/** oklch / tailwind: multiplier on the seed's chroma (1 = the seed's own chroma). */
+	chromaMult?: number;
+	/** oklch / tailwind: peak-chroma floor so muted seeds still yield a usable accent. */
+	minChroma?: number;
+	/** oklch / tailwind: degrees of hue drift toward the dark end (0 = constant hue). */
+	hueTorsion?: number;
+	/** oklch / tailwind: envelope-tapered (default) or pushed to the gamut cusp (vivid). */
+	chromaMode?: "consistent" | "max";
+	/** oklch / tailwind: pin the exact seed lightness at this step. */
+	preserveSeedAt?: string;
+	/** contrast: WCAG 2 or APCA contrast targeting. */
+	formula?: "wcag2" | "apca";
+	/** contrast: chroma expressed as 0–100 saturation (the kernel maps it to chroma). */
+	saturation?: number;
+	/** contrast: per-step target contrast ratios. */
+	ratios?: number[];
+	/** material: per-step tones (0–100). */
+	tones?: number[];
+}
+
 export interface ColorConfig {
 	algorithm: AlgorithmId;
 	/** Scale step names; defaults to the kernel's `50`..`950`. */
 	steps?: string[];
 	seeds: PaletteSeeds;
+	/** Optional per-producer tuning; absent for the default palette. */
+	knobs?: ColorKnobs;
 }
 
 /**

--- a/www/src/registry/theme/index.ts
+++ b/www/src/registry/theme/index.ts
@@ -13,6 +13,7 @@ export { emitCss, type EmitCssOptions, resolveTarget } from "./emit-css";
 export {
 	type AlgorithmId,
 	type ColorConfig,
+	type ColorKnobs,
 	DEFAULT_COLOR_CONFIG,
 	GENERATIVE_ALGORITHMS,
 	type PaletteSeeds,

--- a/www/src/registry/theme/primitives.spec.ts
+++ b/www/src/registry/theme/primitives.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { toOklch } from "@dotui/colors";
+
 import { DEFAULT_COLOR_CONFIG, type ColorConfig } from "./color-config";
 import { emitPrimitivesCss, resolveColorConfig } from "./primitives";
 
@@ -46,6 +48,21 @@ describe("resolveColorConfig", () => {
 	it("rejects a non-generative algorithm with a clear error (seeds are not ramps)", () => {
 		const bad = { algorithm: "fixed", seeds: DEFAULT_COLOR_CONFIG.seeds } as unknown as ColorConfig;
 		expect(() => resolveColorConfig(bad)).toThrow(/generative/);
+	});
+
+	it("forwards per-producer knobs to the kernel (hueTorsion shifts hue, chromaMult scales chroma)", () => {
+		const seeds = DEFAULT_COLOR_CONFIG.seeds;
+		const accentAt = (config: ColorConfig, step: string) => {
+			const value = resolveColorConfig(config).light.accent?.[step];
+			expect(value).toBeDefined();
+			return toOklch(value ?? "oklch(0 0 0)");
+		};
+		// the blue accent's dark end drifts toward the violet anchor under torsion
+		const torsionedHue = accentAt({ algorithm: "oklch", seeds, knobs: { hueTorsion: 40 } }, "950").h;
+		expect(torsionedHue).not.toBeCloseTo(accentAt({ algorithm: "oklch", seeds }, "950").h, 0);
+		// chromaMult 0 drops accent chroma to the minChroma floor (below the seed-driven default)
+		const mutedChroma = accentAt({ algorithm: "oklch", seeds, knobs: { chromaMult: 0 } }, "500").c;
+		expect(mutedChroma).toBeLessThan(accentAt({ algorithm: "oklch", seeds }, "500").c);
 	});
 });
 

--- a/www/src/registry/theme/primitives.ts
+++ b/www/src/registry/theme/primitives.ts
@@ -86,8 +86,9 @@ export function resolveColorConfig(config: ColorConfig): ResolvedPalettes {
 	}
 
 	// algorithm is a runtime-validated discriminant the kernel's zod schema checks. The object
-	// targets the kernel's `BaseThemeOptions` view, so no cast is needed.
-	const theme = createTheme({ algorithm, palettes, steps, modes: { light: true } });
+	// targets the kernel's `BaseThemeOptions` view (no cast); knobs are forwarded verbatim and
+	// each producer's schema keeps only the ones it understands.
+	const theme = createTheme({ algorithm, palettes, steps, modes: { light: true }, ...config.knobs });
 
 	const lightMode = theme.light;
 	if (!lightMode) throw new Error("resolveColorConfig: kernel produced no `light` mode");


### PR DESCRIPTION
Makes **every generative parameter tweakable** in `/create` (the "all tweaks via UI" goal), and fixes the last two UI gaps the audit flagged (missing Info seed, hardcoded summary).

## Changes
- **Model**: `ColorConfig` gains an optional `knobs` bag — `chromaMult`, `minChroma`, `hueTorsion`, `chromaMode`, `preserveSeedAt` (oklch/tailwind); `formula`, `saturation`, `ratios` (contrast); `tones` (material). **Absent** from `DEFAULT_COLOR_CONFIG`, so an untouched palette still encodes to `undefined`. `resolveColorConfig` spreads it into the kernel; each producer's zod schema keeps only the knobs it understands (PR-B's `BaseThemeOptions` makes this typed + cast-free).
- **Setter**: `setColorKnob` in `use-design-system` (mirrors `setColorSeed`).
- **UI** (`color-knobs.tsx`, new): algorithm-gated controls — oklch/tailwind → Chroma / Min-chroma / Hue-shift sliders + Chroma-mode + Pin-seed-lightness selects; contrast → formula + saturation. (Array editors for `ratios`/`tones` land in the niche-knobs PR.)
- **Info seed**: added to the seed grid (the 6th palette was generated + shown but not editable).
- **Live summary**: the collapsed Colors card now reads the real recipe (base / accent / algorithm) instead of the hardcoded `neutral` / `blue` mock.

## Verification
- New tests: knob threading (`hueTorsion` shifts the dark-end hue, `chromaMult: 0` drops chroma to the floor) + codec knob round-trip. `tsc` + **146 vitest** + oxlint/oxfmt green; `base/colors.css` unchanged (knobs absent from the default → **no drift**).
- **In-browser**: the Colors panel renders all 6 pickers + the knob controls + the live summary; a `hueTorsion: 40` preset drives the iframe accent's dark end to the violet anchor (`--accent-950` hue **290** vs `--accent-50` 216). Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)