### PR TITLE
fix(create): preview mode ownership (forcedTheme) + design-system handshake

### DIFF
--- a/www/src/modules/create/preset/iframe-sync.ts
+++ b/www/src/modules/create/preset/iframe-sync.ts
@@ -56,27 +56,30 @@ export function useIframeMessageListener(onMessage: (data: DesignSystem) => void
 }
 
 /**
- * Inside the preview iframe: apply display-mode messages from the customizer by
- * toggling the `.dark` class (the customizer owns the previewed mode, overriding
- * the iframe's own theme state).
+ * Inside the preview iframe: the display mode (light / dark) the customizer has chosen, or
+ * `undefined` when not in an iframe (the main app owns its own theme). Returned so the root
+ * `ThemeProvider` can take it as `forcedTheme` — which deterministically wins over the iframe's
+ * system/storage theme listeners (they no-op while forced), instead of toggling `.dark`
+ * out-of-band where the provider would revert it on the next OS-pref / storage event.
  */
-export function useIframePreviewModeListener() {
+export function usePreviewForcedTheme(): PreviewMode | undefined {
+	const [mode, setMode] = React.useState<PreviewMode | undefined>(undefined);
+
 	React.useEffect(() => {
 		if (!isInIframe()) return;
 
 		const handleMessage = (event: MessageEvent) => {
 			if (event.data?.type === "preview-mode") {
-				const mode: PreviewMode = event.data.mode === "dark" ? "dark" : "light";
-				const root = document.documentElement;
-				root.classList.toggle("dark", mode === "dark");
-				root.style.colorScheme = mode;
+				setMode(event.data.mode === "dark" ? "dark" : "light");
 			}
 		};
 
 		window.addEventListener("message", handleMessage);
-		// Signal readiness so the parent can push the current mode — its load-event
-		// send can race ahead of this listener mounting.
+		// Signal readiness so the parent (re)sends the current mode — its load-event send can
+		// race ahead of this listener mounting.
 		window.parent.postMessage({ type: "preview-ready" }, "*");
 		return () => window.removeEventListener("message", handleMessage);
 	}, []);
+
+	return mode;
 }

--- a/www/src/modules/create/preset/index.ts
+++ b/www/src/modules/create/preset/index.ts
@@ -5,7 +5,7 @@ export {
 	sendPreviewMode,
 	sendToIframe,
 	useIframeMessageListener,
-	useIframePreviewModeListener,
+	usePreviewForcedTheme,
 } from "./iframe-sync";
 export { useDesignSystem } from "./use-design-system";
 export type { Density, DesignSystem, DesignSystemState } from "./types";

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "starter-themes";
 
 import { siteConfig } from "@/config/site";
 import { truncateOnWord } from "@/lib/text";
+import { usePreviewForcedTheme } from "@/modules/create/preset";
 import { ToastProvider } from "@/registry/ui/toast";
 import appCss from "@/styles.css?url";
 
@@ -104,8 +105,11 @@ function FaviconSwitcher() {
 }
 
 function RootComponent() {
+	// In the /create preview iframe, the customizer owns the displayed mode — force it so the
+	// provider's own system / storage listeners can't revert it. `undefined` everywhere else.
+	const forcedTheme = usePreviewForcedTheme();
 	return (
-		<ThemeProvider>
+		<ThemeProvider forcedTheme={forcedTheme}>
 			<FaviconSwitcher />
 			{/* <DrawerProvider> */}
 			<RootDocument>

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -42,7 +42,8 @@ function CreatePage() {
 		// oxlint-disable-next-line react/exhaustive-deps -- keep live preset changes on the postMessage channel to avoid iframe reloads
 	}, [effectivePreview]);
 
-	// Send design system to iframe on changes + iframe load
+	// Send the design system to the iframe on change, on load, and when the iframe signals it's
+	// ready — its message listener can mount after the load event, racing the load-fired send.
 	useEffect(() => {
 		const iframe = iframeRef.current;
 		if (!iframe) return;
@@ -52,7 +53,14 @@ function CreatePage() {
 		if (iframe.contentWindow) send();
 
 		iframe.addEventListener("load", send);
-		return () => iframe.removeEventListener("load", send);
+		const onReady = (event: MessageEvent) => {
+			if (event.data?.type === "preview-ready") send();
+		};
+		window.addEventListener("message", onReady);
+		return () => {
+			iframe.removeEventListener("load", send);
+			window.removeEventListener("message", onReady);
+		};
 	}, [designSystem]);
 
 	// Forward the previewed display mode (light / dark) to the iframe — on change,

--- a/www/src/routes/preview/$slug.tsx
+++ b/www/src/routes/preview/$slug.tsx
@@ -5,12 +5,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { DesignSystemProvider } from "@/modules/core/styles";
-import {
-	DEFAULTS,
-	decodePreset,
-	useIframeMessageListener,
-	useIframePreviewModeListener,
-} from "@/modules/create/preset";
+import { DEFAULTS, decodePreset, useIframeMessageListener } from "@/modules/create/preset";
 import { ExamplesIndex, GroupExamplesIndex } from "@/registry/__generated__/examples";
 
 import type { DesignSystem } from "@/modules/create/preset";
@@ -43,7 +38,6 @@ function PreviewPage() {
 	const [designSystem, setDesignSystem] = useState<DesignSystem>(() => (preset ? decodePreset(preset) : DEFAULTS));
 
 	useIframeMessageListener(useCallback((ds: DesignSystem) => setDesignSystem(ds), []));
-	useIframePreviewModeListener();
 
 	const promise = getExamplesPromise(slug);
 


### PR DESCRIPTION
Two preview-pipeline hardening fixes from the audit.

## Mode ownership
The customizer toggled the iframe's `.dark` **out-of-band**, which the root `starter-themes` `ThemeProvider` reverts on the next OS-pref / cross-tab-storage / remount event. Now the preview-mode message drives the root provider's **`forcedTheme`** — `light`/`dark` inside the preview iframe, `undefined` everywhere else. `forcedTheme` makes the provider's own system/storage listeners no-op, so the customizer's choice **wins deterministically** and the main app's theme is untouched (it keeps `forcedTheme={undefined}`). `useIframePreviewModeListener` (classList hack) → `usePreviewForcedTheme` (returns the mode for the root provider).

## Design-system handshake
The parent now also resends the design system on the iframe's `preview-ready` signal (mirroring the mode channel), covering the case where the iframe's message listener mounts after the `load` event.

## Verification
- `tsc` + **146 vitest** + oxlint/oxfmt green.
- **In-browser**: toggling "preview mode" flips the iframe to near-black dark (`--color-bg: oklch(0.13 0 0)`) and **holds** (no revert); toggling back returns to light. Zero console errors.

## Deferred (tracked)
Debouncing the color-picker drag's URL write is a separate **perf** change — it needs an optimistic-state layer in `useDesignSystem` + iframe-resolve throttling (ideally the kernel's colorjs.io→culori hot-path swap). Not a correctness bug: `replace: true` already prevents history spam, and the preview updates live today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)