### PR TITLE
feat(www): self-demoing animated component previews (fake cursor + hover-to-play)

### DIFF
--- a/www/src/modules/docs/components-list/anim/AUTHORING.md
+++ b/www/src/modules/docs/components-list/anim/AUTHORING.md
@@ -1,0 +1,111 @@
+# Authoring animated previews
+
+Each component on the components page gets a **self-demoing** preview: a fake cursor
+loops through a short demo of the component, and **hovering the card pauses the loop,
+hides the cursor, and hands the real component to the user** to play with.
+
+## The contract
+
+Create `anim/demos/<slug>.tsx` (filename === the component slug). It is auto-registered.
+
+```tsx
+"use client";
+
+import { useState } from "react";
+
+import { Checkbox } from "@/registry/ui/checkbox";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [selected, setSelected] = useState(false);
+	return (
+		<AnimatedPreview
+			reset={() => setSelected(false)} // restore the initial state (loop start + tab-away)
+			script={async (s) => {
+				// one iteration of the loop; it runs forever, restarting after each pass
+				await s.wait(500);
+				await s.click("box", () => setSelected(true));
+				await s.wait(1300);
+				await s.click("box", () => setSelected(false));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<span ref={ref("box")}>
+					<Checkbox isSelected={selected} onChange={setSelected}>
+						Subscribe
+					</Checkbox>
+				</span>
+			)}
+		</AnimatedPreview>
+	);
+}
+```
+
+## Hard rules
+
+- **Render the REAL component, controlled** (`value`/`isSelected`/`isOpen`/… + `onChange`).
+  Read `registry/ui/<slug>/base.tsx` and `registry/ui/<slug>/demos/*.tsx` for the exact API.
+- **Drive everything via React state**, never via dispatched events or `el.focus()` — React
+  Aria ignores synthetic events, and real focus across many cards steals focus from the page.
+  The cursor is purely visual.
+- **`reset` must fully restore the initial state.** It is called before every loop and when
+  the user tabs away. The same state is what the user manipulates on hover (via `onChange`).
+- **Default export, `"use client"`, no unused vars** (`noUnusedLocals` is on).
+- Keep it **compact** — cards are ~128–180px tall. Keep labels short, lists to 3–4 items.
+- Keep one loop **snappy: ~3–5s**. End by moving the cursor off and a short pause.
+
+## Driver API (`s`)
+
+- `s.moveTo(target, { anchor?: "center"|"top"|"bottom" })` — move the cursor to a target.
+- `s.click(target, onDown?)` — moveTo + a press; `onDown` fires at the bottom of the press
+  (put the state change here).
+- `s.press(onDown?)` — press at the current spot.
+- `s.hover(target, { dwell?, onEnter?, onLeave? })` — move + dwell (for tooltips / hover states).
+- `s.type(target, text, onText, { perChar?, start? })` — move to a field, then call `onText`
+  with the accumulated string for each character (set the controlled value with it).
+- `s.drag(from, to, onProgress, { steps? })` — press + drag, calling `onProgress(t)` 0→1.
+  For a slider/color thumb, pass the thumb as BOTH `from` and `to` and set the value from `t`;
+  the cursor re-resolves the target each step so it follows the thumb.
+- `s.wait(ms)`, `s.do(fn)`, `s.moveOff()`.
+
+**target** = a ref name (string, registered via `ref("name")`), `{ selector: "input" }`
+(queried within the card), `{ el }`, or `{ x, y }` (coords relative to the card).
+
+## Targeting
+
+`ref(name)` (from the render prop) returns a ref callback. Put it on a **wrapper element**
+around the thing the cursor should point at — `<span ref={ref("box")}>` for inline components,
+`<div ref={ref("field")} className="w-56">` for block ones. Or target by `{ selector }`
+(e.g. `{ selector: "input" }` for a slider thumb / text input). Point at the actual control,
+not a big label, when you can.
+
+## Patterns
+
+- **Toggle (checkbox, switch, toggle-button):** click on → wait → click off → wait. See `checkbox`/`switch`.
+- **Press (button, file-trigger, link):** click once, optionally a tiny scale-down via a `pressed`
+  state for feedback. See `button`.
+- **Single-select (radio-group, tabs, tag-group, list-box, segmented):** click option A → wait →
+  click option B → wait. Drive `value`/`selectedKeys`.
+- **Type (input, text-field, search-field, number-field, otp, color-field, command):** `s.type`.
+  Read `registry/ui/<slug>` for whether the value prop is on the field or the input.
+- **Drag (slider, color-area, color-slider):** `s.drag` with the thumb as from+to. For 2D
+  (color-area) you can pass `to` coords and set x/y from progress.
+- **Expand (accordion, disclosure):** click the trigger to open a panel, wait, collapse.
+- **Static / display-only (badge, avatar, kbd, separator, empty, skeleton, loader, card,
+  scroll-fade, table, alert):** these have no interaction. Either render the demo with NO cursor
+  (just return the component inside `AnimatedPreview` with an empty-ish script that only
+  `moveOff`s, or better, a subtle entrance), or pick the single most representative state.
+  Don't force a cursor where it makes no sense. `progress-bar` and `toast` animate nicely on a
+  timer (no cursor needed) — drive their value/visibility on a loop.
+
+## Don't
+
+- Don't import from other `demos/` files. Each is standalone.
+- Don't use `el.focus()`, `dispatchEvent`, refs into react-aria internals, or `setTimeout` loops
+  outside the script (the script + `reset` are the only choreography).
+- Don't leave the component in a non-initial state at the end of the loop without a `reset`
+  that returns to it.

--- a/www/src/modules/docs/components-list/anim/animated-preview.tsx
+++ b/www/src/modules/docs/components-list/anim/animated-preview.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { animate, useMotionValue, useReducedMotion } from "motion/react";
+
+import { cn } from "@/registry/lib/utils";
+
+import { FakeCursor } from "./cursor";
+
+// Thrown to unwind the animation loop when it is cancelled (hover / offscreen / unmount).
+const ABORT = Symbol("preview-abort");
+
+const SPRING = { type: "spring", stiffness: 220, damping: 26, mass: 0.9 } as const;
+
+type Target = string | { selector: string } | { x: number; y: number } | { el: HTMLElement | null };
+
+/** Imperative driver handed to a preview's `script`. Every method is cancellable. */
+export interface Driver {
+	/** Move the cursor to an element (by ref name / selector / element) or to coords. */
+	moveTo: (target: Target, opts?: { anchor?: "center" | "top" | "bottom" }) => Promise<void>;
+	/** Animate a press at the current position; `onDown` fires at the bottom of the press. */
+	press: (onDown?: () => void) => Promise<void>;
+	/** moveTo + press, the common "click this" gesture. */
+	click: (target: Target, onDown?: () => void) => Promise<void>;
+	/** Move to a target, dwell, optionally toggling a hovered visual via callbacks. */
+	hover: (target: Target, opts?: { dwell?: number; onEnter?: () => void; onLeave?: () => void }) => Promise<void>;
+	/** Type `text` into a target: each step calls `onText` with the accumulated string. */
+	type: (
+		target: Target,
+		text: string,
+		onText: (value: string) => void,
+		opts?: { perChar?: number; start?: string },
+	) => Promise<void>;
+	/** Drag from one point to another while reporting progress 0→1 (sliders, color area). */
+	drag: (
+		from: Target,
+		to: Target | { x: number; y: number },
+		onProgress: (t: number) => void,
+		opts?: { steps?: number },
+	) => Promise<void>;
+	/** Cancellable delay. */
+	wait: (ms: number) => Promise<void>;
+	/** Run a state change inline (sugar for choreographing without a press). */
+	do: (fn: () => void) => Promise<void>;
+	/** Move the cursor out of the card and fade it. */
+	moveOff: () => Promise<void>;
+}
+
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+
+interface AnimatedPreviewProps {
+	/** The looping animation. Receives a fresh, cancellable driver each iteration. */
+	script: (s: Driver) => Promise<void>;
+	/** Reset the component to its initial state (called before each loop + on hover takeover). */
+	reset?: () => void;
+	/** Render the component; `ref(name)` registers an element as a cursor target. */
+	children: (ref: (name: string) => (el: HTMLElement | null) => void) => React.ReactNode;
+	className?: string;
+}
+
+export function AnimatedPreview({ script, reset, children, className }: AnimatedPreviewProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const refs = useRef(new Map<string, HTMLElement>());
+
+	const x = useMotionValue(-100);
+	const y = useMotionValue(-100);
+	const scale = useMotionValue(1);
+	const opacity = useMotionValue(0);
+	const ripple = useMotionValue(0);
+
+	const [interactive, setInteractive] = useState(false);
+
+	// Latest props without re-subscribing the loop.
+	const scriptRef = useRef(script);
+	scriptRef.current = script;
+	const resetRef = useRef(reset);
+	resetRef.current = reset;
+
+	const reduceMotion = useReducedMotion();
+	const abortRef = useRef<AbortController | null>(null);
+
+	const resolve = useCallback(
+		(target: Target, anchor: "center" | "top" | "bottom" = "center") => {
+			const c = containerRef.current;
+			if (!c) return { x: 0, y: 0 };
+			if (typeof target === "object" && "x" in target) return { x: target.x, y: target.y };
+			let el: HTMLElement | null = null;
+			if (typeof target === "string") el = refs.current.get(target) ?? null;
+			else if ("selector" in target) el = c.querySelector<HTMLElement>(target.selector);
+			else el = target.el;
+			if (!el) return { x: x.get(), y: y.get() };
+			const r = el.getBoundingClientRect();
+			const cr = c.getBoundingClientRect();
+			const cy = anchor === "top" ? r.top : anchor === "bottom" ? r.bottom : r.top + r.height / 2;
+			// Offset so the arrow tip (not its box corner) lands on the target.
+			return { x: r.left - cr.left + r.width / 2 - 4, y: cy - cr.top - 2 };
+		},
+		[x, y],
+	);
+
+	const makeDriver = useCallback(
+		(signal: AbortSignal): Driver => {
+			const guard = () => {
+				if (signal.aborted) throw ABORT;
+			};
+			const run = async (controls: { stop: () => void; then: PromiseLike<unknown>["then"] }) => {
+				const onAbort = () => controls.stop();
+				signal.addEventListener("abort", onAbort, { once: true });
+				try {
+					await controls;
+				} finally {
+					signal.removeEventListener("abort", onAbort);
+				}
+				guard();
+			};
+			const moveTo: Driver["moveTo"] = async (target, opts) => {
+				guard();
+				if (opacity.get() < 1) await run(animate(opacity, 1, { duration: 0.2 }) as never);
+				const p = resolve(target, opts?.anchor);
+				await Promise.all([run(animate(x, p.x, SPRING) as never), run(animate(y, p.y, SPRING) as never)]);
+			};
+			const press: Driver["press"] = async (onDown) => {
+				guard();
+				await run(animate(scale, 0.8, { duration: 0.09 }) as never);
+				ripple.set(ripple.get() + 1);
+				onDown?.();
+				await run(animate(scale, 1, { duration: 0.14 }) as never);
+			};
+			const wait: Driver["wait"] = (ms) =>
+				new Promise<void>((res, rej) => {
+					guard();
+					const t = setTimeout(res, ms);
+					signal.addEventListener(
+						"abort",
+						() => {
+							clearTimeout(t);
+							rej(ABORT);
+						},
+						{ once: true },
+					);
+				});
+			const click: Driver["click"] = async (target, onDown) => {
+				await moveTo(target);
+				await wait(140);
+				await press(onDown);
+			};
+			return {
+				moveTo,
+				press,
+				wait,
+				click,
+				hover: async (target, opts) => {
+					await moveTo(target);
+					opts?.onEnter?.();
+					await wait(opts?.dwell ?? 900);
+					opts?.onLeave?.();
+				},
+				type: async (target, text, onText, opts) => {
+					await moveTo(target);
+					await wait(180);
+					let acc = opts?.start ?? "";
+					for (const ch of text) {
+						acc += ch;
+						guard();
+						onText(acc);
+						await wait(opts?.perChar ?? 80);
+					}
+				},
+				drag: async (from, to, onProgress, opts) => {
+					await moveTo(from);
+					await run(animate(scale, 0.82, { duration: 0.1 }) as never);
+					const start = { x: x.get(), y: y.get() };
+					const fixedEnd = typeof to === "object" && "x" in to ? to : null;
+					const steps = opts?.steps ?? 28;
+					for (let i = 1; i <= steps; i++) {
+						guard();
+						const t = i / steps;
+						// Update the value first so the target (e.g. a slider thumb) moves, then
+						// re-resolve it so the cursor follows it precisely.
+						onProgress(t);
+						await wait(16);
+						const end = fixedEnd ?? resolve(to as Target);
+						x.set(lerp(start.x, end.x, t));
+						y.set(lerp(start.y, end.y, t));
+					}
+					await run(animate(scale, 1, { duration: 0.12 }) as never);
+				},
+				do: async (fn) => {
+					guard();
+					fn();
+				},
+				moveOff: async () => {
+					guard();
+					const c = containerRef.current;
+					const tx = c ? c.clientWidth * 0.5 : 0;
+					const ty = c ? c.clientHeight + 24 : 0;
+					await Promise.all([run(animate(x, tx, SPRING) as never), run(animate(y, ty, SPRING) as never)]);
+					await run(animate(opacity, 0, { duration: 0.2 }) as never);
+				},
+			};
+		},
+		[opacity, resolve, ripple, scale, x, y],
+	);
+
+	const stop = useCallback(() => {
+		abortRef.current?.abort();
+		abortRef.current = null;
+	}, []);
+
+	const start = useCallback(() => {
+		if (abortRef.current) return;
+		const ac = new AbortController();
+		abortRef.current = ac;
+		const driver = makeDriver(ac.signal);
+		(async () => {
+			try {
+				while (!ac.signal.aborted) {
+					resetRef.current?.();
+					await scriptRef.current(driver);
+				}
+			} catch (e) {
+				if (e !== ABORT) throw e;
+			}
+		})();
+	}, [makeDriver]);
+
+	// Orchestrate: only animate when on-screen, tab-visible, not hovered, motion allowed.
+	useEffect(() => {
+		const c = containerRef.current;
+		if (!c) return;
+		let onScreen = false;
+		const evaluate = () => {
+			const should = onScreen && !document.hidden && !interactive && !reduceMotion;
+			if (should) start();
+			else {
+				stop();
+				// Whenever the loop isn't running the cursor must disappear.
+				opacity.set(0);
+				scale.set(1);
+				// Reset to the initial state when idle (offscreen / tab hidden), but NOT on hover
+				// takeover — there we hand the component to the user from its current state.
+				if (!interactive) resetRef.current?.();
+			}
+		};
+		const io = new IntersectionObserver(
+			(entries) => {
+				const entry = entries[0];
+				if (!entry) return;
+				onScreen = entry.isIntersecting;
+				evaluate();
+			},
+			{ rootMargin: "120px" },
+		);
+		io.observe(c);
+		const onVis = () => evaluate();
+		document.addEventListener("visibilitychange", onVis);
+		return () => {
+			io.disconnect();
+			document.removeEventListener("visibilitychange", onVis);
+			stop();
+		};
+	}, [interactive, reduceMotion, start, stop, opacity, scale]);
+
+	return (
+		<div
+			ref={containerRef}
+			className={cn("relative isolate flex size-full items-center justify-center overflow-hidden", className)}
+			onPointerEnter={() => setInteractive(true)}
+			onPointerLeave={() => setInteractive(false)}
+		>
+			{children((name) => (el) => {
+				if (el) refs.current.set(name, el);
+				else refs.current.delete(name);
+			})}
+			{!reduceMotion && <FakeCursor x={x} y={y} scale={scale} opacity={opacity} ripple={ripple} />}
+		</div>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/animated-preview.tsx
+++ b/www/src/modules/docs/components-list/anim/animated-preview.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
 
 import { animate, useMotionValue, useReducedMotion } from "motion/react";
+import { UNSAFE_PortalProvider } from "react-aria/PortalProvider";
 
 import { cn } from "@/registry/lib/utils";
 
 import { FakeCursor } from "./cursor";
+
+// `contain` mode (overlays/pickers): portal overlays into the card + pin the modal's
+// runtime viewport vars so it sizes to the card, like the static overlay previews.
+const CONTAIN_VARS = { "--page-height": "100%", "--visual-viewport-height": "100%" } as CSSProperties;
+const CONTAIN_CLASS = "[&_:has(>[data-slot=modal-viewport])]:!h-full [&_[data-slot=modal-viewport]]:!h-full";
 
 // Thrown to unwind the animation loop when it is cancelled (hover / offscreen / unmount).
 const ABORT = Symbol("preview-abort");
@@ -57,11 +64,16 @@ interface AnimatedPreviewProps {
 	/** Render the component; `ref(name)` registers an element as a cursor target. */
 	children: (ref: (name: string) => (el: HTMLElement | null) => void) => React.ReactNode;
 	className?: string;
+	/** Overlay/picker demos: portal overlays into the card + render client-only (SSR-safe). */
+	contain?: boolean;
 }
 
-export function AnimatedPreview({ script, reset, children, className }: AnimatedPreviewProps) {
+export function AnimatedPreview({ script, reset, children, className, contain = false }: AnimatedPreviewProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const refs = useRef(new Map<string, HTMLElement>());
+	// `contain` demos render client-only (Select/Combobox/Menu crash React during SSR).
+	const [mounted, setMounted] = useState(!contain);
+	useEffect(() => setMounted(true), []);
 
 	const x = useMotionValue(-100);
 	const y = useMotionValue(-100);
@@ -262,17 +274,31 @@ export function AnimatedPreview({ script, reset, children, className }: Animated
 		};
 	}, [interactive, reduceMotion, start, stop, opacity, scale]);
 
+	const refFor = (name: string) => (el: HTMLElement | null) => {
+		if (el) refs.current.set(name, el);
+		else refs.current.delete(name);
+	};
+	const content = mounted ? children(refFor) : null;
+
 	return (
 		<div
 			ref={containerRef}
-			className={cn("relative isolate flex size-full items-center justify-center overflow-hidden", className)}
+			className={cn(
+				"relative isolate flex size-full items-center justify-center overflow-hidden",
+				contain && CONTAIN_CLASS,
+				className,
+			)}
+			style={contain ? CONTAIN_VARS : undefined}
 			onPointerEnter={() => setInteractive(true)}
 			onPointerLeave={() => setInteractive(false)}
 		>
-			{children((name) => (el) => {
-				if (el) refs.current.set(name, el);
-				else refs.current.delete(name);
-			})}
+			{contain ? (
+				<UNSAFE_PortalProvider getContainer={() => containerRef.current ?? document.body}>
+					{content}
+				</UNSAFE_PortalProvider>
+			) : (
+				content
+			)}
 			{!reduceMotion && <FakeCursor x={x} y={y} scale={scale} opacity={opacity} ripple={ripple} />}
 		</div>
 	);

--- a/www/src/modules/docs/components-list/anim/cursor.tsx
+++ b/www/src/modules/docs/components-list/anim/cursor.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { motion } from "motion/react";
+
+import type { MotionValue } from "motion/react";
+
+interface FakeCursorProps {
+	x: MotionValue<number>;
+	y: MotionValue<number>;
+	scale: MotionValue<number>;
+	opacity: MotionValue<number>;
+	/** Click ripple trigger — increment to fire a ripple at the current position. */
+	ripple: MotionValue<number>;
+}
+
+/**
+ * A decorative pointer that the preview animations drive around the card. Purely
+ * visual (pointer-events: none); the real interaction is faked via controlled
+ * state, so this never steals real focus or pointer input.
+ */
+export function FakeCursor({ x, y, scale, opacity }: FakeCursorProps) {
+	return (
+		<motion.div
+			aria-hidden
+			className="pointer-events-none absolute top-0 left-0 z-50 will-change-transform"
+			style={{ x, y, opacity }}
+		>
+			<motion.svg
+				width="20"
+				height="22"
+				viewBox="0 0 20 22"
+				fill="none"
+				style={{ scale }}
+				className="origin-top-left drop-shadow-[0_1px_2px_rgba(0,0,0,0.45)]"
+			>
+				{/* macOS-style arrow: white outline + dark fill so it reads on any theme */}
+				<path
+					d="M3.5 2.2 L3.5 16.4 L7.1 12.9 L9.5 18.6 L12.1 17.5 L9.7 11.9 L14.7 11.9 Z"
+					fill="black"
+					stroke="white"
+					strokeWidth="1.4"
+					strokeLinejoin="round"
+				/>
+			</motion.svg>
+		</motion.div>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/accordion.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/accordion.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+
+import { Accordion } from "@/registry/ui/accordion";
+import { Disclosure, DisclosurePanel, DisclosureTrigger } from "@/registry/ui/disclosure";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
+	return (
+		<AnimatedPreview
+			reset={() => setExpandedKeys(new Set())}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click("shipping", () => setExpandedKeys(new Set(["shipping"])));
+				await s.wait(1500);
+				await s.click("returns", () => setExpandedKeys(new Set(["returns"])));
+				await s.wait(1500);
+				await s.click("returns", () => setExpandedKeys(new Set()));
+				await s.wait(600);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<div className="w-64">
+					<Accordion expandedKeys={expandedKeys} onExpandedChange={(keys) => setExpandedKeys(keys as Set<string>)}>
+						<Disclosure id="shipping">
+							<span ref={ref("shipping")} className="block">
+								<DisclosureTrigger>Shipping</DisclosureTrigger>
+							</span>
+							<DisclosurePanel>Free worldwide shipping on all orders.</DisclosurePanel>
+						</Disclosure>
+						<Disclosure id="returns">
+							<span ref={ref("returns")} className="block">
+								<DisclosureTrigger>Returns</DisclosureTrigger>
+							</span>
+							<DisclosurePanel>30-day hassle-free returns, no questions asked.</DisclosurePanel>
+						</Disclosure>
+					</Accordion>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/alert.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/alert.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+
+import { CheckCircle2Icon } from "@/registry/__generated__/icons";
+import { Alert, AlertDescription, AlertTitle } from "@/registry/ui/alert";
+
+import { AnimatedPreview } from "../animated-preview";
+
+// Display-only: no cursor. The alert subtly slides + fades in each loop.
+export default function Demo() {
+	const [shown, setShown] = useState(false);
+	return (
+		<AnimatedPreview
+			reset={() => setShown(false)}
+			script={async (s) => {
+				await s.wait(250);
+				await s.do(() => setShown(true));
+				await s.wait(3200);
+			}}
+		>
+			{() => (
+				<div
+					className="w-64 transition-all duration-500 ease-out"
+					style={{ opacity: shown ? 1 : 0, transform: shown ? "translateY(0)" : "translateY(8px)" }}
+				>
+					<Alert variant="success">
+						<CheckCircle2Icon />
+						<AlertTitle>Changes saved</AlertTitle>
+						<AlertDescription>Your update is now live.</AlertDescription>
+					</Alert>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/avatar.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/avatar.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarGroup, AvatarGroupCount, AvatarImage } from "@/registry/ui/avatar";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	return (
+		<AnimatedPreview
+			script={async (s) => {
+				await s.moveOff();
+				await s.wait(2400);
+			}}
+		>
+			{() => (
+				<AvatarGroup>
+					<Avatar>
+						<AvatarImage src="https://github.com/mehdibha.png" alt="@mehdibha" />
+						<AvatarFallback>M</AvatarFallback>
+					</Avatar>
+					<Avatar>
+						<AvatarImage src="https://github.com/tannerlinsley.png" alt="@tannerlinsley" />
+						<AvatarFallback>T</AvatarFallback>
+					</Avatar>
+					<Avatar>
+						<AvatarImage src="https://github.com/devongovett.png" alt="@devongovett" />
+						<AvatarFallback>D</AvatarFallback>
+					</Avatar>
+					<AvatarGroupCount>+3</AvatarGroupCount>
+				</AvatarGroup>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/badge.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/badge.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Badge } from "@/registry/ui/badge";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	return (
+		<AnimatedPreview
+			script={async (s) => {
+				await s.moveOff();
+				await s.wait(2400);
+			}}
+		>
+			{() => (
+				<div className="flex flex-wrap items-center justify-center gap-2">
+					<Badge variant="success">Active</Badge>
+					<Badge variant="warning">Pending</Badge>
+					<Badge variant="danger">Failed</Badge>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/breadcrumbs.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/breadcrumbs.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator, Breadcrumbs } from "@/registry/ui/breadcrumbs";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	return (
+		<AnimatedPreview
+			script={async (s) => {
+				await s.wait(600);
+				await s.hover("home", { dwell: 900 });
+				await s.hover("components", { dwell: 900 });
+				await s.wait(400);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<Breadcrumbs>
+					<BreadcrumbItem>
+						<span ref={ref("home")}>
+							<BreadcrumbLink href="#">Home</BreadcrumbLink>
+						</span>
+						<BreadcrumbSeparator />
+					</BreadcrumbItem>
+					<BreadcrumbItem>
+						<span ref={ref("components")}>
+							<BreadcrumbLink href="#">Components</BreadcrumbLink>
+						</span>
+						<BreadcrumbSeparator />
+					</BreadcrumbItem>
+					<BreadcrumbItem>
+						<BreadcrumbLink>Breadcrumbs</BreadcrumbLink>
+					</BreadcrumbItem>
+				</Breadcrumbs>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/button.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/button.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/registry/ui/button";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [pressed, setPressed] = useState(false);
+	return (
+		<AnimatedPreview
+			reset={() => setPressed(false)}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click("btn", () => {
+					setPressed(true);
+					setTimeout(() => setPressed(false), 160);
+				});
+				await s.wait(1400);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<span ref={ref("btn")} className="inline-block transition-transform" style={{ scale: pressed ? 0.94 : 1 }}>
+					<Button variant="primary">Get started</Button>
+				</span>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/calendar.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/calendar.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+
+import { CalendarDate } from "@internationalized/date";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+
+import type * as CalendarPrimitives from "react-aria-components/Calendar";
+
+import { Button } from "@/registry/ui/button";
+import {
+	Calendar,
+	CalendarCell,
+	CalendarGrid,
+	CalendarGridBody,
+	CalendarGridHeader,
+	CalendarHeader,
+	CalendarHeaderCell,
+	CalendarHeading,
+} from "@/registry/ui/calendar";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const initial = new CalendarDate(2024, 6, 12);
+
+export default function Demo() {
+	const [value, setValue] = useState<CalendarPrimitives.DateValue>(initial);
+	const [focused, setFocused] = useState<CalendarDate>(initial);
+
+	const reset = () => {
+		setValue(initial);
+		setFocused(initial);
+	};
+
+	return (
+		<AnimatedPreview
+			reset={reset}
+			script={async (s) => {
+				await s.wait(600);
+				// Page forward a month — the selection follows to the same day…
+				await s.click("next", () => {
+					setFocused((f) => f.add({ months: 1 }));
+					setValue((v) => v.add({ months: 1 }));
+				});
+				await s.wait(1100);
+				// …then page back to where we started.
+				await s.click("prev", () => {
+					setFocused((f) => f.add({ months: -1 }));
+					setValue((v) => v.add({ months: -1 }));
+				});
+				await s.wait(1000);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{(ref) => (
+				<div className="origin-center scale-[0.66]">
+					<Calendar
+						aria-label="Date"
+						value={value}
+						onChange={(v) => {
+							if (v) setValue(v);
+						}}
+						focusedValue={focused}
+						onFocusChange={setFocused}
+						className="gap-3"
+					>
+						<CalendarHeader>
+							<span ref={ref("prev")} className="inline-flex">
+								<Button slot="previous" variant="quiet" isIconOnly>
+									<ChevronLeftIcon />
+								</Button>
+							</span>
+							<CalendarHeading />
+							<span ref={ref("next")} className="inline-flex">
+								<Button slot="next" variant="quiet" isIconOnly>
+									<ChevronRightIcon />
+								</Button>
+							</span>
+						</CalendarHeader>
+						<CalendarGrid>
+							<CalendarGridHeader>{(day) => <CalendarHeaderCell>{day}</CalendarHeaderCell>}</CalendarGridHeader>
+							<CalendarGridBody>{(date) => <CalendarCell date={date} />}</CalendarGridBody>
+						</CalendarGrid>
+					</Calendar>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/card.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/card.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button } from "@/registry/ui/button";
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/registry/ui/card";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	return (
+		<AnimatedPreview
+			script={async (s) => {
+				await s.moveOff();
+				await s.wait(2400);
+			}}
+		>
+			{() => (
+				<Card size="sm" className="w-60">
+					<CardHeader>
+						<CardTitle>Upgrade to Pro</CardTitle>
+						<CardDescription>Unlock advanced analytics and priority support.</CardDescription>
+					</CardHeader>
+					<CardFooter>
+						<Button variant="primary" size="sm" className="w-full">
+							Upgrade
+						</Button>
+					</CardFooter>
+				</Card>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/checkbox-group.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/checkbox-group.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+
+import { Checkbox, CheckboxControl } from "@/registry/ui/checkbox";
+import { CheckboxGroup } from "@/registry/ui/checkbox-group";
+import { FieldGroup, Label } from "@/registry/ui/field";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState<string[]>(["react"]);
+	const toggle = (key: string) => setValue((v) => (v.includes(key) ? v.filter((k) => k !== key) : [...v, key]));
+	return (
+		<AnimatedPreview
+			reset={() => setValue(["react"])}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click("vue", () => toggle("vue"));
+				await s.wait(800);
+				await s.click("svelte", () => toggle("svelte"));
+				await s.wait(900);
+				await s.click("react", () => toggle("react"));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{(ref) => (
+				<CheckboxGroup aria-label="Frameworks" value={value} onChange={setValue}>
+					<FieldGroup>
+						<span ref={ref("react")}>
+							<Checkbox value="react">
+								<CheckboxControl />
+								<Label>React</Label>
+							</Checkbox>
+						</span>
+						<span ref={ref("vue")}>
+							<Checkbox value="vue">
+								<CheckboxControl />
+								<Label>Vue</Label>
+							</Checkbox>
+						</span>
+						<span ref={ref("svelte")}>
+							<Checkbox value="svelte">
+								<CheckboxControl />
+								<Label>Svelte</Label>
+							</Checkbox>
+						</span>
+					</FieldGroup>
+				</CheckboxGroup>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/checkbox.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/checkbox.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+
+import { Checkbox } from "@/registry/ui/checkbox";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [selected, setSelected] = useState(false);
+	return (
+		<AnimatedPreview
+			reset={() => setSelected(false)}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click("box", () => setSelected(true));
+				await s.wait(1300);
+				await s.click("box", () => setSelected(false));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<span ref={ref("box")}>
+					<Checkbox isSelected={selected} onChange={setSelected}>
+						Subscribe to updates
+					</Checkbox>
+				</span>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/color-area.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/color-area.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+
+import { parseColor } from "react-aria-components/ColorArea";
+
+import { ColorArea } from "@/registry/ui/color-area";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const INITIAL = parseColor("hsb(280, 30%, 90%)");
+
+export default function Demo() {
+	const [value, setValue] = useState(INITIAL);
+	return (
+		<AnimatedPreview
+			reset={() => setValue(INITIAL)}
+			script={async (s) => {
+				await s.wait(500);
+				// 2D drag: the cursor tracks the thumb while saturation follows x-progress and
+				// brightness follows (inverted) y-progress.
+				await s.drag(
+					{ selector: "[data-slot=color-thumb]" },
+					{ selector: "[data-slot=color-thumb]" },
+					(t) =>
+						setValue((c) => c.withChannelValue("saturation", 30 + t * 60).withChannelValue("brightness", 90 - t * 55)),
+					{ steps: 36 },
+				);
+				await s.wait(1200);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{() => (
+				<ColorArea
+					aria-label="Color"
+					value={value}
+					onChange={setValue}
+					colorSpace="hsb"
+					xChannel="saturation"
+					yChannel="brightness"
+					className="w-36"
+				/>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/color-field.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/color-field.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+
+import { type Color, parseColor } from "react-aria-components/ColorField";
+
+import { ColorField } from "@/registry/ui/color-field";
+import { Label } from "@/registry/ui/field";
+import { Input } from "@/registry/ui/input";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const INITIAL = parseColor("hsl(0, 90%, 55%)");
+
+export default function Demo() {
+	const [color, setColor] = useState<Color | null>(INITIAL);
+	return (
+		<AnimatedPreview
+			reset={() => setColor(INITIAL)}
+			script={async (s) => {
+				await s.wait(500);
+				// Type a hue value digit-by-digit; every accumulated number is a valid channel value,
+				// so the field updates live (and never sees an unparseable partial string).
+				await s.type("field", "265", (acc) => setColor(INITIAL.withChannelValue("hue", Number(acc))), {
+					start: "",
+					perChar: 230,
+				});
+				await s.wait(1400);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<div ref={ref("field")} className="w-32">
+					<ColorField colorSpace="hsl" channel="hue" value={color} onChange={setColor}>
+						<Label>Hue</Label>
+						<Input />
+					</ColorField>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/color-picker.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/color-picker.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+
+import { type Color, parseColor } from "react-aria-components/ColorArea";
+
+import { ColorPicker } from "@/registry/ui/color-picker";
+import { ColorSlider, ColorSliderControl } from "@/registry/ui/color-slider";
+import { ColorSwatch } from "@/registry/ui/color-swatch";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const INITIAL = parseColor("hsl(8, 85%, 55%)");
+
+export default function Demo() {
+	const [value, setValue] = useState<Color>(INITIAL);
+	return (
+		<AnimatedPreview
+			reset={() => setValue(INITIAL)}
+			script={async (s) => {
+				await s.wait(500);
+				// Drag the hue slider; the picker's swatch recolors live from the shared value.
+				await s.drag(
+					{ selector: "[data-slot=color-thumb]" },
+					{ selector: "[data-slot=color-thumb]" },
+					(t) => setValue((c) => c.withChannelValue("hue", t * 360)),
+					{ steps: 40 },
+				);
+				await s.wait(1100);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{() => (
+				<ColorPicker value={value} onChange={setValue}>
+					<div className="flex w-48 items-center gap-3">
+						<ColorSwatch className="size-9 shrink-0 rounded-md" />
+						<ColorSlider aria-label="Hue" channel="hue" className="flex-1">
+							<ColorSliderControl />
+						</ColorSlider>
+					</div>
+				</ColorPicker>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/color-slider.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/color-slider.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+
+import { parseColor } from "react-aria-components/ColorSlider";
+
+import { ColorSlider, ColorSliderControl } from "@/registry/ui/color-slider";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const INITIAL = parseColor("hsl(15, 100%, 50%)");
+
+export default function Demo() {
+	const [value, setValue] = useState(INITIAL);
+	return (
+		<AnimatedPreview
+			reset={() => setValue(INITIAL)}
+			script={async (s) => {
+				await s.wait(500);
+				// Sweep the hue thumb across the spectrum (15 → 330).
+				await s.drag(
+					{ selector: "[data-slot=color-thumb]" },
+					{ selector: "[data-slot=color-thumb]" },
+					(t) => setValue((c) => c.withChannelValue("hue", 15 + t * 315)),
+					{ steps: 40 },
+				);
+				await s.wait(1200);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{() => (
+				<div className="w-48">
+					<ColorSlider aria-label="Hue" value={value} onChange={setValue} channel="hue">
+						<ColorSliderControl />
+					</ColorSlider>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/color-swatch-picker.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/color-swatch-picker.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+import { type Color, parseColor } from "react-aria-components/ColorArea";
+
+import { ColorSwatchPicker, ColorSwatchPickerItem } from "@/registry/ui/color-swatch-picker";
+
+import { AnimatedPreview } from "../animated-preview";
+
+// ColorSwatchPicker is a react-aria collection (ListBox) — items must be direct children,
+// so we target swatches by nth-child selector rather than wrapping them in a ref span.
+const SWATCHES = ["#f43f5e", "#f59e0b", "#22c55e", "#3b82f6", "#8b5cf6", "#0ea5e9"] as const;
+const INITIAL = parseColor(SWATCHES[0]);
+
+export default function Demo() {
+	const [value, setValue] = useState<Color>(INITIAL);
+	return (
+		<AnimatedPreview
+			reset={() => setValue(INITIAL)}
+			script={async (s) => {
+				await s.wait(450);
+				await s.click({ selector: ".cspick > *:nth-child(5)" }, () => setValue(parseColor(SWATCHES[4])));
+				await s.wait(1000);
+				await s.click({ selector: ".cspick > *:nth-child(3)" }, () => setValue(parseColor(SWATCHES[2])));
+				await s.wait(1000);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{() => (
+				<ColorSwatchPicker className="cspick" value={value} onChange={setValue}>
+					{SWATCHES.map((color) => (
+						<ColorSwatchPickerItem key={color} color={color} />
+					))}
+				</ColorSwatchPicker>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/combobox.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/combobox.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+
+import { ChevronDownIcon } from "lucide-react";
+
+import { Button } from "@/registry/ui/button";
+import { Combobox } from "@/registry/ui/combobox";
+import { Input, InputGroup, InputGroupAddon } from "@/registry/ui/input";
+import { ListBox, ListBoxItem } from "@/registry/ui/list-box";
+import { Popover } from "@/registry/ui/popover";
+
+import { AnimatedPreview } from "../animated-preview";
+
+// Combobox opens its list on real focus/typing (which we avoid — it would steal page focus),
+// so the autoplay types into the field; hovering the card lets the user open the real list.
+export default function Demo() {
+	const [inputValue, setInputValue] = useState("");
+	return (
+		<AnimatedPreview
+			contain
+			reset={() => setInputValue("")}
+			script={async (s) => {
+				await s.wait(600);
+				await s.type("field", "France", setInputValue);
+				await s.wait(1600);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<div ref={ref("field")} className="w-52">
+					<Combobox aria-label="Country" inputValue={inputValue} onInputChange={setInputValue}>
+						<InputGroup>
+							<Input placeholder="Select a country..." />
+							<InputGroupAddon>
+								<Button variant="quiet" isIconOnly>
+									<ChevronDownIcon />
+								</Button>
+							</InputGroupAddon>
+						</InputGroup>
+						<Popover>
+							<ListBox>
+								<ListBoxItem id="ca">Canada</ListBoxItem>
+								<ListBoxItem id="fr">France</ListBoxItem>
+								<ListBoxItem id="de">Germany</ListBoxItem>
+							</ListBox>
+						</Popover>
+					</Combobox>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/command.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/command.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { CalculatorIcon, CalendarIcon, SettingsIcon, SmileIcon } from "lucide-react";
+
+import { Card } from "@/registry/ui/card";
+import {
+	Command,
+	CommandContent,
+	CommandInput,
+	CommandItem,
+	CommandSection,
+	CommandSectionHeader,
+} from "@/registry/ui/command";
+import { Kbd } from "@/registry/ui/kbd";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	// The command palette is an Autocomplete + ListBox; that collection throws during
+	// SSR (`selectionManager` null), which would blank the page. Render it only after
+	// mount and show a lightweight placeholder until then. The script always runs
+	// client-side (after the card is on-screen), so the cursor target exists by then.
+	const [mounted, setMounted] = useState(false);
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+
+	return (
+		<AnimatedPreview
+			script={async (s) => {
+				await s.wait(700);
+				await s.hover("input", { dwell: 1100 });
+				await s.wait(500);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<Card className="w-[260px] p-0">
+					{mounted ? (
+						<Command aria-label="Command menu">
+							<span ref={ref("input")} className="block">
+								<CommandInput placeholder="Type a command..." />
+							</span>
+							<CommandContent aria-label="Commands">
+								<CommandSection>
+									<CommandSectionHeader>Suggestions</CommandSectionHeader>
+									<CommandItem textValue="Calendar">
+										<CalendarIcon />
+										<span>Calendar</span>
+									</CommandItem>
+									<CommandItem textValue="Search Emoji">
+										<SmileIcon />
+										<span>Search Emoji</span>
+									</CommandItem>
+									<CommandItem textValue="Calculator">
+										<CalculatorIcon />
+										<span>Calculator</span>
+										<Kbd>⌘K</Kbd>
+									</CommandItem>
+									<CommandItem textValue="Settings">
+										<SettingsIcon />
+										<span>Settings</span>
+									</CommandItem>
+								</CommandSection>
+							</CommandContent>
+						</Command>
+					) : (
+						<div className="flex flex-col gap-2 p-1.5" aria-hidden="true">
+							<div className="h-8 rounded-sm border bg-muted" />
+							<div className="space-y-1.5 px-1">
+								<div className="h-3 w-20 rounded bg-muted" />
+								<div className="h-3 w-28 rounded bg-muted" />
+								<div className="h-3 w-24 rounded bg-muted" />
+							</div>
+						</div>
+					)}
+				</Card>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/date-field.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/date-field.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+
+import { parseDate } from "@internationalized/date";
+
+import type * as DateFieldPrimitives from "react-aria-components/DateField";
+
+import { DateField } from "@/registry/ui/date-field";
+import { DateInput } from "@/registry/ui/input";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const initial = parseDate("2024-06-12");
+
+export default function Demo() {
+	const [value, setValue] = useState<DateFieldPrimitives.DateValue>(initial);
+	return (
+		<AnimatedPreview
+			reset={() => setValue(initial)}
+			script={async (s) => {
+				await s.wait(500);
+				// Spin the day segment up a few notches…
+				await s.moveTo({ selector: '[data-type="day"]' });
+				await s.wait(120);
+				for (let i = 0; i < 3; i++) {
+					await s.press(() => setValue((v) => v.add({ days: 1 })));
+					await s.wait(260);
+				}
+				await s.wait(500);
+				// …then bump the month forward.
+				await s.click({ selector: '[data-type="month"]' }, () => setValue((v) => v.add({ months: 1 })));
+				await s.wait(1100);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{() => (
+				<div className="w-48">
+					<DateField
+						aria-label="Meeting date"
+						value={value}
+						onChange={(v) => {
+							if (v) setValue(v);
+						}}
+					>
+						<DateInput />
+					</DateField>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/date-picker.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/date-picker.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+
+import { CalendarDate } from "@internationalized/date";
+
+import type * as CalendarPrimitives from "react-aria-components/Calendar";
+
+import { CalendarIcon } from "@/registry/__generated__/icons";
+import { Button } from "@/registry/ui/button";
+import { Calendar } from "@/registry/ui/calendar";
+import { DatePicker } from "@/registry/ui/date-picker";
+import { DialogContent } from "@/registry/ui/dialog";
+import { DateInput, InputGroup, InputGroupAddon } from "@/registry/ui/input";
+import { Popover } from "@/registry/ui/popover";
+
+import { AnimatedPreview } from "../animated-preview";
+
+// A controlled value pins the open calendar to a known month (June 2024), so the
+// targeted day cell is stable across reloads and the trigger stays coherent with
+// the grid. In an en-US (Sunday-start) grid, June 2024 lays out as:
+//   row3 = Jun 9–15  → col4 (Wed) = Jun 12  (the day the cursor picks)
+//   row4 = Jun 16–22 → col3 (Tue) = Jun 18  (the initial selection)
+const INITIAL = new CalendarDate(2024, 6, 18);
+const PICKED = new CalendarDate(2024, 6, 12);
+const DAY_CELL = '[data-calendar-grid-body] tr:nth-child(3) td:nth-child(4) [role="button"]';
+
+export default function Demo() {
+	const [open, setOpen] = useState(false);
+	const [value, setValue] = useState<CalendarPrimitives.DateValue | null>(INITIAL);
+
+	return (
+		<AnimatedPreview
+			contain
+			reset={() => {
+				setOpen(false);
+				setValue(INITIAL);
+			}}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click("trigger", () => setOpen(true));
+				await s.wait(800);
+				// Move to an in-month day (3rd week, 4th column = Jun 12), then pick it.
+				await s.moveTo({ selector: DAY_CELL });
+				await s.wait(450);
+				await s.click({ selector: DAY_CELL }, () => {
+					setValue(PICKED);
+					setOpen(false);
+				});
+				await s.wait(1300);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<DatePicker
+					aria-label="Meeting date"
+					value={value}
+					onChange={setValue}
+					isOpen={open}
+					onOpenChange={setOpen}
+					className="w-52"
+				>
+					<span ref={ref("trigger")} className="block">
+						<InputGroup>
+							<DateInput />
+							<InputGroupAddon>
+								<Button variant="default" size="sm" isIconOnly>
+									<CalendarIcon />
+								</Button>
+							</InputGroupAddon>
+						</InputGroup>
+					</span>
+					<Popover>
+						<DialogContent>
+							<Calendar />
+						</DialogContent>
+					</Popover>
+				</DatePicker>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/dialog.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/dialog.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/registry/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/registry/ui/dialog";
+import { Overlay } from "@/registry/ui/overlay";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [open, setOpen] = useState(false);
+	return (
+		<AnimatedPreview
+			contain
+			reset={() => setOpen(false)}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click("trigger", () => setOpen(true));
+				await s.wait(1100);
+				await s.click({ selector: '[data-slot="dialog-footer"] button' }, () => setOpen(false));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<Dialog isOpen={open} onOpenChange={setOpen}>
+					<span ref={ref("trigger")}>
+						<Button variant="danger" size="sm">
+							Delete
+						</Button>
+					</span>
+					<Overlay>
+						<DialogContent role="alertdialog" className="max-w-72">
+							<DialogHeader>
+								<DialogTitle>Delete project</DialogTitle>
+								<DialogDescription>This action cannot be undone.</DialogDescription>
+							</DialogHeader>
+							<DialogFooter>
+								<Button slot="close" variant="default" size="sm">
+									Cancel
+								</Button>
+								<Button slot="close" variant="danger" size="sm">
+									Delete
+								</Button>
+							</DialogFooter>
+						</DialogContent>
+					</Overlay>
+				</Dialog>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/drawer.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/drawer.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useRef, useState } from "react";
+import type { CSSProperties } from "react";
+
+import { Button } from "@/registry/ui/button";
+import { DialogBody, DialogContent, DialogHeader, DialogTitle } from "@/registry/ui/dialog";
+import { Drawer, DrawerHandle } from "@/registry/ui/drawer";
+
+import { AnimatedPreview } from "../animated-preview";
+
+// Drop the off-screen over-drag bleed so the sheet sits flush in the small card.
+const NO_BLEED = { "--drawer-bleed": "0px" } as CSSProperties;
+
+/**
+ * Drawer is Base UI (portals + `fixed`), so it can't use AnimatedPreview's `contain` mode
+ * (which targets React Aria overlays). Instead this demo gives itself a `translateZ(0)`
+ * containing block and points the drawer's `container` at it, exactly like the static
+ * overlay preview — then drives the open state on a loop.
+ */
+export default function Demo() {
+	const [open, setOpen] = useState(false);
+	const boxRef = useRef<HTMLDivElement>(null);
+	return (
+		<AnimatedPreview
+			reset={() => setOpen(false)}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click("trigger", () => setOpen(true));
+				await s.wait(1700);
+				await s.do(() => setOpen(false));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<div ref={boxRef} className="relative flex size-full [transform:translateZ(0)] items-center justify-center">
+					<span ref={ref("trigger")} className="inline-flex">
+						<Button onPress={() => setOpen(true)}>Open drawer</Button>
+					</span>
+					<Drawer isOpen={open} onOpenChange={setOpen} container={boxRef.current} style={NO_BLEED}>
+						<DialogContent>
+							<DrawerHandle />
+							<DialogHeader>
+								<DialogTitle>Drag me down</DialogTitle>
+							</DialogHeader>
+							<DialogBody>Or click outside to dismiss.</DialogBody>
+						</DialogContent>
+					</Drawer>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/empty.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/empty.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { FolderCodeIcon } from "lucide-react";
+
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/registry/ui/empty";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	return (
+		<AnimatedPreview
+			script={async (s) => {
+				await s.moveOff();
+				await s.wait(2400);
+			}}
+		>
+			{() => (
+				<Empty className="p-2">
+					<EmptyHeader>
+						<EmptyMedia variant="icon">
+							<FolderCodeIcon />
+						</EmptyMedia>
+						<EmptyTitle>No projects yet</EmptyTitle>
+						<EmptyDescription>Create your first project to get started.</EmptyDescription>
+					</EmptyHeader>
+				</Empty>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/field.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/field.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+
+import { Description, Field, FieldContent, Label } from "@/registry/ui/field";
+import { Switch, SwitchControl } from "@/registry/ui/switch";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [selected, setSelected] = useState(false);
+	return (
+		<AnimatedPreview
+			reset={() => setSelected(false)}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click("switch", () => setSelected(true));
+				await s.wait(1300);
+				await s.click("switch", () => setSelected(false));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{(ref) => (
+				<div className="w-60">
+					<Field orientation="horizontal">
+						<FieldContent>
+							<Label>Notifications</Label>
+							<Description>Email me about updates.</Description>
+						</FieldContent>
+						<span ref={ref("switch")}>
+							<Switch aria-label="Notifications" isSelected={selected} onChange={setSelected}>
+								<SwitchControl />
+							</Switch>
+						</span>
+					</Field>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/file-trigger.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/file-trigger.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+
+import { UploadIcon } from "@/registry/__generated__/icons";
+import { Button } from "@/registry/ui/button";
+import { FileTrigger } from "@/registry/ui/file-trigger";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [pressed, setPressed] = useState(false);
+	const [file, setFile] = useState<string | null>(null);
+	return (
+		<AnimatedPreview
+			reset={() => {
+				setPressed(false);
+				setFile(null);
+			}}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click("trigger", () => {
+					setPressed(true);
+					setTimeout(() => setPressed(false), 160);
+					setFile("report.pdf");
+				});
+				await s.wait(1700);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<div className="flex flex-col items-center gap-3">
+					<span
+						ref={ref("trigger")}
+						className="inline-block transition-transform"
+						style={{ scale: pressed ? 0.94 : 1 }}
+					>
+						<FileTrigger
+							onSelect={(e) => {
+								if (e) {
+									const name = Array.from(e)[0]?.name;
+									if (name) setFile(name);
+								}
+							}}
+						>
+							<Button>
+								<UploadIcon /> Upload
+							</Button>
+						</FileTrigger>
+					</span>
+					{file && (
+						<p className="text-sm text-fg-muted">
+							Selected <span className="font-medium text-fg">{file}</span>
+						</p>
+					)}
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/form.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/form.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+
+import * as FormPrimitives from "react-aria-components/Form";
+
+import { Button } from "@/registry/ui/button";
+import { Label } from "@/registry/ui/field";
+import { Input } from "@/registry/ui/input";
+import { TextField } from "@/registry/ui/text-field";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState("");
+	const [pressed, setPressed] = useState(false);
+	return (
+		<AnimatedPreview
+			reset={() => {
+				setValue("");
+				setPressed(false);
+			}}
+			script={async (s) => {
+				await s.wait(500);
+				await s.type("field", "Ada", setValue, { perChar: 130 });
+				await s.wait(600);
+				await s.click("submit", () => {
+					setPressed(true);
+					setTimeout(() => setPressed(false), 170);
+				});
+				await s.wait(1300);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<FormPrimitives.Form
+					className="w-52 space-y-3"
+					onSubmit={(e) => {
+						e.preventDefault();
+					}}
+				>
+					<div ref={ref("field")}>
+						<TextField value={value} onChange={setValue}>
+							<Label>Name</Label>
+							<Input placeholder="Name" />
+						</TextField>
+					</div>
+					<span ref={ref("submit")} className="inline-block transition-transform" style={{ scale: pressed ? 0.94 : 1 }}>
+						<Button variant="primary" type="submit">
+							Submit
+						</Button>
+					</span>
+				</FormPrimitives.Form>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/group.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/group.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+
+import { FlipHorizontalIcon, FlipVerticalIcon, RotateCwIcon } from "@/registry/__generated__/icons";
+import { Button } from "@/registry/ui/button";
+import { Group } from "@/registry/ui/group";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	// index of the momentarily-pressed button (visual feedback only)
+	const [pressed, setPressed] = useState<number | null>(null);
+	const tap = (i: number) => {
+		setPressed(i);
+		setTimeout(() => setPressed(null), 150);
+	};
+	const scale = (i: number) => ({ scale: pressed === i ? 0.9 : 1 }) as const;
+	return (
+		<AnimatedPreview
+			reset={() => setPressed(null)}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click({ selector: "[data-button]:nth-child(1)" }, () => tap(0));
+				await s.wait(800);
+				await s.click({ selector: "[data-button]:nth-child(3)" }, () => tap(2));
+				await s.wait(800);
+				await s.click({ selector: "[data-button]:nth-child(2)" }, () => tap(1));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{() => (
+				<Group aria-label="Transform image">
+					<Button isIconOnly aria-label="Flip horizontal" className="transition-transform" style={scale(0)}>
+						<FlipHorizontalIcon />
+					</Button>
+					<Button isIconOnly aria-label="Flip vertical" className="transition-transform" style={scale(1)}>
+						<FlipVerticalIcon />
+					</Button>
+					<Button isIconOnly aria-label="Rotate" className="transition-transform" style={scale(2)}>
+						<RotateCwIcon />
+					</Button>
+				</Group>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/input-group.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/input-group.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+import { AtSignIcon } from "lucide-react";
+
+import { Input, InputGroup, InputGroupAddon } from "@/registry/ui/input";
+import { TextField } from "@/registry/ui/text-field";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState("");
+	return (
+		<AnimatedPreview
+			reset={() => setValue("")}
+			script={async (s) => {
+				await s.wait(500);
+				await s.type("field", "mehdibha", setValue, { perChar: 100 });
+				await s.wait(1500);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<div ref={ref("field")} className="w-56">
+					<TextField aria-label="Username" value={value} onChange={setValue}>
+						<InputGroup>
+							<InputGroupAddon>
+								<AtSignIcon />
+							</InputGroupAddon>
+							<Input placeholder="username" />
+							<InputGroupAddon>.dev</InputGroupAddon>
+						</InputGroup>
+					</TextField>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/input.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/input.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+
+import { Input } from "@/registry/ui/input";
+import { TextField } from "@/registry/ui/text-field";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState("");
+	return (
+		<AnimatedPreview
+			reset={() => setValue("")}
+			script={async (s) => {
+				await s.wait(500);
+				await s.type("field", "dotUI", setValue, { perChar: 110 });
+				await s.wait(1500);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<div ref={ref("field")} className="w-52">
+					<TextField aria-label="Name" value={value} onChange={setValue}>
+						<Input placeholder="Enter text..." />
+					</TextField>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/kbd.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/kbd.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Kbd, KbdGroup } from "@/registry/ui/kbd";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	return (
+		<AnimatedPreview
+			script={async (s) => {
+				await s.moveOff();
+				await s.wait(2400);
+			}}
+		>
+			{() => (
+				<KbdGroup>
+					<Kbd>⌘</Kbd>
+					<Kbd>Shift</Kbd>
+					<Kbd>P</Kbd>
+				</KbdGroup>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/link.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/link.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+
+import { Link } from "@/registry/ui/link";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [pressed, setPressed] = useState(false);
+	return (
+		<AnimatedPreview
+			reset={() => setPressed(false)}
+			script={async (s) => {
+				await s.wait(500);
+				await s.hover("link", { dwell: 1000 });
+				await s.press(() => {
+					setPressed(true);
+					setTimeout(() => setPressed(false), 160);
+				});
+				await s.wait(1100);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{(ref) => (
+				<p className="text-sm text-fg-muted">
+					Built with{" "}
+					<span ref={ref("link")} className="inline-block transition-transform" style={{ scale: pressed ? 0.94 : 1 }}>
+						<Link href="#">React Aria</Link>
+					</span>{" "}
+					primitives.
+				</p>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/list-box.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/list-box.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+
+import { CopyIcon, PencilIcon, ShareIcon, StarIcon } from "lucide-react";
+
+import type { Key } from "react-aria-components/ListBox";
+
+import { ListBox, ListBoxItem } from "@/registry/ui/list-box";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const initial = new Set<Key>(["edit"]);
+
+export default function Demo() {
+	const [selected, setSelected] = useState<Set<Key>>(initial);
+	return (
+		<AnimatedPreview
+			reset={() => setSelected(initial)}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click({ selector: ".li-share" }, () => setSelected(new Set(["share"])));
+				await s.wait(1100);
+				await s.click({ selector: ".li-favorite" }, () => setSelected(new Set(["favorite"])));
+				await s.wait(1200);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{() => (
+				<div className="w-52 rounded-md border bg-card shadow-sm">
+					<ListBox
+						aria-label="Actions"
+						selectionMode="single"
+						selectedKeys={selected}
+						onSelectionChange={(keys) => {
+							if (keys !== "all") setSelected(new Set(keys));
+						}}
+					>
+						<ListBoxItem id="edit" className="li-edit">
+							<PencilIcon />
+							Edit
+						</ListBoxItem>
+						<ListBoxItem id="copy" className="li-copy">
+							<CopyIcon />
+							Copy link
+						</ListBoxItem>
+						<ListBoxItem id="share" className="li-share">
+							<ShareIcon />
+							Share
+						</ListBoxItem>
+						<ListBoxItem id="favorite" className="li-favorite">
+							<StarIcon />
+							Add to favorites
+						</ListBoxItem>
+					</ListBox>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/loader.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/loader.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Loader } from "@/registry/ui/loader";
+
+import { AnimatedPreview } from "../animated-preview";
+
+// Display-only: no cursor. The loader spins on its own (CSS animation).
+export default function Demo() {
+	return (
+		<AnimatedPreview
+			script={async (s) => {
+				await s.moveOff();
+				await s.wait(2000);
+			}}
+		>
+			{() => (
+				<div className="flex items-center gap-2 text-sm text-fg-muted">
+					<Loader />
+					<span>Loading…</span>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/menu.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/menu.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+import { CreditCardIcon, LogOutIcon, SettingsIcon, UserIcon } from "@/registry/__generated__/icons";
+import { Button } from "@/registry/ui/button";
+import { Menu, MenuContent, MenuItem } from "@/registry/ui/menu";
+import { Popover } from "@/registry/ui/popover";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [open, setOpen] = useState(false);
+	return (
+		<AnimatedPreview
+			contain
+			reset={() => setOpen(false)}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click({ selector: "button" }, () => setOpen(true));
+				await s.wait(700);
+				await s.moveTo({ selector: '[role="menuitem"]:nth-child(2)' });
+				await s.wait(500);
+				await s.click({ selector: '[role="menuitem"]:nth-child(2)' }, () => setOpen(false));
+				await s.wait(1000);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{() => (
+				<Menu isOpen={open} onOpenChange={setOpen}>
+					<Button variant="default" className="w-fit">
+						Open menu
+					</Button>
+					<Popover>
+						<MenuContent className="min-w-44">
+							<MenuItem>
+								<UserIcon />
+								Profile
+							</MenuItem>
+							<MenuItem>
+								<CreditCardIcon />
+								Billing
+							</MenuItem>
+							<MenuItem>
+								<SettingsIcon />
+								Settings
+							</MenuItem>
+							<MenuItem variant="danger">
+								<LogOutIcon />
+								Log out
+							</MenuItem>
+						</MenuContent>
+					</Popover>
+				</Menu>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/modal.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/modal.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/registry/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/registry/ui/dialog";
+import { Modal } from "@/registry/ui/modal";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [open, setOpen] = useState(false);
+	return (
+		<AnimatedPreview
+			contain
+			reset={() => setOpen(false)}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click("trigger", () => setOpen(true));
+				await s.wait(1200);
+				await s.click({ selector: '[data-slot="dialog-footer"] button:last-child' }, () => setOpen(false));
+				await s.wait(800);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<Dialog isOpen={open} onOpenChange={setOpen}>
+					<span ref={ref("trigger")}>
+						<Button size="sm">Delete project</Button>
+					</span>
+					<Modal isDismissable={false}>
+						<DialogContent>
+							<DialogHeader>
+								<DialogTitle>Delete project?</DialogTitle>
+								<DialogDescription>This action cannot be undone.</DialogDescription>
+							</DialogHeader>
+							<DialogFooter className="flex-row! justify-end">
+								<Button slot="close" size="sm">
+									Cancel
+								</Button>
+								<Button slot="close" size="sm" variant="danger">
+									Delete
+								</Button>
+							</DialogFooter>
+						</DialogContent>
+					</Modal>
+				</Dialog>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/number-field.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/number-field.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+
+import { Group } from "@/registry/ui/group";
+import { Input } from "@/registry/ui/input";
+import { NumberField, NumberFieldDecrement, NumberFieldIncrement } from "@/registry/ui/number-field";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState(24);
+	return (
+		<AnimatedPreview
+			reset={() => setValue(24)}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click({ selector: '[slot="increment"]' }, () => setValue((v) => v + 1));
+				await s.wait(280);
+				await s.press(() => setValue((v) => v + 1));
+				await s.wait(280);
+				await s.press(() => setValue((v) => v + 1));
+				await s.wait(950);
+				await s.click({ selector: '[slot="decrement"]' }, () => setValue((v) => v - 1));
+				await s.wait(950);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{() => (
+				<div className="w-44">
+					<NumberField aria-label="Quantity" value={value} onChange={setValue}>
+						<Group>
+							<NumberFieldDecrement />
+							<Input />
+							<NumberFieldIncrement />
+						</Group>
+					</NumberField>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/otp-field.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/otp-field.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+
+import { Group } from "@/registry/ui/group";
+import { Input } from "@/registry/ui/input";
+import { OTPField } from "@/registry/ui/otp-field";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState("");
+	return (
+		<AnimatedPreview
+			reset={() => setValue("")}
+			script={async (s) => {
+				await s.wait(500);
+				await s.type("group", "2048", setValue, { perChar: 230 });
+				await s.wait(1400);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<OTPField aria-label="Verification code" length={4} value={value} onChange={setValue}>
+					<div ref={ref("group")} className="inline-flex">
+						<Group>
+							<Input />
+							<Input aria-label="Digit 2" />
+							<Input aria-label="Digit 3" />
+							<Input aria-label="Digit 4" />
+						</Group>
+					</div>
+				</OTPField>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/popover.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/popover.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+
+import { InfoIcon } from "lucide-react";
+
+import { Button } from "@/registry/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/registry/ui/dialog";
+import { Popover } from "@/registry/ui/popover";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [open, setOpen] = useState(false);
+	return (
+		<AnimatedPreview
+			contain
+			reset={() => setOpen(false)}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click("trigger", () => setOpen(true));
+				await s.wait(1900);
+				await s.click("trigger", () => setOpen(false));
+				await s.wait(700);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<span ref={ref("trigger")} className="inline-flex">
+					<Dialog isOpen={open} onOpenChange={setOpen}>
+						<Button aria-label="Help" isIconOnly>
+							<InfoIcon />
+						</Button>
+						<Popover className="w-56">
+							<DialogContent>
+								<DialogHeader>
+									<DialogTitle>Need help?</DialogTitle>
+								</DialogHeader>
+								<p>Contact our support team if you run into any issues.</p>
+							</DialogContent>
+						</Popover>
+					</Dialog>
+				</span>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/progress-bar.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/progress-bar.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+
+import { Label } from "@/registry/ui/field";
+import { ProgressBar, ProgressBarControl, ProgressBarOutput } from "@/registry/ui/progress-bar";
+
+import { AnimatedPreview } from "../animated-preview";
+
+// Timer-driven: no cursor. The value climbs to 100% then resets and climbs again.
+export default function Demo() {
+	const [value, setValue] = useState(0);
+	return (
+		<AnimatedPreview
+			reset={() => setValue(0)}
+			script={async (s) => {
+				await s.wait(350);
+				const steps = 40;
+				for (let i = 1; i <= steps; i++) {
+					await s.do(() => setValue(Math.round((i / steps) * 100)));
+					await s.wait(55);
+				}
+				await s.wait(900);
+			}}
+		>
+			{() => (
+				<ProgressBar aria-label="Uploading" value={value} className="w-60">
+					<div className="flex items-center justify-between gap-2">
+						<Label>Uploading</Label>
+						<ProgressBarOutput />
+					</div>
+					<ProgressBarControl />
+				</ProgressBar>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/radio-group.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/radio-group.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+
+import { FieldGroup, Label } from "@/registry/ui/field";
+import { Radio, RadioControl, RadioGroup } from "@/registry/ui/radio-group";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState("free");
+	return (
+		<AnimatedPreview
+			reset={() => setValue("free")}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click("pro", () => setValue("pro"));
+				await s.wait(900);
+				await s.click("team", () => setValue("team"));
+				await s.wait(900);
+				await s.click("free", () => setValue("free"));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{(ref) => (
+				<RadioGroup aria-label="Plan" value={value} onChange={setValue}>
+					<FieldGroup>
+						<span ref={ref("free")}>
+							<Radio value="free">
+								<RadioControl />
+								<Label>Free</Label>
+							</Radio>
+						</span>
+						<span ref={ref("pro")}>
+							<Radio value="pro">
+								<RadioControl />
+								<Label>Pro</Label>
+							</Radio>
+						</span>
+						<span ref={ref("team")}>
+							<Radio value="team">
+								<RadioControl />
+								<Label>Team</Label>
+							</Radio>
+						</span>
+					</FieldGroup>
+				</RadioGroup>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/scroll-fade.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/scroll-fade.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRef } from "react";
+
+import { ScrollFade } from "@/registry/ui/scroll-fade";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const items = ["Inbox", "Drafts", "Sent", "Archive", "Spam", "Trash", "Starred", "Snoozed", "Important", "All mail"];
+
+export default function Demo() {
+	const scrollRef = useRef<HTMLDivElement>(null);
+
+	const scrollTo = async (s: { wait: (ms: number) => Promise<void> }, target: number, steps = 24) => {
+		const el = scrollRef.current;
+		if (!el) return;
+		const start = el.scrollTop;
+		for (let i = 1; i <= steps; i++) {
+			el.scrollTop = start + (target - start) * (i / steps);
+			await s.wait(16);
+		}
+	};
+
+	return (
+		<AnimatedPreview
+			reset={() => {
+				if (scrollRef.current) scrollRef.current.scrollTop = 0;
+			}}
+			script={async (s) => {
+				await s.moveOff();
+				await s.wait(700);
+				const el = scrollRef.current;
+				const max = el ? el.scrollHeight - el.clientHeight : 0;
+				await scrollTo(s, max);
+				await s.wait(900);
+				await scrollTo(s, 0);
+				await s.wait(700);
+			}}
+		>
+			{() => (
+				<ScrollFade ref={scrollRef} className="h-32 w-44 rounded-lg border bg-bg p-2">
+					<div className="space-y-1.5">
+						{items.map((item) => (
+							<div key={item} className="rounded-md bg-muted px-3 py-1.5 text-sm">
+								{item}
+							</div>
+						))}
+					</div>
+				</ScrollFade>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/search-field.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/search-field.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+
+import { SearchField } from "@/registry/ui/search-field";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState("");
+	return (
+		<AnimatedPreview
+			reset={() => setValue("")}
+			script={async (s) => {
+				await s.wait(500);
+				await s.type("field", "components", setValue, { perChar: 90 });
+				await s.wait(1300);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<div ref={ref("field")} className="w-56">
+					<SearchField aria-label="Search" placeholder="Search..." value={value} onChange={setValue} />
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/select.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/select.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+
+import { Select, SelectContent, SelectItem, SelectTrigger } from "@/registry/ui/select";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [open, setOpen] = useState(false);
+	const [key, setKey] = useState<string | null>(null);
+	return (
+		<AnimatedPreview
+			contain
+			reset={() => {
+				setOpen(false);
+				setKey(null);
+			}}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click("trigger", () => setOpen(true));
+				await s.wait(700);
+				await s.click({ selector: '[role="option"]:nth-child(2)' }, () => {
+					setKey("replicate");
+					setOpen(false);
+				});
+				await s.wait(1500);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<div ref={ref("trigger")} className="w-52">
+					<Select
+						aria-label="Provider"
+						placeholder="Select a provider"
+						selectedKey={key}
+						onSelectionChange={(k) => setKey(k as string | null)}
+					>
+						<SelectTrigger />
+						<SelectContent isOpen={open} onOpenChange={setOpen}>
+							<SelectItem id="perplexity">Perplexity</SelectItem>
+							<SelectItem id="replicate">Replicate</SelectItem>
+							<SelectItem id="together">Together AI</SelectItem>
+						</SelectContent>
+					</Select>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/separator.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/separator.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Separator } from "@/registry/ui/separator";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	return (
+		<AnimatedPreview
+			script={async (s) => {
+				await s.moveOff();
+				await s.wait(2400);
+			}}
+		>
+			{() => (
+				<div className="w-56">
+					<div>
+						<h3 className="text-sm font-bold">dotUI</h3>
+						<p className="text-xs text-fg-muted">Accessible UI components.</p>
+					</div>
+					<Separator className="my-3" />
+					<div className="flex h-5 items-center space-x-3 text-sm">
+						<span>Docs</span>
+						<Separator orientation="vertical" />
+						<span>Components</span>
+						<Separator orientation="vertical" />
+						<span>Hooks</span>
+					</div>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/skeleton.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/skeleton.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+
+import { Avatar, AvatarFallback } from "@/registry/ui/avatar";
+import { Skeleton } from "@/registry/ui/skeleton";
+
+import { AnimatedPreview } from "../animated-preview";
+
+// Display-only: no cursor. Loops loading placeholders, then reveals the real content.
+export default function Demo() {
+	const [isLoading, setLoading] = useState(true);
+	return (
+		<AnimatedPreview
+			reset={() => setLoading(true)}
+			script={async (s) => {
+				await s.wait(1400);
+				await s.do(() => setLoading(false));
+				await s.wait(1800);
+			}}
+		>
+			{() => (
+				<Skeleton isLoading={isLoading}>
+					<div className="flex items-center gap-4">
+						<Avatar size="lg">
+							<AvatarFallback>DU</AvatarFallback>
+						</Avatar>
+						<div className="space-y-2">
+							<div data-card-title="" className="h-4 w-32 text-sm font-medium">
+								Mehdi Ben Hadj Ali
+							</div>
+							<div data-card-description="" className="h-4 w-24 text-sm text-fg-muted">
+								Product designer
+							</div>
+						</div>
+					</div>
+				</Skeleton>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/slider.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/slider.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+
+import { Slider, SliderControl, SliderFill, SliderThumb, SliderTrack } from "@/registry/ui/slider";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState(20);
+	return (
+		<AnimatedPreview
+			reset={() => setValue(20)}
+			script={async (s) => {
+				await s.wait(500);
+				await s.drag({ selector: "input" }, { selector: "input" }, (t) => setValue(Math.round(20 + t * 65)), {
+					steps: 36,
+				});
+				await s.wait(1300);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{() => (
+				<div className="w-56">
+					<Slider aria-label="Volume" value={value} onChange={(v) => setValue(Array.isArray(v) ? (v[0] ?? 0) : v)}>
+						<SliderControl>
+							<SliderTrack>
+								<SliderFill />
+							</SliderTrack>
+							<SliderThumb />
+						</SliderControl>
+					</Slider>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/switch.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/switch.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+
+import { Switch } from "@/registry/ui/switch";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [selected, setSelected] = useState(false);
+	return (
+		<AnimatedPreview
+			reset={() => setSelected(false)}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click("sw", () => setSelected(true));
+				await s.wait(1300);
+				await s.click("sw", () => setSelected(false));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<span ref={ref("sw")}>
+					<Switch isSelected={selected} onChange={setSelected}>
+						Airplane mode
+					</Switch>
+				</span>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/table.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/table.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+import type { Selection } from "react-aria-components";
+
+import { Table, TableBody, TableCell, TableColumn, TableContainer, TableHeader, TableRow } from "@/registry/ui/table";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const rows = [
+	{ id: "games", name: "Games", type: "Folder" },
+	{ id: "docs", name: "Documents", type: "Folder" },
+	{ id: "notes", name: "notes.txt", type: "Text" },
+];
+
+export default function Demo() {
+	const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set());
+	return (
+		<AnimatedPreview
+			reset={() => setSelectedKeys(new Set())}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click("games", () => setSelectedKeys(new Set(["games"])));
+				await s.wait(1100);
+				await s.click("notes", () => setSelectedKeys(new Set(["games", "notes"])));
+				await s.wait(1400);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{(ref) => (
+				<TableContainer className="w-64">
+					<Table
+						aria-label="Files"
+						selectionMode="multiple"
+						selectedKeys={selectedKeys}
+						onSelectionChange={setSelectedKeys}
+					>
+						<TableHeader>
+							<TableColumn isRowHeader>Name</TableColumn>
+							<TableColumn>Type</TableColumn>
+						</TableHeader>
+						<TableBody>
+							{rows.map((row) => (
+								<TableRow key={row.id} id={row.id}>
+									<TableCell>
+										<span ref={ref(row.id)}>{row.name}</span>
+									</TableCell>
+									<TableCell>{row.type}</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</TableContainer>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/tabs.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/tabs.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+
+import type { Key } from "react-aria-components/Menu";
+
+import { Tab, TabList, TabPanel, Tabs } from "@/registry/ui/tabs";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [selected, setSelected] = useState<Key>("account");
+	return (
+		<AnimatedPreview
+			reset={() => setSelected("account")}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click("password", () => setSelected("password"));
+				await s.wait(1300);
+				await s.click("team", () => setSelected("team"));
+				await s.wait(1300);
+				await s.click("account", () => setSelected("account"));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<Tabs selectedKey={selected} onSelectionChange={setSelected}>
+					<TabList>
+						<Tab id="account">
+							<span ref={ref("account")}>Account</span>
+						</Tab>
+						<Tab id="password">
+							<span ref={ref("password")}>Password</span>
+						</Tab>
+						<Tab id="team">
+							<span ref={ref("team")}>Team</span>
+						</Tab>
+					</TabList>
+					<TabPanel id="account" className="text-sm text-fg-muted">
+						Manage your account.
+					</TabPanel>
+					<TabPanel id="password" className="text-sm text-fg-muted">
+						Change your password.
+					</TabPanel>
+					<TabPanel id="team" className="text-sm text-fg-muted">
+						Invite your team.
+					</TabPanel>
+				</Tabs>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/tag-group.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/tag-group.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+
+import type { Key } from "react-aria-components/TagGroup";
+
+import { Label } from "@/registry/ui/field";
+import { Tag, TagGroup, TagList } from "@/registry/ui/tag-group";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const initial = new Set<Key>(["news"]);
+
+export default function Demo() {
+	const [selected, setSelected] = useState<Set<Key>>(initial);
+	return (
+		<AnimatedPreview
+			reset={() => setSelected(initial)}
+			script={async (s) => {
+				await s.wait(600);
+				await s.click({ selector: ".tag-gaming" }, () => setSelected(new Set(["gaming"])));
+				await s.wait(1000);
+				await s.click({ selector: ".tag-travel" }, () => setSelected(new Set(["travel"])));
+				await s.wait(1100);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{() => (
+				<TagGroup
+					selectionMode="single"
+					selectedKeys={selected}
+					onSelectionChange={(keys) => {
+						if (keys !== "all") setSelected(new Set(keys));
+					}}
+				>
+					<Label>Categories</Label>
+					<TagList>
+						<Tag id="news" className="tag-news">
+							News
+						</Tag>
+						<Tag id="travel" className="tag-travel">
+							Travel
+						</Tag>
+						<Tag id="gaming" className="tag-gaming">
+							Gaming
+						</Tag>
+						<Tag id="shopping" className="tag-shopping">
+							Shopping
+						</Tag>
+					</TagList>
+				</TagGroup>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/text-area.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/text-area.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+
+import { Label } from "@/registry/ui/field";
+import { TextArea } from "@/registry/ui/input";
+import { TextField } from "@/registry/ui/text-field";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState("");
+	return (
+		<AnimatedPreview
+			reset={() => setValue("")}
+			script={async (s) => {
+				await s.wait(500);
+				await s.type("field", "Roses are red,\nviolets are blue.", setValue, { perChar: 55 });
+				await s.wait(1500);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<div ref={ref("field")} className="w-56">
+					<TextField value={value} onChange={setValue}>
+						<Label>Message</Label>
+						<TextArea placeholder="Write something..." />
+					</TextField>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/text-field.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/text-field.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+
+import { Input } from "@/registry/ui/input";
+import { TextField } from "@/registry/ui/text-field";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [value, setValue] = useState("");
+	return (
+		<AnimatedPreview
+			reset={() => setValue("")}
+			script={async (s) => {
+				await s.wait(500);
+				await s.type("field", "hello@dotui.com", setValue);
+				await s.wait(1600);
+				await s.moveOff();
+				await s.wait(700);
+			}}
+		>
+			{(ref) => (
+				<div ref={ref("field")} className="w-56">
+					<TextField aria-label="Email" value={value} onChange={setValue}>
+						<Input placeholder="you@example.com" />
+					</TextField>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/time-field.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/time-field.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+
+import { Time } from "@internationalized/date";
+
+import type * as TimeFieldPrimitives from "react-aria-components/TimeField";
+
+import { DateInput } from "@/registry/ui/input";
+import { TimeField } from "@/registry/ui/time-field";
+
+import { AnimatedPreview } from "../animated-preview";
+
+const initial = new Time(9, 30);
+
+export default function Demo() {
+	const [value, setValue] = useState<TimeFieldPrimitives.TimeValue>(initial);
+	return (
+		<AnimatedPreview
+			reset={() => setValue(initial)}
+			script={async (s) => {
+				await s.wait(500);
+				// Nudge the minute segment upward, like holding the up arrow.
+				await s.moveTo({ selector: '[data-type="minute"]' });
+				await s.wait(140);
+				for (let i = 0; i < 4; i++) {
+					await s.press(() => setValue((v) => v.add({ minutes: 5 })));
+					await s.wait(280);
+				}
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(600);
+			}}
+		>
+			{() => (
+				<div className="w-40">
+					<TimeField
+						aria-label="Reminder time"
+						value={value}
+						onChange={(v) => {
+							if (v) setValue(v);
+						}}
+					>
+						<DateInput />
+					</TimeField>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/toast.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/toast.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+
+import { CircleCheckIcon } from "lucide-react";
+
+import { AnimatedPreview } from "../animated-preview";
+
+// Timer-driven: no cursor. A toast slides up, dwells, then slides back out.
+// The real Toast renders through a fixed, body-level portal managed by a global
+// singleton, which can't live inside a small isolated card — so this mirrors the
+// toast anatomy (bg-card / border / icon / title / description) and animates it.
+export default function Demo() {
+	const [shown, setShown] = useState(false);
+	return (
+		<AnimatedPreview
+			reset={() => setShown(false)}
+			script={async (s) => {
+				await s.wait(400);
+				await s.do(() => setShown(true));
+				await s.wait(2000);
+				await s.do(() => setShown(false));
+				await s.wait(800);
+			}}
+		>
+			{() => (
+				<div className="flex w-full justify-center px-4">
+					<div
+						className="flex w-72 items-center gap-2 rounded-lg border border-border-success bg-card px-3.5 py-3 text-fg shadow-lg transition-all duration-500 ease-out"
+						style={{
+							opacity: shown ? 1 : 0,
+							transform: shown ? "translateY(0)" : "translateY(12px)",
+						}}
+					>
+						<div className="flex size-4 shrink-0 items-center justify-center text-fg-success">
+							<CircleCheckIcon aria-hidden="true" className="size-4" />
+						</div>
+						<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+							<div className="text-sm leading-snug font-medium">Changes saved</div>
+							<div className="text-sm leading-snug text-fg-muted">Your update is now live.</div>
+						</div>
+					</div>
+				</div>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/toggle-button-group.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/toggle-button-group.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+
+import type { Selection } from "react-aria-components";
+
+import { BoldIcon, ItalicIcon, UnderlineIcon } from "@/registry/__generated__/icons";
+import { ToggleButton } from "@/registry/ui/toggle-button";
+import { ToggleButtonGroup } from "@/registry/ui/toggle-button-group";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [selected, setSelected] = useState<Selection>(() => new Set(["bold"]));
+	return (
+		<AnimatedPreview
+			reset={() => setSelected(new Set(["bold"]))}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click({ selector: "[data-toggle-button]:nth-child(2)" }, () =>
+					setSelected(new Set(["bold", "italic"])),
+				);
+				await s.wait(850);
+				await s.click({ selector: "[data-toggle-button]:nth-child(3)" }, () =>
+					setSelected(new Set(["bold", "italic", "underline"])),
+				);
+				await s.wait(900);
+				await s.click({ selector: "[data-toggle-button]:nth-child(1)" }, () =>
+					setSelected(new Set(["italic", "underline"])),
+				);
+				await s.wait(1000);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{() => (
+				<ToggleButtonGroup
+					selectionMode="multiple"
+					selectedKeys={selected}
+					onSelectionChange={setSelected}
+					aria-label="Text formatting"
+				>
+					<ToggleButton id="bold" isIconOnly aria-label="Bold">
+						<BoldIcon />
+					</ToggleButton>
+					<ToggleButton id="italic" isIconOnly aria-label="Italic">
+						<ItalicIcon />
+					</ToggleButton>
+					<ToggleButton id="underline" isIconOnly aria-label="Underline">
+						<UnderlineIcon />
+					</ToggleButton>
+				</ToggleButtonGroup>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/toggle-button.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/toggle-button.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+
+import { PinIcon } from "@/registry/__generated__/icons";
+import { ToggleButton } from "@/registry/ui/toggle-button";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [isSelected, setSelected] = useState(false);
+	return (
+		<AnimatedPreview
+			reset={() => setSelected(false)}
+			script={async (s) => {
+				await s.wait(500);
+				await s.click("tgl", () => setSelected(true));
+				await s.wait(1300);
+				await s.click("tgl", () => setSelected(false));
+				await s.wait(900);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<span ref={ref("tgl")}>
+					<ToggleButton isSelected={isSelected} onChange={setSelected} aria-label="Pin">
+						<PinIcon data-icon-start="" className="rotate-45" />
+						Pin
+					</ToggleButton>
+				</span>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/demos/tooltip.tsx
+++ b/www/src/modules/docs/components-list/anim/demos/tooltip.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+
+import { SquarePenIcon } from "lucide-react";
+
+import { Button } from "@/registry/ui/button";
+import { Kbd } from "@/registry/ui/kbd";
+import { Tooltip, TooltipContent } from "@/registry/ui/tooltip";
+
+import { AnimatedPreview } from "../animated-preview";
+
+export default function Demo() {
+	const [open, setOpen] = useState(false);
+	return (
+		<AnimatedPreview
+			contain
+			reset={() => setOpen(false)}
+			script={async (s) => {
+				await s.wait(600);
+				await s.moveTo("trigger");
+				await s.wait(220);
+				await s.do(() => setOpen(true));
+				await s.wait(1800);
+				await s.do(() => setOpen(false));
+				await s.wait(500);
+				await s.moveOff();
+				await s.wait(500);
+			}}
+		>
+			{(ref) => (
+				<span ref={ref("trigger")}>
+					<Tooltip isOpen={open} onOpenChange={setOpen}>
+						<Button aria-label="Edit" isIconOnly>
+							<SquarePenIcon />
+						</Button>
+						<TooltipContent placement="bottom">
+							Create new issue <Kbd>C</Kbd>
+						</TooltipContent>
+					</Tooltip>
+				</span>
+			)}
+		</AnimatedPreview>
+	);
+}

--- a/www/src/modules/docs/components-list/anim/index.ts
+++ b/www/src/modules/docs/components-list/anim/index.ts
@@ -1,0 +1,19 @@
+import type { ComponentType } from "react";
+
+/**
+ * Animated, self-demoing previews for the components page. Each `demos/<slug>.tsx`
+ * default-exports a component that renders the real component (controlled) and
+ * choreographs a fake cursor through a looping demo; hovering a card pauses the
+ * loop and hands the real component to the user.
+ *
+ * Files are auto-registered by filename (slug) via a Vite glob, so adding a
+ * preview is just dropping a `demos/<slug>.tsx` file — no edits here.
+ */
+const modules = import.meta.glob<{ default: ComponentType }>("./demos/*.tsx", { eager: true });
+
+export const animatedDemos: Record<string, ComponentType> = Object.fromEntries(
+	Object.entries(modules).map(([path, mod]) => {
+		const slug = path.slice(path.lastIndexOf("/") + 1, -".tsx".length);
+		return [slug, mod.default];
+	}),
+);

--- a/www/src/modules/docs/components-list/component-card.tsx
+++ b/www/src/modules/docs/components-list/component-card.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router";
 
 import { cn } from "@/registry/lib/utils";
 
+import { animatedDemos } from "./anim";
 import { componentDemos } from "./demos";
 import { overlayPreviews } from "./previews";
 
@@ -68,10 +69,15 @@ export function ComponentCard({
 	previewClassName,
 }: ComponentCardProps) {
 	const Demo = componentDemos[slug];
+	const Animated = animatedDemos[slug];
 
 	return (
 		<div className="flex flex-col items-center">
-			{preview === "overlay" ? (
+			{Animated ? (
+				<div className={cn("relative h-32 w-full overflow-hidden rounded-lg border bg-bg", previewClassName)}>
+					<Animated />
+				</div>
+			) : preview === "overlay" ? (
 				<OverlayPreview name={name} slug={slug} className={previewClassName} />
 			) : iframe ? (
 				<IframePreview slug={slug} scale={scale} className={previewClassName} />


### PR DESCRIPTION
Every preview on the **/components** page now demos itself: a fake cursor loops through a short, tasteful interaction (type, toggle, select, drag, step, expand, open an overlay…), and **hovering a card pauses the loop, hides the cursor, and hands the real component to you** to play with.

> Stacked on #176 (uses its `Drawer` `container` prop + overlay-containment patterns). Base = `claude/sweet-borg-f86ae6`; retarget to `main` once #176 merges.

## Architecture

A decisive experiment settled it: **React Aria ignores synthetic events**, so animations are driven by **controlled state + a purely-visual fake cursor** (no dispatched events, and crucially **no real `el.focus()`** — that would steal focus across cards). The cursor is decorative; the component reacts via its real controlled props.

- **`anim/cursor.tsx`** — a `motion`-driven pointer (press scale, fades).
- **`anim/animated-preview.tsx`** — `AnimatedPreview` + an abortable async **driver**: `moveTo / click / press / hover / type / drag / wait / do / moveOff`. It loops the script and, on hover, aborts + hides the cursor + makes the real component interactive. Pauses **off-screen** (IntersectionObserver), on **tab-hide**, and for **`prefers-reduced-motion`**. An opt-in **`contain`** mode portals React Aria overlays into the card (+ client-only render) so overlays open *inside* their card.
- **`anim/index.ts`** — a Vite glob: each component is just a `demos/<slug>.tsx` (default export). **`anim/AUTHORING.md`** documents the contract.

## Coverage — all ~56 components

Buttons, inputs, dates, feedback, collections, navigation, data-display, colors, **and** the overlays/pickers (modal, popover, drawer, tooltip, menu, select, combobox, date-picker — cursor opens them *contained* in the card). Display-only components (badge, avatar, kbd, separator, empty, skeleton, loader, alert) show their best state with no cursor; progress-bar/toast animate on a timer.

## Verification (headless Chrome, the real page)

- Every card renders + animates with **no crashes** and **no new console errors**.
- Overlays open **contained** in their card (modal centered, dropdowns/menus/calendar inside) and **hand off on hover**; the rest of the page stays usable (no focus-steal — the original lesson).
- **Performance:** with the page scrolled, only ~12 cursors animate while **41 are paused** (off-screen), thread stays responsive.
- `typecheck`, `oxlint`, `oxfmt`, `lint:ws`, **119 tests**, registry-drift, and a full production **build** all pass.

_Two pre-existing console warnings on this page (a `DateField` hydration mismatch and a `Breadcrumbs` empty `href`) are unrelated and already filed._