### PR TITLE
fix(www): docs code-block styling — installation tabs + consistent indentation

### DIFF
--- a/www/src/modules/docs/code-block-tabs.tsx
+++ b/www/src/modules/docs/code-block-tabs.tsx
@@ -57,7 +57,7 @@ export function CodeBlockTabs({
 
 	return (
 		<Tabs
-			className="mt-4 gap-0"
+			className="mt-4 gap-2"
 			defaultSelectedKey={defaultValue}
 			{...props}
 			{...(groupId
@@ -73,7 +73,7 @@ export function CodeBlockTabs({
 }
 
 export function CodeBlockTabsList(props: TabListProps) {
-	return <TabList className="rounded-t-md border bg-muted" {...props} />;
+	return <TabList className="border bg-muted" {...props} />;
 }
 
 export function CodeBlockTabsTrigger({ value, ...props }: Omit<TabProps, "id"> & { value?: string }) {
@@ -81,11 +81,5 @@ export function CodeBlockTabsTrigger({ value, ...props }: Omit<TabProps, "id"> &
 }
 
 export function CodeBlockTab({ value, ...props }: Omit<TabPanelProps, "id"> & { value?: string }) {
-	return (
-		<TabPanel
-			id={value}
-			className="*:[figure]:mx-0 *:[figure]:mt-0 *:[figure]:rounded-t-none *:[figure]:border-t-0"
-			{...props}
-		/>
-	);
+	return <TabPanel id={value} className="*:[figure]:mx-0 *:[figure]:mt-0" {...props} />;
 }

--- a/www/src/modules/docs/code-block.tsx
+++ b/www/src/modules/docs/code-block.tsx
@@ -67,7 +67,7 @@ export function Pre({ children, className, ...props }: React.ComponentProps<"pre
 	return (
 		<pre
 			className={cn(
-				"w-max min-w-full py-3 **:[.line]:px-4!",
+				"w-max min-w-full py-3 [tab-size:2] **:[.line]:px-4!",
 				// shiki
 				"**:[code]:text-[0.8125rem] **:[code]:**:[span]:text-(--shiki-light) dark:**:[code]:**:[span]:text-(--shiki-dark)",
 				// code


### PR DESCRIPTION
## Summary

Two styling fixes to the docs code blocks (`www/src/modules/docs`).

**1. Installation code-block tabs** — the package-manager tabs (npm/pnpm/yarn/bun) shown above install commands rendered as a broken "glued header": a mismatched 6/8px tab pill sat flush against a code card whose top radius and top border were stripped (`rounded-t-none`, `border-t-0`), with no gap between them. They now render as two clean elements — a uniform rounded tab pill, an 8px gap, then a fully rounded and bordered code card.

**2. Consistent code indentation** — code blocks come from two sources with different indentation: generated/interactive-demo code uses 2 spaces, while MDX-authored Usage/Anatomy blocks (and highlighted source) use tabs. `tab-size` was never set, so tabs fell back to Tailwind preflight's default of `4`, making tab-indented blocks indent ~2× deeper than the demo code on the same page (most visible on accordion, alert, etc.). Set `tab-size: 2` on the shared `Pre` component so all code indents at 2 columns.

## Notes for reviewer

- Both changes live in the shared code-block components, so they apply across every docs page — the installation tabs are used in 62 component docs; the `Pre` change covers all code blocks (MDX usage/anatomy and demo code alike).
- The titled code blocks (e.g. `components.json`) use a separate path and are intentionally unaffected.
- Verified locally against the docs dev server: tab list → card gap `0 → 8px`, card top radius `0 → 6px`, card top border `0 → 1px`; and code-block `tab-size` is `2` on the previously-oversized blocks.
