### PR TITLE
fix(www): use `shadcn init` for the customizer install command

### DIFF
--- a/www/src/modules/create/install-command.tsx
+++ b/www/src/modules/create/install-command.tsx
@@ -39,12 +39,15 @@ export function InstallCommand() {
 	const command = useMemo(() => {
 		const encoded = encodePreset(designSystem);
 		const url = encoded ? `${host}/r/init?preset=${encoded}` : `${host}/r/init`;
-		// `shadcn add <url>` (not `init`) is the working install invocation:
-		//  - it works on any project that already has a components.json (from a
-		//    prior `npx shadcn init`),
-		//  - it merges dotUI theme fields into the project's CSS and installs `src/lib/utils.ts`,
-		//  - per-component `add` follows transitive deps as absolute URLs.
-		return `npx shadcn add ${url}`;
+		// `shadcn init <url>` is the right command for our `registry:base` item:
+		//  - `init` is the only command that merges the item's `config.registries`
+		//    into the consumer's components.json, so a later
+		//    `shadcn add @dotui/<name>` resolves with the same preset baked in.
+		//  - it also installs the deps, writes the theme css/cssVars, and ships
+		//    `src/lib/utils.ts` — everything `add` did, plus the registry wiring.
+		//  - `shadcn add <url>` silently drops `config.registries` on a project that
+		//    already has components.json, which breaks per-component installs.
+		return `npx shadcn init ${url}`;
 	}, [designSystem, host]);
 
 	async function copy() {


### PR DESCRIPTION
## What

The `/create` customizer's copy-to-clipboard install command now emits:

```
npx shadcn init <host>/r/init?preset=…
```

instead of `npx shadcn add …`.

## Why

`/r/init` returns a **`registry:base`** item ([`emitInitItem`](https://github.com/mehdibha/dotUI/blob/main/www/src/publisher/emit-theme.ts)), which is what `shadcn init` is designed to consume — **not** `shadcn add`.

I verified this against the shadcn CLI source (`packages/shadcn/src/commands/{init,add}.ts`):

| | `init <url>` | `add <url>` (existing project) |
|---|---|---|
| Installs `dependencies` | ✅ | ✅ |
| Writes `css` / `cssVars` | ✅ | ✅ |
| Writes `files[]` (`src/lib/utils.ts`) | ✅ | ✅ |
| **Merges `config.registries` into `components.json`** | ✅ | ❌ (silently dropped) |

The `registry:base` item ships a `config.registries` mapping:

```jsonc
"registries": { "@dotui": "<host>/r/{name}?preset=<encoded>" }
```

This is the linchpin of the `?preset=` architecture: it's what lets a follow-up `shadcn add @dotui/button` resolve back to `/r/button?preset=<encoded>` and reproduce the **same** customized preset. On a project that already has a `components.json`, `shadcn add <url>` never writes that mapping (it only runs `addComponents`, skipping the `runInit` path), so `shadcn add @dotui/<name>` would later fail to resolve. Only `init` merges it.

The previous code comment claimed `add` was "the working install invocation" — that was inaccurate, so it's been rewritten to document the real reasoning. (The top-of-file JSDoc, the `/r/init` route comment, and `emit-theme.ts` already correctly referenced `init`.)

## Scope

- The emitted `registry:base` item already works with `init` **as-is** — no item changes needed (`$schema`/`tailwind.baseColor` are optional; the CLI fills them in from project detection).
- The manual-flow doc (`installation.mdx`) uses a separate `/r/{style}/{name}` + `shadcn add @dotui/base` scheme and is intentionally left untouched.
- No tests assert on the command string; `oxfmt --check` and `oxlint` pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)