### PR TITLE
fix(registry): load color-swatch-picker styles in the app

### DIFF
--- a/www/src/registry/styles.css
+++ b/www/src/registry/styles.css
@@ -11,6 +11,7 @@
 @import "./ui/card/styles.css";
 @import "./ui/checkbox/styles.css";
 @import "./ui/color-area/styles.css";
+@import "./ui/color-swatch-picker/styles.css";
 @import "./ui/tag-group/styles.css";
 @import "./ui/field/styles.css";
 @import "./ui/input/styles.css";


### PR DESCRIPTION
## What

`registry/styles.css` `@import`s every component's `styles.css` **except** `color-swatch-picker`'s. So `--color-swatch-picker-item-radius` (defined in `ui/color-swatch-picker/styles.css` as `var(--radius-md)`) was never set in the dotUI app, and `styles.ts:10` uses `rounded-(--color-swatch-picker-item-radius)` **with no fallback** → swatch items rendered with sharp corners on the docs/demo pages.

Consumers were unaffected — the publisher emits the var via `css-to-registry-fields`, so `shadcn add` ships it. This fixes only the dotUI app's own rendering.

## Verification (live, `/docs/components/color-swatch-picker`)
- `--color-swatch-picker-item-radius` now resolves to `calc(0.375rem * 1)` (= `--radius-md`)
- swatch items now compute `border-radius: 6px` (was `0`)
- `build:registry` clean — no generated drift (component CSS isn't part of `base-css.ts`)

> Note: the audit also flagged a `focus-styles` "ship≠run" issue, but on inspection the `focusRing`/`focusInput` tv exports are **unused dead code** (focus styling comes from a `focus-ring` CSS utility), so there was nothing to fix there — left untouched.

Part of the [architecture-audit](https://github.com/mehdibha/dotUI/pull/204) roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)