### PR TITLE
feat(create): contrast readout (surface the verify/ layer)

### DIFF
--- a/www/src/modules/create/color-contrast.spec.ts
+++ b/www/src/modules/create/color-contrast.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_COLOR_CONFIG, resolveColorConfig } from "@/registry/theme";
+
+import { solidContrastReport } from "./color-contrast";
+
+describe("solidContrastReport", () => {
+	it("reports text-on-solid contrast for every palette", () => {
+		const report = solidContrastReport(resolveColorConfig(DEFAULT_COLOR_CONFIG));
+		expect(report.map((r) => r.name).sort()).toEqual(["accent", "danger", "info", "neutral", "success", "warning"]);
+	});
+
+	it("the default palette's solid surfaces all clear WCAG AA (auto-foreground picks the readable pole)", () => {
+		const report = solidContrastReport(resolveColorConfig(DEFAULT_COLOR_CONFIG));
+		expect(report.every((r) => r.meets)).toBe(true);
+		expect(report.every((r) => r.ratio >= 4.5)).toBe(true);
+		expect(report.every((r) => r.level !== "fail")).toBe(true);
+	});
+});

--- a/www/src/modules/create/color-contrast.tsx
+++ b/www/src/modules/create/color-contrast.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { onBlackWhite, type PairingResult, verify } from "@dotui/colors";
+
+import { PALETTE_ORDER, type ResolvedPalettes } from "@/registry/theme";
+
+/** The solid surface every palette's filled components sit on (buttons, badges, …). */
+const SOLID_STEP = "500";
+
+/**
+ * WCAG report for the auto-foreground text on each palette's solid (500) surface — the
+ * pairing dotUI actually ships (`onBlackWhite` mirrors the autocontrast plugin). Surfaces the
+ * kernel's `verify/` layer so a custom palette's accessibility is visible, not blind.
+ */
+export function solidContrastReport(resolved: ResolvedPalettes): PairingResult[] {
+	const pairings = PALETTE_ORDER.flatMap((name) => {
+		const bg = resolved.light[name]?.[SOLID_STEP];
+		return bg ? [{ name, fg: onBlackWhite(bg), bg }] : [];
+	});
+	return verify(pairings, { suggestFix: false }).results;
+}
+
+function LevelBadge({ level }: { level: PairingResult["level"] }) {
+	if (level === "fail") {
+		return <span className="rounded bg-danger px-1.5 py-0.5 text-[10px] font-medium text-fg-on-danger">Fail</span>;
+	}
+	return <span className="rounded bg-neutral-100 px-1.5 py-0.5 text-[10px] font-medium text-fg-muted">{level}</span>;
+}
+
+/** Per-palette readout: text-on-solid contrast ratio + WCAG level (AA / AAA / Fail). */
+export function ContrastReadout({ resolved }: { resolved: ResolvedPalettes }) {
+	const results = solidContrastReport(resolved);
+	if (results.length === 0) return null;
+
+	return (
+		<div className="flex flex-col gap-1.5">
+			<span className="pl-1 text-xs font-medium text-fg-muted">Contrast — text on solid surface</span>
+			<div className="flex flex-col gap-1">
+				{results.map((r) => (
+					<div key={r.name} className="flex items-center gap-2 text-xs">
+						<span
+							className="flex size-5 shrink-0 items-center justify-center rounded text-[10px] font-semibold"
+							style={{ backgroundColor: r.bg, color: r.fg }}
+						>
+							Aa
+						</span>
+						<span className="flex-1 capitalize">{r.name}</span>
+						<span className="text-fg-muted tabular-nums">{r.ratio.toFixed(1)}:1</span>
+						<LevelBadge level={r.level} />
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/www/src/modules/create/colors-config.tsx
+++ b/www/src/modules/create/colors-config.tsx
@@ -17,6 +17,7 @@ import { Select, SelectValue } from "@/registry/ui/select";
 
 import type { AlgorithmId, PaletteSeeds } from "@/registry/theme";
 
+import { ContrastReadout } from "./color-contrast";
 import { ColorKnobsControls } from "./color-knobs";
 import { useDesignSystem } from "./preset";
 
@@ -128,6 +129,8 @@ export function ColorsConfig() {
 				steps={resolved.steps}
 				onChange={setColorKnob}
 			/>
+
+			<ContrastReadout resolved={resolved} />
 
 			<div className="flex flex-col gap-1.5">
 				<span className="pl-1 text-xs font-medium text-fg-muted">Generated ramps</span>


### PR DESCRIPTION
Surfaces `@dotui/colors`' previously-unused `verify/` layer in the customizer — the "feedback half" of full customization.

## What
A compact **"text on solid surface"** readout: per palette, the WCAG contrast ratio + level (**AA / AAA / Fail**) of the auto-foreground (`onBlackWhite` — exactly what ships) on the `500` step, with a small `Aa` swatch demoing the fg-on-bg pairing. So a custom palette's accessibility is visible, not blind.

- New `color-contrast.tsx`: `solidContrastReport(resolved)` (builds pairings → `verify()`) + `ContrastReadout`.
- Rendered in `colors-config` below the knob controls; recomputes live with the palette.

## Verification
- Test: every palette's solid pairing clears AA for the default config. `tsc` + **148 vitest** + oxlint/oxfmt green.
- **In-browser**: readout shows neutral 5.9:1 AA · accent 6.5:1 AA · success 7.0:1 AAA · warning 6.4:1 AA · danger 5.8:1 AA · info 6.3:1 AA. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)