### PR TITLE
feat(registry): route link-capable components through TanStack Router

### DIFF
--- a/www/src/modules/docs/docs-pager.tsx
+++ b/www/src/modules/docs/docs-pager.tsx
@@ -13,7 +13,6 @@ type Neighbours = {
 
 export function DocsPager({ neighbours }: { neighbours: Neighbours }) {
 	const { previous, next } = neighbours;
-	const hrefFor = (path: string) => `/docs/${path}`;
 
 	// When there is no neighbour we render a plain disabled Button rather than a hrefless
 	// LinkButton. A LinkButton without an href renders a non-pressable <span>, and wrapping that
@@ -22,7 +21,12 @@ export function DocsPager({ neighbours }: { neighbours: Neighbours }) {
 	const renderNeighbour = (neighbour: Neighbour | undefined, icon: React.ReactNode, label: string) =>
 		neighbour ? (
 			<Tooltip>
-				<LinkButton aria-label={label} size="sm" isIconOnly href={hrefFor(neighbour.path)}>
+				<LinkButton
+					aria-label={label}
+					size="sm"
+					isIconOnly
+					href={{ to: "/docs/$", params: { _splat: neighbour.path } }}
+				>
 					{icon}
 				</LinkButton>
 				<TooltipContent>{neighbour.name}</TooltipContent>

--- a/www/src/registry/__generated__/showcase-bundle.ts
+++ b/www/src/registry/__generated__/showcase-bundle.ts
@@ -187,7 +187,8 @@ export const SHOWCASE_BUNDLE_SOURCE_FILES: BundleFile[] = [
 	},
 	{
 		target: "registry/ui/button/index.tsx",
-		content: 'export * from "./base";\nexport { buttonStyles, useStyles as useButtonStyles } from "./styles";\n',
+		content:
+			'import { Link as RouterLink } from "@tanstack/react-router";\nimport type { ToOptions } from "@tanstack/react-router";\n\nimport { LinkButton as LinkButtonPrimitive } from "./base";\n\nimport type { LinkButtonProps as BaseLinkButtonProps } from "./base";\n\nexport { Button } from "./base";\nexport type { ButtonProps } from "./base";\nexport { buttonStyles, useStyles as useButtonStyles } from "./styles";\n\ntype LinkButtonProps = Omit<BaseLinkButtonProps, "href"> & { href?: string | ToOptions };\n\nfunction LinkButton({ href, ...props }: LinkButtonProps) {\n\treturn (\n\t\t<LinkButtonPrimitive\n\t\t\thref={href == null ? undefined : typeof href === "object" ? href.to : href}\n\t\t\trender={(domProps) => {\n\t\t\t\tif (!("href" in domProps)) {\n\t\t\t\t\treturn <span {...domProps} />;\n\t\t\t\t}\n\t\t\t\tif (typeof href === "object") {\n\t\t\t\t\treturn <RouterLink {...href} {...domProps} />;\n\t\t\t\t}\n\t\t\t\treturn <a {...domProps} />;\n\t\t\t}}\n\t\t\t{...props}\n\t\t/>\n\t);\n}\n\nexport type { LinkButtonProps };\nexport { LinkButton };\n',
 	},
 	{
 		target: "registry/ui/button/meta.ts",
@@ -470,7 +471,8 @@ export const SHOWCASE_BUNDLE_SOURCE_FILES: BundleFile[] = [
 	},
 	{
 		target: "registry/ui/link/index.tsx",
-		content: 'export * from "./base";\n',
+		content:
+			'import { Link as RouterLink } from "@tanstack/react-router";\nimport type { ToOptions } from "@tanstack/react-router";\n\nimport { Link as LinkPrimitive } from "./base";\n\nimport type { LinkProps as BaseLinkProps } from "./base";\n\ntype LinkProps = Omit<BaseLinkProps, "href"> & { href?: string | ToOptions };\n\nfunction Link({ href, ...props }: LinkProps) {\n\treturn (\n\t\t<LinkPrimitive\n\t\t\thref={href == null ? undefined : typeof href === "object" ? href.to : href}\n\t\t\trender={(domProps) => {\n\t\t\t\tif (!("href" in domProps)) {\n\t\t\t\t\treturn <span {...domProps} />;\n\t\t\t\t}\n\t\t\t\tif (typeof href === "object") {\n\t\t\t\t\treturn <RouterLink {...href} {...domProps} />;\n\t\t\t\t}\n\t\t\t\treturn <a {...domProps} />;\n\t\t\t}}\n\t\t\t{...props}\n\t\t/>\n\t);\n}\n\nexport type { LinkProps };\nexport { Link };\n',
 	},
 	{
 		target: "registry/ui/link/meta.ts",
@@ -489,7 +491,8 @@ export const SHOWCASE_BUNDLE_SOURCE_FILES: BundleFile[] = [
 	},
 	{
 		target: "registry/ui/list-box/index.tsx",
-		content: 'export * from "./base";\n',
+		content:
+			'import { Link as RouterLink } from "@tanstack/react-router";\nimport type { ToOptions } from "@tanstack/react-router";\n\nimport { ListBoxItem as ListBoxItemPrimitive } from "./base";\n\nimport type { ListBoxItemProps as BaseListBoxItemProps } from "./base";\n\nexport {\n\tListBox,\n\tListBoxItemDescription,\n\tListBoxItemLabel,\n\tListBoxSection,\n\tListBoxSectionHeader,\n\tListBoxVirtualizer,\n} from "./base";\nexport type {\n\tListBoxItemDescriptionProps,\n\tListBoxItemLabelProps,\n\tListBoxProps,\n\tListBoxSectionHeaderProps,\n\tListBoxSectionProps,\n\tListBoxVirtualizerProps,\n} from "./base";\n\ntype ListBoxItemProps<T> = Omit<BaseListBoxItemProps<T>, "href"> & { href?: string | ToOptions };\n\nfunction ListBoxItem<T extends object>({ href, ...props }: ListBoxItemProps<T>) {\n\treturn (\n\t\t<ListBoxItemPrimitive\n\t\t\thref={href == null ? undefined : typeof href === "object" ? href.to : href}\n\t\t\trender={(domProps) => {\n\t\t\t\tif (!("href" in domProps)) {\n\t\t\t\t\treturn <div {...domProps} />;\n\t\t\t\t}\n\t\t\t\tif (typeof href === "object") {\n\t\t\t\t\treturn <RouterLink {...href} {...domProps} />;\n\t\t\t\t}\n\t\t\t\treturn <a {...domProps} />;\n\t\t\t}}\n\t\t\t{...props}\n\t\t/>\n\t);\n}\n\nexport type { ListBoxItemProps };\nexport { ListBoxItem };\n',
 	},
 	{
 		target: "registry/ui/list-box/meta.ts",
@@ -690,7 +693,8 @@ export const SHOWCASE_BUNDLE_SOURCE_FILES: BundleFile[] = [
 	},
 	{
 		target: "registry/ui/tabs/index.tsx",
-		content: 'export * from "./base";\n',
+		content:
+			'import { Link as RouterLink } from "@tanstack/react-router";\nimport type { ToOptions } from "@tanstack/react-router";\n\nimport { Tab as TabPrimitive } from "./base";\n\nimport type { TabProps as BaseTabProps } from "./base";\n\nexport { TabIndicator, TabList, TabPanel, Tabs } from "./base";\nexport type { TabIndicatorProps, TabListProps, TabPanelProps, TabsProps } from "./base";\n\ntype TabProps = Omit<BaseTabProps, "href"> & { href?: string | ToOptions };\n\nfunction Tab({ href, ...props }: TabProps) {\n\treturn (\n\t\t<TabPrimitive\n\t\t\thref={href == null ? undefined : typeof href === "object" ? href.to : href}\n\t\t\trender={(domProps) => {\n\t\t\t\tif (!("href" in domProps)) {\n\t\t\t\t\treturn <div {...domProps} />;\n\t\t\t\t}\n\t\t\t\tif (typeof href === "object") {\n\t\t\t\t\treturn <RouterLink {...href} {...domProps} />;\n\t\t\t\t}\n\t\t\t\treturn <a {...domProps} />;\n\t\t\t}}\n\t\t\t{...props}\n\t\t/>\n\t);\n}\n\nexport type { TabProps };\nexport { Tab };\n',
 	},
 	{
 		target: "registry/ui/tabs/meta.ts",
@@ -883,6 +887,7 @@ export const SHOWCASE_BUNDLE_DEPENDENCIES: string[] = [
 	"@fontsource-variable/geist@^5.2.8",
 	"@fontsource/geist-mono@^5.2.7",
 	"@internationalized/date@^3.12.2",
+	"@tanstack/react-router",
 	"clsx@^2.1.0",
 	"lucide-react@^1.16.0",
 	"react-aria@^3.49.0",

--- a/www/src/registry/ui/button/index.tsx
+++ b/www/src/registry/ui/button/index.tsx
@@ -1,2 +1,33 @@
-export * from "./base";
+import { Link as RouterLink } from "@tanstack/react-router";
+import type { ToOptions } from "@tanstack/react-router";
+
+import { LinkButton as LinkButtonPrimitive } from "./base";
+
+import type { LinkButtonProps as BaseLinkButtonProps } from "./base";
+
+export { Button } from "./base";
+export type { ButtonProps } from "./base";
 export { buttonStyles, useStyles as useButtonStyles } from "./styles";
+
+type LinkButtonProps = Omit<BaseLinkButtonProps, "href"> & { href?: string | ToOptions };
+
+function LinkButton({ href, ...props }: LinkButtonProps) {
+	return (
+		<LinkButtonPrimitive
+			href={href == null ? undefined : typeof href === "object" ? href.to : href}
+			render={(domProps) => {
+				if (!("href" in domProps)) {
+					return <span {...domProps} />;
+				}
+				if (typeof href === "object") {
+					return <RouterLink {...href} {...domProps} />;
+				}
+				return <a {...domProps} />;
+			}}
+			{...props}
+		/>
+	);
+}
+
+export type { LinkButtonProps };
+export { LinkButton };

--- a/www/src/registry/ui/link/index.tsx
+++ b/www/src/registry/ui/link/index.tsx
@@ -1,1 +1,29 @@
-export * from "./base";
+import { Link as RouterLink } from "@tanstack/react-router";
+import type { ToOptions } from "@tanstack/react-router";
+
+import { Link as LinkPrimitive } from "./base";
+
+import type { LinkProps as BaseLinkProps } from "./base";
+
+type LinkProps = Omit<BaseLinkProps, "href"> & { href?: string | ToOptions };
+
+function Link({ href, ...props }: LinkProps) {
+	return (
+		<LinkPrimitive
+			href={href == null ? undefined : typeof href === "object" ? href.to : href}
+			render={(domProps) => {
+				if (!("href" in domProps)) {
+					return <span {...domProps} />;
+				}
+				if (typeof href === "object") {
+					return <RouterLink {...href} {...domProps} />;
+				}
+				return <a {...domProps} />;
+			}}
+			{...props}
+		/>
+	);
+}
+
+export type { LinkProps };
+export { Link };

--- a/www/src/registry/ui/list-box/index.tsx
+++ b/www/src/registry/ui/list-box/index.tsx
@@ -1,1 +1,46 @@
-export * from "./base";
+import { Link as RouterLink } from "@tanstack/react-router";
+import type { ToOptions } from "@tanstack/react-router";
+
+import { ListBoxItem as ListBoxItemPrimitive } from "./base";
+
+import type { ListBoxItemProps as BaseListBoxItemProps } from "./base";
+
+export {
+	ListBox,
+	ListBoxItemDescription,
+	ListBoxItemLabel,
+	ListBoxSection,
+	ListBoxSectionHeader,
+	ListBoxVirtualizer,
+} from "./base";
+export type {
+	ListBoxItemDescriptionProps,
+	ListBoxItemLabelProps,
+	ListBoxProps,
+	ListBoxSectionHeaderProps,
+	ListBoxSectionProps,
+	ListBoxVirtualizerProps,
+} from "./base";
+
+type ListBoxItemProps<T> = Omit<BaseListBoxItemProps<T>, "href"> & { href?: string | ToOptions };
+
+function ListBoxItem<T extends object>({ href, ...props }: ListBoxItemProps<T>) {
+	return (
+		<ListBoxItemPrimitive
+			href={href == null ? undefined : typeof href === "object" ? href.to : href}
+			render={(domProps) => {
+				if (!("href" in domProps)) {
+					return <div {...domProps} />;
+				}
+				if (typeof href === "object") {
+					return <RouterLink {...href} {...domProps} />;
+				}
+				return <a {...domProps} />;
+			}}
+			{...props}
+		/>
+	);
+}
+
+export type { ListBoxItemProps };
+export { ListBoxItem };

--- a/www/src/registry/ui/menu/index.tsx
+++ b/www/src/registry/ui/menu/index.tsx
@@ -1,1 +1,40 @@
-export * from "./base";
+import { Link as RouterLink } from "@tanstack/react-router";
+import type { ToOptions } from "@tanstack/react-router";
+
+import { MenuItem as MenuItemPrimitive } from "./base";
+
+import type { MenuItemProps as BaseMenuItemProps } from "./base";
+
+export { Menu, MenuContent, MenuItemDescription, MenuItemLabel, MenuSection, MenuSectionHeader, MenuSub } from "./base";
+export type {
+	MenuContentProps,
+	MenuItemDescriptionProps,
+	MenuItemLabelProps,
+	MenuProps,
+	MenuSectionHeaderProps,
+	MenuSectionProps,
+	MenuSubProps,
+} from "./base";
+
+type MenuItemProps<T> = Omit<BaseMenuItemProps<T>, "href"> & { href?: string | ToOptions };
+
+function MenuItem<T extends object>({ href, ...props }: MenuItemProps<T>) {
+	return (
+		<MenuItemPrimitive
+			href={href == null ? undefined : typeof href === "object" ? href.to : href}
+			render={(domProps) => {
+				if (!("href" in domProps)) {
+					return <div {...domProps} />;
+				}
+				if (typeof href === "object") {
+					return <RouterLink {...href} {...domProps} />;
+				}
+				return <a {...domProps} />;
+			}}
+			{...props}
+		/>
+	);
+}
+
+export type { MenuItemProps };
+export { MenuItem };

--- a/www/src/registry/ui/tabs/index.tsx
+++ b/www/src/registry/ui/tabs/index.tsx
@@ -1,1 +1,32 @@
-export * from "./base";
+import { Link as RouterLink } from "@tanstack/react-router";
+import type { ToOptions } from "@tanstack/react-router";
+
+import { Tab as TabPrimitive } from "./base";
+
+import type { TabProps as BaseTabProps } from "./base";
+
+export { TabIndicator, TabList, TabPanel, Tabs } from "./base";
+export type { TabIndicatorProps, TabListProps, TabPanelProps, TabsProps } from "./base";
+
+type TabProps = Omit<BaseTabProps, "href"> & { href?: string | ToOptions };
+
+function Tab({ href, ...props }: TabProps) {
+	return (
+		<TabPrimitive
+			href={href == null ? undefined : typeof href === "object" ? href.to : href}
+			render={(domProps) => {
+				if (!("href" in domProps)) {
+					return <div {...domProps} />;
+				}
+				if (typeof href === "object") {
+					return <RouterLink {...href} {...domProps} />;
+				}
+				return <a {...domProps} />;
+			}}
+			{...props}
+		/>
+	);
+}
+
+export type { TabProps };
+export { Tab };


### PR DESCRIPTION
## What

Link-capable React Aria components rendered plain links and ignored client-side routing — only `breadcrumbs` was wired up to TanStack Router. This adapts the rest so navigation goes through the router.

Changed (app-internal `index.tsx` only — every published `base.tsx` is **untouched**):

| Component | Wrapped export |
|-----------|----------------|
| `link` | `Link` |
| `button` | `LinkButton` |
| `menu` | `MenuItem` |
| `list-box` | `ListBoxItem` (propagates to `select` & `command`, which import it) |
| `tabs` | `Tab` |

Plus a regenerated `__generated__/showcase-bundle.ts` (it bundles `index.tsx` source and now carries the `@tanstack/react-router` dep).

## How

Each wrapper widens `href` to `string | ToOptions` and uses React Aria's `render` prop, following the existing [`breadcrumbs/index.tsx`](https://github.com/mehdibha/dotUI/blob/main/www/src/registry/ui/breadcrumbs/index.tsx) reference:

- **object `href`** (`{ to: "/x", params }`) → TanStack `<RouterLink>` (client-side navigation)
- **string `href`** → native `<a>` (full navigation, e.g. external links)
- **no `href`** → the component's default element

The discriminant is RAC's documented `"href" in domProps` check, which narrows the render-param union to the anchor variant — needed because collection items (`MenuItem`/`ListBoxItem`/`Tab`) expose a `div | anchor` union that otherwise fails the `RouterLink` spread on `tsc`. No casts required (React 19 forwards `ref` as a prop).

## Why this layer

`meta.ts` publishes only `base.tsx` → `ui/{component}.tsx`, so `base.tsx` stays clean, router-agnostic source for anyone copying components out. `index.tsx` is the app-internal entry point that's never published, so it's the correct place to take the `@tanstack/react-router` dependency.

## Excluded (intentional)

`table` (Row) and `tag-group` (Tag) are **not** adapted: the HTML spec forbids rendering a `<tr>`/tag as `<a>`, so React Aria's own docs say to navigate them via `onAction` + `useNavigate`, not `href` + `render`. `tree`/gridlist have no `base.tsx`, and `context-menu` only exports the trigger (its items come from `menu`). Happy to wire `table`/`tag-group` via `onAction` in a follow-up.

## Verification

- ✅ Full `pnpm typecheck` (`build:registry` + `tsc --noEmit`) — green
- ✅ `oxfmt` + `oxlint` clean on all touched files
- ✅ Registry integrity check passes; `showcase-bundle` no longer drifts
- ✅ Adversarial multi-agent review: all base exports & generics preserved, no consumer breaks (`select`/`command`/`combobox`/`pagination`/doc `types.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)