### PR TITLE
fix(create): default preview to the site's light/dark mode

### DIFF
--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
 
+import { useTheme } from "starter-themes";
 import { z } from "zod";
 
 import { CustomizerPanel } from "@/modules/create/customizer-panel";
@@ -28,8 +29,19 @@ export const Route = createFileRoute("/_app/create")({
 function CreatePage() {
 	const { preview, preset } = Route.useSearch();
 	const { designSystem } = useDesignSystem();
+	const { resolvedTheme } = useTheme();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const [previewMode, setPreviewMode] = useState<PreviewMode>("light");
+
+	// Open the preview in the same light / dark mode the site is currently in. Seeded on
+	// mount rather than via the useState initializer: this page is server-rendered and the
+	// server can't know the client's stored theme (it always resolves "light"), so reading
+	// it during render would mismatch the SSR'd toggle icon on hydration. Runs once — the
+	// preview mode is toggled independently of the site theme afterwards.
+	useEffect(() => {
+		setPreviewMode(resolvedTheme);
+		// oxlint-disable-next-line react/exhaustive-deps -- seed once from the site theme at open; preview mode is independent thereafter
+	}, []);
 
 	const effectivePreview = preview;
 


### PR DESCRIPTION
## What

The `/create` preview hardcoded its display mode to `light` on first render. Opening `/create` while browsing the site in **dark** mode snapped the preview to light — a mismatch with the rest of the site.

This seeds the preview's display mode from the site's current theme on open, so the preview starts in the same light/dark mode as the website.

## How

- Read the site's resolved theme via `useTheme()` from `starter-themes` (the same hook the site's `ThemeToggle` uses).
- Seed `previewMode` from it in a mount effect.

It's seeded in a mount effect rather than the `useState` initializer because `/create` is server-rendered: the server can't know the client's stored theme (it always resolves `light`), so reading it during render would mismatch the SSR'd toggle icon on hydration. The seed runs once — the preview mode stays independently togglable afterwards.

## Verification

Ran the dev server and loaded `/create` fresh in both site themes:

| Site theme | Preview iframe | Toggle icon |
|---|---|---|
| dark  | dark ✅  | Sun  |
| light | light ✅ | Moon |

- Toggling the preview mode still works and does **not** change the site theme.
- No hydration-mismatch warnings in the console.
- `tsc --noEmit`, `oxlint`, and `oxfmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
