### PR TITLE
fix(create): functional seed editors + algorithm test locks + final-review cleanups

### DIFF
--- a/www/src/modules/create/colors-config.tsx
+++ b/www/src/modules/create/colors-config.tsx
@@ -6,11 +6,14 @@ import { ChevronDownIcon } from "lucide-react";
 
 import { DEFAULT_COLOR_CONFIG, PALETTE_ORDER, resolveColorConfig } from "@/registry/theme";
 import { Button } from "@/registry/ui/button";
-import { ColorEditor } from "@/registry/ui/color-editor";
+import { ColorArea } from "@/registry/ui/color-area";
+import { ColorField } from "@/registry/ui/color-field";
 import { ColorPicker } from "@/registry/ui/color-picker";
+import { ColorSlider } from "@/registry/ui/color-slider";
 import { ColorSwatch } from "@/registry/ui/color-swatch";
 import { DialogContent } from "@/registry/ui/dialog";
 import { Label } from "@/registry/ui/field";
+import { Input } from "@/registry/ui/input";
 import { ListBox, ListBoxItem } from "@/registry/ui/list-box";
 import { Popover } from "@/registry/ui/popover";
 import { Select, SelectValue } from "@/registry/ui/select";
@@ -113,8 +116,17 @@ export function ColorsConfig() {
 									</Button>
 								</div>
 								<Popover>
-									<DialogContent>
-										<ColorEditor />
+									<DialogContent className="flex flex-col gap-2">
+										{/* Raw primitives so they consume THIS ColorPicker's context. ColorEditor
+										    wraps its own ColorPickerPrimitives.ColorPicker (defaultValue "#6366F1"),
+										    which would shadow the outer value/onChange and make the seed uneditable. */}
+										<div className="flex gap-2">
+											<ColorArea colorSpace="hsb" xChannel="saturation" yChannel="brightness" />
+											<ColorSlider orientation="vertical" colorSpace="hsb" channel="hue" />
+										</div>
+										<ColorField aria-label="Hex" className="w-full">
+											<Input size="sm" className="w-full" />
+										</ColorField>
 									</DialogContent>
 								</Popover>
 							</>

--- a/www/src/modules/create/customizer-panel.tsx
+++ b/www/src/modules/create/customizer-panel.tsx
@@ -285,7 +285,7 @@ export function CustomizerPanel({
 	}
 
 	return (
-		<div className="relative flex w-72 flex-col rounded-xl border bg-card">
+		<div className="relative flex w-72 shrink-0 flex-col rounded-xl border bg-card">
 			{/* Header */}
 			<div className="relative overflow-hidden border-b p-2">
 				<div className="flex w-full items-center gap-2">

--- a/www/src/modules/create/preset/types.ts
+++ b/www/src/modules/create/preset/types.ts
@@ -31,14 +31,6 @@ export type DesignSystem = {
 	color?: ColorConfig;
 };
 
-export function toCompact(ds: DesignSystem): DesignSystemState {
-	const state: DesignSystemState = {};
-	if (Object.keys(ds.componentParams).length > 0) state.p = ds.componentParams;
-	if (Object.keys(ds.tokens).length > 0) state.t = ds.tokens;
-	if (ds.color) state.c = ds.color;
-	return state;
-}
-
 export function fromCompact(state: DesignSystemState): DesignSystem {
 	return {
 		componentParams: state.p ?? {},

--- a/www/src/registry/theme/primitives.spec.ts
+++ b/www/src/registry/theme/primitives.spec.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { toOklch } from "@dotui/colors";
+import { onBlackWhite, toOklch, wcag2 } from "@dotui/colors";
 
-import { DEFAULT_COLOR_CONFIG, type ColorConfig } from "./color-config";
+import { type ColorConfig, DEFAULT_COLOR_CONFIG, GENERATIVE_ALGORITHMS } from "./color-config";
 import { emitPrimitivesCss, resolveColorConfig } from "./primitives";
+
+const PALETTES = ["neutral", "accent", "success", "warning", "danger", "info"] as const;
 
 describe("resolveColorConfig", () => {
 	const resolved = resolveColorConfig(DEFAULT_COLOR_CONFIG);
@@ -63,6 +65,64 @@ describe("resolveColorConfig", () => {
 		// chromaMult 0 drops accent chroma to the minChroma floor (below the seed-driven default)
 		const mutedChroma = accentAt({ algorithm: "oklch", seeds, knobs: { chromaMult: 0 } }, "500").c;
 		expect(mutedChroma).toBeLessThan(accentAt({ algorithm: "oklch", seeds }, "500").c);
+	});
+});
+
+// Lock the dotUI wrapper (primary→accent rename, neutral stretch, dark-by-reversal) for EVERY
+// UI-exposed producer — the kernel's own sweep doesn't cover this seam, and producers diverge.
+describe.each(GENERATIVE_ALGORITHMS)("resolveColorConfig — %s producer through the wrapper", (algorithm) => {
+	const resolved = resolveColorConfig({ ...DEFAULT_COLOR_CONFIG, algorithm });
+
+	it("produces all six palettes (primary renamed to accent)", () => {
+		expect(Object.keys(resolved.light).sort()).toEqual(["accent", "danger", "info", "neutral", "success", "warning"]);
+		expect(resolved.light).not.toHaveProperty("primary");
+	});
+
+	it("emits 11 oklch() steps per ramp in both modes", () => {
+		for (const mode of [resolved.light, resolved.dark]) {
+			for (const palette of PALETTES) {
+				const ramp = mode[palette];
+				expect(ramp).toBeDefined();
+				expect(Object.keys(ramp ?? {})).toHaveLength(11);
+				for (const value of Object.values(ramp ?? {})) expect(value).toMatch(/^oklch\(/);
+			}
+		}
+	});
+
+	it("derives dark as the reversed light ladder (50 ↔ 950)", () => {
+		for (const palette of PALETTES) {
+			expect(resolved.dark[palette]?.["50"]).toBe(resolved.light[palette]?.["950"]);
+			expect(resolved.dark[palette]?.["950"]).toBe(resolved.light[palette]?.["50"]);
+		}
+	});
+
+	it("keeps the neutral backbone monotonically descending in lightness (post-stretch)", () => {
+		const ls = Object.values(resolved.light.neutral ?? {}).map((v) => toOklch(v).l);
+		expect(ls).toEqual([...ls].sort((a, b) => b - a));
+	});
+
+	it("every step's auto-foreground clears WCAG AA in both modes", () => {
+		for (const mode of [resolved.light, resolved.dark]) {
+			for (const palette of PALETTES) {
+				for (const value of Object.values(mode[palette] ?? {})) {
+					expect(wcag2(onBlackWhite(value), value)).toBeGreaterThanOrEqual(4.5);
+				}
+			}
+		}
+	});
+});
+
+describe("resolveColorConfig — neutral lightness stretch (near-white → near-black surfaces)", () => {
+	const { light, dark } = resolveColorConfig(DEFAULT_COLOR_CONFIG);
+	const neutralLs = Object.values(light.neutral ?? {}).map((v) => toOklch(v).l);
+
+	it("stretches the neutral backbone to the configured 0.13 … 0.985 span", () => {
+		expect(Math.min(...neutralLs)).toBeCloseTo(0.13, 2);
+		expect(Math.max(...neutralLs)).toBeCloseTo(0.985, 2);
+	});
+
+	it("makes the dark surface (reversed neutral-50) near-black", () => {
+		expect(toOklch(dark.neutral?.["50"] ?? "oklch(1 0 0)").l).toBeLessThan(0.16);
 	});
 });
 

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -92,7 +92,7 @@ function CreatePage() {
 				key={effectivePreview}
 				src={iframeSrc}
 				title="preview"
-				className="flex-1 rounded-xl border"
+				className="min-w-0 flex-1 rounded-xl border"
 			/>
 		</div>
 	);


### PR DESCRIPTION
Addresses the final adversarial review's verdict (it found one real **high-severity** bug + two test-coverage gaps the 7-PR program had missed).

## 🔴 Seed color editors were non-functional (headline fix)
Each seed-picker Popover rendered `<ColorEditor/>`, which nests its **own** `ColorPicker` (`defaultValue="#6366F1"`) — shadowing the customizer's controlled context. So opening a seed showed the wrong color and **edits were a silent no-op** (`setColorSeed` never fired → no ramp regen, no URL write). My earlier seed verification used URL presets, which bypass the editor, so this slipped through.

**Fix:** replace `<ColorEditor/>` with raw `ColorArea`/`ColorSlider`/`ColorField` that consume the surrounding `ColorPicker` context (the reference `color-picker/demos/basic.tsx` pattern). Verified live: the hex binds to the seed, and editing regenerates the ramp + writes the preset.

## Test locks (the review's other must-fixes)
- **All 4 generative algorithms through `resolveColorConfig`** (`primitives.spec.ts`): a `describe.each(GENERATIVE_ALGORITHMS)` asserting the 6-palette shape, `dark = reversed-light`, post-stretch neutral monotonicity, and the `on-*` AA floor — the wrapper seam (rename/stretch/reverse) was only oklch-tested though producers diverge.
- **Neutral stretch poles** `0.13 / 0.985` + near-black dark surface — the most visible output (near-black dark) had no committed assertion (the achromatic regex passes for any lightness).

## Cleanups
- Delete dead/stale `toCompact` (zero callers; it dropped `density` and didn't diff defaults).
- Fix `/create` horizontal overflow below ~480px (`min-w-0` on the iframe + `shrink-0` on the panel).

## Verification
`tsc` + **170 vitest** (+22) + oxlint/oxfmt green. Seed-editor fix verified live (real-click Puppeteer): hex binds to the seed, hue drag regenerates `--accent-500` and writes `?preset`.

> Broader root cause (separate, pre-existing): `ColorEditor` always nesting its own `ColorPicker` also breaks the public color-picker demos (controlled/uncontrolled/playground + docs), which all render `#6366F1`. Tracked separately — the proper remedy is making `ColorEditor` consume an existing `ColorPickerStateContext` when present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)