### PR TITLE
fix(www): eliminate hero font flicker on load

### DIFF
--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -4,6 +4,13 @@ import { useEffect } from "react";
 
 import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
 
+// Above-the-fold fonts: Geist (hero/body) and Josefin (header logo). Imported as
+// URLs so we can <link rel="preload"> them — the browser fetches them in parallel
+// with the HTML/CSS instead of only discovering them after the CSS is parsed, so
+// they're ready by first paint and there's no flash of fallback text. Vite emits
+// the same hashed asset the @fontsource CSS references, so this is not a 2nd fetch.
+import geistFontUrl from "@fontsource-variable/geist/files/geist-latin-wght-normal.woff2?url";
+import josefinFontUrl from "@fontsource-variable/josefin-sans/files/josefin-sans-latin-wght-normal.woff2?url";
 // import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { ThemeProvider } from "starter-themes";
 
@@ -40,6 +47,12 @@ export const Route = createRootRoute({
 				{ name: "twitter:creator", content: siteConfig.twitter.creator },
 			],
 			links: [
+				// Preload above-the-fold fonts so they're fetched in parallel with the
+				// document (not discovered late, after CSS parse). `crossorigin` is
+				// required even same-origin — fonts fetch in CORS mode, and without it
+				// the preload wouldn't match the actual request, causing a double fetch.
+				{ rel: "preload", href: geistFontUrl, as: "font", type: "font/woff2", crossOrigin: "anonymous" },
+				{ rel: "preload", href: josefinFontUrl, as: "font", type: "font/woff2", crossOrigin: "anonymous" },
 				{ rel: "stylesheet", href: appCss },
 				// The SVG favicon is injected by <FaviconSwitcher /> and kept in sync
 				// with the system color scheme. These PNG/ICO entries are the fallback

--- a/www/src/styles.css
+++ b/www/src/styles.css
@@ -6,10 +6,41 @@
 
 @source "./registry/**/*.{ts,tsx}";
 
+/*
+ * Metric-adjusted fallback fonts.
+ *
+ * The web fonts load with `font-display: swap`, so before they arrive the
+ * browser paints with a fallback. Without metric adjustment that fallback has
+ * a different x-height / advance width than the real font, so the swap visibly
+ * reflows the text (worst on large headings) — the "font flicker" on load.
+ *
+ * These faces re-shape local Arial to match each web font's metrics so the
+ * pre-swap layout is identical and the swap is imperceptible (zero CLS). This
+ * is the same technique next/font uses; the override values were generated with
+ * Capsize (@capsizecss/core `createFontStack`) from the latin .woff2 files.
+ * Regenerate them if the font files change.
+ */
+@font-face {
+	font-family: "Geist Variable Fallback";
+	src: local("Arial"), local("ArialMT");
+	ascent-override: 95.9379%;
+	descent-override: 28.1609%;
+	line-gap-override: 0%;
+	size-adjust: 104.7553%;
+}
+@font-face {
+	font-family: "Josefin Sans Variable Fallback";
+	src: local("Arial"), local("ArialMT");
+	ascent-override: 81.1531%;
+	descent-override: 27.051%;
+	line-gap-override: 0%;
+	size-adjust: 92.418%;
+}
+
 @theme {
-	--font-sans: "Geist Variable", ui-sans-serif, system-ui, sans-serif;
+	--font-sans: "Geist Variable", "Geist Variable Fallback", ui-sans-serif, system-ui, sans-serif;
 	--font-mono: "Geist Mono", ui-monospace, monospace;
-	--font-josefin: "Josefin Sans Variable", ui-sans-serif, system-ui, sans-serif;
+	--font-josefin: "Josefin Sans Variable", "Josefin Sans Variable Fallback", ui-sans-serif, system-ui, sans-serif;
 
 	--breakpoint-xs: 30rem;
 	--breakpoint-3xl: 120rem;


### PR DESCRIPTION
## The flicker

On load the hero headline (and body text) briefly renders in a system font, then **swaps** to Geist once the web font downloads — a visible flash + reflow, worst on the large hero `<h1>`. shadcn doesn't have this because Next's `next/font` does two things automatically that our setup was missing.

## Root cause

Fonts are loaded via `@fontsource` `@import`s in [styles.css](www/src/styles.css) with `font-display: swap` and **no preload**:

1. **Late discovery** — the browser only finds the `.woff2` *after* downloading and parsing the CSS bundle (HTML → CSS → parse → fetch font). So Geist isn't ready at first paint and `swap` shows the fallback first.
2. **No metric-matched fallback** — `--font-sans` fell back to `ui-sans-serif, system-ui`, whose x-height/advance width differ from Geist, so the swap visibly reflowed the text (CLS). Large text = obvious jump.

## The fix (mirrors `next/font`)

**1. Preload above-the-fold fonts** ([__root.tsx](www/src/routes/__root.tsx)) — Geist (hero/body) + Josefin (header logo) latin subsets, imported as `?url` and added to the root `head().links` so they're fetched in parallel with the document. `crossorigin` is set so the preload matches the CORS-mode font fetch (no double download). Vite emits the same hashed asset the `@fontsource` CSS references, so this is not a second request.

**2. Metric-matched fallback faces** ([styles.css](www/src/styles.css)) — `@font-face` rules that reshape local Arial to each web font's exact metrics (`ascent-override`/`descent-override`/`size-adjust`), wired into `--font-sans` and `--font-josefin`. Even before the web font loads, the fallback occupies identical space, so the swap is imperceptible (zero CLS). Override values were generated with **Capsize** (`@capsizecss/core`, the same lib `next/font` uses) from the latin `.woff2` files — no new runtime/build dependency, just static CSS.

Preload alone removes the flicker for most connections; the metric fallback guarantees no visible swap even on slow/cold loads.

## How to test

1. `pnpm --filter www dev`, open the landing page, hard-reload (disable cache / try a throttled profile in DevTools).
2. The hero headline should paint in its final position with no flash or jump.
3. DevTools → Network: `geist-latin-*.woff2` is requested early (Priority: High) with no "preloaded but not used" console warning.

## Notes

- Scoped to the two above-the-fold display faces (Geist + Josefin). Geist **Mono** is intentionally not preloaded — it's below the fold (small label / code) and over-preloading competes for bandwidth with critical resources.
- ⚠️ Unrelated: a full `pnpm build` currently fails on `main`'s working tree because the in-progress date-field/time-field playground rewrite no longer exports `DateFieldPlayground`/`TimeFieldPlayground` (still imported by the `.mdx`). Not touched by this PR — flagging since it'll block deploy until resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)