### PR TITLE
refactor: color-system dead-code sweep

### DIFF
--- a/www/src/modules/create/customizer-panel.tsx
+++ b/www/src/modules/create/customizer-panel.tsx
@@ -133,7 +133,6 @@ const menu: MenuItem[] = [
 ];
 
 export const MENU_IDS = new Set(menu.map((m) => m.id));
-const menuIds = MENU_IDS;
 
 /* -------------------------------- Panel -------------------------------- */
 
@@ -259,7 +258,7 @@ export function CustomizerPanel({
 		}
 
 		// Component detail view (non-menu id)
-		if (!menuIds.has(id)) {
+		if (!MENU_IDS.has(id)) {
 			return (
 				<>
 					<ViewHeader title={getComponentDisplayName(id)} onBack={pop} />
@@ -351,12 +350,6 @@ export function CustomizerPanel({
 								</div>
 							</ButtonPrimitives.Button>
 						))}
-
-						{/* Grouped components — shared style across visually related components */}
-						{/* <div className="mt-2 flex flex-col gap-2">
-							<div className="px-1 text-[10px] text-fg-muted uppercase tracking-widest">Grouped components</div>
-							<GroupedComponentsView onSelect={(group) => push(group)} />
-						</div> */}
 
 						{/* All components directly accessible from home */}
 						<div className="mt-2 flex flex-col gap-2">

--- a/www/src/publisher/emit-theme.ts
+++ b/www/src/publisher/emit-theme.ts
@@ -38,11 +38,6 @@ const DEFAULT_DEPENDENCIES = [
 	"tailwindcss-autocontrast",
 ];
 
-// shadcn's `utils` (the `cn` helper) lives in a 4xx-gated path on the default
-// registry under v4 Tailwind, so we ship our own copy inside this item's
-// `files[]` instead of declaring it as a `registryDependencies` entry.
-const DEFAULT_REGISTRY_DEPENDENCIES: string[] = [];
-
 const CN_UTILS_TS = `import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
@@ -113,7 +108,9 @@ export function emitInitItem(input: EmitThemeInput): RegistryItem {
 		type: "registry:base",
 		extends: "none",
 		dependencies: DEFAULT_DEPENDENCIES,
-		registryDependencies: DEFAULT_REGISTRY_DEPENDENCIES,
+		// shadcn's `cn` utils sit in a 4xx-gated path under v4 Tailwind, so we ship our own copy
+		// in `files[]` rather than declaring a registry dependency.
+		registryDependencies: [],
 		...(css ? { css } : {}),
 		...(cssVars ? { cssVars } : {}),
 		files: [


### PR DESCRIPTION
Final cleanliness pass on the color-system stack. **No behavior change.**

- **customizer-panel**: drop the redundant `menuIds = MENU_IDS` alias (use `MENU_IDS` directly at the one call site); remove the commented-out `GroupedComponentsView` block.
- **emit-theme**: inline the `DEFAULT_REGISTRY_DEPENDENCIES = []` indirection, moving its explanatory comment to the sole use site.

(The earlier audit's larger cleanliness items — palette-order/seed duplication, the kernel `as unknown as` casts, the hardcoded summary, the hand-maintained knob list — were already resolved in PRs A/B/D. `ResolvedPalettes.steps`, flagged as dead, is now used by the "pin seed lightness" knob, so it stays.)

`tsc` + **148 vitest** + oxlint/oxfmt green.

### Deferred by design
The remaining model knobs — contrast `ratios`, material `tones` (per-step number arrays) and scale `steps` (count) — are **model-supported and preset-shareable** but have no dedicated UI control: a per-step array editor is niche + clunky, and changing `steps` labels is semantically load-bearing (would dangle `DEFAULT_SEMANTICS` refs). Left out of the customizer to keep it clean; revisit if there's demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)