### PR TITLE
chore: upgrade to pnpm 11.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	],
 	"engines": {
 		"node": "^24.11.1",
-		"pnpm": "^10.24.0"
+		"pnpm": "^11.5.3"
 	},
 	"scripts": {
 		"build": "turbo run build",
@@ -60,14 +60,5 @@
 		"typescript": "catalog:",
 		"vitest": "^4.0.16"
 	},
-	"packageManager": "pnpm@10.24.0",
-	"pnpm": {
-		"overrides": {
-			"@types/react": "19.2.2",
-			"@types/react-dom": "19.2.1"
-		},
-		"patchedDependencies": {
-			"tailwindcss-react-aria-components@2.1.1": "patches/tailwindcss-react-aria-components@2.1.1.patch"
-		}
-	}
+	"packageManager": "pnpm@11.5.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,11 +13,18 @@ catalog:
   tailwindcss: ^4.3.0
   typescript: ^6.0.3
 
-onlyBuiltDependencies:
-  - "@tailwindcss/oxide"
-  - bufferutil
-  - core-js-pure
-  - esbuild
-  - msw
-  - puppeteer
-  - sharp
+allowBuilds:
+  "@tailwindcss/oxide": true
+  bufferutil: true
+  core-js-pure: true
+  esbuild: true
+  msw: true
+  puppeteer: true
+  sharp: true
+
+overrides:
+  "@types/react": 19.2.2
+  "@types/react-dom": 19.2.1
+
+patchedDependencies:
+  tailwindcss-react-aria-components@2.1.1: patches/tailwindcss-react-aria-components@2.1.1.patch


### PR DESCRIPTION
Closes <!-- n/a -->

## Summary

- Bump pnpm `10.24.0` → `11.5.3` (`packageManager` + `engines.pnpm`), and update the global Corepack default locally.
- **pnpm 11 breaking change 1:** the `pnpm` field in `package.json` is no longer read. Moved `overrides` and `patchedDependencies` (incl. the `tailwindcss-react-aria-components` `:is()` patch from #172) into `pnpm-workspace.yaml` so they keep applying — otherwise the patch silently stops applying and the input focus ring regresses.
- **pnpm 11 breaking change 2:** `onlyBuiltDependencies` (list) is replaced by `allowBuilds` (map). Converted the previously-approved native build deps (`@tailwindcss/oxide`, `bufferutil`, `core-js-pure`, `esbuild`, `msw`, `puppeteer`, `sharp`) to `allowBuilds: true`.

### Reviewer notes

- `pnpm-lock.yaml` is **unchanged** — pnpm 11 keeps `lockfileVersion: '9.0'`, so no lockfile churn and pnpm-10 contributors won't hit format drift.
- Verified after a fresh install: all build scripts run, the patch resolves (`patch_hash=…` in the lockfile), `overrides` resolve (`@types/react` → 19.2.2), and `pnpm check` passes (1 pre-existing non-null-assertion warning, 0 errors).
- CI uses `pnpm/action-setup@v3` with no pinned version, so it reads `packageManager` and will pick up 11.5.3 automatically.
- Contributors using Corepack switch automatically; others should run `corepack enable` to avoid an `engines` warning.