### PR TITLE
fix(www): navbar polish

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -5,8 +5,8 @@
 	"portless": "dotui",
 	"scripts": {
 		"postinstall": "fumadocs-mdx",
-		"dev": "portless run vite dev",
-		"dev:clean": "rm -rf node_modules/.vite .cache && portless run vite dev",
+		"dev": "vite dev",
+		"dev:clean": "rm -rf node_modules/.vite .cache && vite dev",
 		"build:registry": "tsx scripts/registry-build.ts",
 		"build": "pnpm build:registry && NODE_OPTIONS='--max-old-space-size=8192' vite build && pnpm build:postprocess",
 		"build:postprocess": "([ -n \"$VERCEL\" ] && cp -r .vercel/output/dist/client/__tsr .vercel/output/static/__tsr 2>/dev/null || true); node scripts/patch-vercel-config.mjs",

--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -68,7 +68,7 @@ export function Header({ className, items = [] }: HeaderProps) {
 			<div className="flex items-center gap-2">
 				<SearchCommand keyboardShortcut items={items}>
 					<Button variant="default" className="max-md:size-8 max-md:px-0 md:text-fg-muted">
-						<SearchIcon data-icon-start="" className="md:hidden" />
+						<SearchIcon className="md:hidden" />
 						<span className="mr-6 flex-1 max-md:hidden">Search docs...</span>
 						<Kbd className="max-md:hidden">⌘ K</Kbd>
 					</Button>

--- a/www/src/components/layout/mobile-nav.tsx
+++ b/www/src/components/layout/mobile-nav.tsx
@@ -19,7 +19,7 @@ export function MobileNav({ items }: { items: PageTree.Node[] }) {
 				aria-label="Toggle Menu"
 				size="md"
 				isIconOnly
-				className="md:hidden relative flex items-center justify-center"
+				className="relative flex items-center justify-center md:hidden"
 			>
 				<div className="relative h-3.5 w-4 [&>span]:absolute [&>span]:left-0 [&>span]:block [&>span]:h-0.5 [&>span]:w-4 [&>span]:rounded-full [&>span]:bg-fg [&>span]:transition-all [&>span]:duration-150 [&>span]:ease-out">
 					<span className={cn("top-0.25", isOpen && "translate-y-[0.31rem] -rotate-45")} />

--- a/www/src/components/layout/mobile-nav.tsx
+++ b/www/src/components/layout/mobile-nav.tsx
@@ -16,9 +16,10 @@ export function MobileNav({ items }: { items: PageTree.Node[] }) {
 	return (
 		<Dialog isOpen={isOpen} onOpenChange={setIsOpen}>
 			<Button
-				size="sm"
-				className={cn("md:hidden", "relative flex items-center justify-center")}
 				aria-label="Toggle Menu"
+				size="md"
+				isIconOnly
+				className="md:hidden relative flex items-center justify-center"
 			>
 				<div className="relative h-3.5 w-4 [&>span]:absolute [&>span]:left-0 [&>span]:block [&>span]:h-0.5 [&>span]:w-4 [&>span]:rounded-full [&>span]:bg-fg [&>span]:transition-all [&>span]:duration-150 [&>span]:ease-out">
 					<span className={cn("top-0.25", isOpen && "translate-y-[0.31rem] -rotate-45")} />


### PR DESCRIPTION
## Summary

Polish the www navbar:

- **Mobile nav toggle**: switch the menu button to `size="md"` + `isIconOnly` so the hamburger icon is properly sized and centered.
- **Search button**: drop the stray `data-icon-start` attribute on the mobile search icon.
- **Dev script**: run `vite dev` directly instead of via `portless run`.
