### PR TITLE
chore: add .git-blame-ignore-revs for the oxfmt reformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Commits that git blame should skip (mass mechanical changes).
+# GitHub's blame view honors this file automatically. Locally, run once:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# style: repo-wide oxfmt reformat + final sortImports config (#222)
+2cbd23ff77a89906e08134d33eee63cd25fa1f9c


### PR DESCRIPTION
Closes —

## Summary

- Adds `.git-blame-ignore-revs` listing the squashed reformat commit `2cbd23ff` (#222) so GitHub's blame view skips it and shows the real author of every line.
- Locally, enable once with: `git config blame.ignoreRevsFile .git-blame-ignore-revs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)