### PR TITLE
test: exclude .claude/worktrees from vitest sweep

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       '**/node_modules/**',
       '**/fixtures/**',
       '**/templates/**',
+      '**/.claude/worktrees/**',
     ],
   },
 })


### PR DESCRIPTION
## What

Adds `**/.claude/worktrees/**` to the root vitest `test.exclude` list (and reformats the config to multi-line per oxfmt).

## Why

Running `vitest` from the main checkout was sweeping up duplicate spec copies living inside Claude Code worktrees under `.claude/worktrees/`, running every test once per worktree.

## Notes for review

- The exclude glob matches paths relative to the project root, so running vitest *inside* a worktree still works — its own specs don't contain `.claude/worktrees` in their relative paths. Verified with `vitest list` from a worktree: all real specs are still discovered.
- File is oxfmt-formatted, so `pnpm check` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)