### PR TITLE
fix(www): align showcase masonry card tops in Safari

### DIFF
--- a/www/src/components/marketing/showcase/cards.tsx
+++ b/www/src/components/marketing/showcase/cards.tsx
@@ -17,6 +17,17 @@ import { TeamName } from "@/components/marketing/showcase/team-name";
 import { TwoFactor } from "@/components/marketing/showcase/two-factor";
 import { UploadAvatar } from "@/components/marketing/showcase/upload-avatar";
 
+// One masonry cell. The vertical gap between cards is the cell's *padding*-bottom,
+// never a margin: in a CSS multi-column layout WebKit/Safari leaks a child's
+// `margin-bottom` onto the top of the *next* column, so a `*:mb-4` on the grid
+// pushes whichever card lands at the top of a balanced column down by 16px — only
+// in Safari (Chromium aligns them). Padding stays inside the cell's box at the
+// column break, so every column's first card starts flush at the top everywhere.
+// `break-inside-avoid` keeps each card whole instead of splitting across columns.
+function Cell({ children }: { children: React.ReactNode }) {
+	return <div className="break-inside-avoid pb-4">{children}</div>;
+}
+
 // The real showcase cards, centered. On large screens it's capped at `--grid-max`
 // and centered, with the extra space going to the skeleton rails beside it. Below
 // `lg` there are no rails: the grid is deliberately wider than the viewport (a
@@ -25,24 +36,58 @@ import { UploadAvatar } from "@/components/marketing/showcase/upload-avatar";
 // bleed off both edges and get darkened by the overlay in `Cards`.
 function RealCards() {
 	return (
-		<div className="relative z-20 w-[max(52rem,120vw)] max-w-none shrink-0 columns-3 gap-4 *:mb-4 *:break-inside-avoid lg:w-full lg:max-w-(--grid-max) lg:min-w-0 lg:shrink xl:columns-4">
-			<Booking />
-			<TwoFactor />
-			<Filters />
-			<Storage />
-			<Notifications className="h-100" />
-			<CookiePreferences />
-			<InviteMembers />
-			<Shortcuts />
-			<Payment />
-			<ComputerUse />
-			<AccountMenu />
-			<Faq />
-			<ColorEditorCard />
-			<UploadAvatar />
-			<TeamName />
-			<AskAi />
-			<LoginForm className="max-w-none" />
+		<div className="relative z-20 w-[max(52rem,120vw)] max-w-none shrink-0 columns-3 gap-4 lg:w-full lg:max-w-(--grid-max) lg:min-w-0 lg:shrink xl:columns-4">
+			<Cell>
+				<Booking />
+			</Cell>
+			<Cell>
+				<TwoFactor />
+			</Cell>
+			<Cell>
+				<Filters />
+			</Cell>
+			<Cell>
+				<Storage />
+			</Cell>
+			<Cell>
+				<Notifications className="h-100" />
+			</Cell>
+			<Cell>
+				<CookiePreferences />
+			</Cell>
+			<Cell>
+				<InviteMembers />
+			</Cell>
+			<Cell>
+				<Shortcuts />
+			</Cell>
+			<Cell>
+				<Payment />
+			</Cell>
+			<Cell>
+				<ComputerUse />
+			</Cell>
+			<Cell>
+				<AccountMenu />
+			</Cell>
+			<Cell>
+				<Faq />
+			</Cell>
+			<Cell>
+				<ColorEditorCard />
+			</Cell>
+			<Cell>
+				<UploadAvatar />
+			</Cell>
+			<Cell>
+				<TeamName />
+			</Cell>
+			<Cell>
+				<AskAi />
+			</Cell>
+			<Cell>
+				<LoginForm className="max-w-none" />
+			</Cell>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- The landing-page components showcase (`www/src/components/marketing/showcase/cards.tsx`) is a CSS multi-column masonry (`columns-3`) that used a per-card `margin-bottom` (`*:mb-4`) for the vertical gap.
- **WebKit/Safari leaks a child's `margin-bottom` onto the top of the next balanced column**, so the card landing at the top of the middle column (Invite Members) rendered **16px lower** than its neighbours — reported on iPhone. Chromium aligns all column tops, so it's invisible in a desktop/Chromium preview.
- Fix: provide the gap with **`padding-bottom` on a `break-inside-avoid` cell wrapper** instead of margin. Padding stays inside the cell's box at the column break and can't leak. No design change otherwise.

## Why margin → padding (and not `gap`/`row-gap`)

`row-gap`/`gap` don't apply to block-direction spacing in CSS multi-column (Chromium ignores them), which is why the original used per-item margin. Margin is the one thing WebKit mishandles at column breaks, so the gap is moved to padding on a transparent wrapper.

## Verification

Reproduced in **real WebKit** (Playwright — same engine as iOS Safari; the Chromium-only preview can't surface this), then confirmed the fix in WebKit **and** Chromium:

- Column tops aligned (`topSpread = 0`) at 393 / 430 / 768 / 1280 / 1536px, including the `xl` 4-column layout (before: middle col top `476` vs others `460` in WebKit).
- 16px inter-card gaps preserved.
- `oxfmt`, `oxlint`, and `tsc --noEmit` all clean.