### PR TITLE
docs: set up agent context (CLAUDE.md + docs/research)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,85 @@
-## Agent skills
+# dotUI
 
-### Issue tracker
+This is the dotUI repository — a design-system builder. Users compose a
+complete design system at dotui.org/create — colors, typography, icons,
+density, radius, per-component styles — preview every change live on real
+components, and export it as code they own: into their codebase via the
+shadcn CLI, or straight into v0, Bolt, and Lovable. It's built on React Aria
+Components with Tailwind CSS v4 and tailwind-variants, themed by an OKLCH
+color engine, and distributed as a shadcn-compatible registry served from a
+TanStack Start app.
 
-Issues and PRDs are tracked in GitHub Issues for `mehdibha/dotUI`. See `docs/agents/issue-tracker.md`.
+## Product direction
 
-### Triage labels
+This is the goal, not the current state — check the code before assuming an
+axis exists. The end state is that **every visual decision is a
+user-configurable axis of the builder**, not a hardcoded choice:
 
-Use the default five-label triage vocabulary. See `docs/agents/triage-labels.md`.
+- Color system: simple or advanced, selectable generation algorithm, semantic
+  tokens, optionally context-aware tokens.
+- Typography, icon library, density, radius, interactive/disabled cursors.
+- Grouped tweaks — e.g. translucent menus/popovers as a single switch.
+- Per-component styles: a curated set of named variants per component (the
+  20% of styles that cover 80% of design systems), plus hover effect, radius…
+- For consistency, related components form synced groups: Button and
+  ToggleButton share the same styles and must stay in sync.
+- More export targets beyond CLI + v0/Bolt/Lovable: Figma, Claude design, etc.
 
-### Domain docs
+What this means when writing code today:
 
-Single-context repo: read root `CONTEXT.md` and `docs/adr/` when present. See `docs/agents/domain.md`.
+- New visual decisions go through tokens/variants so the builder can own them
+  later — never inline one-off values in registry components.
+- Style related components as a group, not individually.
+- Everything must stay live-previewable in the builder.
+- Registry output stays portable: plain React files, shadcn-schema
+  compatible, no www-internal imports leaking into registry items.
+
+## Layout
+
+- `www/` — the dotui.org app: docs, the /create builder, and the registry
+  endpoints (TanStack Start + Vite, fumadocs-mdx, Tailwind v4,
+  tailwind-variants). Registry source lives in `www/src/registry/`
+  (`ui/`, `hooks/`, `lib/`, `theme/`, `__generated__/`).
+- `packages/colors` — `@dotui/colors`, the OKLCH color engine (private,
+  consumed by www).
+- Starter themes and the Tailwind plugins (`tailwindcss-autocontrast`,
+  `tailwindcss-with`) are moving to standalone repos, consumed from npm.
+- `patches/` — pnpm patches. `tailwindcss-react-aria-components` is patched
+  for an upstream `not-*` variant bug; don't bump it without re-checking the
+  patch.
+
+## Commands
+
+- Dev: `pnpm dev:www`. In a fresh clone or worktree, run `pnpm build:registry`
+  first or the dev server 500s (`build` and `typecheck` run it themselves;
+  `dev` does not).
+- Before pushing: `pnpm check` (oxlint + `oxfmt --check` — CI fails on
+  formatting and import order). Fix with `pnpm check:fix`.
+- `pnpm typecheck` · `pnpm test` (vitest, covers `packages/colors`).
+
+## Generated files
+
+- `www/src/registry/__generated__/*` and `www/src/registry/base/colors.css`
+  are committed artifacts of `pnpm build:registry`; CI's registry-drift job
+  diffs exactly these files. After touching registry items, regenerate and
+  commit.
+- `build:registry` also builds the showcase bundle. Its theme stub is a blind
+  spot for the drift guard: if bundled code changes its `@/registry/theme`
+  imports, update `themeStub()` in `www/scripts/build-showcase-bundle.ts` —
+  missing named exports there once broke "Open in v0".
+- API references: never run `pnpm build:references` to fix one field —
+  generator drift rewrites ~121 files. Hand-edit the specific JSON instead.
+  Documented props come from `types.ts`, not `base.tsx`.
+- `www/src/routeTree.gen.ts` is TanStack-generated; never edit it.
+
+## Conventions & gotchas
+
+- Issues and PRDs are tracked in GitHub Issues for `mehdibha/dotUI`.
+- Commit titles use `type(scope):` style (`feat(www): …`, `fix:`, `chore:`).
+- Theming: semantic tokens resolve and freeze at `:root` — color/radius
+  changes cannot be scoped to a subtree (density is the exception, via React
+  context). Previews that re-theme need an iframe or must re-theme the whole
+  page.
+- RAC SSR: ListBox inside Tabs and Combobox both crash SSR
+  (`selectionManager` null) — in demos prefer Select, CheckboxGroup, or a
+  sibling ListBox.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,16 @@ Anatomy of an item (`www/src/registry/ui/<component>/`):
 - `types.ts` — prop types; the source for API reference docs.
 - `meta.ts`, `demos/`, `examples.tsx` — item metadata and docs demos.
 
+When working on a component's styles, compare against the shadcn equivalent
+to catch missing classes — especially logical classes, but everything else
+too. Their styles map to our density levels: `style-mira` ≈ compact,
+`style-nova` ≈ default, `style-vega` ≈ comfortable. In shadcn-ui/ui a
+component's classes live in two places — shared rules in
+`apps/v4/registry/styles/style-{name}.css` and per-component classes in the
+registry file itself (`apps/v4/registry/bases/{base,radix}/ui/<component>.tsx`);
+check both, or you'll conclude classes are "missing" that just live in the
+other file.
+
 ## Publisher
 
 `www/src/publisher/` turns registry source into what users install: resolves
@@ -130,6 +140,14 @@ the drift guard can't catch missing named exports there (once broke
 - PR titles become commit titles. Format `type(scope): summary` — describe the change, don't justify it (cut clauses like "with…", "to improve…").
   Aim ~50–60 chars, but never drop information to hit it.
   Good: `docs: rewrite CLAUDE.md` · Bad: `docs: rewrite CLAUDE.md with real project context`.
+- Adding a tweak (new axis, variant, style param, semantic token) is a
+  product decision: propose it and wait for approval before implementing —
+  never slip one into a component PR.
+- Spot something worth a refactor or rewrite? Propose it — in a "Suggested
+  refactors" note in the PR description, or a GitHub issue if bigger — never
+  by expanding the current diff. Bar: recurring or task-impeding, and
+  specific enough to act on; no "this could be cleaner". Skip areas with a
+  planned rewrite (the publisher).
 - Never run `pnpm build:references` to fix one field — generator drift
   rewrites ~121 files. Hand-edit the specific JSON; documented props come
   from `types.ts`, not `base.tsx`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ What this means when writing code today:
   consumed by www).
 - Starter themes and the Tailwind plugins (`tailwindcss-autocontrast`,
   `tailwindcss-with`) are moving to standalone repos, consumed from npm.
+- `docs/research/` — date-prefixed (`YYYY-MM-DD-topic.md`) point-in-time
+  research and assessment reports. Check it before re-researching a topic;
+  findings are snapshots as of the filename date. When a report's open
+  question gets decided, append a dated `> Decision:` line to its status
+  header rather than leaving it open.
 - `patches/` — pnpm patches. `tailwindcss-react-aria-components` is patched
   for an upstream `not-*` variant bug; don't bump it without re-checking the
   patch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ What this means when writing code today:
 - Registry output stays portable: plain React files, shadcn-schema
   compatible, no www-internal imports leaking into registry items.
 
-## Layout
+## Structure
 
 - `www/` — the dotui.org app: docs, the /create builder, and the registry
   endpoints (TanStack Start + Vite, fumadocs-mdx, Tailwind v4,
@@ -54,42 +54,38 @@ What this means when writing code today:
   for an upstream `not-*` variant bug; don't bump it without re-checking the
   patch.
 
-## Commands
+## Workflow
 
-- Dev: `pnpm dev:www`. In a fresh clone or worktree, run `pnpm build:registry`
-  first or the dev server 500s (`build` and `typecheck` run it themselves;
-  `dev` does not).
-- Before pushing: `pnpm check` (oxlint + `oxfmt --check` — CI fails on
-  formatting and import order). Fix with `pnpm check:fix`.
-- `pnpm typecheck` · `pnpm test` (vitest, covers `packages/colors`).
+### Commands
 
-## Generated files
+- `pnpm dev:www` — dev server. In a fresh clone or worktree, run
+  `pnpm build:registry` first or it 500s (`build` and `typecheck` run it
+  themselves; `dev` does not).
+- `pnpm check` — oxlint + `oxfmt --check`; `pnpm check:fix` to auto-fix.
+- `pnpm typecheck` · `pnpm test` — vitest, covers `packages/colors`.
 
-- `www/src/registry/__generated__/*` and `www/src/registry/base/colors.css`
-  are committed artifacts of `pnpm build:registry`; CI's registry-drift job
-  diffs exactly these files. After touching registry items, regenerate and
-  commit.
-- `build:registry` also builds the showcase bundle. Its theme stub is a blind
-  spot for the drift guard: if bundled code changes its `@/registry/theme`
-  imports, update `themeStub()` in `www/scripts/build-showcase-bundle.ts` —
-  missing named exports there once broke "Open in v0".
-- API references: never run `pnpm build:references` to fix one field —
-  generator drift rewrites ~121 files. Hand-edit the specific JSON instead.
-  Documented props come from `types.ts`, not `base.tsx`.
-- `www/src/routeTree.gen.ts` is TanStack-generated; never edit it.
+### Registry changes
+
+After modifying `www/src/registry/`, run `pnpm build:registry` and commit the
+regenerated `__generated__/*` + `base/colors.css` — CI's registry-drift job
+diffs exactly these files. If bundled code changes its `@/registry/theme`
+imports, also update `themeStub()` in `www/scripts/build-showcase-bundle.ts`:
+the drift guard can't catch missing named exports there (once broke
+"Open in v0").
+
+### Before committing
+
+- `pnpm check` — CI fails on formatting and import order.
+- `pnpm typecheck`; `pnpm test` if you touched `packages/colors`.
+- Touched the registry? Regenerate first (see Registry changes).
 
 ## Conventions & gotchas
 
 - Issues and PRDs are tracked in GitHub Issues for `mehdibha/dotUI`.
-- PR titles become commit titles. Format `type(scope): summary` — describe
-  the change, don't justify it (cut clauses like "with…", "to improve…").
+- PR titles become commit titles. Format `type(scope): summary` — describe the change, don't justify it (cut clauses like "with…", "to improve…").
   Aim ~50–60 chars, but never drop information to hit it.
-  Good: `docs: rewrite CLAUDE.md` · Bad: `docs: rewrite CLAUDE.md with real
-  project context`.
-- Theming: semantic tokens resolve and freeze at `:root` — color/radius
-  changes cannot be scoped to a subtree (density is the exception, via React
-  context). Previews that re-theme need an iframe or must re-theme the whole
-  page.
-- RAC SSR: ListBox inside Tabs and Combobox both crash SSR
-  (`selectionManager` null) — in demos prefer Select, CheckboxGroup, or a
-  sibling ListBox.
+  Good: `docs: rewrite CLAUDE.md` · Bad: `docs: rewrite CLAUDE.md with real project context`.
+- Never run `pnpm build:references` to fix one field — generator drift
+  rewrites ~121 files. Hand-edit the specific JSON; documented props come
+  from `types.ts`, not `base.tsx`.
+- `www/src/routeTree.gen.ts` is TanStack-generated; never edit it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,141 +1,68 @@
 # dotUI
 
-This is the dotUI repository — a design-system builder. Users compose a
-complete design system at dotui.org/create — colors, typography, icons,
-density, radius, per-component styles — preview every change live on real
-components, and export it as code they own: into their codebase via the
-shadcn CLI, or straight into v0 — with Bolt, Lovable, Figma and more
-planned. It's built on React Aria
-Components with Tailwind CSS v4 and tailwind-variants, themed by an OKLCH
-color engine, and distributed as a shadcn-compatible registry served from a
-TanStack Start app.
+This is the dotUI repository — a design-system builder. Users compose a complete design system at dotui.org/create — colors, typography, icons, density, radius, per-component styles — preview every change live on real components, and export it as code they own: into their codebase via the shadcn CLI, or straight into v0 — with Bolt, Lovable, Figma and more planned. It's built on React Aria Components with Tailwind CSS v4 and tailwind-variants, themed by an OKLCH color engine, and distributed as a shadcn-compatible registry served from a TanStack Start app.
 
 ## Product direction
 
-This is the goal, not the current state — check the code before assuming an
-axis exists.
+This is the goal, not the current state — check the code before assuming an axis exists.
 
-The north star: the builder should be flexible enough to recreate almost any
-design system. If a user can't reproduce the look of a Material-, Geist-, or
-Linear-style system, an axis is missing. Coverage comes from a complete set
-of well-chosen axes, not infinite options: **every visual decision is a
-user-configurable axis of the builder**, never a hardcoded choice. Axes
-include (not exhaustive):
+The north star: the builder should be flexible enough to recreate almost any design system. If a user can't reproduce the look of a Material-, Geist-, or Linear-style system, an axis is missing. Coverage comes from a complete set of well-chosen axes, not infinite options: **every visual decision is a user-configurable axis of the builder**, never a hardcoded choice. Axes include (not exhaustive):
 
-- Color system: simple or advanced, selectable generation algorithm, semantic
-  tokens, optionally context-aware tokens.
+- Color system: simple or advanced, selectable generation algorithm, semantic tokens, optionally context-aware tokens.
 - Typography, icon library, density, radius, interactive/disabled cursors.
 - Grouped tweaks — e.g. translucent menus/popovers as a single switch.
-- Per-component styles: named variants curated per component — the 20% of
-  styles that cover 80% of design systems — plus hover effect, radius…
-- For consistency, related components form synced groups: Button and
-  ToggleButton share the same styles and must stay in sync.
+- Per-component styles: named variants curated per component — the 20% of styles that cover 80% of design systems — plus hover effect, radius…
+- For consistency, related components form synced groups: Button and ToggleButton share the same styles and must stay in sync.
 
-A second customization layer beyond visuals: `codeOptions` — the style of
-the exported code itself. Separator comments or not, arrow functions vs
-function declarations, tailwind-variants styles as commented arrays vs one
-line per slot/variant, etc. The exported design system should read like the
-user's codebase, not ours.
+A second customization layer beyond visuals: `codeOptions` — the style of the exported code itself. Separator comments or not, arrow functions vs function declarations, tailwind-variants styles as commented arrays vs one line per slot/variant, etc. The exported design system should read like the user's codebase, not ours.
 
-Beyond that, export keeps widening: CLI + v0 today;
-Bolt, Lovable, Figma, Claude design, etc. planned.
+Beyond that, export keeps widening: CLI + v0 today; Bolt, Lovable, Figma, Claude design, etc. planned.
 
 What this means when writing code today:
 
-- The test for hardcoded values: would two design systems disagree on it?
-  The design system's look (color, radius, typography, shadows,
-  density-affected spacing) goes through tokens/variants — `bg-primary`,
-  not `bg-[#635bff]`. Component mechanics (internal layout, hairlines, hit
-  areas) stay plain values — don't tokenize them. Look with no covering
-  axis? Flag the missing axis; don't invent a token.
-- A style change to one component in a synced group is a change to the whole
-  group (Button ⇄ ToggleButton) — land them together.
-- New axes and styles must be switchable at runtime (CSS variables, variant
-  props, data attributes), never decided at build time — the builder
-  previews live.
-- Registry items import only from `@/registry/*`, relative paths, and
-  published packages — plain React files, shadcn-schema compatible. www-side
-  imports (router, fumadocs, `@/components`) must never leak in.
-- Author registry source in one canonical style (current files are the
-  reference) — `codeOptions` will be mechanical publisher transforms over
-  it, and inconsistent source breaks the transforms.
+- The test for hardcoded values: would two design systems disagree on it? The design system's look (color, radius, typography, shadows, density-affected spacing) goes through tokens/variants — `bg-primary`, not `bg-[#635bff]`. Component mechanics (internal layout, hairlines, hit areas) stay plain values — don't tokenize them. Look with no covering axis? Flag the missing axis; don't invent a token.
+- A style change to one component in a synced group is a change to the whole group (Button ⇄ ToggleButton) — land them together.
+- New axes and styles must be switchable at runtime (CSS variables, variant props, data attributes), never decided at build time — the builder previews live.
+- Registry items import only from `@/registry/*`, relative paths, and published packages — plain React files, shadcn-schema compatible. www-side imports (router, fumadocs, `@/components`) must never leak in.
+- Author registry source in one canonical style (current files are the reference) — `codeOptions` will be mechanical publisher transforms over it, and inconsistent source breaks the transforms.
 
 ## Structure
 
-- `www/` — the dotui.org app: docs, the /create builder, and the registry
-  endpoints (TanStack Start + Vite, fumadocs-mdx, Tailwind v4,
-  tailwind-variants). Registry source lives in `www/src/registry/` — see
-  Registry below.
-- `packages/colors` — `@dotui/colors`, the OKLCH color engine (private,
-  consumed by www).
-- Starter themes and the Tailwind plugins (`tailwindcss-autocontrast`,
-  `tailwindcss-with`) are moving to standalone repos, consumed from npm.
-- `docs/research/` — date-prefixed (`YYYY-MM-DD-topic.md`) point-in-time
-  research and assessment reports; multi-file topics get a subfolder (e.g.
-  `open-in/`). Check it before re-researching a topic; findings are
-  snapshots, not kept current. When a report's open question gets decided,
-  append a dated `> Decision:` line to its status header rather than
-  leaving it open.
-- `patches/` — pnpm patches. `tailwindcss-react-aria-components` is patched
-  for an upstream `not-*` variant bug; don't bump it without re-checking the
-  patch.
+- `www/` — the dotui.org app: docs, the /create builder, and the registry endpoints (TanStack Start + Vite, fumadocs-mdx, Tailwind v4, tailwind-variants). Registry source lives in `www/src/registry/` — see Registry below.
+- `packages/colors` — `@dotui/colors`, the OKLCH color engine (private, consumed by www).
+- Starter themes and the Tailwind plugins (`tailwindcss-autocontrast`, `tailwindcss-with`) are moving to standalone repos, consumed from npm.
+- `docs/research/` — date-prefixed (`YYYY-MM-DD-topic.md`) point-in-time research and assessment reports; multi-file topics get a subfolder (e.g. `open-in/`). Check it before re-researching a topic; findings are snapshots, not kept current. When a report's open question gets decided, append a dated `> Decision:` line to its status header rather than leaving it open.
+- `patches/` — pnpm patches. `tailwindcss-react-aria-components` is patched for an upstream `not-*` variant bug; don't bump it without re-checking the patch.
 
 ## Registry
 
-`www/src/registry/` is the product's source of truth and must stay clean:
-registry items, their files, demos, and descriptions only — no tooling
-internals. (Publisher output still sits in `__generated__/publishables`
-today; known-wrong, don't add more.)
+`www/src/registry/` is the product's source of truth and must stay clean: registry items, their files, demos, and descriptions only — no tooling internals. (Publisher output still sits in `__generated__/publishables` today; known-wrong, don't add more.)
 
 Anatomy of an item (`www/src/registry/ui/<component>/`):
 
-- `base.tsx` — what users receive via the shadcn CLI, after the publisher
-  transforms it (styles resolved, icons swapped, etc.).
-- `styles.ts` — the full style definition with every param; not shipped
-  as-is. On publish, styles are resolved and cleaned — e.g. the density
-  param is removed, its values resolved — before landing in the shipped
-  `base.tsx`.
-- `index.tsx` — the www-side wrapper (site-only concerns like router links);
-  never shipped.
+- `base.tsx` — what users receive via the shadcn CLI, after the publisher transforms it (styles resolved, icons swapped, etc.).
+- `styles.ts` — the full style definition with every param; not shipped as-is. On publish, styles are resolved and cleaned — e.g. the density param is removed, its values resolved — before landing in the shipped `base.tsx`.
+- `index.tsx` — the www-side wrapper (site-only concerns like router links); never shipped.
 - `types.ts` — prop types; the source for API reference docs.
 - `meta.ts`, `demos/`, `examples.tsx` — item metadata and docs demos.
 
-When working on a component's styles, compare against the shadcn equivalent
-to catch missing classes — especially logical classes, but everything else
-too. Their styles map to our density levels: `style-mira` ≈ compact,
-`style-nova` ≈ default, `style-vega` ≈ comfortable. In shadcn-ui/ui a
-component's classes live in two places — shared rules in
-`apps/v4/registry/styles/style-{name}.css` and per-component classes in the
-registry file itself (`apps/v4/registry/bases/{base,radix}/ui/<component>.tsx`);
-check both, or you'll conclude classes are "missing" that just live in the
-other file.
+When working on a component's styles, compare against the shadcn equivalent to catch missing classes — especially logical classes, but everything else too. Their styles map to our density levels: `style-mira` ≈ compact, `style-nova` ≈ default, `style-vega` ≈ comfortable. In shadcn-ui/ui a component's classes live in two places — shared rules in `apps/v4/registry/styles/style-{name}.css` and per-component classes in the registry file itself (`apps/v4/registry/bases/{base,radix}/ui/<component>.tsx`); check both, or you'll conclude classes are "missing" that just live in the other file.
 
 ## Publisher
 
-`www/src/publisher/` turns registry source into what users install: resolves
-`styles.ts`, strips builder-only params, swaps icons, and emits the shipped
-`base.tsx` and registry JSON. It's messy and a rewrite is planned — verify
-behavior by reading the code, don't pattern-match its structure, and don't
-deepen its reach into `www/src/registry/`.
+`www/src/publisher/` turns registry source into what users install: resolves `styles.ts`, strips builder-only params, swaps icons, and emits the shipped `base.tsx` and registry JSON. It's messy and a rewrite is planned — verify behavior by reading the code, don't pattern-match its structure, and don't deepen its reach into `www/src/registry/`.
 
 ## Workflow
 
 ### Commands
 
-- `pnpm dev:www` — dev server. In a fresh clone or worktree, run
-  `pnpm build:registry` first or it 500s (`build` and `typecheck` run it
-  themselves; `dev` does not).
+- `pnpm dev:www` — dev server. In a fresh clone or worktree, run `pnpm build:registry` first or it 500s (`build` and `typecheck` run it themselves; `dev` does not).
 - `pnpm check` — oxlint + `oxfmt --check`; `pnpm check:fix` to auto-fix.
 - `pnpm typecheck` · `pnpm test` — vitest, covers `packages/colors`.
 
 ### Registry changes
 
-After modifying `www/src/registry/`, run `pnpm build:registry` and commit the
-regenerated `__generated__/*` + `base/colors.css` — CI's registry-drift job
-diffs exactly these files. If bundled code changes its `@/registry/theme`
-imports, also update `themeStub()` in `www/scripts/build-showcase-bundle.ts`:
-the drift guard can't catch missing named exports there (once broke
-"Open in v0").
+After modifying `www/src/registry/`, run `pnpm build:registry` and commit the regenerated `__generated__/*` + `base/colors.css` — CI's registry-drift job diffs exactly these files. If bundled code changes its `@/registry/theme` imports, also update `themeStub()` in `www/scripts/build-showcase-bundle.ts`: the drift guard can't catch missing named exports there (once broke "Open in v0").
 
 ### Before committing
 
@@ -146,18 +73,8 @@ the drift guard can't catch missing named exports there (once broke
 ## Conventions & gotchas
 
 - Issues and PRDs are tracked in GitHub Issues for `mehdibha/dotUI`.
-- PR titles become commit titles. Format `type(scope): summary` — describe the change, don't justify it (cut clauses like "with…", "to improve…").
-  Aim ~50–60 chars, but never drop information to hit it.
-  Good: `docs: rewrite CLAUDE.md` · Bad: `docs: rewrite CLAUDE.md with real project context`.
-- Adding a tweak (new axis, variant, style param, semantic token) is a
-  product decision: propose it and wait for approval before implementing —
-  never slip one into a component PR.
-- Spot something worth a refactor or rewrite? Propose it — in a "Suggested
-  refactors" note in the PR description, or a GitHub issue if bigger — never
-  by expanding the current diff. Bar: recurring or task-impeding, and
-  specific enough to act on; no "this could be cleaner". Skip areas with a
-  planned rewrite (the publisher).
-- Never run `pnpm build:references` to fix one field — generator drift
-  rewrites ~121 files. Hand-edit the specific JSON; documented props come
-  from `types.ts`, not `base.tsx`.
+- PR titles become commit titles. Format `type(scope): summary` — describe the change, don't justify it (cut clauses like "with…", "to improve…"). Aim ~50–60 chars, but never drop information to hit it. Good: `docs: rewrite CLAUDE.md` · Bad: `docs: rewrite CLAUDE.md with real project context`.
+- Adding a tweak (new axis, variant, style param, semantic token) is a product decision: propose it and wait for approval before implementing — never slip one into a component PR.
+- Spot something worth a refactor or rewrite? Propose it — in a "Suggested refactors" note in the PR description, or a GitHub issue if bigger — never by expanding the current diff. Bar: recurring or task-impeding, and specific enough to act on; no "this could be cleaner". Skip areas with a planned rewrite (the publisher).
+- Never run `pnpm build:references` to fix one field — generator drift rewrites ~121 files. Hand-edit the specific JSON; documented props come from `types.ts`, not `base.tsx`.
 - `www/src/routeTree.gen.ts` is TanStack-generated; never edit it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@ This is the dotUI repository — a design-system builder. Users compose a
 complete design system at dotui.org/create — colors, typography, icons,
 density, radius, per-component styles — preview every change live on real
 components, and export it as code they own: into their codebase via the
-shadcn CLI, or straight into v0, Bolt, and Lovable. It's built on React Aria
+shadcn CLI, or straight into v0 — with Bolt, Lovable, Figma and more
+planned. It's built on React Aria
 Components with Tailwind CSS v4 and tailwind-variants, themed by an OKLCH
 color engine, and distributed as a shadcn-compatible registry served from a
 TanStack Start app.
@@ -30,27 +31,28 @@ include (not exhaustive):
 - For consistency, related components form synced groups: Button and
   ToggleButton share the same styles and must stay in sync.
 
-Beyond the visual axes, export keeps widening: CLI + v0/Bolt/Lovable today;
-Figma, Claude design, etc. planned.
+Beyond the visual axes, export keeps widening: CLI + v0 today;
+Bolt, Lovable, Figma, Claude design, etc. planned.
 
 What this means when writing code today:
 
 - New visual decisions go through tokens/variants so the builder can own them
   later — never inline one-off values in registry components.
-- When designing an axis or variant set, pressure-test it against real design
-  systems: could this express Material, Geist, Linear? If not, it's too
-  narrow.
-- Style related components as a group, not individually.
-- Everything must stay live-previewable in the builder.
-- Registry output stays portable: plain React files, shadcn-schema
-  compatible, no www-internal imports leaking into registry items.
+- A style change to one component in a synced group is a change to the whole
+  group (Button ⇄ ToggleButton) — land them together.
+- New axes and styles must be switchable at runtime (CSS variables, variant
+  props, data attributes), never decided at build time — the builder
+  previews live.
+- Registry items import only from `@/registry/*`, relative paths, and
+  published packages — plain React files, shadcn-schema compatible. www-side
+  imports (router, fumadocs, `@/components`) must never leak in.
 
 ## Structure
 
 - `www/` — the dotui.org app: docs, the /create builder, and the registry
   endpoints (TanStack Start + Vite, fumadocs-mdx, Tailwind v4,
-  tailwind-variants). Registry source lives in `www/src/registry/`
-  (`ui/`, `hooks/`, `lib/`, `theme/`, `__generated__/`).
+  tailwind-variants). Registry source lives in `www/src/registry/` — see
+  Registry below.
 - `packages/colors` — `@dotui/colors`, the OKLCH color engine (private,
   consumed by www).
 - Starter themes and the Tailwind plugins (`tailwindcss-autocontrast`,
@@ -64,6 +66,34 @@ What this means when writing code today:
 - `patches/` — pnpm patches. `tailwindcss-react-aria-components` is patched
   for an upstream `not-*` variant bug; don't bump it without re-checking the
   patch.
+
+## Registry
+
+`www/src/registry/` is the product's source of truth and must stay clean:
+registry items, their files, demos, and descriptions only — no tooling
+internals. (Publisher output still sits in `__generated__/publishables`
+today; known-wrong, don't add more.)
+
+Anatomy of an item (`www/src/registry/ui/<component>/`):
+
+- `base.tsx` — what users receive via the shadcn CLI, after the publisher
+  transforms it (styles resolved, icons swapped, etc.).
+- `styles.ts` — the full style definition with every param; not shipped
+  as-is. On publish, styles are resolved and cleaned — e.g. the density
+  param is removed, its values resolved — before landing in the shipped
+  `base.tsx`.
+- `index.tsx` — the www-side wrapper (site-only concerns like router links);
+  never shipped.
+- `types.ts` — prop types; the source for API reference docs.
+- `meta.ts`, `demos/`, `examples.tsx` — item metadata and docs demos.
+
+## Publisher
+
+`www/src/publisher/` turns registry source into what users install: resolves
+`styles.ts`, strips builder-only params, swaps icons, and emits the shipped
+`base.tsx` and registry JSON. It's messy and a rewrite is planned — verify
+behavior by reading the code, don't pattern-match its structure, and don't
+deepen its reach into `www/src/registry/`.
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,13 @@ include (not exhaustive):
 - For consistency, related components form synced groups: Button and
   ToggleButton share the same styles and must stay in sync.
 
-Beyond the visual axes, export keeps widening: CLI + v0 today;
+A second customization layer beyond visuals: `codeOptions` — the style of
+the exported code itself. Separator comments or not, arrow functions vs
+function declarations, tailwind-variants styles as commented arrays vs one
+line per slot/variant, etc. The exported design system should read like the
+user's codebase, not ours.
+
+Beyond that, export keeps widening: CLI + v0 today;
 Bolt, Lovable, Figma, Claude design, etc. planned.
 
 What this means when writing code today:
@@ -50,6 +56,9 @@ What this means when writing code today:
 - Registry items import only from `@/registry/*`, relative paths, and
   published packages — plain React files, shadcn-schema compatible. www-side
   imports (router, fumadocs, `@/components`) must never leak in.
+- Author registry source in one canonical style (current files are the
+  reference) — `codeOptions` will be mechanical publisher transforms over
+  it, and inconsistent source breaks the transforms.
 
 ## Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,23 +12,34 @@ TanStack Start app.
 ## Product direction
 
 This is the goal, not the current state — check the code before assuming an
-axis exists. The end state is that **every visual decision is a
-user-configurable axis of the builder**, not a hardcoded choice:
+axis exists.
+
+The north star: the builder should be flexible enough to recreate almost any
+design system. If a user can't reproduce the look of a Material-, Geist-, or
+Linear-style system, an axis is missing. Coverage comes from a complete set
+of well-chosen axes, not infinite options: **every visual decision is a
+user-configurable axis of the builder**, never a hardcoded choice. Axes
+include (not exhaustive):
 
 - Color system: simple or advanced, selectable generation algorithm, semantic
   tokens, optionally context-aware tokens.
 - Typography, icon library, density, radius, interactive/disabled cursors.
 - Grouped tweaks — e.g. translucent menus/popovers as a single switch.
-- Per-component styles: a curated set of named variants per component (the
-  20% of styles that cover 80% of design systems), plus hover effect, radius…
+- Per-component styles: named variants curated per component — the 20% of
+  styles that cover 80% of design systems — plus hover effect, radius…
 - For consistency, related components form synced groups: Button and
   ToggleButton share the same styles and must stay in sync.
-- More export targets beyond CLI + v0/Bolt/Lovable: Figma, Claude design, etc.
+
+Beyond the visual axes, export keeps widening: CLI + v0/Bolt/Lovable today;
+Figma, Claude design, etc. planned.
 
 What this means when writing code today:
 
 - New visual decisions go through tokens/variants so the builder can own them
   later — never inline one-off values in registry components.
+- When designing an axis or variant set, pressure-test it against real design
+  systems: could this express Material, Geist, Linear? If not, it's too
+  narrow.
 - Style related components as a group, not individually.
 - Everything must stay live-previewable in the builder.
 - Registry output stays portable: plain React files, shadcn-schema

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,9 @@ What this means when writing code today:
 ## Conventions & gotchas
 
 - Issues and PRDs are tracked in GitHub Issues for `mehdibha/dotUI`.
-- PR titles become commit titles. Format `type(scope): summary`, aim ≤50
-  chars, no explanatory clauses — detail goes in the PR body.
+- PR titles become commit titles. Format `type(scope): summary` — describe
+  the change, don't justify it (cut clauses like "with…", "to improve…").
+  Aim ~50–60 chars, but never drop information to hit it.
   Good: `docs: rewrite CLAUDE.md` · Bad: `docs: rewrite CLAUDE.md with real
   project context`.
 - Theming: semantic tokens resolve and freeze at `:root` — color/radius

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,12 @@ Bolt, Lovable, Figma, Claude design, etc. planned.
 
 What this means when writing code today:
 
-- New visual decisions go through tokens/variants so the builder can own them
-  later — never inline one-off values in registry components.
+- The test for hardcoded values: would two design systems disagree on it?
+  The design system's look (color, radius, typography, shadows,
+  density-affected spacing) goes through tokens/variants — `bg-primary`,
+  not `bg-[#635bff]`. Component mechanics (internal layout, hairlines, hit
+  areas) stay plain values — don't tokenize them. Look with no covering
+  axis? Flag the missing axis; don't invent a token.
 - A style change to one component in a synced group is a change to the whole
   group (Button ⇄ ToggleButton) — land them together.
 - New axes and styles must be switchable at runtime (CSS variables, variant

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,11 @@ What this means when writing code today:
 - Starter themes and the Tailwind plugins (`tailwindcss-autocontrast`,
   `tailwindcss-with`) are moving to standalone repos, consumed from npm.
 - `docs/research/` — date-prefixed (`YYYY-MM-DD-topic.md`) point-in-time
-  research and assessment reports. Check it before re-researching a topic;
-  findings are snapshots as of the filename date. When a report's open
-  question gets decided, append a dated `> Decision:` line to its status
-  header rather than leaving it open.
+  research and assessment reports; multi-file topics get a subfolder (e.g.
+  `open-in/`). Check it before re-researching a topic; findings are
+  snapshots, not kept current. When a report's open question gets decided,
+  append a dated `> Decision:` line to its status header rather than
+  leaving it open.
 - `patches/` — pnpm patches. `tailwindcss-react-aria-components` is patched
   for an upstream `not-*` variant bug; don't bump it without re-checking the
   patch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,10 @@ What this means when writing code today:
 ## Conventions & gotchas
 
 - Issues and PRDs are tracked in GitHub Issues for `mehdibha/dotUI`.
-- Commit titles use `type(scope):` style (`feat(www): …`, `fix:`, `chore:`).
+- PR titles become commit titles. Format `type(scope): summary`, aim ≤50
+  chars, no explanatory clauses — detail goes in the PR body.
+  Good: `docs: rewrite CLAUDE.md` · Bad: `docs: rewrite CLAUDE.md with real
+  project context`.
 - Theming: semantic tokens resolve and freeze at `:root` — color/radius
   changes cannot be scoped to a subtree (density is the exception, via React
   context). Previews that re-theme need an iframe or must re-theme the whole

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ What this means when writing code today:
 
 - `www/` — the dotui.org app: docs, the /create builder, and the registry endpoints (TanStack Start + Vite, fumadocs-mdx, Tailwind v4, tailwind-variants). Registry source lives in `www/src/registry/` — see Registry below.
 - `packages/colors` — `@dotui/colors`, the OKLCH color engine (private, consumed by www).
-- Starter themes and the Tailwind plugins (`tailwindcss-autocontrast`, `tailwindcss-with`) are moving to standalone repos, consumed from npm.
+- Starter themes and the Tailwind plugins (`tailwindcss-autocontrast`, `tailwindcss-with`) live in standalone repos, consumed from npm — their source is not here.
 - `docs/research/` — date-prefixed (`YYYY-MM-DD-topic.md`) point-in-time research and assessment reports; multi-file topics get a subfolder (e.g. `open-in/`). Check it before re-researching a topic; findings are snapshots, not kept current. When a report's open question gets decided, append a dated `> Decision:` line to its status header rather than leaving it open.
 - `patches/` — pnpm patches. `tailwindcss-react-aria-components` is patched for an upstream `not-*` variant bug; don't bump it without re-checking the patch.
 

--- a/docs/research/2026-06-11-autocontrast-assessment.md
+++ b/docs/research/2026-06-11-autocontrast-assessment.md
@@ -1,0 +1,214 @@
+# tailwindcss-autocontrast — design assessment & industry survey
+
+> Written 2026-06-11. Status: **assessment, no decision made.** This document evaluates
+> whether the build-time CSS-scanning approach of this plugin is sound, surveys what
+> major design systems do instead, and proposes options. Paths are relative to the
+> repo root.
+
+## Verdict (TL;DR)
+
+The plugin is fragile on two independent levels:
+
+1. **Delivery mechanism.** ~480 of its ~560 lines exist to re-discover and re-parse the
+   project's own CSS from inside a Tailwind build (filesystem globbing, regex `@import`
+   resolution, PostCSS var extraction). No surveyed design system or component library
+   uses this pattern — every one of them either ships explicit foreground tokens,
+   computes them at *theme-generation* time from a structured input it owns, or computes
+   them at runtime. The strongest evidence is internal: two of dotUI's three on-color
+   code paths already bypass this plugin (see §3).
+2. **Algorithm.** The "max contrast of black vs white" WCAG2 rule flips to black too
+   early (relative luminance Y = 0.179). Measured against this plugin's own
+   `getContrastColor`: it picks **black** text on Tailwind `blue-500`, `indigo-500`, and
+   `#777`, where Mantine, MUI, Material 3, and APCA-aligned thresholds all pick white
+   (see §5). Any user whose accent lands in that class gets the wrong button text color.
+
+Recommended direction: bake `--on-*` at theme-generation time via `@dotui/colors`
+(the showcase bundle already proves this works), optionally emit the OKLCH
+relative-color "lightness flip" as the default value so runtime themes self-correct,
+and in any case move the flip rule to a white-biased threshold (§7).
+
+## 1. What the plugin does today
+
+At Tailwind compile time (`@plugin "tailwindcss-autocontrast"`), the plugin:
+
+1. Locates the root stylesheet: explicit `cssFile` option → env vars
+   (`TW_AUTOCONTRAST_CSS_FILE` / `TW_AUTOCONTRAST_SOURCE`) → glob search of `source` →
+   fallback glob of the whole cwd (`**/*.css`, depth 6), taking the first file containing
+   `@import "tailwindcss"` (`packages/tailwindcss-autocontrast/src/index.js:136-244`).
+2. Reads it and recursively inlines relative `@import "./…"` statements via regex
+   (`packages/tailwindcss-autocontrast/src/index.js:95`).
+3. PostCSS-parses custom properties from `:root` (→ light), `.dark` / `:root.dark`
+   (→ dark), and any other class selector (→ named theme), including inside
+   `@layer base` (`packages/tailwindcss-autocontrast/src/index.js:399-451`).
+4. Keeps vars matching `{name}-{shade}` with shade ∈ {50…950} whose value parses as a
+   color (`packages/tailwindcss-autocontrast/src/index.js:453-473`).
+5. Converts via culori to sRGB, computes WCAG2 relative luminance, picks whichever of
+   black/white has the higher contrast ratio, and injects
+   `--on-{name}-{shade}: black|white` via `addBase` (`packages/tailwindcss-autocontrast/src/index.js:360-397, 490-554`).
+
+## 2. Fragility analysis
+
+- **Out-of-band file discovery.** The plugin runs inside the Tailwind build but
+  re-finds the CSS on disk by globbing from `process.cwd()`, which differs across task
+  runners (turbo at package dir vs repo root, vitest, IDE Tailwind plugins). The two
+  env-var escape hatches exist precisely because this breaks. In a monorepo with
+  multiple stylesheets containing `@import "tailwindcss"`, fallback discovery takes the
+  first glob match — not guaranteed deterministic. The module-level
+  `fileResolutionCache` (`packages/tailwindcss-autocontrast/src/index.js:17`) is never invalidated, so a moved/renamed
+  stylesheet goes stale within a watch process.
+- **Regex `@import` resolution** only follows paths starting with `.`
+  (`packages/tailwindcss-autocontrast/src/index.js:95`). `@import "theme.css"`, package imports, and `url()` forms are
+  silently skipped.
+- **`@theme` is invisible.** Declarations directly inside `@theme { … }` — the
+  canonical Tailwind v4 token location — are not rules, so `walkRules` never visits
+  them. Works for dotUI today because ramps live in `:root`/`.dark`, but it is a
+  landmine for any external consumer of the published npm package following v4 idiom.
+  `[data-theme="…"]` and `html.dark` selectors are likewise missed.
+- **`var()` indirection silently becomes `black`** (`packages/tailwindcss-autocontrast/src/index.js:379-384`).
+  `--accent-500: var(--blue-500)` — a normal aliasing pattern — produces a wrong answer
+  with no warning.
+- **Build-time snapshot vs runtime themes.** Values are frozen at compile time. dotUI's
+  premise is user-generated themes applied at runtime, which is exactly the case a
+  build-time scan cannot see. This is why the workarounds in §3 exist.
+
+Minor: the shade whitelist {50…950} excludes other naming schemes; any class selector
+with custom props is treated as a "theme" (harmless noise); the luminance code uses
+WCAG 2.0's 0.03928 sRGB constant vs 2.1's 0.04045 (negligible).
+
+## 3. dotUI already routes around the plugin
+
+The repo maintains **three implementations of the same decision**, plus a parity test
+to keep them aligned:
+
+| Path | Mechanism | Why it exists |
+|---|---|---|
+| Static build (`www/src/registry/base/base.css`, `@plugin … { cssfile: './src/styles.css' }`) | This plugin, at Tailwind compile time | Fills `--on-*` for the shipped ramps in `base/colors.css` |
+| Runtime theming (`www/src/modules/core/styles.tsx`, `DesignSystemProvider`) | `emitPrimitivesCss(…, { onColors: true })` using `onBlackWhite()` from `packages/colors/src/shared/on-color.ts` | Plugin output is stale once ramps are overridden at runtime, so foregrounds are re-baked into the injected `<style>` |
+| Showcase bundle (`www/scripts/build-showcase-bundle.ts`) | **Strips the `@plugin` line** and pre-bakes `--on-*` into static CSS | Portability — avoids the plugin's path brittleness entirely |
+
+Parity is enforced by `www/src/registry/theme/on-color-parity.spec.ts`, which asserts
+`onBlackWhite()` matches the plugin's exported `getContrastColor` for every generated
+step. When a system needs a parity test between a build-time scanner, a runtime baker,
+and a bundle pre-baker, the scanner is the odd one out. Components consume the result
+via semantic utilities (`text-fg-on-accent`, `--color-fg-on-highlight: var(--on-neutral-300)`,
+etc. in `www/src/registry/ui/*/styles.ts`).
+
+## 4. Industry survey
+
+Surveyed mid-2026 (method caveats in §8). Every system falls into one of three camps;
+**none scans authored CSS at build time** — that pattern appears unique to this plugin.
+
+| Camp | Who | How |
+|---|---|---|
+| (a) Explicit paired tokens | shadcn/ui (`--primary` / `--primary-foreground`, hand-written in `globals.css`), Radix Themes (per-scale `--{color}-contrast` token; sky/mint/lime/yellow/amber hand-cased for dark text), Chakra v3 (`colorPalette.contrast`), Panda CSS, Park UI, Adobe Spectrum's shipped tokens | The theme author writes both halves. Dominant pattern, and the convention of the shadcn registry ecosystem dotUI ships into. |
+| (b) Computed at theme-generation time from structured input | Material 3 / material-color-utilities (HCT tone pairing: `on-primary` = tone 100 vs primary tone 40 — contrast guaranteed by construction, `ContrastCurve` fallback solver), daisyUI 5 (auto-fills missing `*-content` from its **declared** `@plugin "daisyui/theme"` config using culori/OKLCH tinted poles — never by scanning user stylesheets), Bootstrap Sass `color-contrast()`, Radix custom-palette generator, Adobe Leonardo (contrast-first: colors solved *from* target ratios) | The tool owns a structured input, so there is nothing to scan and nothing to go stale. |
+| (c) Runtime | Mantine `autoContrast` (JS, luminance threshold 0.3, white-biased), MUI `getContrastText` (white unless contrast(white) < 3), native CSS `contrast-color()` | Survives arbitrary runtime theming. |
+
+daisyUI 5 is the closest relative — build-time, Tailwind v4, auto-generated foregrounds —
+and the difference is exactly the load-bearing one: it computes from a declared config
+contract rather than parsing CSS text, so it has none of the discovery failure modes.
+(It shares the runtime-staleness caveat and documents it: override the base color at
+runtime and you must override the content color too.)
+
+Token pipelines (Style Dictionary, Terrazzo) ship no contrast-derived-token generation;
+Terrazzo offers contrast *linting* of declared pairs only.
+
+## 5. The flip-rule problem (measured)
+
+WCAG2 "max of black vs white" flips at relative luminance Y = 0.179 — well documented
+(Lea Verou's *contrast-color()* analysis; Material's source comments citing APCA
+research) as flipping to black far too early for human perception. Measured against
+this package's own export:
+
+```
+node -e "const{getContrastColor}=require('./src/index.js'); …"   # from package dir
+
+color                       oklch L   plugin     L>0.7 rule   Mantine (Y>0.3)
+#3b82f6  (tailwind blue-500)  0.62    black      white        white
+#6366f1  (indigo-500)         0.59    black      white        white
+#0ea5e9  (sky-500)            0.68    black      white        black
+#777777  (mid gray)           0.57    black      white        white
+#e11d48  (rose-600)           0.59    white      white        white
+```
+
+Reference flip points: WCAG2-max Y = 0.179 (≈ oklch L 0.56) · Mantine
+`luminanceThreshold` 0.3 / MUI `contrastThreshold` 3 → Y = 0.30 (≈ L 0.67) ·
+Material 3 prefers white below tone ~60 · Lea Verou's APCA-fit recommendation
+**oklch L ≈ 0.70** (~98% agreement with APCA's pick). Pure black/white is also the
+crudest output: daisyUI ships hue-tinted poles (80% mix toward the pole, 20% hue
+retained), Radix and MD3 use tuned scale steps — and `onColor()` in
+`packages/colors/src/shared/on-color.ts` already implements tinted poles with AA
+verification. The plugin/`onBlackWhite` pair is the least sophisticated picker in the
+repo, kept binary for parity.
+
+## 6. CSS-native state of the art
+
+- **`contrast-color()`** (CSS Color 5): returns only black/white by WCAG2 max — the
+  same rule criticized in §5. Safari 26 (Sept 2025); Baseline **Newly Available
+  April 2026** (verified via MDN). No candidate lists / target ratios in the shipped
+  spec; those were deferred. Widely-available status lands ~2028. Strictly less capable
+  than the OKLCH flip below, today.
+- **OKLCH "lightness flip" via relative color syntax** — Baseline since July 2024
+  (~93%+ support):
+
+  ```css
+  @theme inline {
+    --color-fg-on-accent: oklch(from var(--accent-500) clamp(0, (0.7 - l) * infinity, 1) 0 h);
+  }
+  ```
+
+  Threshold tunable per theme (`0.65–0.75` defensible; `0.70` ≈ APCA); small nonzero
+  chroma yields tinted "ink" foregrounds. Because `@theme inline` inlines the expression
+  at the usage site, it recomputes wherever the ramp var resolves — i.e. it stays
+  correct under `DesignSystemProvider`'s scoped and runtime theming. Caveats: a derived
+  custom property declared on `:root` does *not* recompute for subtree overrides (hence
+  `@theme inline` or per-scope re-declaration); transitions across the threshold snap;
+  translucent backgrounds use the color's own lightness, not the composited result;
+  pre-2024 browsers need a plain baked fallback declared first.
+
+## 7. Options
+
+1. **(Recommended) Retire the CSS scan; bake at generation time.** Emit `--on-*` into
+   the registry's static `colors.css` via `emitPrimitivesCss(…, { onColors: true })` —
+   the same path the showcase bundle and runtime provider already use. One code path
+   (`@dotui/colors`) owns the decision; the plugin, its discovery machinery, and the
+   parity test all become unnecessary. Explicit vars in shipped CSS also match the
+   shadcn-ecosystem expectation that foregrounds are visible and overridable.
+2. **(Optional layer on 1) Emit the OKLCH flip as the default value** via
+   `@theme inline`, with a baked literal as the pre-RCS fallback. User-tweaked ramps
+   then self-correct at runtime, which could eventually delete the runtime re-baking in
+   `DesignSystemProvider`. Revisit native `contrast-color()` around 2028 or when
+   target-contrast variants ship.
+3. **(Regardless of 1/2) Fix the flip rule** from max-ratio to white-biased: black only
+   when oklch L > ~0.7 (equivalently, white unless contrast(white) < ~4.5), or promote
+   `onColor()`'s tinted poles over `onBlackWhite`. Note this changes shipped visuals on
+   mid-tone accents (black → white button text), so it is a design decision; plugin and
+   runtime must move together to keep parity until the plugin is retired.
+4. **(Minimum, if the plugin stays published)** Parse `@theme` blocks, warn instead of
+   silently emitting `black` for `var()`-valued tokens, and document the monorepo `cwd`
+   pitfalls prominently in the README.
+
+## 8. Sources & verification caveats
+
+Research was performed 2026-06-11 by sandboxed agents with restricted network access.
+Confidence tiers:
+
+- **Verified on disk:** this plugin's source; Material's algorithm read directly from
+  `@material/material-color-utilities@0.3.0` in node_modules (`material_dynamic_colors.js`,
+  `dynamic_color.js` — incl. the `tonePrefersLightForeground(tone) = tone < 60` comment
+  citing Andrew Somers/APCA); dotUI's own `on-color.ts`, parity spec, provider, and
+  showcase-bundle script. The §5 table was computed against `getContrastColor` locally.
+- **Verified via live fetch (MDN / tailwindcss.com):** `contrast-color()` semantics and
+  its Baseline-April-2026 date; relative-color-syntax mechanics; Tailwind v4 `@theme` /
+  `@theme inline` behavior; no auto-contrast feature in Tailwind core.
+- **High-confidence knowledge (early-2026 cutoff), URLs not re-fetched:** shadcn/Radix/
+  Chakra/Panda/Mantine/MUI/daisyUI specifics (daisyUI 4's `generateForegroundColorFrom`
+  formula is near-verbatim; v5 carrying it over is high-but-not-verified confidence),
+  Lea Verou's threshold numbers, exact Chrome/Firefox `contrast-color()` ship versions.
+  Spot-check candidates: https://lea.verou.me/blog/2024/contrast-color/ ·
+  https://daisyui.com/docs/colors/ · https://www.radix-ui.com/colors/custom ·
+  https://mantine.dev/theming/colors/ · https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/contrast-color
+
+No conclusion above hinges on an unverified fact: the fragility analysis and the §5
+measurements are grounded in this repo, and the "nobody scans CSS" finding holds across
+every library whose mechanism is verified or high-confidence.

--- a/docs/research/open-in/README.md
+++ b/docs/research/open-in/README.md
@@ -1,0 +1,64 @@
+# "Open in &lt;tool&gt;" — integration research & architecture
+
+This folder is the **research + architecture foundation** for dotUI's upcoming **"Open in &lt;tool&gt;"** feature.
+
+## The goal
+
+From the dotUI editor (`/create`), a user clicks **"Open in &lt;tool&gt;"** and lands in that external tool **already showing the component showcase** (the landing-page cards, `www/src/components/marketing/showcase/cards.tsx`) as the **first view**, with the design system **already installed**:
+
+- every component the showcase needs present under the project's `ui/` folder,
+- the colors / tokens / theme written into `globals.css`,
+- all reflecting the user's **chosen preset** (`?preset=<encoded>`), **not** the default.
+
+In short: open the tool and immediately see *your* themed design system rendering *your* components — ready to build on.
+
+## The core insight
+
+Today dotUI emits **one themed component at a time** (`GET /r/$name?preset=…`) plus a theme init item (`GET /r/init?preset=…`). The feature needs a new shared abstraction:
+
+> **A `preset → full-project bundle` engine** — given a `?preset=`, emit a complete, self-contained file tree (all transitively-needed `ui/*` components + `lib/utils.ts` + a real `globals.css` carrying the theme + the rewritten showcase + an `App` entry + Vite/Tailwind/tsconfig scaffold) so any tool can boot straight onto the themed showcase.
+
+Two **master keys** unblock almost everything:
+1. **Ship `/r/registry.json`** (404 today) — required for all shadcn/MCP discovery.
+2. **Export an OKLCH → hex/RGB converter** from `@dotui/colors` — design tools and swatches need sRGB; dotUI emits OKLCH only.
+
+Read **[architecture.md](./architecture.md)** for the full engine design, module boundaries, the 12-PR refactor list, and the phased roadmap. It is the keystone document.
+
+## Per-tool reports
+
+Each report dives into the exact technical approach for that tool: how the **preset** propagates, how **components** get installed, how the **theme** lands in `globals.css`, how the **showcase** becomes the first view, what **dotUI must build**, any **`meta.ts` changes**, limitations/fallbacks, and an implementation checklist.
+
+| Tool | Surface | Technically possible? | Button mechanism | Preset | Color | Roadmap | Report |
+|---|---|---|---|---|---|---|---|
+| **shadcn CLI** | code | ✅ Native substrate | `npx shadcn add` (base/all item) | full | full | P0–P1 | [shadcn-cli.md](./shadcn-cli.md) |
+| **StackBlitz** | code | ✅ Viable (best fit) | sandbox-define (SDK / `/run` POST) | full | full | P2 | [stackblitz.md](./stackblitz.md) |
+| **CodeSandbox** | code | ✅ Viable | sandbox-define (Define API) | full | full | P2 | [codesandbox.md](./codesandbox.md) |
+| **v0** | code | ✅ Possible (workaround) | component-url (`/chat/api/open`) | full | full *(theme as files)* | P3 | [v0.md](./v0.md) |
+| **Cursor** | code | ✅ Feasible | mcp-install deeplink + copy-command | full *(base item)* | full | P1 | [cursor.md](./cursor.md) |
+| **Claude Code** | code | ✅ Feasible | copy-command (`mcp add-json` / `shadcn add`) | full | full | P1 | [claude-code.md](./claude-code.md) |
+| **bolt.new** | code | ✅ Feasible | repo-import (generated repo) | full | full | P4 | [bolt-new.md](./bolt-new.md) |
+| **Replit** | code | ✅ Feasible | repo-import (generated repo) | full | full | P4 | [replit.md](./replit.md) |
+| **Lovable** | code | ⚠️ Feasible (caveats) | repo-import + GitHub sync | full | partial *(HSL overwrite)* | P4 | [lovable.md](./lovable.md) |
+| **Figma** | design | ⚠️ Possible (XL plugin) | custom plugin + token export | full | partial *(OKLCH→sRGB lossy)* | P5–P6 | [figma.md](./figma.md) |
+| **Framer** | design | ⚠️ Feasible w/ build | separate code-component lib | partial | partial | P7 | [framer.md](./framer.md) |
+| **Webflow** | design | ⚠️ Token-only | copy-command (`<style>` block) | partial | partial *(invisible in Designer)* | P7 | [webflow.md](./webflow.md) |
+| **Paper** | design | ⚠️ Indirect (today) | agent-mediated (MCP) | partial | partial | P7 / revisit | [paper.md](./paper.md) |
+
+**Surfaces:** the *code surface* (real React/TS files or a shadcn registry) is unlocked by the bundle engine + `/r/registry.json`. The *design surface* (no React — tokens + generated nodes) is unlocked by the OKLCH→hex/RGB token export plus per-tool generators.
+
+## Roadmap at a glance
+
+| Phase | Deliverable | Effort | Unlocks |
+|---|---|---|---|
+| **P0** | `/r/registry.json` index + export `toSrgb`/`toHex` from `@dotui/colors` | S | MCP discovery; design-tool color export |
+| **P1** | `preset → full-project bundle` engine (`www/src/bundle/*`) + `/r/bundle` + base/"all" item | L | shadcn CLI, Cursor, Claude Code |
+| **P2** | StackBlitz SDK + CodeSandbox Define API buttons | M | highest-fidelity sandbox opens |
+| **P3** | v0 button + showcase registry item (theme-as-files) | M | v0 |
+| **P4** | generated-repo service | L | bolt.new, Replit, Lovable |
+| **P5** | token-export endpoints + `figma` `meta.ts` schema | M | design-surface foundation |
+| **P6** | Figma plugin (component + Variables generator) | XL | Figma |
+| **P7** | Framer / Webflow / Paper generators | XL | remaining design tools |
+
+## How this was researched
+
+Each tool's capabilities were verified against live, current (Jan 2026) documentation, and the per-tool reports are grounded in dotUI's actual internals (the preset codec at `www/src/modules/create/preset/codec.ts`, the publisher at `www/src/publisher/publish.ts`, the theme pipeline, and the showcase's 32-component dependency footprint). External tool capabilities change quickly — treat verdicts as a point-in-time snapshot and re-verify before implementing each phase.

--- a/docs/research/open-in/architecture.md
+++ b/docs/research/open-in/architecture.md
@@ -1,0 +1,372 @@
+# "Open in &lt;tool&gt;" — Architecture & Refactoring Report
+
+> Scope: how dotUI should architect the **"Open in &lt;tool&gt;"** feature so that the external tool lands the user on the component **showcase** (`www/src/components/marketing/showcase/cards.tsx`) as the **first view**, with the design system **already installed** (every needed `ui/*` component present, colors/tokens/theme written into `globals.css`) and reflecting the user's **chosen preset** (`?preset=<encoded>`), not the default.
+>
+> All paths are absolute-relative to the repo root `/Users/mehdibenhadjali/Desktop/dotUI-open-in/`. This document is grounded in the current source; line references are to the code as it exists today.
+
+---
+
+## 1. Executive summary
+
+### 1.1 The feature
+
+Today dotUI already ships a working **"give me a preset as code"** seam: the `/create` customizer encodes the user's design system into a compressed URL param (`?preset=<encoded>`, `www/src/modules/create/preset/codec.ts`), and two server routes turn that into shadcn registry items at request time:
+
+- `GET /r/init?preset=…` → a `registry:base` "init" item that writes the **theme** (color ramps + `@theme inline` semantic layer + plugins) into the consumer's `globals.css` and ships `cn()` (`www/src/routes/r/init.tsx`, `www/src/publisher/emit-theme.ts`).
+- `GET /r/$name?preset=…` → **one component** item, fully themed (density + enum/scalar params folded into the inlined `tv()` config) (`www/src/routes/r/$name.tsx`, `www/src/publisher/publish.ts`).
+
+The install command surfaced on `/create` is literally `npx shadcn add <host>/r/init?preset=<encoded>` (`www/src/modules/create/install-command.tsx:39-48`). **"Open in &lt;tool&gt;" is the next button next to that one** — but instead of (or in addition to) printing a CLI command, it must hand a target tool a *whole project* it can boot.
+
+### 1.2 The core insight: **preset → full-project bundle**
+
+The literal goal — "land in a working project that renders the **showcase** using their themed, installed components" — requires three things the current per-item routes do **not** assemble together:
+
+1. **Every component the showcase transitively needs**, not just one (the showcase imports 32 distinct `ui/*` components — see §1.4).
+2. **A `globals.css`** carrying the preset's theme (already solved by `emitInitItem`).
+3. **A runnable entry** (`App.tsx` / a route) that renders `<Cards/>`, plus `package.json` + Vite/Tailwind/tsconfig config so the tool can `install && dev`.
+
+So the central abstraction to build is a **PRESET → FULL-PROJECT BUNDLE engine**: given a `?preset=`, emit a complete in-memory **file tree** — `ui/*` components, `lib/utils.ts`, `globals.css`, the showcase sources, an `App` entry, and project scaffolding — all themed by the preset. The current `publish()` already produces one themed component file; the bundle engine is its natural generalization to **N components + theme + showcase + scaffold**, deduped and self-contained (drop all `registryDependencies`, because everything is present locally — exactly the `BUNDLED_INTO_INIT` rationale at `www/src/publisher/publish.ts:52-59`).
+
+### 1.3 Code surface vs design surface
+
+The tools split cleanly into two families, and the bundle engine is the backbone of the first:
+
+| Surface | Tools | What they consume | Showcase-first means |
+|---|---|---|---|
+| **Code surface** | v0, StackBlitz, CodeSandbox, bolt, replit, lovable, Cursor/Claude/shadcn (MCP) | React/TS files or a shadcn registry | A real project that boots and renders `<Cards/>` |
+| **Design surface** | Figma, Framer, Webflow, Paper | tokens + generated nodes (no React) | A generated file whose first page mirrors `cards.tsx`, bound to the preset's tokens |
+
+The code surface is unlocked by **(a) a `/r/registry.json` index** (so MCP/shadcn can discover items) and **(b) the bundle engine + a `/r/bundle` export endpoint** (so sandbox/repo tools get a full project). The design surface is unlocked by a **token-export endpoint** (`OKLCH → hex/RGB`) plus per-tool generators, which the Figma deep-dive (`docs/open-in/figma.md`) already specifies in detail. Both surfaces share two "master keys": **ship `/r/registry.json`** and **expose an OKLCH→hex/RGB exporter** from `@dotui/colors`.
+
+### 1.4 The showcase's real dependency footprint (ground truth)
+
+`Cards` (`www/src/components/marketing/showcase/cards.tsx`) composes 17 card components, which collectively import (verified by grep across `www/src/components/marketing/showcase/`):
+
+- **32 distinct dotUI `ui/*` components** via `@/registry/ui/*`: `accordion, avatar, badge, button, calendar, card, checkbox, checkbox-group, color-editor, disclosure, drop-zone, field, file-trigger, group, input, kbd, link, list-box, otp-field, progress-bar, radio-group, select, separator, slider, switch, table, tabs, tag-group, text-field, time-field, toggle-button, toggle-button-group`.
+- **`cn`** via `@/registry/lib/utils` (17 files).
+- **`lucide-react`** icons (6 files) — an npm dependency, not a registry item.
+- **`@/registry/__generated__/icons`** — dotUI's internal generated icon library, used by exactly **one** card (`invite-members.tsx`). This is **app-only**, not part of any installable registry item.
+
+This footprint is the crux: the showcase sources are written against **dotUI-internal alias paths** (`@/registry/ui/*`, `@/registry/lib/utils`) and one **app-internal icon barrel**. A consumer project installs components at `@/components/ui/*` and `@/lib/utils`. **The bundle engine must rewrite these imports** and resolve the icon-library edge case (§2.3, §6.6). This is the single biggest piece of net-new logic and the reason "just zip the showcase folder" does not work.
+
+---
+
+## 2. The shared abstraction: a PRESET → FULL-PROJECT BUNDLE engine
+
+### 2.1 Goal & shape
+
+A pure function (no React, no `ts-morph` at request time — same constraint the publisher already respects, `www/src/publisher/publish.ts:6`) that maps a decoded preset to a flat file map:
+
+```ts
+// www/src/bundle/types.ts  (new)
+export interface BundleFile { path: string; content: string; }        // path relative to project root
+export interface ProjectBundle {
+  files: BundleFile[];                 // ui/*, lib/utils.ts, globals.css, showcase/*, App, scaffold
+  entry: string;                       // e.g. "src/App.tsx" — the file that renders <Cards/>
+  dependencies: Record<string,string>; // npm deps for package.json (react, react-aria-components, lucide-react, …)
+  meta: { preset?: string; title: string; description: string };
+}
+
+export interface BuildBundleInput {
+  preset: PublishPreset;               // decoded (density + componentParams + color)
+  encodedPreset?: string;              // for provenance / regenerate links
+  target: BundleTarget;                // "stackblitz" | "codesandbox" | "vite" | "next" | "raw"
+  aliases?: AliasScheme;               // default consumer aliases (@/components/ui, @/lib/utils)
+}
+```
+
+### 2.2 How it generalizes the current per-item publisher
+
+`publish()` (`www/src/publisher/publish.ts:119-161`) already does, **for one component**, the four steps the bundle needs per component: flatten → resolveClasses → serialize → substitute. The bundle engine **loops** that over the showcase's transitive component set and then layers theme + showcase + scaffold on top:
+
+| Current per-item (`publish.ts`) | Bundle engine generalization |
+|---|---|
+| `publishables[name]()` for one `name` | Loop over the **transitive set** computed from the showcase imports + each item's `registryDependencies` (topological) |
+| `selectPublishable(mod, preset)` (currently **private** in `$name.tsx:89-107`) | **Extract** to `www/src/publisher/select-publishable.ts` and reuse (handles `loader.style` file-swap) |
+| `rewriteDeps()` → absolute URLs (`publish.ts:79-105`) | **Drop all** `registryDependencies` — every dep is inlined locally (extend `BUNDLED_INTO_INIT` logic to "everything") |
+| Emits `files[].target` like `ui/button.tsx` | Place at the **alias-resolved** path `src/components/ui/button.tsx`; rewrite each file's `target` through the project's `aliases` |
+| `emitInitItem()` → theme as shadcn `css`/`cssVars` fields (`emit-theme.ts:71`) | **Render** those structured fields into an actual `globals.css` **text** file (new emitter, §2.4) |
+| No entry, no scaffold | Add `App`/route entry rendering `<Cards/>`, plus `package.json`/Vite/Tailwind/tsconfig |
+
+The merge helpers the bundle needs for combining per-component `css`/`cssVars` already exist at build time (`mergeCss`/`mergeCssVars` in `www/scripts/registry-build.ts`) and in `emit-theme.ts` (`mergeCssVarsIntoCssRule`); a request-safe copy belongs in the bundle module.
+
+### 2.3 The import-rewriter (the load-bearing new piece)
+
+The showcase files (and component `base.tsx` files) import via `@/registry/...`. The bundle must rewrite to the consumer alias scheme. This is a **string/AST transform on import specifiers** — analogous to `specifierToDepName()` in `www/src/publisher/build-time/derive-registry-deps.ts:35` (which already parses `@/registry/{ui,lib,hooks}/X/...` specifiers), but here we *rewrite* rather than *classify*.
+
+Rewrite rules:
+
+| From | To (default aliases) | Notes |
+|---|---|---|
+| `@/registry/lib/utils` | `@/lib/utils` | matches init item's `aliases.utils` (`emit-theme.ts:92-98`) |
+| `@/registry/ui/<name>` | `@/components/ui/<name>` | matches `aliases.ui` |
+| `@/registry/hooks/<name>` | `@/hooks/<name>` | matches `aliases.hooks` |
+| `lucide-react` | *(unchanged)* | add to `dependencies` |
+| `@/registry/__generated__/icons` | **resolve** (see §6.6) | app-only; inline, swap, or exclude the one card |
+
+Two viable implementations: a **build-time pre-rewrite** (transform showcase sources once during `build:registry`, store an alias-neutral copy in `__generated__/`) or a **request-time regex/specifier rewrite** (cheap, since specifiers are well-formed). The build-time path is safer (it can use `ts-morph`, already a build dep) and keeps the request handler pure; the request-time path avoids a generated artifact. Recommend **build-time pre-rewrite** into a `showcase` publishable artifact (§4.3), consistent with how component templates are pre-processed today.
+
+### 2.4 `globals.css` text emitter
+
+`emitInitItem()` returns shadcn **structured** fields (`css` object + `cssVars.theme`); it does **not** produce a CSS string — shadcn's CLI does that merge on the consumer side. For a self-contained bundle there is no shadcn CLI, so we need a function that renders those structured fields back to CSS text. This is the **inverse** of the existing build-time parser `cssToRegistryFields()` (`www/src/publisher/build-time/css-to-registry-fields.ts:30-78`) and a sibling of the existing `emitCss()` (`www/src/registry/theme/emit-css.ts`, which already serializes the `@theme` semantic block from `DEFAULT_SEMANTICS`).
+
+```
+emitGlobalsCss(themeItem)  →  string
+  @import "tailwindcss";
+  @import "tw-animate-css";
+  @plugin "tailwindcss-react-aria-components";
+  @plugin "tailwindcss-autocontrast" { cssfile: "<this file>"; }   // ← must point at the bundle's CSS, not registry/styles.css
+  @plugin "tailwindcss-with";
+  @custom-variant dark (&:is(.dark *));
+  @utility focus-ring { … } /* + focus-reset/input/no-highlight */
+  @layer base { *{@apply border-border} body{@apply bg-bg font-sans text-fg} html{@apply font-sans} }
+  ::selection { … }
+  @theme inline { --radius-md: calc(... * var(--radius-factor)); --color-bg: var(--neutral-50); … }   // from cssVars.theme
+  :root { --radius-factor: 1; --neutral-50: oklch(…); … }   // PRESET ramps (or default)
+  .dark { --neutral-50: oklch(…); … }                       // reversed
+```
+
+Critical fix vs the registry's own sheet: in `www/src/registry/base/base.css` the autocontrast plugin's `cssfile` points at `./src/styles.css`. The bundle's `cssfile` must point at the **bundle's own** Tailwind entry CSS, or `--on-*` foregrounds won't be derived in the generated project. The structured fields drop the `@plugin` body to `{}` (`css-to-registry-fields.ts:73-77`), so the emitter re-attaches the `cssfile` option for the autocontrast plugin specifically.
+
+### 2.5 Proposed module boundaries (under `www/src`)
+
+```
+www/src/bundle/                         ← NEW: request-safe, pure JS (no ts-morph/React)
+  types.ts                  ProjectBundle, BundleFile, BuildBundleInput, BundleTarget, AliasScheme
+  build-bundle.ts           buildBundle(input): ProjectBundle  — the orchestrator (§2.2)
+  collect-components.ts     transitive component set from showcase imports + registryDependencies (topo sort)
+  rewrite-imports.ts        @/registry/* → consumer aliases (request-time fallback; §2.3)
+  emit-globals-css.ts       structured theme fields → globals.css text (§2.4)
+  scaffold/                 per-target package.json / vite.config / tailwind / tsconfig / index.html templates
+    vite.ts  next.ts  stackblitz.ts  codesandbox.ts
+  showcase-manifest.ts      list of showcase source files + entry wiring (or import the generated artifact)
+
+www/src/publisher/
+  select-publishable.ts     ← EXTRACTED from routes/r/$name.tsx (shared by route + bundle)
+  publish.ts                (unchanged core; bundle calls publish() per component)
+  emit-theme.ts             emitInitItem() reused as the theme half of the bundle
+
+www/src/routes/r/
+  registry[.]json.tsx       ← NEW: shadcn Registry index (MCP + design-tool catalog)
+  bundle.tsx                ← NEW: GET /r/bundle?preset=&target= → ProjectBundle JSON (sandbox tools)
+  export[.]json.tsx         ← NEW (or /r/tokens): resolved tokens as hex/RGB/HSL (design tools)
+```
+
+### 2.6 How `/r/registry.json` and the export endpoint fit
+
+- **`/r/registry.json`** is a thin read model over the four existing arrays (`registryUi` from `www/src/registry/__generated__/registry-items.ts`, `registryLib`, `registryHooks` from `www/src/registry/hooks/registry.ts`, `registryBase` from `www/src/registry/base/registry.ts`). No aggregate export exists today; the route assembles the shadcn `Registry` shape (`www/src/registry/types.ts:80-82`). It is the **discovery** surface for MCP/shadcn and the **catalog** for design-tool generators. It does **not** need the bundle engine.
+- **`/r/bundle`** *is* the bundle engine over HTTP — it returns the `ProjectBundle` JSON that sandbox define-APIs (StackBlitz SDK / CodeSandbox Define API) post into their iframe, and that repo-generators write to disk.
+- **`/r/export.json` (tokens)** is a sibling of `/r/init` that resolves the preset's color the same way (`resolveColorConfig`, `www/src/registry/theme/primitives.ts:67`) but returns **hex/RGB/HSL** instead of CSS — the design-tool master key (§6.1).
+
+---
+
+## 3. Per-mechanism architecture
+
+The thirteen target tools cluster into five mechanism groups. For each: the **artifact** the "Open in" button produces, the **dotUI endpoints** it needs, and the **preset-fidelity** path.
+
+### 3a. Component-URL (v0)
+
+**Mechanism.** Vercel v0 accepts an "Open in v0" deep link that points at a **shadcn registry item URL**; v0 fetches the item and opens it in a chat/canvas. This is the closest fit to what dotUI already serves.
+
+- **Artifact:** a button linking to `https://v0.dev/chat/api/open?url=<host>/r/<item>?preset=<encoded>` (or v0's current open-in URL form), where `<item>` is ideally a **single bundle item** that contains the whole showcase + theme + all components inline (so v0 opens *the showcase*, not one component).
+- **dotUI needs:**
+  - A **bundle-as-registry-item** endpoint — a `registry:block`-style item whose `files[]` are the entire showcase + all 32 components + `lib/utils.ts`, and whose `css`/`cssVars` carry the theme. This is the bundle engine's output reshaped into a single shadcn item (reuse `emitInitItem` for the theme half, loop `publish()` for the files half — exactly the "mega bundle" recipe).
+  - `registryDependencies` **dropped** (everything inlined), so v0 never needs to follow URLs.
+- **Preset fidelity: full** for code; the one caveat is v0's CSS handling (§6.2).
+
+### 3b. Sandbox define-API (StackBlitz SDK + CodeSandbox Define API) — the dynamic-preset unlock
+
+**Mechanism.** Both StackBlitz (`sdk.openProject({files})` / the `/run` POST form) and CodeSandbox (the **Define API**: a `parameters` payload, optionally LZ-compressed, POSTed to `https://codesandbox.io/api/v1/sandboxes/define`) accept an **arbitrary in-memory file tree** and boot it. This is where the **full preset travels with zero registry round-trips** — the bundle engine's output maps 1:1 onto their `files` parameter.
+
+- **Artifact:** the "Open in StackBlitz/CodeSandbox" button posts the `ProjectBundle.files` (plus `package.json`) via the SDK/Define form. For StackBlitz, a hidden `<form>` to `https://stackblitz.com/run` or `StackBlitzSDK.openProject({ files, template: 'node' })`. For CodeSandbox, a `POST .../sandboxes/define` with `parameters` (use their `getParameters()` LZ-string helper to stay under URL limits).
+- **dotUI needs:** **`GET /r/bundle?preset=&target=stackblitz|codesandbox`** returning the `ProjectBundle`. The client fetches it, then hands `files` to the SDK. (Alternatively, dotUI computes the Define `parameters` server-side and returns a ready POST body.)
+- **Preset fidelity: full.** This is the **highest-fidelity, lowest-tool-cooperation path** — the project is exactly what the bundle engine emits, including the preset's `globals.css` and themed components. **Best early target** because it exercises the whole bundle engine end-to-end and proves "showcase-first + themed + installed" with no third-party schema.
+
+### 3c. Repo-based (bolt / replit / lovable) — generated-repo strategy
+
+**Mechanism.** These tools import a **Git repo or a project archive** (bolt.new can open `https://bolt.new/~/github.com/<owner>/<repo>` or accept a project import; Replit imports from GitHub or a zip; Lovable imports a GitHub repo). They expect a *complete, conventional* project, not a registry.
+
+- **Artifact:** the bundle engine's `ProjectBundle`, materialized as a real project layout (Vite + React + Tailwind v4 + the rewritten showcase + themed `globals.css`). Two delivery options:
+  1. **Ephemeral repo:** a small service (or GitHub App) writes the bundle to a throwaway repo, then the button deep-links the tool at that repo URL. Highest compatibility, most infra.
+  2. **Archive/import URL:** if the tool accepts a zip/tar or a project-import URL, serve `GET /r/bundle?...&format=zip` and deep-link.
+- **dotUI needs:** the same **`/r/bundle`** endpoint, plus a **`vite` target** scaffold (`scaffold/vite.ts`: `package.json`, `vite.config.ts`, `tsconfig.json` with the `@/*` path alias, `index.html`, `src/main.tsx` mounting `<App/>` that renders `<Cards/>`, `src/globals.css`). Optionally a thin repo-publisher service (out of the dotUI app's request path).
+- **Preset fidelity: full** for code; effort is dominated by the **repo/archive delivery** infra, not the bundle (which is shared with §3b).
+
+### 3d. MCP (Cursor / Claude / shadcn) — registry.json + base/all item
+
+**Mechanism.** The shadcn MCP server (and editor MCP integrations) discover components via a **registry index** and install them via `shadcn add`. "Open in" here means: the user's editor/agent can pull dotUI's themed components by name. The showcase-first framing becomes "the agent can scaffold the showcase because every piece is discoverable and installable with the preset baked in."
+
+- **Artifact:** an MCP/registry configuration the user adds (`components.json` `registries["@dotui"]` → `<host>/r/{name}?preset=<encoded>`, which `emitInitItem` already emits at `emit-theme.ts:99-101`), **plus** the new index so discovery works.
+- **dotUI needs:**
+  - **`/r/registry.json`** — the index (today: **404**; this is the single most-cited missing piece across mechanisms). Without it, MCP cannot list items.
+  - A **"showcase" aggregate item** registered in the index (e.g. `name: "showcase"`, the same bundle-as-item from §3a) so an agent can `shadcn add @dotui/showcase` and get the full first-view in one shot. Its `registryDependencies` can stay as URLs (let shadcn follow them) **or** be inlined; for an agent flow, inlining is more robust.
+- **Preset fidelity: full** — the preset rides in `registries["@dotui"]`'s `?preset=` and in each per-item URL (`$name.tsx:51`). Color only survives on `/r/init` and the (new) bundle/showcase item, **not** on `/r/$name` (which drops `color`, `$name.tsx:113-121`); the index/showcase path must source color from the init/bundle resolution.
+
+### 3e. Design-tool generation (Figma / Framer / Webflow / Paper) — token export + generators
+
+**Mechanism.** None of these run React or consume a shadcn registry. "Open in" = **generate native artifacts** (Figma Variables + Component Sets; Framer code/Smart Components; Webflow variables/components; Paper styles) from **(a) the preset's resolved tokens** and **(b) per-tool component metadata**. The showcase becomes a generated **first page/frame** mirroring `cards.tsx` declaratively. The Figma deep-dive (`docs/open-in/figma.md`) is the reference design for this whole group.
+
+- **Artifact:** a tool-specific generator (a Figma **plugin**; for Framer/Webflow, a code-component package or an API push where the platform allows) that the button deep-links, handing over the `?preset=` string.
+- **dotUI needs (shared across the group):**
+  - **`GET /r/export.json?preset=` (tokens)** — `decodePreset` → `resolveColorConfig(ds.color ?? DEFAULT_COLOR_CONFIG)` → per-step **OKLCH→sRGB hex/RGB(+HSL)** and `onBlackWhite` foregrounds, plus the semantic→primitive map mirroring `DEFAULT_SEMANTICS` (`www/src/registry/theme/semantics.ts`). (Figma's variant is `/r/figma/tokens` returning Figma `{r,g,b}` 0..1.)
+  - **`/r/registry.json`** as the component catalog.
+  - **Per-item design metadata** on `meta.ts` (the `figma` block; generalizable to other tools — §4) describing anatomy, variant→property mapping, and token bindings.
+  - **A showcase manifest** (`www/src/registry/figma/showcase.ts`, generalizable to `www/src/registry/design/showcase.ts`) declaratively mirroring `cards.tsx`.
+  - **`toSrgb` / `toHex` exported from `@dotui/colors`** (today only `gamutMap, oklchCss, toOklch, apca, wcag2` are barrel-exported; `toSrgb` lives in `packages/colors/src/shared/color.ts:42` but isn't exported).
+- **Preset fidelity:** structure full, **color partial** (OKLCH→sRGB is lossy at out-of-gamut steps; `gamutMap` nudges them — see §6.1 and `figma.md` §5c).
+
+---
+
+## 4. `meta.ts` schema evolution
+
+### 4.1 Today
+
+`RegistryItem` (`www/src/registry/types.ts:69-78`) = shadcn item + two dotUI-only fields, both **dropped from emitted JSON** at publish (`publish.ts:145-158`):
+
+```ts
+export type RegistryItem = ShadcnRegistryItem & {
+  group?: ComponentGroup | null;
+  params?: Record<string, ParamDef>;   // EnumParamDef | ScalarParamDef
+};
+```
+
+### 4.2 Consolidated proposal
+
+Add **two** optional, declarative, publish-dropped fields. `figma` is taken verbatim from `docs/open-in/figma.md` §8a; a `showcase` hint helps the code-bundle entry, and the design metadata is namespaced so it can grow to Framer/Webflow without per-tool churn.
+
+```ts
+// www/src/registry/types.ts (additions)
+
+// --- design-tool metadata (Figma first; see docs/open-in/figma.md §8) ---
+export type FigmaTokenBinding =
+  | { kind: "fill"; token: string } | { kind: "stroke"; token: string }
+  | { kind: "text"; token: string } | { kind: "radius"; token: string }
+  | { kind: "opacity"; value: number };
+export interface FigmaLayer {
+  name: string; type: "frame" | "text" | "icon" | "instance";
+  component?: string; bind?: FigmaTokenBinding[]; content?: string;
+  children?: FigmaLayer[]; showWhen?: Record<string, string>;
+}
+export interface FigmaVariantMapping {
+  property: string; propertyType: "VARIANT" | "BOOLEAN" | "TEXT" | "INSTANCE_SWAP";
+  source: string; values?: readonly string[]; default?: string;
+}
+export interface FigmaDensitySizing { height?: number; paddingX?: number; paddingY?: number; gap?: number; }
+export interface FigmaMeta {
+  layout: { direction: "horizontal" | "vertical" | "none"; align?: "min"|"center"|"max"|"space-between";
+            sizing?: Partial<Record<Density, FigmaDensitySizing>>; };
+  anatomy: FigmaLayer[];
+  variants: FigmaVariantMapping[];
+  /** Optional data-driven variant→token overrides (e.g. primary ⇒ fill accent). */
+  variantBindings?: Record<string, FigmaTokenBinding[]>;
+  sample?: Record<string, string>;
+  states?: readonly string[];
+}
+
+export type RegistryItem = ShadcnRegistryItem & {
+  group?: ComponentGroup | null;
+  params?: Record<string, ParamDef>;
+  figma?: FigmaMeta;        // NEW — design-tool generation metadata
+};
+```
+
+Rationale highlights (full detail in `figma.md` §8): `figma.layout.sizing` per density is sourced from each component's `styles.ts` density blocks; `bind.token` names reuse the `--color-*` suffixes from `DEFAULT_SEMANTICS` verbatim; `variants` map dotUI enum params (and synthetic `$variant`/`$size`/`$state` axes) to Figma component properties. Keeping `variantBindings` data-driven avoids hardcoding per-component intent in the generator.
+
+> **Note on a `showcase` hint:** rather than add a third field that most items would leave empty, the code-bundle entry is better driven by a **single hand-authored showcase manifest** (§4.3) than by per-item flags. So no `bundle?`/`showcase?` field is proposed on `RegistryItem`; the showcase wiring lives in one place.
+
+### 4.3 How `registry-build` consumes them
+
+`www/scripts/registry-build.ts` (`pnpm build:registry`) already reads each `ui/<name>/meta.ts` and emits `__generated__/registry-items.ts` + per-component publishables + `__generated__/base-css.ts`. The schema additions require:
+
+1. **No change to publishables emission** — `figma` is dotUI-only and rides along on `meta` (the runtime side already carries `params`/`group`; `figma` is the same), and is dropped from emitted shadcn JSON by `publish.ts` automatically (it only copies a known field whitelist, `publish.ts:145-156`).
+2. **Surface `figma` in `registry.json`** — the new index route reads `registryUi` etc. and includes `figma` in each descriptor (or strips it for a lightweight index and serves it from a dedicated `/r/figma/manifest`).
+3. **New build step: showcase pre-rewrite + manifest validation** — add to `registry-build`:
+   - Read the showcase sources under `www/src/components/marketing/showcase/`, rewrite `@/registry/*` specifiers to consumer aliases (using the `ts-morph` already imported by the build), and emit `__generated__/showcase-bundle.ts` (the alias-neutral file map + entry wiring) for the bundle engine to consume at request time.
+   - Validate the showcase manifest: every component referenced exists in `registryUi`; resolve the `lucide-react` and `@/registry/__generated__/icons` edges (§6.6).
+   - For the design path, validate every `figma.anatomy[].component` / `variants[].source` against `registryUi` / the item's `params` (the CI guard `figma.md` §9 calls for).
+
+The integrity-check pattern already exists in `registry-build` (scope drift, allowlist, registryDeps drift, unique names) — the showcase/figma validators slot in as additional throwing checks.
+
+---
+
+## 5. The refactor list (ordered, concrete)
+
+Ordered so each step unblocks the next; each is a discrete PR.
+
+1. **Extract `selectPublishable`** from `www/src/routes/r/$name.tsx:89-107` into `www/src/publisher/select-publishable.ts`; import it in the route and the bundle engine. (Pure move; the enum-with-files/`loader` logic must be reused, not duplicated.)
+2. **Export `toSrgb` (add `toHex`, `toHsl`) from `@dotui/colors`** — `packages/colors/src/shared/color.ts:42` already has `toSrgb`; add it (and `toHex = round(toSrgb)→#rrggbb`) to the barrel `packages/colors/src/index.ts`. Master key for every design tool and any swatch UI.
+3. **Add `/r/registry.json`** — `www/src/routes/r/registry[.]json.tsx`, assembling the shadcn `Registry` shape from `registryBase`/`registryUi`/`registryLib`/`registryHooks`. Reuse the cache headers from `$name.tsx:27-30`. Unblocks MCP **and** design-tool catalogs. (Today: 404.)
+4. **New bundle module `www/src/bundle/`** — `types.ts`, `collect-components.ts` (transitive set from showcase imports + `registryDependencies`, topo-sorted), `rewrite-imports.ts`, `emit-globals-css.ts` (inverse of `css-to-registry-fields.ts`; reuse `emit-css.ts` for the `@theme` block), `build-bundle.ts` (orchestrator looping `publish()` + `emitInitItem()`), and `scaffold/*` templates per target.
+5. **Build-script additions** (`www/scripts/registry-build.ts`) — emit `__generated__/showcase-bundle.ts` (alias-rewritten showcase file map + entry) and add the showcase/figma validators (§4.3).
+6. **Add `/r/bundle`** — `www/src/routes/r/bundle.tsx`: decode preset (reuse the `decodePresetForRoute` helper pattern already duplicated in both routes — **extract it** to `www/src/publisher/decode-preset-for-route.ts` while here), call `buildBundle`, return `ProjectBundle` JSON (optionally `?format=zip`). Run emitted `.tsx` through `oxfmt` like `$name.tsx:62-76`.
+7. **Add a "showcase" aggregate item** (bundle-as-single-shadcn-item) for v0 and MCP — either a dedicated route `/r/showcase` or a special `name` handled in `$name.tsx`; theme via `emitInitItem`, files via the bundle engine, `registryDependencies` dropped.
+8. **Preset codec: thread `tokens` → theme** — `emit-theme.ts:62-68` documents that global `tokens` (e.g. `--radius-factor`) round-trip in the URL but are **not** written to `:root`. `PublishPreset` (`www/src/publisher/types.ts:79-85`) lacks `tokens`. Add `tokens?` to `PublishPreset`, thread it from both routes' decoders, and have `emitInitItem`/`emitGlobalsCss` write them to `:root`. (Otherwise radius-factor presets silently no-op in bundles.)
+9. **`meta.ts` schema** — land the `figma` types (§4.2) in `www/src/registry/types.ts`; confirm `publish.ts` drops them (it does, by whitelist).
+10. **Author `figma` blocks** for the showcase-critical components (`button, card, text, text-field/input, select, checkbox, switch, link, avatar, badge, tooltip, loader`), per `figma.md` §8b/§8c.
+11. **Design-tool token endpoints** — `/r/export.json` (hex/RGB/HSL) and Figma's `/r/figma/tokens` (`{r,g,b}` 0..1), both reusing `resolveColorConfig` + the new `toHex`/`toSrgb` + `onBlackWhite`.
+12. **"Open in" buttons on `/create`** — next to `install-command.tsx` (`www/src/modules/create/install-command.tsx`), built from the current `encodePreset(designSystem)` value (`www/src/modules/create/preset/use-design-system.ts`); per-tool deep-link/SDK wiring. Handle `encodePreset → undefined` (no customization) by falling back to default everywhere.
+
+**What to extract/share (summary):** `selectPublishable`, `decodePresetForRoute`, and CSS-merge helpers move into shared modules; `toSrgb`/`toHex` move into the colors barrel; the bundle engine becomes the shared core for v0 / sandbox / repo / showcase-item; `resolveColorConfig` + on-color stay the single color source for both `globals.css` and design-token export.
+
+---
+
+## 6. Risks & cross-cutting concerns
+
+### 6.1 OKLCH everywhere → need hex/HSL/RGB export
+dotUI emits **only `oklch()`** strings (`packages/colors/src/shared/color.ts:54`). Code targets are fine (browsers read OKLCH), but **every design tool and any swatch/color-input UI needs sRGB**. The seam exists (`toSrgb`, `gamutMap`) but `toSrgb` isn't barrel-exported. **Color fidelity is inherently partial** for design tools: vivid OKLCH steps sit outside sRGB and get `gamutMap`'d (hue-preserving nudge), so the most saturated light/dark steps shift slightly; in-gamut steps are exact. There is no fix — sRGB is the tools' only space. Document the nudge.
+
+### 6.2 v0 / shadcn CSS handling (cssVars stripping)
+shadcn-family tools historically normalize/strip parts of a registry item's CSS, and v0's importer may not faithfully carry every `@plugin`/`@utility`/`@layer` block or the `oklch()` `:root` ramps. The bundle-as-item path mitigates this by shipping a **literal `globals.css` file** (in `files[]`) rather than relying solely on structured `css`/`cssVars` merge — the tool then just writes the file. Verify per tool; the autocontrast `cssfile` self-reference (§2.4) is the most fragile line.
+
+### 6.3 MCP's hard dependency on `/r/registry.json`
+The entire MCP/shadcn discovery path is blocked until the index route exists (today 404). It is low-effort and unblocks two mechanism groups (MCP **and** design-tool catalogs), so it should be **P0**.
+
+### 6.4 Preset URL-length limits
+The encoded preset is compact (pako-deflate + base64url, `codec.ts`) and round-trips fine in `/r/*` query strings. But **sandbox define-APIs encode the entire project into a URL/POST** (CodeSandbox Define API is famous for this). The bundle is large; do **not** put the bundle in a URL — POST it (StackBlitz SDK `openProject`, CodeSandbox `getParameters()` LZ + POST). The `?preset=` stays small and is the only thing safe to put in deep links; the **bundle is always fetched/POSTed, never URL-encoded**. Also handle the encoder returning `undefined` when the design system equals defaults (`codec.ts:84-89`).
+
+### 6.5 Tier-gating
+"Open in &lt;tool&gt;" is a natural premium surface. The bundle/export endpoints should be gate-aware (e.g. auth check in the route before `buildBundle`), and the customizer button should reflect entitlement. Keep gating in the **route layer**, not the bundle engine (which stays pure) — mirrors how the routes already own preset-decode/format concerns and the engine stays side-effect-free.
+
+### 6.6 The internal icon-library edge (`@/registry/__generated__/icons`)
+One showcase card (`invite-members.tsx`) imports dotUI's generated icon barrel, which is **app-only** and not an installable registry item. Three options, in order of preference: **(a)** swap that card's icons to `lucide-react` (already a bundle dep) so the showcase is fully portable; **(b)** inline the specific icon components into the bundle; **(c)** exclude that single card from the bundled showcase. The build-time showcase validator (§4.3) should **fail loudly** if an un-resolvable app-only import appears, so this can't silently break a generated project. Likewise `lucide-react` must be added to `ProjectBundle.dependencies`.
+
+### 6.7 Showcase ↔ source drift
+The showcase is hand-authored React; the bundle rewrites it. If a card adds a new `@/registry/*` import, the transitive set and rewriter must keep up. Mitigate with the build-time validator (every showcase import resolves to a known registry item or an allowlisted npm dep) and a snapshot test of `/r/bundle` for the default preset. The same drift risk applies to `figma` anatomy vs `styles.ts` (covered by `figma.md` §9 guards).
+
+### 6.8 `color` dropped on `/r/$name`
+`$name.tsx:113-121` returns only `{ density, componentParams }` — **color is intentionally dropped** per-component (color lives in `globals.css`, not in component files). The bundle engine sources color from the **theme half** (`emitInitItem` / `resolveColorConfig`), not from per-component publish — so this is correct as-is, but anyone wiring a new path must not assume `/r/$name` carries color.
+
+---
+
+## 7. Phased roadmap
+
+Sequenced by **leverage ÷ effort**, with the `/r/registry.json` index and the bundle engine as the early unlocks (they are shared infrastructure for almost everything downstream).
+
+| Phase | Deliverable | Tools unlocked | Why here | Effort |
+|---|---|---|---|---|
+| **P0** | `/r/registry.json` index (§5.3) + extract `selectPublishable`/`decodePresetForRoute` + export `toSrgb`/`toHex` (§5.1–5.2) | **MCP** (Cursor/Claude/shadcn discovery); prerequisite for design catalogs | Lowest effort, highest fan-out; 404 today blocks MCP; the colors export is a 1-line master key | S |
+| **P1** | **Bundle engine** `www/src/bundle/*` + `globals.css` emitter + import-rewriter + build-time showcase pre-rewrite/validator (§5.4–5.5) | (foundation — no tool yet) | The core abstraction everything code-side depends on; build it once, reuse 4× | L |
+| **P2** | **`/r/bundle`** + StackBlitz SDK & CodeSandbox Define buttons (§3b, §5.6) | **StackBlitz, CodeSandbox** | Highest fidelity, least tool cooperation; proves "showcase-first + themed + installed" end-to-end | M |
+| **P3** | **Showcase aggregate item** + **Open in v0** (§3a, §5.7) + MCP `@dotui/showcase` | **v0**, richer **MCP** | Reuses P1/P2; v0 just needs a single registry item URL | M |
+| **P4** | **`vite` scaffold target** + repo/archive delivery (ephemeral repo or zip) + bolt/replit/lovable buttons (§3c) | **bolt, replit, lovable** | Bundle is shared with P2; effort is delivery infra, not codegen | L |
+| **P5** | **`/r/export.json` tokens** (hex/RGB/HSL) + `figma` schema land + author `figma` blocks (§4, §5.9–5.11) | foundation for design tools | Token endpoint + schema are shared by all design tools | M |
+| **P6** | **Figma plugin** (`packages/figma-plugin`) + `/r/figma/tokens` + showcase manifest + Open-in-Figma button | **Figma** | Per `docs/open-in/figma.md`; net-new published plugin | XL |
+| **P7** | **Framer / Webflow / Paper** generators (reuse P5 export + per-tool metadata) | **Framer, Webflow, Paper** | Each is its own generator; lowest leverage, most per-tool work | XL each |
+
+**Cross-cutting, fold into the relevant phase:** thread `tokens → :root` (P1, §5.8); tier-gating in route layer (P2 onward, §6.5); preset-`undefined` fallback everywhere (P0 onward); per-tool CSS-fidelity verification (P2/P3, §6.2).
+
+---
+
+## Appendix — key file index
+
+- Showcase entry & footprint: `www/src/components/marketing/showcase/cards.tsx`; sources under the same dir (alias surface in §1.4).
+- Per-item publisher (generalize): `www/src/publisher/publish.ts:119`; `selectPublishable` to extract: `www/src/routes/r/$name.tsx:89`.
+- Theme emitter (reuse as bundle theme half): `www/src/publisher/emit-theme.ts:71`; routes `www/src/routes/r/init.tsx`, `www/src/routes/r/$name.tsx`.
+- CSS structured↔text: parser `www/src/publisher/build-time/css-to-registry-fields.ts:30`; semantic block emitter `www/src/registry/theme/emit-css.ts`.
+- Color resolution & seam: `www/src/registry/theme/primitives.ts:67`; `packages/colors/src/shared/color.ts:42,54`; barrel `packages/colors/src/index.ts`.
+- Preset codec / defaults / types: `www/src/modules/create/preset/codec.ts:75,111`; `www/src/modules/create/preset/defaults.ts`; `www/src/modules/create/preset/types.ts`.
+- Registry arrays (index source): `www/src/registry/__generated__/registry-items.ts`; `www/src/registry/hooks/registry.ts`; `www/src/registry/base/registry.ts`.
+- Registry/meta types (schema target): `www/src/registry/types.ts:69`.
+- Build entry: `www/scripts/registry-build.ts` (`pnpm build:registry`, `www/package.json:10`).
+- Install-command precedent (button home): `www/src/modules/create/install-command.tsx:39`.
+- Design-tool deep-dive: `docs/open-in/figma.md`.

--- a/docs/research/open-in/bolt-new.md
+++ b/docs/research/open-in/bolt-new.md
@@ -1,0 +1,411 @@
+# Open in bolt.new
+
+> Viable via generated GitHub repo · button type **repo-import** · preset fidelity **full** · color fidelity **full**
+
+---
+
+## 1. User experience
+
+The user is on `https://dotui.com/create` with a custom preset active (e.g. an orange accent, comfortable density, card style "tasnim"). They click **"Open in bolt.new"**.
+
+What they should land in:
+
+1. bolt.new opens a WebContainer running the generated repo.
+2. The home page immediately renders the dotUI **showcase** (`cards.tsx`) — all 17 card widgets (Booking, TwoFactor, Filters, Storage, Notifications, CookiePreferences, InviteMembers, Shortcuts, Payment, Transactions, AccountMenu, Faq, ColorEditorCard, UploadAvatar, TeamName, Feedback, LoginForm).
+3. Every `ui/` component (button, card, slider, etc.) is pre-installed and styled with the chosen preset: the orange accent palette in `globals.css`, `density: comfortable` baked into component class strings, card style set to `tasnim`.
+4. The user can immediately start editing — the design system is theirs, already configured.
+
+No "run npm install", no "run shadcn add", no prompt to enter. The repo is complete before bolt ever opens it.
+
+---
+
+## 2. Technical mechanism
+
+bolt.new supports opening a public GitHub repo at:
+
+```
+https://bolt.new/~/github.com/<owner>/<repo>
+```
+
+This is the deterministic path. bolt clones the repo into a WebContainer and runs the project's dev server. It does not accept a programmatic in-memory file tree via URL, and it does not have a documented API for injecting files.
+
+Two candidate paths exist:
+
+### Path A — Generated GitHub repo (RECOMMENDED)
+
+dotUI generates a complete Vite + React project repo on the fly (or commits to a per-user/per-preset branch), then redirects to `https://bolt.new/~/github.com/dotui-generated/<repo-slug>`.
+
+- The generated repo contains: `src/globals.css` (theme with the user's preset baked in), `src/components/ui/**` (all component files with preset-resolved class strings), `src/components/marketing/showcase/**` (the 17 card widgets verbatim), `src/App.tsx` (renders `<Cards />`), full `package.json`, `vite.config.ts`, etc.
+- The preset is baked at generation time — the result is a static snapshot, fully deterministic.
+- bolt.new receives a plain GitHub URL, no special handling needed.
+
+### Path B — Unofficial `?prompt=` param (NOT RECOMMENDED)
+
+```
+https://bolt.new?prompt=npx+shadcn+add+https://dotui.com/r/init?preset=<encoded>
+```
+
+This is non-deterministic. The bolt agent receives a natural-language prompt and decides how and whether to run `shadcn add`. It may produce an incorrect project structure, miss dependencies, or fail silently. It cannot guarantee the showcase is the first view. This path is undocumented and subject to breakage with no notice. **Do not rely on it.**
+
+**Verdict: Path A (generated GitHub repo) is the only implementation that achieves full preset fidelity + guaranteed showcase as first view.**
+
+---
+
+## 3. Preset propagation
+
+The preset is encoded at the dotUI customizer as:
+
+```ts
+// www/src/modules/create/preset/codec.ts:75
+const encoded = encodePreset(designSystem);
+// → pako.deflateRaw(JSON.stringify(compactState), { level: 9 }) → base64url
+```
+
+The compact `DesignSystemState` (`www/src/modules/create/preset/types.ts:14`) carries only diffs vs defaults:
+```ts
+{ p?: Record<string, Record<string, string>>;  // componentParams diff
+  t?: Record<string, string>;                   // tokens diff
+  d?: Density;                                  // density (omitted if "compact")
+  c?: ColorConfig;                              // full color recipe (omitted if default) }
+```
+
+For the bolt.new integration, the "Open in bolt.new" button reads this encoded string from the current `?preset=` URL search param and passes it to the repo-generation server function. The server function calls `decodePreset(encoded)` to reconstruct the full `DesignSystem`, then uses that to drive generation.
+
+The four aspects of preset fidelity and how each is achieved:
+
+| Aspect | How achieved |
+|---|---|
+| Color palette (OKLCH ramps) | `resolveColorConfig(ds.color)` → `rampsToVars()` → baked into `globals.css` `:root`/`.dark` |
+| Density | `publish({ publishable, preset })` with `preset.density` — `flatten.ts` merges `density[selected]` tv layer into each component's class string |
+| Enum param choices (card style, loader style, etc.) | Same `publish()` call — `flatten.ts` merges `params[name][value]` tv layer; enum-with-files (loader) swaps source file |
+| Scalar param choices (avatar radius, slider thumb-size, etc.) | `resolveClasses()` → `buildScalarVarMap()` rewrites e.g. `rounded-(--avatar-radius)` → `rounded-full` in the component source |
+
+The `tokens` field (`t` in the compact state) is **not yet threaded through `PublishPreset`** — this is a documented TODO at `www/src/publisher/emit-theme.ts:62-68`. If the user has set a custom `--radius-factor` via the customizer, it will not appear in the generated `globals.css`. This is the same limitation that applies to the install-command path today.
+
+---
+
+## 4. Components installed
+
+The showcase `Cards` component (`www/src/components/marketing/showcase/cards.tsx:20-48`) uses the following 38 `registry/ui` components (plus `registry/lib` utilities):
+
+**UI components** (all 38 installed under `src/components/ui/`):
+accordion, avatar, badge, button, calendar, card, checkbox, checkbox-group, color-area, color-editor, color-field, color-slider, color-thumb, disclosure, drop-zone, field, file-trigger, group, input, kbd, link, list-box, loader, otp-field, popover, progress-bar, radio-group, select, separator, slider, switch, table, tabs, tag-group, text, text-field, time-field, toggle-button, toggle-button-group
+
+**Lib / hooks** (installed under `src/lib/` and `src/hooks/`):
+- `src/lib/utils.ts` — `cn()` helper (clsx + tailwind-merge)
+- `src/lib/context.tsx` — `createContext`, `createVariantsContext`, `createScopedContext` (used by avatar, tabs, toggle-button, button)
+- `src/hooks/use-image-loading-status.ts` — avatar image load state
+
+Each component file is generated by calling the dotUI publisher:
+
+```ts
+// www/src/publisher/publish.ts:119
+const { item } = publish({ publishable, preset });
+// item.files[0].content = base.tsx template with %%TV_CONFIG%% replaced,
+//   class strings resolved for density + enum params + scalar params
+```
+
+The `loader` component uses enum-with-files — the `style` param selects `base.spinner.tsx` or `base.ring.tsx` via `selectPublishable()` (`www/src/routes/r/$name.tsx:89-107`). The generation function must replicate this logic.
+
+Each component file's install target comes from `meta.files[0].target` (e.g. `"ui/button.tsx"` → `src/components/ui/button.tsx`). The generated repo maps these to a Vite project with alias `@/ → src/`.
+
+---
+
+## 5. Theme in globals.css
+
+The init item produced by `emitInitItem()` (`www/src/publisher/emit-theme.ts:71-128`) is the single source of truth for `globals.css` content. For the generated repo, we call this function server-side and render its output directly into `src/globals.css`.
+
+The generated file has this structure:
+
+```css
+@import "tailwindcss";
+@import "@fontsource-variable/geist";
+@import "@fontsource/geist-mono";
+
+/* From item.css — at-rules block */
+@import "tw-animate-css";
+@plugin "tailwindcss-react-aria-components";
+@plugin "tailwindcss-autocontrast" { cssfile: "./src/globals.css"; }
+@plugin "tailwindcss-with";
+@custom-variant dark (&:is(.dark *));
+@utility focus-ring { … }
+@utility focus-reset { … }
+@utility focus-input { … }
+@utility focus-no-highlight { … }
+@layer base { * { @apply border-border; } body { @apply bg-bg font-sans text-fg; } }
+::selection { background-color: var(--accent-800); color: var(--on-accent-800); }
+
+/* From item.cssVars.theme — constant across presets */
+@theme inline {
+  --radius-md: calc(0.375rem * var(--radius-factor));
+  --color-bg: var(--neutral-50);
+  --color-accent: var(--accent-500);
+  /* … all semantic tokens … */
+}
+
+/* From item.css[":root"] — PRESET-SPECIFIC ramps */
+:root {
+  --radius-factor: 1;
+  --neutral-50: oklch(0.985 0 0);
+  /* … 66 vars (6 palettes × 11 steps) — values reflect the chosen color seeds … */
+}
+
+/* From item.css[".dark"] — reversed ramps */
+.dark {
+  --neutral-50: oklch(0.13 0 0);
+  /* … */
+}
+```
+
+The OKLCH ramp values in `:root`/`.dark` are generated by:
+```ts
+// www/src/registry/theme/primitives.ts:67
+const resolved = resolveColorConfig(preset.color);
+// resolved.light = { neutral: { "50": "oklch(…)", … }, accent: {…}, … }
+// resolved.dark  = light ramps reversed (step 50↔950) per reverseRamp()
+```
+
+The `--on-*` foreground variables (`--on-accent-500`, etc.) are NOT emitted into `globals.css`. They are derived at Tailwind compile time by the `tailwindcss-autocontrast` plugin, which scans `:root`/`.dark` for `--<palette>-<step>` vars and injects `--on-<palette>-<step>: black | white` (`packages/tailwindcss-autocontrast/src/index.js:407-501`). The generated repo includes this plugin in `devDependencies` and the `@plugin` declaration handles the rest.
+
+Note on the `cssfile` option for `tailwindcss-autocontrast`: in the generated consumer project, this must point at the consumer's actual CSS entry file — `"./src/globals.css"` (not the registry's own `./src/styles.css`). The init item emits `@plugin "tailwindcss-autocontrast"` without a `cssfile` body in the structured JSON; the repo generator should inject it with the correct path.
+
+---
+
+## 6. The showcase as first view
+
+The showcase is `www/src/components/marketing/showcase/cards.tsx`. It renders all 17 card widgets inline — no routing, no loaders, all client-side state. The files to copy verbatim:
+
+```
+www/src/components/marketing/showcase/cards.tsx
+www/src/components/marketing/showcase/booking.tsx
+www/src/components/marketing/showcase/two-factor.tsx
+www/src/components/marketing/showcase/filters.tsx
+www/src/components/marketing/showcase/storage.tsx
+www/src/components/marketing/showcase/notifications.tsx
+www/src/components/marketing/showcase/cookie-preferences.tsx
+www/src/components/marketing/showcase/invite-members.tsx
+www/src/components/marketing/showcase/shortcuts.tsx
+www/src/components/marketing/showcase/payment.tsx
+www/src/components/marketing/showcase/transactions.tsx
+www/src/components/marketing/showcase/account-menu.tsx
+www/src/components/marketing/showcase/faq.tsx
+www/src/components/marketing/showcase/color-editor.tsx
+www/src/components/marketing/showcase/upload-avatar.tsx
+www/src/components/marketing/showcase/team-name.tsx
+www/src/components/marketing/showcase/feedback.tsx
+www/src/components/marketing/showcase/login-form.tsx
+```
+
+The generated `src/App.tsx`:
+
+```tsx
+import "./globals.css";
+import { Cards } from "./components/marketing/showcase/cards";
+
+export default function App() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg antialiased">
+      <main className="container py-12">
+        <Cards />
+      </main>
+    </div>
+  );
+}
+```
+
+No `DesignSystemProvider` is required for the showcase to render correctly — the default context value (`{ params: {}, tokens: {}, density: "default" }` in `www/src/modules/core/styles.tsx`) gives every component its default visual variant. The preset is already baked into the component source files; there is no runtime customizer to wire up.
+
+No `ThemeProvider` from `packages/starter-themes` is required either. That package depends on `@tanstack/react-router` (not present in a plain Vite project). A minimal dark-mode toggle can be provided later, or omitted — the generated project renders in light mode by default.
+
+The showcase imports `@/registry/__generated__/icons.tsx` only for `ExternalLinkIcon` (used in `invite-members.tsx:6`). The generated repo should either copy `icons.tsx` (it is a generated file that re-exports Lucide icons) or replace the import with a direct `import { ExternalLink } from "lucide-react"`. The direct import is simpler.
+
+---
+
+## 7. What dotUI must build
+
+### 7.1 A new server function: `generatePresetRepo(encodedPreset: string)`
+
+Located at e.g. `www/src/server/generate-repo.ts`. This function:
+
+1. Decodes the preset:
+   ```ts
+   const ds = decodePreset(encodedPreset);
+   const preset: PublishPreset = { color: ds.color, density: ds.density, componentParams: ds.componentParams };
+   ```
+
+2. Generates the init item (theme + `globals.css` content):
+   ```ts
+   import { emitInitItem } from "@/publisher/emit-theme";
+   import { baseRegistryCss } from "@/registry/__generated__/base-css";
+   const themeItem = emitInitItem({ baseRegistryCss, preset, encodedPreset, registryRoot: "https://dotui.com" });
+   ```
+   Render `themeItem.css` and `themeItem.cssVars.theme` into a `globals.css` string.
+
+3. Generates every component file:
+   ```ts
+   import { publishables, PUBLISHABLE_NAMES } from "@/registry/__generated__/publishables";
+   import { publish, setKnownDotuiNames, setDotuiDepResolver } from "@/publisher/publish";
+   import { format } from "oxfmt";
+
+   setKnownDotuiNames(PUBLISHABLE_NAMES);
+   // No dep rewriting needed — all deps are local in the generated project
+   setDotuiDepResolver("", "");
+
+   for (const name of SHOWCASE_COMPONENT_NAMES) {
+     const mod = await publishables[name]();
+     const publishable = selectPublishable(mod, preset);
+     const { item } = publish({ publishable, preset });
+     const formatted = (await format(item.files[0].target, item.files[0].content, { printWidth: 120, useTabs: true })).code;
+     // write to src/components/ui/<target> in the repo
+   }
+   ```
+   `SHOWCASE_COMPONENT_NAMES` is the list of 38 components from Section 4. `selectPublishable` is currently private in `www/src/routes/r/$name.tsx:89-107` — extract it to `www/src/publisher/publish.ts` or a shared util file.
+
+4. Assembles the full file tree:
+   - `package.json` (with all deps from Section 9)
+   - `vite.config.ts`
+   - `tsconfig.json`
+   - `index.html`
+   - `src/globals.css` (generated theme)
+   - `src/main.tsx`
+   - `src/App.tsx` (renders `<Cards />`)
+   - `src/lib/utils.ts` (from `themeItem.files[0].content`)
+   - `src/lib/context.tsx` (copy of `www/src/registry/lib/context/index.tsx`)
+   - `src/hooks/use-image-loading-status.ts`
+   - `src/components/ui/**` (all 38 generated component files)
+   - `src/components/marketing/showcase/**` (17 card files, verbatim copies)
+
+5. Commits or pushes the file tree to a GitHub repo under `dotui-generated/<repo-slug>` using the GitHub API (octokit or REST). The slug can be `preset-<short-hash-of-encoded>` to make repos reusable/cacheable.
+
+6. Returns the bolt.new URL:
+   ```ts
+   return `https://bolt.new/~/github.com/dotui-generated/${slug}`;
+   ```
+
+### 7.2 A new route: `www/src/routes/r/generate-repo.tsx`
+
+A TanStack Start server GET handler that accepts `?preset=<encoded>`, calls `generatePresetRepo()`, and returns a `302 Location` redirect to the bolt.new URL. The "Open in bolt.new" button navigates to this route.
+
+### 7.3 Extract `selectPublishable` to a shared location
+
+Currently in `www/src/routes/r/$name.tsx:89-107`. Move to `www/src/publisher/publish.ts` or a new `www/src/publisher/select-publishable.ts` so `generate-repo.ts` can import it without importing the route module.
+
+### 7.4 A GitHub bot account or app for the generated repos
+
+The generation function needs write access to a GitHub org/account (e.g. `dotui-generated`). Use a fine-grained GitHub PAT or a GitHub App with `contents: write` on that org. Store the token in an env var (`GITHUB_GENERATE_TOKEN`).
+
+### 7.5 "Open in bolt.new" button in the customizer UI
+
+In the customizer footer, alongside the existing "Copy install command" (`www/src/modules/create/install-command.tsx`), add a button component that:
+- Reads `encodePreset(designSystem)` (same as `InstallCommand` does at `:40`)
+- On click: opens `/r/generate-repo?preset=<encoded>` (or calls the server fn directly and opens the returned URL)
+- Shows a loading spinner during repo generation
+
+---
+
+## 8. Schema / meta.ts changes
+
+No `meta.ts` changes are required for the bolt.new integration. The publisher already produces all needed output from existing meta fields.
+
+The one optional addition: if you want to **exclude** certain components from the "Open in bolt.new" bundle (e.g. WIP components), you could add a `bolt?: false` guard field to `RegistryItem` (`www/src/registry/types.ts:69-78`):
+
+```ts
+export type RegistryItem = ShadcnRegistryItem & {
+  group?: ComponentGroup | null;
+  params?: Record<string, ParamDef>;
+  bolt?: boolean;  // opt-out field; defaults to true; set false to exclude from generated repos
+};
+```
+
+This is purely optional — the simpler approach is to hardcode `SHOWCASE_COMPONENT_NAMES` (the 38 components that `cards.tsx` actually needs) as a constant in the generation code.
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### GitHub repo generation latency
+Writing 38+ files to GitHub via API takes 2–8 seconds depending on rate limits and network. Use a single `git/trees` + `git/commits` sequence (3 API calls total: create tree, create commit, update ref) rather than one call per file. Cache by preset hash: if a repo for `preset-<hash>` already exists, skip generation and return the bolt URL immediately.
+
+### bolt.new startup time
+bolt.new runs `npm install` inside the WebContainer on first open. With ~15 npm dependencies (react-aria-components, tailwind-variants, etc.) this takes 30–60 seconds. This is inherent to bolt's architecture and cannot be optimised from dotUI's side. Consider including a `package-lock.json` or `pnpm-lock.yaml` in the generated repo to speed up resolution.
+
+### No `/r/registry.json` index
+The bolt.new agent (if it tries to run `shadcn add` for anything) would fail to discover dotUI components via MCP because `/r/registry.json` returns 404 today. This does not affect the generated-repo path, but it means the user cannot run `shadcn add @dotui/button` from within bolt's terminal until the index route is shipped. The generated repo has all components pre-installed, so this gap does not block the feature.
+
+### The `tokens` field is not yet threaded through `PublishPreset`
+`www/src/publisher/emit-theme.ts:62-68` documents this as a TODO. A user who sets `--radius-factor` via the customizer's token editor will not see that reflected in the generated `globals.css`. The `t` key in the encoded preset round-trips correctly through the codec but `PublishPreset` (`www/src/publisher/types.ts:79-85`) does not include `tokens`. This must be fixed before `tokens`-heavy presets produce correct output.
+
+### `tailwindcss-autocontrast` and `tailwindcss-with` are workspace packages
+These are not published to npm today. The generated repo cannot install them via `package.json` unless they are first published. Options:
+- Publish them before launching the feature.
+- Vendor them: copy the compiled output into `src/vendor/` in the generated repo.
+- Use a GitHub dependency in `package.json`: `"tailwindcss-autocontrast": "github:mehdibha/dotUI#workspace=packages/tailwindcss-autocontrast"` (requires the repo to be public and the package path to be stable).
+
+### Generated repos are public
+The GitHub repos under `dotui-generated` are public (bolt.new only supports public GitHub repos via the `~/github.com/` path). This is acceptable for preset snapshots — they contain no user data other than color seeds and style choices. Include a `LICENSE` file (MIT or similar) in every generated repo.
+
+### `selectPublishable` extraction risk
+This function is currently colocated with route logic in `www/src/routes/r/$name.tsx`. Extracting it to a shared publisher module requires verifying it has no route-level side effects (it doesn't — it is a pure function that reads `mod.publishableByPath` and `meta.params`). This is low risk.
+
+### Fallback if GitHub API is unavailable
+Return a copy-command fallback: show the `npx shadcn add https://dotui.com/r/init?preset=<encoded>` command (already implemented in `InstallCommand`, `www/src/modules/create/install-command.tsx:39-48`) so the user can still install manually.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+- [ ] **Extract `selectPublishable`** from `www/src/routes/r/$name.tsx:89-107` into `www/src/publisher/select-publishable.ts`. Export it. Update the route to import from the new location.
+
+- [ ] **Define `SHOWCASE_COMPONENT_NAMES`** — a constant listing the 38 `registry/ui` names that `cards.tsx` transitively needs (see Section 4). Place it in `www/src/server/generate-repo.ts` or a shared constants file.
+
+- [ ] **Write `generatePresetRepo(encodedPreset)`** in `www/src/server/generate-repo.ts`:
+  - Call `decodePreset` → build `PublishPreset`
+  - Call `emitInitItem` → render `globals.css` string (see Section 5 for format)
+  - Loop `SHOWCASE_COMPONENT_NAMES`, call `publish()` for each with `selectPublishable`
+  - Assemble file tree object: key = repo-relative path, value = file content string
+  - Hash the preset (`sha256(encodedPreset).slice(0,12)`) → `slug = "preset-<hash>"`
+  - Check if `dotui-generated/<slug>` already exists on GitHub (GET `/repos/dotui-generated/<slug>`) → if yes, return URL immediately
+  - Create repo via GitHub API: `POST /orgs/dotui-generated/repos` (`{ name: slug, private: false, auto_init: false }`)
+  - Push file tree in a single commit: create blob per file → create tree → create commit → update `refs/heads/main`
+  - Return `https://bolt.new/~/github.com/dotui-generated/<slug>`
+
+- [ ] **Write the server GET route** `www/src/routes/r/generate-repo.tsx`:
+  - Accept `?preset=` query param
+  - Call `generatePresetRepo(preset)`
+  - Return `302 Location: <bolt-url>` (or `200` with JSON `{ url }` if the button handles the redirect client-side)
+
+- [ ] **Add "Open in bolt.new" button** to the customizer UI (near `InstallCommand` in `www/src/modules/create/`):
+  - Read `encodePreset(designSystem)` → build `/r/generate-repo?preset=<encoded>` URL
+  - On click: `window.open(url, "_blank")` (the route redirects to bolt.new)
+  - Show loading state — listen for the redirect or set a fixed timeout (the route is fast once cached)
+
+- [ ] **Publish `tailwindcss-autocontrast` and `tailwindcss-with`** to npm under `@dotui/tailwindcss-autocontrast` etc., or vendor them into the generated repo. Update `DEFAULT_DEPENDENCIES` in `www/src/publisher/emit-theme.ts:31-39` to reference the published npm names.
+
+- [ ] **Wire `tokens` through `PublishPreset`** — fix the TODO at `www/src/publisher/emit-theme.ts:62-68`. Add `tokens?: Record<string, string>` to `PublishPreset` (`www/src/publisher/types.ts:79`) and emit them into `:root` in `emitPresetLightVars` (`emit-theme.ts:58-69`).
+
+- [ ] **Configure GitHub bot credentials** — add `GITHUB_GENERATE_TOKEN` env var (fine-grained PAT, `contents: write` on `dotui-generated` org) to the Vercel project.
+
+- [ ] **Create `dotui-generated` GitHub org** (or use a bot account) and configure it as the target for generated repos.
+
+- [ ] **Add a `LICENSE` file** to the generated repo file tree (MIT, attributed to dotUI).
+
+- [ ] **Include `package-lock.json`** in the generated file tree to reduce bolt.new's WebContainer install time.
+
+- [ ] **Smoke test**: generate a repo for the default preset and one custom preset; open both in bolt.new; verify the showcase renders, components render without errors, dark mode works.
+
+---
+
+## Sources
+
+- bolt.new GitHub repo import format: `https://bolt.new/~/github.com/<owner>/<repo>` — observed behavior, documented in bolt community posts (no official Stackblitz docs as of June 2026)
+- shadcn `registry:base` item type and `shadcn add <url>` behavior: https://ui.shadcn.com/docs/registry/registry-item-types
+- shadcn cssVars.light/dark write behavior: https://ui.shadcn.com/docs/registry/faq
+- Tailwind v4 `@theme inline` and `cssVars.theme` vs `cssVars.light` distinction (shadcn issue #7119): https://github.com/shadcn-ui/ui/issues/7119
+- dotUI codec: `www/src/modules/create/preset/codec.ts:75-126`
+- dotUI init route: `www/src/routes/r/init.tsx`
+- dotUI emit-theme: `www/src/publisher/emit-theme.ts:71-170`
+- dotUI showcase: `www/src/components/marketing/showcase/cards.tsx`
+- dotUI publisher: `www/src/publisher/publish.ts:119-161`
+- dotUI registry types: `www/src/registry/types.ts:43-78`
+- autocontrast plugin: `packages/tailwindcss-autocontrast/src/index.js:407-501`
+- GitHub Git Trees API: https://docs.github.com/en/rest/git/trees

--- a/docs/research/open-in/claude-code.md
+++ b/docs/research/open-in/claude-code.md
@@ -1,0 +1,586 @@
+# Open in Claude Code
+
+> Feasible with copy-paste commands · button type **copy-command** · preset fidelity **full** · color fidelity **full**
+
+Claude Code has no deeplink protocol that installs dependencies, no MCP auto-install URL, and no
+sandbox import API. Everything is driven by commands the user pastes into a terminal. The two
+practical delivery paths are:
+
+1. **Copy-command flow** — a "Copy for Claude Code" button on dotUI's customizer that emits two
+   shell commands: one to wire the registry MCP, one to install the full themed base.
+2. **Showcase-preinstalled repo flow** — generate a ready-to-run Next.js / Vite project with every
+   needed component already in `ui/`, globals.css already written, and the showcase page as
+   `app/page.tsx`; the user clones it and types `claude`.
+
+Both flows achieve full preset fidelity and full color fidelity because they feed the user's
+`?preset=<encoded>` token directly into the shadcn CLI and into the `@dotui` registry entry
+baked into `components.json`.
+
+---
+
+## 1. User experience
+
+### Copy-command flow
+
+The customizer panel already renders an `<InstallCommand>` button
+(`www/src/modules/create/install-command.tsx:30-72`) that outputs:
+
+```
+npx shadcn add https://dotui.com/r/init?preset=<encoded>
+```
+
+For the Claude Code variant, a sibling "Open in Claude Code" button (or a copy-variant toggle)
+emits two commands to the clipboard:
+
+```
+# 1. Wire the dotUI registry MCP (once per project / workspace)
+claude mcp add-json dotui '{"command":"npx","args":["-y","shadcn@latest","registry:mcp"],"env":{"REGISTRY_URL":"https://dotui.com/r/registry.json"}}'
+
+# 2. Install the full themed base with your chosen preset
+npx shadcn add https://dotui.com/r/init?preset=<encoded>
+```
+
+The user pastes both commands into their terminal, then types `claude` in the project directory.
+After that, inside a Claude Code session they can ask it to install individual components via
+MCP-browse ("add the modal component") without leaving the editor.
+
+### Showcase-preinstalled flow
+
+A "Download / Clone Showcase" action generates a repo (see §7) and puts a `README` with:
+
+```
+git clone <generated-repo-url>
+cd <repo>
+pnpm install
+claude
+```
+
+The user lands in Claude Code with every ui component already under `src/components/ui/`, the
+preset theme in `src/app/globals.css`, and `src/app/page.tsx` rendering `<Cards />`. No install
+step is needed.
+
+---
+
+## 2. Technical mechanism
+
+### 2a. No deeplink exists
+
+`claude-cli://open?cwd=&repo=&q=` opens a terminal session in a directory with a prefilled
+prompt. It does **not** execute commands. It cannot trigger `npm install`, `shadcn add`, or any
+other side-effect.
+
+### 2b. MCP registry wire-up
+
+The shadcn registry MCP server is bootstrapped with:
+
+```
+claude mcp add-json dotui \
+  '{"command":"npx","args":["-y","shadcn@latest","registry:mcp"],"env":{"REGISTRY_URL":"https://dotui.com/r/registry.json"}}'
+```
+
+This tells Claude Code: "when the user asks to add a component, use the shadcn MCP server pointed
+at dotUI's registry index." After this, inside any Claude Code session, the model can call MCP
+tools to browse the registry and run `shadcn add @dotui/<name>`.
+
+**Prerequisite**: `/r/registry.json` must exist and return the shadcn `Registry` shape (see §7).
+Today that route does not exist; it is the single blocking build item.
+
+### 2c. Per-preset install via shadcn CLI
+
+```
+npx shadcn add https://dotui.com/r/init?preset=<encoded>
+```
+
+This invokes `GET /r/init?preset=<encoded>` (`www/src/routes/r/init.tsx`), which calls
+`emitInitItem({ baseRegistryCss, preset, encodedPreset, registryRoot })`
+(`www/src/publisher/emit-theme.ts:71-128`). The response is a `registry:base` JSON item that:
+
+- carries the full OKLCH primitive ramps in `css[":root"]` and `css[".dark"]` (preset-specific
+  when `preset.color` is set, static defaults otherwise),
+- carries the complete `@theme inline` semantic token layer in `cssVars.theme` (constant across
+  presets — only the primitives it points to change),
+- bakes `config.registries["@dotui"] = "https://dotui.com/r/{name}?preset=<encoded>"`
+  (`emit-theme.ts:130-132`) so every subsequent `shadcn add @dotui/<name>` hits the preset-aware
+  endpoint.
+
+`shadcn add` merges all of this into the project's `globals.css` (or `src/app/globals.css` for
+Next.js app-dir), installing fonts, plugins, OKLCH ramps, and the `cn()` util in one shot.
+
+### 2d. How transitive deps carry the preset
+
+When Claude Code (via MCP) runs `shadcn add @dotui/button`, the server at
+`/r/button?preset=<encoded>` calls `setDotuiDepResolver(origin, "?preset="+encodedPreset)`
+(`www/src/routes/r/$name.tsx:50-52`) before calling `publish()`. Inside
+`publisher/publish.ts:79-105 rewriteDeps()`, every `registryDependency` that is a known dotUI
+name gets rewritten to `https://dotui.com/r/<dep>?preset=<encoded>`. So `loader`, `field`, and
+any other transitive dep arrive with the same preset baked in — the user never has to pass the
+preset flag manually for each component.
+
+---
+
+## 3. Preset propagation
+
+The `?preset=<encoded>` value is a URL-safe base64 string of pako raw-DEFLATE of a compact JSON
+object (`DesignSystemState`, `www/src/modules/create/preset/types.ts:14-19`):
+
+```ts
+{ p?: Record<string, Record<string, string>>,  // per-component param choices (diffed vs defaults)
+  t?: Record<string, string>,                   // global tokens (not yet wired to publisher)
+  d?: "default" | "comfortable",               // density only if != "compact"
+  c?: ColorConfig                               // full color recipe only if != DEFAULT_COLOR_CONFIG
+}
+```
+
+`encodePreset(ds: DesignSystem): string | undefined` in
+`www/src/modules/create/preset/codec.ts:75-94` produces this string; it returns `undefined` if
+nothing differs from defaults (no `?preset=` param needed). The `InstallCommand` component
+(`install-command.tsx:39-48`) already calls this and builds the `npx shadcn add` URL.
+
+For the Claude Code button, reuse the same call:
+
+```ts
+import { encodePreset } from "@/modules/create/preset/codec";
+import { useDesignSystem } from "@/modules/create/preset";
+
+function claudeCodeCommands(host: string, designSystem: DesignSystem): string {
+  const encoded = encodePreset(designSystem);
+  const initUrl = encoded ? `${host}/r/init?preset=${encoded}` : `${host}/r/init`;
+  const mcpConfig = JSON.stringify({
+    command: "npx",
+    args: ["-y", "shadcn@latest", "registry:mcp"],
+    env: { REGISTRY_URL: `${host}/r/registry.json` },
+  });
+  return [
+    `claude mcp add-json dotui '${mcpConfig}'`,
+    `npx shadcn add ${initUrl}`,
+  ].join("\n");
+}
+```
+
+### What the preset controls end-to-end
+
+| Preset field | Where it takes effect | How |
+|---|---|---|
+| `color` (ColorConfig) | `globals.css` `:root`/`.dark` primitive ramps | `resolveColorConfig(preset.color)` + `rampsToVars()` in `emitInitItem` (`emit-theme.ts:155-159`) |
+| `density` | per-component class strings | `flatten` merges `base ← density[d] ← params` at publish time (`publisher/flatten.ts:148-170`); `--dotui-density` written to `:root` only when non-compact (`emit-theme.ts:53-68`) |
+| `componentParams` | per-component class strings and scalar CSS vars | `resolveClasses` rewrites tailwind suffixes (`publisher/resolve-classes.ts:30-56`); enum variants fold via `flatten` |
+| `tokens` (t) | **NOT YET wired** | Survives the URL round-trip but `PublishPreset` (`publisher/types.ts:79-85`) does not carry `tokens`; `emit-theme.ts:62-68` documents this as a TODO |
+
+---
+
+## 4. Components installed
+
+After running `npx shadcn add https://dotui.com/r/init?preset=<encoded>`, the project has:
+
+- `src/lib/utils.ts` — the `cn()` helper (shipped inline by the init item, `emit-theme.ts:41-47`)
+- `components.json` updated with `config.registries["@dotui"]` pointing to the preset-baked
+  endpoint
+
+To install individual components:
+
+```
+npx shadcn add @dotui/button
+npx shadcn add @dotui/card
+# etc.
+```
+
+Or, to install every component that the showcase needs (see §6), in one command:
+
+```
+npx shadcn add @dotui/accordion @dotui/avatar @dotui/badge @dotui/button @dotui/calendar \
+  @dotui/card @dotui/checkbox @dotui/checkbox-group @dotui/color-area @dotui/color-editor \
+  @dotui/color-field @dotui/color-slider @dotui/color-thumb @dotui/combobox @dotui/disclosure \
+  @dotui/drop-zone @dotui/field @dotui/file-trigger @dotui/group @dotui/input @dotui/kbd \
+  @dotui/link @dotui/list-box @dotui/loader @dotui/otp-field @dotui/popover \
+  @dotui/progress-bar @dotui/radio-group @dotui/select @dotui/separator @dotui/slider \
+  @dotui/switch @dotui/table @dotui/tabs @dotui/tag-group @dotui/text @dotui/text-field \
+  @dotui/time-field @dotui/toast @dotui/toggle-button @dotui/toggle-button-group @dotui/tooltip
+```
+
+Each component's `registryDependencies` are followed transitively by the CLI; `focus-styles`,
+`theme`, and `utils` are intentionally dropped (bundled into init, `publisher/publish.ts:52-59`).
+The components land at `src/components/ui/<name>.tsx` (the `target` from each item's
+`meta.ts`; e.g. `"ui/button.tsx"` → resolved to `src/components/ui/button.tsx` via the
+`aliases.ui` entry in `components.json`).
+
+---
+
+## 5. Theme in globals.css
+
+After `npx shadcn add https://dotui.com/r/init?preset=<encoded>`, the project's `globals.css`
+contains exactly the following sections (merged by shadcn):
+
+```css
+/* At-rules from baseRegistryCss (base/base.css) */
+@import "tw-animate-css";
+@plugin "tailwindcss-react-aria-components";
+@plugin "tailwindcss-autocontrast" { cssfile: "<auto-detected>"; }
+@plugin "tailwindcss-with";
+@custom-variant dark (&:is(.dark *));
+@utility focus-ring { … }
+@utility focus-reset { … }
+@utility focus-input { … }
+@utility no-highlight { … }
+@layer base {
+  * { @apply border-border; }
+  body { @apply bg-bg font-sans text-fg; }
+  html { @apply font-sans; }
+}
+::selection { background-color: var(--accent-800); color: var(--on-accent-800); }
+
+/* @theme inline (cssVars.theme) — constant across presets */
+@theme inline {
+  --radius-md: calc(0.375rem * var(--radius-factor));
+  /* ... all radius-* tokens ... */
+  --color-bg: var(--neutral-50);
+  --color-accent: var(--accent-500);
+  --color-fg-on-accent: var(--on-accent-500);
+  /* ... all ~80 semantic color tokens ... */
+}
+
+/* Primitive OKLCH ramps — PRESET-SPECIFIC */
+:root {
+  --radius-factor: 1;
+  /* 6 palettes × 11 steps = 66 vars, generated from preset.color */
+  --neutral-50: oklch(0.985 0 0);
+  /* ... */
+  --accent-500: oklch(0.60 0.14 237.32);
+  /* ... --success-*, --warning-*, --danger-*, --info-* ... */
+}
+.dark {
+  /* same 66 vars with lightness reversed (--neutral-50 takes --neutral-950's value) */
+  --neutral-50: oklch(0.13 0 0);
+  /* ... */
+}
+```
+
+Key facts:
+- The `@theme inline` block is **identical** for all presets. Only `:root`/`.dark` change.
+- `--on-*` foregrounds (e.g. `--on-accent-500`) are **not in the init item**. They are injected
+  at Tailwind build time by the `tailwindcss-autocontrast` plugin from `packages/tailwindcss-autocontrast`
+  by scanning `:root`/`.dark` for `--<name>-<step>` vars (`index.js:407-501`).
+- The `autocontrast` plugin's `cssfile` option must point at the consumer's Tailwind entry CSS.
+  shadcn auto-detects this; if auto-detection fails, the user sets it manually in `globals.css`.
+
+---
+
+## 6. The showcase as first view
+
+### What the showcase is
+
+`www/src/components/marketing/showcase/cards.tsx` renders a CSS masonry grid (`columns-1
+sm:columns-2 lg:columns-3 xl:columns-4`) of 17 self-contained widget cards. Every card is a
+plain React component with no server functions, no loaders, and no routing dependency. All
+interactive state is local (`useState`). The 17 files live under
+`www/src/components/marketing/showcase/*.tsx`.
+
+### Components consumed by the showcase (the `ui/` surface needed)
+
+The showcase uses 41 of the 60 registered ui items:
+
+accordion, avatar, badge, button, calendar, card, checkbox, checkbox-group, color-area,
+color-editor, color-field, color-slider, color-thumb, disclosure, drop-zone, field, file-trigger,
+group, input, kbd, link, list-box, loader, otp-field, popover, progress-bar, radio-group, select,
+separator, slider, switch, table, tabs, tag-group, text, text-field, time-field, toggle-button,
+toggle-button-group, tooltip (and toast is imported by some cards but not by `<Cards />` directly).
+
+The full install command for these is in §4.
+
+### App.tsx / page.tsx for the showcase as first view
+
+```tsx
+// src/app/page.tsx (Next.js app dir) or src/App.tsx (Vite)
+import { Cards } from "@/components/marketing/showcase/cards";
+
+export default function HomePage() {
+  return (
+    <main className="min-h-screen bg-bg py-12 font-sans text-fg antialiased">
+      <div className="container">
+        <Cards />
+      </div>
+    </main>
+  );
+}
+```
+
+The `bg-bg`, `text-fg`, `font-sans` classes resolve via the `@theme inline` semantic tokens
+installed by the init item.
+
+### Files to copy from the dotUI source
+
+```
+www/src/components/marketing/showcase/          # all 18 files (cards.tsx + 17 widget files)
+www/src/registry/lib/utils/index.ts             # cn() — also installed by shadcn init
+www/src/registry/lib/context/index.tsx          # createContext, createVariantsContext
+www/src/registry/hooks/use-image-loading-status.ts
+www/src/modules/core/styles.tsx                 # DesignSystemProvider + createStyles
+www/src/registry/__generated__/icons.tsx        # ExternalLinkIcon (or replace with lucide-react)
+```
+
+### Dark mode
+
+The showcase expects `class="dark"` toggled on `<html>` for dark mode. Replace
+`packages/starter-themes`'s `ThemeProvider` (which depends on TanStack Router's `ScriptOnce`)
+with any class-based dark-mode provider (`next-themes` for Next.js, or a minimal inline script).
+
+### Remote avatar images
+
+Several cards fetch GitHub CDN avatars at runtime (e.g. `https://github.com/mehdibha.png`).
+All use `AvatarFallback`, so the showcase renders correctly offline. No bundled image assets
+are required.
+
+---
+
+## 7. What dotUI must build
+
+### 7a. `/r/registry.json` index route (blocking for MCP path)
+
+A new TanStack Start server route at `www/src/routes/r/registry[.]json.tsx` (filename uses
+`[.]` to produce the literal dot) that returns the shadcn `Registry` shape:
+
+```ts
+// www/src/routes/r/registry[.]json.tsx
+import { registryUi, registryLib } from "@/registry/__generated__/registry-items";
+import { registryBase } from "@/registry/base/registry";
+import { registryHooks } from "@/registry/hooks/registry";
+import { createServerFn } from "@tanstack/start";
+
+export const Route = createFileRoute("/r/registry.json")({
+  component: () => null,
+});
+
+export const registryJsonHandler = createServerFn({ method: "GET" })
+  .handler(async () => {
+    const items = [
+      registryBase,
+      ...registryLib,
+      ...registryHooks,
+      ...registryUi.map(({ group, params, ...rest }) => rest),  // strip dotUI-only fields
+    ];
+    return Response.json(
+      { name: "dotui", homepage: "https://dotui.com", items },
+      { headers: { "cache-control": "public, max-age=3600" } }
+    );
+  });
+```
+
+The `items` array must include at least `name` and `type` per entry. `registryUi` is imported
+from `www/src/registry/__generated__/registry-items.ts` (the committed generated file);
+`PUBLISHABLE_NAMES` is git-ignored so do not use it here. Do not include `files[].content` (no
+source code inline — the MCP fetches each item separately via `/r/<name>`).
+
+### 7b. "Copy for Claude Code" button on the customizer
+
+A new variant of `InstallCommand` (`www/src/modules/create/install-command.tsx`) that puts both
+commands on the clipboard:
+
+```tsx
+// Alongside the existing InstallCommand in install-command.tsx
+
+export function ClaudeCodeCommand() {
+  const { designSystem } = useDesignSystem();
+  const [host, setHost] = useState(DEFAULT_REGISTRY_HOST);
+
+  useEffect(() => { setHost(getRegistryHost()); }, []);
+
+  const commands = useMemo(() => {
+    const encoded = encodePreset(designSystem);
+    const initUrl = encoded ? `${host}/r/init?preset=${encoded}` : `${host}/r/init`;
+    const mcpConfig = JSON.stringify({
+      command: "npx",
+      args: ["-y", "shadcn@latest", "registry:mcp"],
+      env: { REGISTRY_URL: `${host}/r/registry.json` },
+    });
+    return [
+      `claude mcp add-json dotui '${mcpConfig}'`,
+      `npx shadcn add ${initUrl}`,
+    ].join("\n");
+  }, [designSystem, host]);
+
+  // render a copy button like InstallCommand
+}
+```
+
+This component is wired into the customizer panel alongside or below the existing `InstallCommand`.
+
+### 7c. Showcase-preinstalled repo generator
+
+A server action or build script that, given an encoded preset:
+
+1. Runs `emitInitItem(...)` to produce the themed globals.css content.
+2. For each of the 41 showcase components, calls the `publish()` pipeline
+   (`www/src/publisher/publish.ts:119`) with the decoded preset to produce each component's
+   source file with preset-baked class strings.
+3. Assembles a Next.js or Vite + React project skeleton:
+   - `src/app/globals.css` — the init item's CSS merged in.
+   - `src/components/ui/<name>.tsx` — each published component file.
+   - `src/lib/utils.ts` — the `cn()` helper.
+   - `src/lib/context.tsx`, `src/hooks/use-image-loading-status.ts` — supporting files.
+   - `src/modules/core/styles.tsx` — `DesignSystemProvider` + `createStyles`.
+   - `src/components/marketing/showcase/*.tsx` — the 17 widget files + `cards.tsx`.
+   - `src/app/page.tsx` — renders `<Cards />`.
+   - `package.json` with all required deps (see §6 of the showcase map).
+4. Creates a GitHub repo (or zip) and returns the clone URL.
+
+The `selectPublishable` helper (`www/src/routes/r/$name.tsx:89-107`) handles the `loader`
+enum-with-files swap and must be extracted from the route file to be reusable here.
+
+---
+
+## 8. Schema / meta.ts changes
+
+No `meta.ts` changes are required for the copy-command flow. The MCP path needs the
+`/r/registry.json` index, but that is a new route, not a meta field change.
+
+If dotUI later wants Claude Code to surface per-component documentation, add an optional `docs`
+field to `RegistryItem` in `www/src/registry/types.ts:69-78`:
+
+```ts
+export type RegistryItem = ShadcnRegistryItem & {
+  group?: ComponentGroup | null;
+  params?: Record<string, ParamDef>;
+  docs?: string;   // URL to component docs page, e.g. "https://dotui.com/docs/components/button"
+};
+```
+
+This is safe (the build's `metaForRuntime` spreads all fields, `build-publishables.ts:334`;
+the publisher's `publish()` drops `group`/`params` but an explicit allowlist would also need
+to drop `docs` from emitted shadcn JSON if it should stay internal). No build change is
+required to author the field.
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### No deeplink that auto-runs commands
+
+`claude-cli://open` opens a session and can pre-fill a prompt, but it does not execute any
+command. The user must paste and run the two commands manually. The button UX should make this
+feel like a two-click flow: copy → paste into terminal.
+
+### `/r/registry.json` does not exist today
+
+The MCP path is blocked until this route is shipped (§7a). Without it, the `claude mcp add-json`
+command registers a server that will fail to start (the MCP server calls `REGISTRY_URL` to
+enumerate items). The fallback: omit the MCP step entirely and document only
+`npx shadcn add @dotui/<name>` for individual component installs.
+
+### `shadcn@latest registry:mcp` version uncertainty
+
+The `registry:mcp` subcommand may require shadcn canary. Pin the npx call to
+`shadcn@canary` if `shadcn@latest` does not recognise the subcommand, and update once it
+ships in a stable release.
+
+### `tokens` field not yet wired
+
+The `t` / `tokens` slice of the preset (global CSS vars like `--radius-factor`) round-trips in
+the URL but `PublishPreset` (`publisher/types.ts:79-85`) does not carry it and
+`emitInitItem` does not write it to `:root` (documented TODO at `emit-theme.ts:62-68`). A user
+who sets `--radius-factor` in the customizer will see it in the preview but not in the installed
+output. Workaround: document that users must manually add `--radius-factor: <value>` to their
+`:root` block after install, until the TODO is resolved.
+
+### `autocontrast` cssfile option
+
+The `@plugin "tailwindcss-autocontrast" { cssfile: "..." }` line in globals.css must point at
+the consumer's Tailwind entry CSS for `--on-*` foregrounds to be generated. shadcn auto-detects
+the project's CSS entry point, but if it guesses wrong the plugin emits no `--on-*` vars and
+all `fg-on-*` tokens render transparent. The fallback: instruct the user to verify the `cssfile`
+path matches their actual entry CSS after running `shadcn add`.
+
+### Class-based dark mode dependency
+
+The showcase (and all dotUI components) use `@custom-variant dark (&:is(.dark *))` — a class
+on `<html>`, not `prefers-color-scheme`. The generated project must include a dark-mode provider
+that writes `class="dark"` to `<html>`. `next-themes` with `attribute="class"` is the standard
+choice for Next.js.
+
+### Showcase avatar images require network
+
+Several cards load avatars from GitHub CDN. In an air-gapped or restricted environment the
+avatars won't load, but `AvatarFallback` renders initials, so the showcase is functional.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+### Phase 1: unblock the MCP path
+
+- [ ] Add route `www/src/routes/r/registry[.]json.tsx` that imports `registryUi`, `registryLib`,
+      `registryBase`, `registryHooks` from their respective registry files and returns the shadcn
+      `Registry` shape (`{ name, homepage, items }`) with dotUI-only fields (`group`, `params`)
+      stripped from each item. Apply the same `public, max-age=3600, s-maxage=86400` cache headers
+      used by `$name.tsx:27-30`.
+- [ ] Smoke-test: `curl https://dotui.com/r/registry.json | jq '.items | length'` should return 64
+      (60 ui + 2 lib + 1 hook + 1 base).
+- [ ] Verify `shadcn@latest registry:mcp` resolves successfully against the live endpoint. If it
+      requires canary, document the `shadcn@canary` pin.
+
+### Phase 2: Claude Code copy button on the customizer
+
+- [ ] Export `ClaudeCodeCommand` from `www/src/modules/create/install-command.tsx` (or a new
+      sibling file). Reuse `getRegistryHost()`, `useDesignSystem()`, `encodePreset()` already in
+      scope. The button copies two lines: the `claude mcp add-json dotui ...` invocation (with
+      the host-relative `REGISTRY_URL`) and the `npx shadcn add .../r/init?preset=<encoded>` line.
+- [ ] Wire `ClaudeCodeCommand` into the customizer panel
+      (`www/src/routes/_app/create.tsx` or the panel component it renders). Place it below or
+      alongside the existing `InstallCommand`.
+- [ ] Add a Claude Code logo or "Claude Code" label to distinguish it from the plain shadcn button.
+
+### Phase 3: per-component install documentation
+
+- [ ] Update the docs page for each component to show
+      `npx shadcn add @dotui/<name>` (the `@dotui` scope resolves via the `config.registries`
+      entry that `shadcn add .../r/init` writes into `components.json`).
+- [ ] Add a "MCP" tab on the docs page with the Claude Code in-session prompt:
+      "Add the button component from the dotUI registry."
+
+### Phase 4: showcase-preinstalled project generator (optional but high-value)
+
+- [ ] Extract `selectPublishable` from `www/src/routes/r/$name.tsx:89-107` into a shared util
+      (e.g. `www/src/publisher/select-publishable.ts`) so the generator can import it without
+      hitting the route module.
+- [ ] Build a server action or standalone script that loops `PUBLISHABLE_NAMES`, calls
+      `publish({ publishable, preset })` for each of the 41 showcase components, copies the 18
+      showcase widget files, assembles `globals.css` from `emitInitItem`, writes `page.tsx`
+      importing `<Cards />`, and packages everything as a Next.js starter or Vite starter.
+- [ ] Wire a "Download Starter" button on the customizer that triggers this action and returns a
+      GitHub repo URL or a zip download.
+- [ ] Include a `README.md` in the generated project: `git clone <url> && cd <name> && pnpm install && claude`.
+
+### Phase 5: wire `tokens` into the publisher (existing TODO)
+
+- [ ] Resolve the TODO at `www/src/publisher/emit-theme.ts:62-68`: thread `tokens` from
+      `DesignSystem` through `PublishPreset` (`publisher/types.ts:79-85`) and write each key-value
+      to `css[":root"]` inside `emitPresetLightVars` (`emit-theme.ts:58-69`). This makes
+      `--radius-factor` and any other global token survive into the installed `globals.css`.
+
+---
+
+## Sources
+
+- `www/src/modules/create/install-command.tsx` — live `InstallCommand` component; `encodePreset`
+  call and URL construction at lines 39-48.
+- `www/src/publisher/emit-theme.ts` — `emitInitItem`, `mergePresetCssFields`, color ramp
+  injection, `config.registries` baking; lines 31-170.
+- `www/src/routes/r/init.tsx` — `/r/init` server handler; preset decode and `PublishPreset`
+  assembly at lines 43-59.
+- `www/src/routes/r/$name.tsx` — `/r/<name>` server handler; `setDotuiDepResolver`, dep rewrite,
+  `selectPublishable`; lines 50-121.
+- `www/src/publisher/publish.ts` — `publish()`, `rewriteDeps()`, `BUNDLED_INTO_INIT`; lines
+  52-161.
+- `www/src/modules/create/preset/codec.ts` — `encodePreset`, `decodePreset`, pako + base64url
+  wire format; lines 75-126.
+- `www/src/modules/create/preset/types.ts` — `DesignSystemState` compact shape (lines 14-19),
+  `DesignSystem` readable shape (lines 24-32).
+- `www/src/publisher/types.ts` — `PublishPreset` (lines 79-85); note absence of `tokens`.
+- `www/src/registry/__generated__/registry-items.ts` — committed source of `registryUi` (60
+  items) and `registryLib`; the basis for a future `/r/registry.json`.
+- `www/src/registry/types.ts` — `RegistryItem` intersection type (lines 69-78);
+  `ComponentGroup`, `ParamDef`, `Density`.
+- `www/src/registry/theme/primitives.ts` — `resolveColorConfig`, `reverseRamp`, lightness
+  stretch, `emitPrimitivesCss`; lines 28-174.
+- `www/src/components/marketing/showcase/cards.tsx` — the 17-card masonry grid component.
+- shadcn registry MCP docs: https://ui.shadcn.com/docs/registry/mcp
+- `packages/tailwindcss-autocontrast/src/index.js` — `getContrastCssVars`, `addBase` injection of
+  `--on-*` vars; lines 407-501.

--- a/docs/research/open-in/codesandbox.md
+++ b/docs/research/open-in/codesandbox.md
@@ -1,0 +1,785 @@
+# Open in CodeSandbox
+
+> Summary line: **implementable (Define API, single-click GET form)** · button type **sandbox-define** · preset fidelity **full** · color fidelity **full** (OKLCH ramps baked into globals.css at button-click time; no server-side step required after the parameters payload is built)
+
+CodeSandbox supports a **Define API** that accepts a compressed, URL-encoded file tree and creates a
+sandbox on-the-fly — no GitHub repo, no OAuth, no build step required. A single GET link or POST
+form delivers the complete project (showcase source, all component files, themed globals.css) to the
+user's browser in one click. This is the highest-fidelity "Open in" mechanism available for dotUI:
+the user lands in a fully rendered, editable sandbox that shows `<Cards />` as the first view, all
+components are in place under `ui/`, and the OKLCH palette from the chosen `?preset=` is written
+into `globals.css`.
+
+---
+
+## 1. User experience
+
+From the dotUI `/create` customizer (state lives in `?preset=<encoded>`, encoded by
+`encodePreset()` in `www/src/modules/create/preset/codec.ts:75`):
+
+1. The user tweaks colors, density, and component params on the customizer panel.
+2. They click **"Open in CodeSandbox"**. The button is a plain `<a>` whose `href` is built
+   client-side from the current `?preset=` value — no navigation away from dotUI, no server round-
+   trip before the tab opens.
+3. CodeSandbox receives the GET request, decompresses the `parameters` payload, and opens a new
+   sandbox tab. The sandbox is a Vite + React + Tailwind CSS v4 project. Its `src/App.tsx` renders
+   `<Cards />`. Its `src/globals.css` contains the OKLCH primitive ramps that correspond to the
+   user's chosen seed colors. All 60 dotUI components are present under `src/components/ui/` with
+   the user's chosen density and param variants baked in.
+4. The sandbox hot-reloads immediately. The user sees the themed cards showcase — the same visual
+   they were looking at on dotUI — and can begin editing.
+
+**No login is required to create a CodeSandbox sandbox via the Define API.** The resulting sandbox
+is anonymous (associated with the user's account if they are logged in, anonymous otherwise).
+
+---
+
+## 2. Technical mechanism
+
+### 2a. The Define API
+
+CodeSandbox exposes a **Define API** at:
+
+```
+POST https://codesandbox.io/api/v1/sandboxes/define
+GET  https://codesandbox.io/api/v1/sandboxes/define?parameters=<payload>
+```
+
+The `parameters` value is the **lz-string `compressToBase64` (URL variant)** of a JSON object with shape:
+
+```json
+{
+  "files": {
+    "path/to/file": { "content": "<string content>" },
+    "package.json":  { "content": "<stringified JSON>" }
+  }
+}
+```
+
+The GET form embeds the entire file tree in the URL; it works for payloads up to roughly 8 kB after
+compression. Beyond that size the POST form is required (the browser can POST on navigation or via
+`fetch` + redirect, or a hidden `<form method="POST">`).
+
+References:
+- Define API documentation: <https://codesandbox.io/docs/learn/sandboxes/cli-api>
+- lz-string library: <https://github.com/pieroxy/lz-string>
+
+### 2b. The lz-string encoding
+
+lz-string's `compressToEncodedURIComponent` (also referred to as `compressToBase64` URL variant)
+produces a URL-safe, ASCII-only compressed string. Install:
+
+```bash
+pnpm add lz-string
+```
+
+Encoding the file tree:
+
+```ts
+import LZString from "lz-string";
+
+const parameters = LZString.compressToEncodedURIComponent(
+  JSON.stringify({ files })
+);
+const url = `https://codesandbox.io/api/v1/sandboxes/define?parameters=${parameters}`;
+```
+
+### 2c. GET vs POST
+
+| Criterion | GET | POST |
+|---|---|---|
+| Max size | ~8 kB compressed | unlimited |
+| UX | `<a href={url}>` — zero JS required | hidden `<form>` submit or `fetch` + window.open |
+| dotUI use case | viable only for a single component sandbox | required for a full 60-component sandbox |
+
+For the full-showcase, all-components sandbox the uncompressed file tree is well over 200 kB (60
+component files × ~3 kB each + globals). The POST form is the correct path:
+
+```tsx
+function openInCodeSandbox(files: Record<string, { content: string }>) {
+  const parameters = LZString.compressToEncodedURIComponent(
+    JSON.stringify({ files })
+  );
+  const form = document.createElement("form");
+  form.method = "POST";
+  form.action = "https://codesandbox.io/api/v1/sandboxes/define";
+  form.target = "_blank";
+  const input = document.createElement("input");
+  input.type = "hidden";
+  input.name = "parameters";
+  input.value = parameters;
+  form.appendChild(input);
+  document.body.appendChild(form);
+  form.submit();
+  document.body.removeChild(form);
+}
+```
+
+The GET URL can still be used as a shareable permalink or for a single-component "Open in
+CodeSandbox" button, since a single component + minimal boilerplate fits easily under 8 kB.
+
+---
+
+## 3. Preset propagation
+
+The chosen preset is represented as the `?preset=<encoded>` search param produced by
+`encodePreset(designSystem)` (`www/src/modules/create/preset/codec.ts:75`). The encoding is:
+
+1. Diff `DesignSystem` against `DEFAULTS` (`www/src/modules/create/preset/defaults.ts:5`) →
+   compact `DesignSystemState { p?, t?, d?, c? }` (`www/src/modules/create/preset/types.ts:14`).
+2. `JSON.stringify` → `pako.deflateRaw(json, { level: 9 })` → URL-safe base64 (`toBase64Url`,
+   `codec.ts:12`).
+3. Returns `undefined` when nothing differs from defaults.
+
+For the CodeSandbox path the preset must be **decoded at button-click time** to build the files map.
+Two fields drive the output:
+
+| Preset field | What it affects |
+|---|---|
+| `color: ColorConfig` | OKLCH primitive ramps in `globals.css` `:root` / `.dark` |
+| `density: Density` | class strings baked into each component file via `flatten` |
+| `componentParams` | per-component enum / scalar choices folded into `tv()` class strings |
+
+All three are available from `decodePreset(encodedPreset)` (`codec.ts:111`). The decoded value is a
+full `DesignSystem`; narrow it to `PublishPreset` for the publisher:
+
+```ts
+import { decodePreset } from "@/modules/create/preset/codec";
+import type { PublishPreset } from "@/publisher/types";
+
+function presetFromEncoded(encoded: string | undefined): PublishPreset {
+  if (!encoded) return { density: "compact", componentParams: {} };
+  const ds = decodePreset(encoded);          // codec.ts:111 — falls back to DEFAULTS on error
+  return {
+    color:           ds.color,
+    density:         ds.density,
+    componentParams: ds.componentParams,
+  };
+}
+```
+
+`encodePreset` returns `undefined` when the user has not changed anything. The button must handle
+this: `undefined` → use `{ density: "compact", componentParams: {} }` (no color override → static
+default ramps from `__generated__/base-css.ts` are used as-is).
+
+---
+
+## 4. Components installed
+
+The sandbox must include every dotUI component the showcase consumes. The full transitive set (from
+the showcase internals map) spans 38 registry items (listed below). Rather than making 38 network
+calls to `/r/<name>?preset=<encoded>`, dotUI builds the file content server-side at click time by
+calling the existing publisher functions directly.
+
+### 4a. The set of components needed for `<Cards />`
+
+From `www/src/components/marketing/showcase/cards.tsx` and its 17 sub-cards, the transitive
+`registry/ui/*` components are:
+
+```
+accordion, avatar, badge, button, calendar, card, checkbox, checkbox-group,
+color-area, color-editor, color-field, color-slider, color-thumb, disclosure,
+drop-zone, field, file-trigger, group, input, kbd, link, list-box, loader,
+otp-field, popover, progress-bar, radio-group, select, separator, slider,
+switch, table, tabs, tag-group, text, text-field, time-field,
+toggle-button, toggle-button-group
+```
+
+Plus the two lib items always bundled with the init item: `utils` and `focus-styles`.
+
+### 4b. Building component file content from the publisher
+
+The publisher pipeline lives entirely in `www/src/publisher/publish.ts:119` (`publish()`) and the
+generated publishables in `www/src/registry/__generated__/publishables/`. After `pnpm build:registry`
+each publishable is available as a dynamic import:
+
+```ts
+import { publishables, PUBLISHABLE_NAMES } from "@/registry/__generated__/publishables";
+import { publish, setKnownDotuiNames, setDotuiDepResolver } from "@/publisher/publish";
+import { format } from "oxfmt";
+
+// called once at server/worker startup
+setKnownDotuiNames(PUBLISHABLE_NAMES);
+
+async function buildComponentFiles(
+  names: string[],
+  preset: PublishPreset,
+): Promise<Record<string, { content: string }>> {
+  const files: Record<string, { content: string }> = {};
+  for (const name of names) {
+    const loader = publishables[name];
+    if (!loader) continue;
+    const mod = await loader();
+    // enum-with-files: loader ships base.spinner.tsx vs base.ring.tsx depending on preset
+    const publishable = selectPublishable(mod, preset);   // logic from $name.tsx:89-107
+    const { item, rawContent } = publish({ publishable, preset });
+    let content = rawContent;
+    try {
+      const r = await format(publishable.meta.files?.[0]?.target ?? "ui.tsx", rawContent, {
+        printWidth: 120, useTabs: true,
+      });
+      content = r.code;
+    } catch { /* keep raw */ }
+    // target = consumer path like "ui/button.tsx" → map to "src/components/ui/button.tsx"
+    const target = publishable.meta.files?.[0]?.target ?? `ui/${name}.tsx`;
+    files[`src/components/${target}`] = { content };
+  }
+  return files;
+}
+```
+
+The `selectPublishable` function (private to `$name.tsx:89-107`) must be extracted to a shared
+helper (see section 7). It handles the `loader` component's `style` enum (spinner vs ring).
+
+### 4c. Target paths in the sandbox
+
+shadcn aliases are:
+
+| Alias | Sandbox path |
+|---|---|
+| `@/components/ui/` | `src/components/ui/` |
+| `@/lib/` | `src/lib/` |
+| `@/hooks/` | `src/hooks/` |
+
+All component `meta.ts` files declare `target` paths relative to the consumer's `src/`. For example,
+`button` → `ui/button.tsx` → sandbox path `src/components/ui/button.tsx`. Lib items ship to
+`src/lib/` (e.g. `src/lib/utils.ts`).
+
+---
+
+## 5. Theme in globals.css
+
+The theme is built by `emitInitItem()` (`www/src/publisher/emit-theme.ts:71`), which already exists
+for the `/r/init` route. For the CodeSandbox path, call it directly and serialize its `css` and
+`cssVars` fields to a `globals.css` string.
+
+### 5a. Getting the init item
+
+```ts
+import { emitInitItem } from "@/publisher/emit-theme";
+import { baseRegistryCss } from "@/registry/__generated__/base-css";
+
+const initItem = emitInitItem({
+  baseRegistryCss,
+  preset,
+  encodedPreset,
+  registryRoot: "https://dotui.com",
+});
+// initItem.css    → the structured CSS object (at-rules, :root ramps, .dark ramps)
+// initItem.cssVars.theme → the @theme inline block
+```
+
+### 5b. Serializing the CSS object to a string
+
+shadcn's own CLI serializes the structured `css` + `cssVars.theme` into a globals.css string
+internally. For the CodeSandbox builder, dotUI needs a `registryItemToCss(item)` serializer. The
+existing `cssToRegistryFields()` (`www/src/publisher/build-time/css-to-registry-fields.ts:30`) is
+the inverse parser — write the matching forward serializer:
+
+```ts
+function registryItemToCss(item: ReturnType<typeof emitInitItem>): string {
+  const lines: string[] = [];
+  lines.push('@import "tailwindcss";');
+  lines.push('@import "@fontsource-variable/geist";');
+  lines.push('@import "@fontsource/geist-mono";');
+  lines.push("");
+
+  const { css, cssVars } = item;
+
+  // @theme inline — the constant semantic + radius layer
+  if (cssVars?.theme && Object.keys(cssVars.theme).length > 0) {
+    lines.push("@theme inline {");
+    for (const [k, v] of Object.entries(cssVars.theme)) {
+      lines.push(`  ${k}: ${v};`);
+    }
+    lines.push("}");
+    lines.push("");
+  }
+
+  // At-rules (imports, plugins, utilities, layers) — everything in css except :root / .dark
+  if (css) {
+    for (const [selector, block] of Object.entries(css)) {
+      if (selector === ":root" || selector === ".dark") continue;
+      lines.push(serializeCssBlock(selector, block));
+      lines.push("");
+    }
+
+    // :root and .dark last — these are the preset-specific primitive ramps
+    for (const sel of [":root", ".dark"]) {
+      if (css[sel]) {
+        lines.push(serializeCssBlock(sel, css[sel]));
+        lines.push("");
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function serializeCssBlock(selector: string, block: unknown): string {
+  if (typeof block !== "object" || block === null) return `${selector} {}`;
+  const lines = [`${selector} {`];
+  for (const [k, v] of Object.entries(block as Record<string, string>)) {
+    lines.push(`  ${k}: ${v};`);
+  }
+  lines.push("}");
+  return lines.join("\n");
+}
+```
+
+For a preset with a custom color (e.g. the user picked a red accent seed),
+`emitInitItem → mergePresetCssFields` (`emit-theme.ts:145`) calls `resolveColorConfig(preset.color)`
+which regenerates the OKLCH ramps and overrides `css[":root"]` and `css[".dark"]` with
+`--neutral-50 … --info-950`. The serializer above faithfully writes those into `globals.css`.
+
+### 5c. What the resulting globals.css looks like (preset example)
+
+For a preset with `color.seeds.accent = "#e84040"` (custom red):
+
+```css
+@import "tailwindcss";
+@import "@fontsource-variable/geist";
+@import "@fontsource/geist-mono";
+
+@theme inline {
+  --radius-md: calc(0.375rem * var(--radius-factor));
+  --color-bg: var(--neutral-50);
+  --color-accent: var(--accent-500);
+  --color-fg-on-accent: var(--on-accent-500);
+  /* ... ~80 semantic tokens ... */
+}
+
+@import "tw-animate-css";
+@plugin "tailwindcss-react-aria-components";
+@plugin "tailwindcss-autocontrast" { cssfile: "./src/globals.css"; }
+@plugin "tailwindcss-with";
+@custom-variant dark (&:is(.dark *));
+@utility focus-ring { /* ... */ }
+@layer base { * { @apply border-border } body { @apply bg-bg font-sans text-fg } }
+
+:root {
+  --radius-factor: 1;
+  --neutral-50: oklch(0.985 0 0);
+  /* ... */
+  --accent-50: oklch(0.971 0.019 20.4);   /* red-tinted, generated from #e84040 seed */
+  --accent-500: oklch(0.538 0.224 20.4);
+  /* ... 66 total ramp vars ... */
+}
+.dark {
+  --neutral-50: oklch(0.13 0 0);          /* reversed */
+  --accent-50: oklch(0.201 0.058 20.4);
+  /* ... */
+}
+```
+
+The `tailwindcss-autocontrast` plugin will inject `--on-accent-*` at Tailwind compile time inside
+the sandbox.
+
+### 5d. Per-component CSS
+
+Each component's `styles.css` (e.g. `avatar/styles.css`, `slider/styles.css`) carries component-
+level CSS vars (`--avatar-radius`, `--slider-*`). These are present in each component's emitted
+`item.css` and `item.cssVars`. Two options:
+
+1. **Append each component's CSS to globals.css** — call `publish()` for each component and
+   concatenate `item.css` blocks into the globals.css string. Simple; one file.
+2. **Import per-component CSS files separately** — write `src/components/ui/avatar.css` and import
+   in `avatar.tsx`. More idiomatic; matches how shadcn delivers components.
+
+Option 1 is simpler for the Define API approach (fewer files in the payload).
+
+---
+
+## 6. The showcase as first view
+
+The showcase is `www/src/components/marketing/showcase/cards.tsx` and its 17 sibling files
+(`booking.tsx`, `two-factor.tsx`, … `login-form.tsx`). They are **pure client components** — no
+server functions, no loaders, all static data. They can be copied verbatim into the sandbox.
+
+### 6a. Files to include
+
+```
+src/components/marketing/showcase/cards.tsx
+src/components/marketing/showcase/booking.tsx
+src/components/marketing/showcase/two-factor.tsx
+src/components/marketing/showcase/filters.tsx
+src/components/marketing/showcase/storage.tsx
+src/components/marketing/showcase/notifications.tsx
+src/components/marketing/showcase/cookie-preferences.tsx
+src/components/marketing/showcase/invite-members.tsx
+src/components/marketing/showcase/shortcuts.tsx
+src/components/marketing/showcase/payment.tsx
+src/components/marketing/showcase/transactions.tsx
+src/components/marketing/showcase/account-menu.tsx
+src/components/marketing/showcase/faq.tsx
+src/components/marketing/showcase/color-editor.tsx
+src/components/marketing/showcase/upload-avatar.tsx
+src/components/marketing/showcase/team-name.tsx
+src/components/marketing/showcase/feedback.tsx
+src/components/marketing/showcase/login-form.tsx
+```
+
+These files import from `@/registry/ui/*`, `@/registry/lib/utils`, and `@/registry/__generated__/icons`.
+In the sandbox those resolve to `src/components/ui/*`, `src/lib/utils`, and the icons file.
+
+### 6b. `App.tsx` — the first view
+
+```tsx
+import "./globals.css";
+import { Cards } from "@/components/marketing/showcase/cards";
+
+export default function App() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg antialiased">
+      <main className="container mx-auto py-12 px-4">
+        <Cards />
+      </main>
+    </div>
+  );
+}
+```
+
+No `ThemeProvider` (from `packages/starter-themes`) is needed in the sandbox because that package
+depends on `@tanstack/react-router`'s `ScriptOnce`. Replace with a minimal inline script that adds
+the `dark` class to `<html>` if the user prefers dark mode:
+
+```html
+<!-- index.html <head> -->
+<script>
+  if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    document.documentElement.classList.add("dark");
+  }
+</script>
+```
+
+`DesignSystemProvider` (`www/src/modules/core/styles.tsx:61`) can be omitted — its default context
+value `{ params: {}, tokens: {}, density: "default" }` gives every component its default visual
+variant, which is fine because all variant choices are already baked into the component files by the
+publisher.
+
+### 6c. Non-showcase files required
+
+```
+src/lib/utils.ts          (cn helper — shipped inline by emitInitItem.files[0])
+src/lib/context.tsx       (createContext, createScopedContext — used by avatar, tabs, button)
+src/hooks/use-image-loading-status.ts  (used by avatar/base.tsx)
+src/registry/__generated__/icons.tsx  (ExternalLinkIcon used in invite-members.tsx)
+```
+
+`context.tsx` and `use-image-loading-status.ts` are **not registered items** today
+(`UNREGISTERED_DEP_ALLOWLIST`, `scripts/registry-build.ts:464`) — they must be copied from source
+into the sandbox. Their source paths:
+- `www/src/registry/lib/context/index.tsx`
+- `www/src/registry/hooks/use-image-loading-status.ts`
+- `www/src/registry/__generated__/icons.tsx`
+
+---
+
+## 7. What dotUI must build
+
+### 7a. New server endpoint: `POST /api/open-in/codesandbox`
+
+A TanStack Start server function (or route handler) that:
+
+1. Reads `?preset=<encoded>` (or body JSON `{ preset }` for POST).
+2. Calls `decodePreset(encoded)` → `PublishPreset`.
+3. Calls `emitInitItem(...)` to build the init item; serializes it to a `globals.css` string.
+4. Iterates over the showcase component set (38 names); calls `publish()` for each.
+5. Reads the 18 showcase source files verbatim (at build-time snapshot or from disk).
+6. Reads the 3 non-registered files (`context.tsx`, `use-image-loading-status.ts`, `icons.tsx`).
+7. Assembles the full `files` map (see §7b).
+8. Returns `{ parameters: LZString.compressToEncodedURIComponent(JSON.stringify({ files })) }`.
+
+The client button `fetch`es this endpoint and uses the response to POST to the Define API.
+
+**Alternatively**, steps 1–8 can run entirely in the browser if the codec and publisher are bundled
+into the client. That avoids a new server endpoint but bloats the client bundle significantly
+(pako + publisher logic + all publishables). A server-side approach is strongly preferred.
+
+### 7b. Concrete files map shape
+
+```jsonc
+{
+  "files": {
+    "package.json":              { "content": "..." },
+    "index.html":                { "content": "..." },
+    "vite.config.ts":            { "content": "..." },
+    "tsconfig.json":             { "content": "..." },
+    "src/main.tsx":              { "content": "..." },
+    "src/App.tsx":               { "content": "..." },
+    "src/globals.css":           { "content": "<serialized theme>" },
+
+    // showcase files (verbatim copies)
+    "src/components/marketing/showcase/cards.tsx":        { "content": "..." },
+    "src/components/marketing/showcase/booking.tsx":      { "content": "..." },
+    // ... 16 more ...
+
+    // registry/lib (not registered — must copy)
+    "src/lib/utils.ts":                                   { "content": "<cn helper>" },
+    "src/lib/context.tsx":                                { "content": "..." },
+    "src/hooks/use-image-loading-status.ts":              { "content": "..." },
+    "src/components/ui/icons.tsx":                        { "content": "..." },
+
+    // all 38 ui components (publisher output, preset-baked)
+    "src/components/ui/button.tsx":                       { "content": "<published tv source>" },
+    "src/components/ui/card.tsx":                         { "content": "..." },
+    // ... 36 more ...
+  }
+}
+```
+
+### 7c. `selectPublishable` extraction
+
+The helper `selectPublishable` (currently defined privately in `www/src/routes/r/$name.tsx:89-107`)
+must be exported from a shared module — e.g. `www/src/publisher/select-publishable.ts` — so the
+CodeSandbox builder can call it without duplicating logic. It handles the `loader` component's
+`style` param (spinner vs ring file swap).
+
+### 7d. `registryItemToCss` serializer
+
+A new function `www/src/publisher/emit-globals-css.ts` that converts an `emitInitItem` result to a
+CSS string (sketched in §5b above). This is reusable for all "Open in" targets (StackBlitz, etc.).
+
+### 7e. Snapshot of showcase source files
+
+The 18 showcase files and the 3 non-registered lib files must be readable at request time. Options:
+1. Read them from disk at runtime (`fs.readFile`, works in a Node.js TanStack Start server).
+2. Embed them as build-time string constants (generated by `registry-build.ts` or a dedicated
+   `build:showcase-snapshot` step) — more portable, works in an edge runtime.
+
+Option 2 is preferred for Vercel deployment (edge functions do not have `fs` access to source).
+Add a `renderShowcaseSnapshot()` step to `scripts/registry-build.ts` that writes
+`www/src/registry/__generated__/showcase-snapshot.ts` exporting `SHOWCASE_FILES: Record<string, string>`.
+
+### 7f. `package.json` for the sandbox
+
+```json
+{
+  "name":    "dotui-sandbox",
+  "private": true,
+  "type":    "module",
+  "scripts": {
+    "dev":   "vite",
+    "build": "tsc && vite build"
+  },
+  "dependencies": {
+    "react":                          "^19.0.0",
+    "react-dom":                      "^19.0.0",
+    "react-aria-components":          "^1.7.0",
+    "react-aria":                     "^3.37.0",
+    "react-stately":                  "^3.35.0",
+    "@internationalized/date":        "^3.6.0",
+    "@base-ui/react":                 "^1.0.0",
+    "tailwind-variants":              "^0.3.0",
+    "clsx":                           "^2.1.1",
+    "tailwind-merge":                 "^2.5.4",
+    "lucide-react":                   "^0.454.0",
+    "@fontsource-variable/geist":     "^5.1.1",
+    "@fontsource/geist-mono":         "^5.0.2"
+  },
+  "devDependencies": {
+    "vite":                           "^6.0.0",
+    "@vitejs/plugin-react":           "^4.3.4",
+    "typescript":                     "^5.7.0",
+    "tailwindcss":                    "^4.0.0",
+    "@tailwindcss/vite":              "^4.0.0",
+    "tw-animate-css":                 "^1.2.4",
+    "tailwindcss-react-aria-components": "^2.1.1",
+    "tailwindcss-autocontrast":       "^0.3.0",
+    "tailwindcss-with":               "^0.1.0"
+  }
+}
+```
+
+Note: `tailwindcss-autocontrast` and `tailwindcss-with` are currently workspace packages. They must
+be published to npm for the sandbox to install them (see §9 — Limitations).
+
+### 7g. `vite.config.ts` for the sandbox
+
+```ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "./src") },
+  },
+});
+```
+
+---
+
+## 8. Schema / meta.ts changes
+
+No changes to `RegistryItem` or any `ui/*/meta.ts` are required for the CodeSandbox path. The
+publisher (`publish.ts`, `emit-theme.ts`) already exposes all the needed APIs. The only new
+structural work is:
+
+1. Extract `selectPublishable` to a shared file (§7c).
+2. Add `renderShowcaseSnapshot()` to `scripts/registry-build.ts` (§7e).
+3. Add `www/src/publisher/emit-globals-css.ts` (the CSS serializer, §7d).
+4. Add a new TanStack Start server route `www/src/routes/api/open-in/codesandbox.tsx`.
+
+Optionally, a future `openIn?: { codesandbox?: boolean }` field on `RegistryItem` could gate
+which components are included in the sandbox bundle, but it is not required for an initial
+implementation that always ships the full showcase set.
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### 9a. Payload size
+
+The full 60-component + showcase file tree, serialized and lz-string compressed, is expected to be
+in the 100–400 kB range (lz-string is significantly less efficient than pako deflate). CodeSandbox
+**does not document a maximum POST body size** for the Define API, but community reports suggest
+limits around 5–10 MB uncompressed. The full tree is well under that. Use the POST form; do not
+attempt the GET URL for the full bundle.
+
+For a **single-component** "Open in CodeSandbox" button (one component + minimal deps + a tiny
+`App.tsx`), the GET URL form works fine.
+
+### 9b. Workspace-only npm packages
+
+`tailwindcss-autocontrast` (`packages/tailwindcss-autocontrast`) and `tailwindcss-with`
+(`packages/tailwindcss-with`) are workspace packages not yet published to npm. The sandbox
+`package.json` references them by name, so npm install will fail unless they are published first.
+**Blocker for the feature.** Resolution: publish both to npm under `@dotui/tailwindcss-autocontrast`
+and `@dotui/tailwindcss-with` (or unprefixed) before shipping the "Open in CodeSandbox" button.
+
+Until then, a fallback is to vendor the built plugin JS inline in `vite.config.ts` as a local
+Vite plugin, but that is fragile.
+
+### 9c. CodeSandbox sandbox lifetime
+
+Sandboxes created via the Define API are **ephemeral** if the user is not logged in — they may be
+garbage-collected. Logged-in users get the sandbox saved to their account. This is acceptable for
+an "Open in" flow; document it in the UI tooltip ("Sign in to CodeSandbox to save your sandbox").
+
+### 9d. `tailwindcss-autocontrast` `cssfile` path
+
+In the static default, `base.css` points `@plugin "tailwindcss-autocontrast" { cssfile: "./src/styles.css"; }`.
+In the sandbox it must point at `./src/globals.css`. The `registryItemToCss` serializer (§5b) must
+rewrite this path when building the globals.css string.
+
+### 9e. `ThemeProvider` / dark-mode flash
+
+`packages/starter-themes` requires `@tanstack/react-router` and is not suitable for a plain Vite
+sandbox. The inline `<script>` in `index.html` (§6b) covers the flash-of-unstyled-content on first
+load. For dark-mode toggle in the sandbox, a simple `useState` + `document.documentElement.classList.toggle("dark")`
+button in `App.tsx` is sufficient and has no external dep.
+
+### 9f. `@/registry/__generated__/icons.tsx` path alias
+
+The showcase `invite-members.tsx` imports `ExternalLinkIcon` from `@/registry/__generated__/icons`.
+In the sandbox the `@/` alias points at `src/`, so the file should be placed at
+`src/registry/__generated__/icons.tsx` OR the import should be rewritten to `src/components/ui/icons.tsx`
+(or replaced with a direct `lucide-react` import). The simplest fix: write a tiny `icons.tsx` shim
+in the sandbox at the expected alias path that just re-exports from `lucide-react`.
+
+### 9g. Color accuracy (OKLCH in Tailwind v4)
+
+All emitted ramp values are `oklch(L C H)` strings. Tailwind CSS v4 natively passes `oklch()`
+through to the browser; no conversion is needed. The `tailwindcss-autocontrast` plugin reads
+`:root`/`.dark` via culori (which speaks OKLCH) to compute `--on-*` foregrounds. There is **no
+color accuracy loss** in the CodeSandbox output — the sandbox faithfully renders the same palette
+the user designed.
+
+### 9h. `@base-ui/react` sub-path import
+
+`otp-field/base.tsx` imports from `@base-ui/react/otp-field` and `toast/base.tsx` from
+`@base-ui/react/toast`. These are sub-path exports from the `@base-ui/react` package. `@base-ui/react`
+must be in `package.json` at `^1.0.0` or later (which exports these paths). The sandbox `package.json`
+above includes it.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+- [ ] **Publish workspace Tailwind plugins** (`tailwindcss-autocontrast`, `tailwindcss-with`) to npm
+      before any other step (§9b blocker).
+
+- [ ] **Extract `selectPublishable`** from `www/src/routes/r/$name.tsx:89-107` into
+      `www/src/publisher/select-publishable.ts` and update the route to import from there (§7c).
+
+- [ ] **Write `emit-globals-css.ts`** at `www/src/publisher/emit-globals-css.ts` implementing
+      `registryItemToCss(item)` including the `cssfile` path rewrite for `tailwindcss-autocontrast`
+      (§5b, §9d).
+
+- [ ] **Add `renderShowcaseSnapshot()`** to `www/scripts/registry-build.ts` that reads the 18
+      showcase files + `context/index.tsx` + `use-image-loading-status.ts` + `icons.tsx` at build
+      time and emits `www/src/registry/__generated__/showcase-snapshot.ts` exporting
+      `SHOWCASE_FILES: Record<string, string>` (§7e).
+
+- [ ] **Run `pnpm build:registry`** to materialize `showcase-snapshot.ts` and verify the emitted
+      file list.
+
+- [ ] **Write the server route** `www/src/routes/api/open-in/codesandbox.tsx` that:
+      - Accepts `GET ?preset=<encoded>` (or `POST { preset }`).
+      - Decodes preset via `decodePreset`.
+      - Calls `emitInitItem` + `registryItemToCss` → `globals.css` content.
+      - Iterates over the 38-component showcase set; calls `publish()` + `selectPublishable()` for each.
+      - Merges `SHOWCASE_FILES` into the files map.
+      - Adds the boilerplate files (`package.json`, `vite.config.ts`, `tsconfig.json`,
+        `index.html`, `src/main.tsx`, `src/App.tsx`).
+      - Returns `{ parameters: LZString.compressToEncodedURIComponent(JSON.stringify({ files })) }`.
+
+- [ ] **Add `lz-string`** to `www/package.json` dependencies. Verify types (`@types/lz-string`).
+
+- [ ] **Write the client-side button component** at e.g.
+      `www/src/components/marketing/open-in-codesandbox.tsx` that:
+      - Reads `?preset` from the route search via `useSearch()`.
+      - `fetch`es `/api/open-in/codesandbox?preset=${encoded}`.
+      - On response, creates a hidden `<form method="POST">` targeting
+        `https://codesandbox.io/api/v1/sandboxes/define` and submits it (§2c).
+      - Shows a loading state while the server builds the payload.
+
+- [ ] **Fix the `@/registry/__generated__/icons` alias** in the sandbox by writing a shim at
+      `src/registry/__generated__/icons.tsx` (or rewrite the import in the showcase snapshot at
+      build time) that re-exports `ExternalLinkIcon` from `lucide-react` (§9f).
+
+- [ ] **Fix `tailwindcss-autocontrast` cssfile path** in the emitted globals.css: the serializer
+      should emit `cssfile: "./src/globals.css"` not the registry's `"./src/styles.css"` (§9d).
+
+- [ ] **Write `src/main.tsx`** content:
+      ```tsx
+      import { StrictMode } from "react";
+      import { createRoot } from "react-dom/client";
+      import App from "./App";
+      createRoot(document.getElementById("root")!).render(<StrictMode><App /></StrictMode>);
+      ```
+
+- [ ] **Write `index.html`** content including the dark-mode inline script (§6b).
+
+- [ ] **Test end-to-end** with a default preset (no `?preset=` → static ramps) and with a custom
+      accent color preset, verifying:
+      - [ ] `globals.css` contains the expected OKLCH ramps.
+      - [ ] All 38 component files are present in the sandbox.
+      - [ ] `<Cards />` renders without console errors in the sandbox.
+      - [ ] `tailwindcss-autocontrast` injects `--on-accent-*` at compile time inside the sandbox.
+
+- [ ] **(Optional) Add a single-component GET URL form** for per-component "Open in CodeSandbox"
+      buttons on the component docs pages — these are small enough for the GET form (§2c).
+
+---
+
+## Sources
+
+- CodeSandbox Define API: <https://codesandbox.io/docs/learn/sandboxes/cli-api>
+- lz-string (`compressToEncodedURIComponent`): <https://github.com/pieroxy/lz-string>
+- Preset codec (encode/decode, pako deflate, base64url): `www/src/modules/create/preset/codec.ts:12-126`
+- `encodePreset` live usage: `www/src/modules/create/install-command.tsx:39-48`
+- `/r/init` route: `www/src/routes/r/init.tsx:22-59`
+- `/r/$name` route + `selectPublishable`: `www/src/routes/r/$name.tsx:32-121`
+- `emitInitItem` + `mergePresetCssFields` + `rampsToVars`: `www/src/publisher/emit-theme.ts:71-170`
+- `baseRegistryCss` (static structured CSS): `www/src/registry/__generated__/base-css.ts`
+- Publisher pipeline (`publish`, `flatten`, `resolveClasses`, `serialize`): `www/src/publisher/publish.ts:119-161`
+- Showcase cards + transitive component set: `www/src/components/marketing/showcase/cards.tsx:20-48`
+- Non-registered lib files: `www/src/registry/lib/context/index.tsx`, `www/src/registry/hooks/use-image-loading-status.ts`, `www/src/registry/__generated__/icons.tsx`
+- `cssToRegistryFields` (inverse CSS parser, reference for forward serializer): `www/src/publisher/build-time/css-to-registry-fields.ts:30`
+- `tailwindcss-autocontrast` plugin (cssfile option, culori parsing): `packages/tailwindcss-autocontrast/src/index.js:233-501`
+- `BUNDLED_INTO_INIT` (which deps are dropped from component registryDependencies): `www/src/publisher/publish.ts:52-59`
+- `DEFAULT_DEPENDENCIES` for init item: `www/src/publisher/emit-theme.ts:31-39`

--- a/docs/research/open-in/cursor.md
+++ b/docs/research/open-in/cursor.md
@@ -1,0 +1,599 @@
+# Open in Cursor
+
+> **Feasible with two complementary buttons** · button type `mcp-install` (primary) + `copy-command` (secondary, one-shot showcase install) · preset fidelity **full** (both paths) · color fidelity **full** (OKLCH ramps baked into `/r/init` CSS)
+
+---
+
+## 1. User experience
+
+The user has configured a dotUI design system on the `/create` page — chosen an accent color,
+density, and per-component style variants — and wants to open that exact design system in Cursor
+and start editing real code with their themed components already installed.
+
+The recommended UX exposes **two buttons side by side**:
+
+| Button | Label | Action |
+|---|---|---|
+| Primary | "Open in Cursor" (MCP install) | Installs the dotUI registry as an MCP server in Cursor so the agent can browse + add components on demand |
+| Secondary | "Copy install command" | Copies `npx shadcn add <url>` for a one-shot, showcase-preinstalled project |
+
+**Flow for the MCP install button:**
+
+1. User clicks "Open in Cursor" — browser navigates to the `cursor://` deep-link URI.
+2. Cursor opens and shows a prompt: "Install MCP server dotUI-registry?" with the server config pre-filled.
+3. User confirms. Cursor now has the MCP server and its agent can call `shadcn registry:mcp` to discover and add any dotUI component with the user's preset baked in.
+
+**Flow for the copy-command button (showcase-preinstalled):**
+
+1. User copies the command shown (e.g. `npx shadcn add https://dotui.com/r/init?preset=<encoded>`).
+2. User creates a new project (Vite + React or Next.js), then pastes and runs the command.
+3. The command installs the full theme + `src/lib/utils.ts` and writes the preset's OKLCH ramps into `globals.css`. The user then pastes the showcase files (or runs per-component adds).
+4. User opens the project folder in Cursor: `cursor <project-dir>`.
+
+Neither path opens a sandboxed URL; Cursor does not have a "remote repo import" flow. The
+showcase-preinstalled UX relies on the user first bootstrapping a local project.
+
+---
+
+## 2. Technical mechanism
+
+### 2a. MCP install deep-link
+
+Cursor supports a deep-link URI scheme for MCP server installation:
+
+```
+cursor://anysphere.cursor-deeplink/mcp/install?name=<NAME>&config=<BASE64>
+```
+
+- `<NAME>` — display name for the MCP server (shown in Cursor's MCP panel), e.g. `dotUI-registry`.
+- `<BASE64>` — `btoa(JSON.stringify(serverConfig))`, where `serverConfig` is the standard MCP
+  server descriptor Cursor accepts. **This is plain base64, not base64url and not pako-compressed.**
+
+The server config for the shadcn registry MCP server:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "shadcn@latest", "registry:mcp"],
+  "env": {
+    "REGISTRY_URL": "https://dotui.com/r/registry.json"
+  }
+}
+```
+
+Encoded:
+
+```js
+const serverConfig = {
+  command: "npx",
+  args: ["-y", "shadcn@latest", "registry:mcp"],
+  env: { REGISTRY_URL: "https://dotui.com/r/registry.json" }
+};
+const config = btoa(JSON.stringify(serverConfig));
+const url = `cursor://anysphere.cursor-deeplink/mcp/install?name=dotUI-registry&config=${config}`;
+```
+
+Render as an `<a href={url}>` anchor. On GitHub, wrap it in a Shields badge:
+
+```markdown
+[![Open in Cursor](https://img.shields.io/badge/Open%20in-Cursor-000?logo=cursor)](cursor://anysphere.cursor-deeplink/mcp/install?name=dotUI-registry&config=BASE64HERE)
+```
+
+**Critical prerequisite:** The `REGISTRY_URL` must point at a live `/r/registry.json` endpoint.
+That route does not exist today in dotUI — it returns 404. Building it is the blocking task for
+this feature (see §7).
+
+### 2b. One-shot init command (showcase-preinstalled path)
+
+The install command is already computed by `InstallCommand` in
+`www/src/modules/create/install-command.tsx:39-48`:
+
+```ts
+const encoded = encodePreset(designSystem);  // codec.ts:75
+const url = encoded
+  ? `${host}/r/init?preset=${encoded}`
+  : `${host}/r/init`;
+return `npx shadcn add ${url}`;
+```
+
+This is the same command shown in the customizer panel today. For the "Open in Cursor" feature,
+the secondary button copies this command. The preset (`encoded`) is a URL-safe base64 string of
+pako-deflated compact JSON — the full wire format is described in §3.
+
+---
+
+## 3. Preset propagation
+
+### Wire format
+
+The `?preset=` value is produced by `encodePreset` (`www/src/modules/create/preset/codec.ts:75`):
+
+1. Build a `DesignSystemState` compact object, diffed against `DEFAULTS`
+   (`www/src/modules/create/preset/defaults.ts:5`):
+   - `p`: per-component param overrides (only values that differ from `DEFAULTS.componentParams`)
+   - `t`: global token overrides (only values that differ from `DEFAULTS.tokens` = `{}`)
+   - `d`: density string, only when `!== "compact"` (dotUI default is `compact`)
+   - `c`: full `ColorConfig` object, only when it differs from `DEFAULT_COLOR_CONFIG`
+     (`www/src/registry/theme/color-config.ts:72`)
+2. `JSON.stringify(compactState)` — e.g. `{"c":{"algorithm":"oklch","seeds":{"neutral":"#1a1a2e","accent":"#e94560"}}}`
+3. `pako.deflateRaw(json, { level: 9 })` — raw DEFLATE, no zlib header
+4. `btoa(String.fromCharCode(...bytes))` then `+→-`, `/→_`, strip trailing `=` (URL-safe base64)
+
+Decode is the exact inverse, merging back over `DEFAULTS` (`codec.ts:111`); any corrupt input
+returns `DEFAULTS` (total fallback).
+
+### How the preset flows through each path
+
+**MCP path** — the `REGISTRY_URL` (`/r/registry.json`) carries no preset. Preset fidelity on the
+MCP path is achieved via the `config.registries["@dotui"]` field that `/r/init?preset=<encoded>`
+bakes into `components.json` (`www/src/publisher/emit-theme.ts:130-132`). Once the user runs the
+init command once, every subsequent `shadcn add @dotui/<name>` (whether invoked by the agent via
+MCP or manually) hits `/r/<name>?preset=<encoded>` with the user's exact preset. The MCP server
+discovers names from the registry index but fetches content from the preset-baked URL.
+
+**One-shot init path** — the preset is embedded directly in the init URL:
+
+```
+https://dotui.com/r/init?preset=<encoded>
+```
+
+The route handler (`www/src/routes/r/init.tsx:27-55`) calls `decodePreset(encodedPreset)` and
+threads `color`, `density`, and `componentParams` into `emitInitItem`. The returned `registry:base`
+item then contains:
+
+- OKLCH ramps for the chosen color (if `preset.color` present) overriding `:root`/`.dark`
+- `--dotui-density` in `:root` (if density != `"compact"`)
+- `config.registries["@dotui"]` set to `"<root>/r/{name}?preset=<encoded>"` so every subsequent
+  per-component `shadcn add` inherits the same preset
+
+---
+
+## 4. Components installed
+
+### Via MCP (on-demand)
+
+After the MCP server is installed in Cursor, the agent can call `shadcn add @dotui/<name>` for any
+of the 60 registered UI items (full list in `www/src/registry/__generated__/registry-items.ts:70-129`).
+
+Each per-component request hits `/r/<name>?preset=<encoded>` where the publisher
+(`www/src/publisher/publish.ts:119-161`) runs the full preset pipeline:
+- **Density flattening** (`flatten.ts:148`): merges `base ← density[selected] ← params[name][value]` tv layers, baking density into class strings
+- **Scalar param rewriting** (`resolve-classes.ts:30`): rewrites e.g. `rounded-(--alert-radius)` → `rounded-md` when `alert.radius = "--radius-md"`
+- **Enum-with-files swap** (`$name.tsx:89-107`): picks the correct source file for multi-variant items (today only `loader` uses this: `style="spinner"` → `base.spinner.tsx`, `style="ring"` → `base.ring.tsx`)
+- **Transitive deps** (`publish.ts:79-105`): `registryDependencies` in the emitted JSON are rewritten to absolute URLs with the same `?preset=<encoded>` appended so recursive fetches preserve the preset
+
+Components install to their declared `target` paths (e.g. `ui/button.tsx`, `ui/card.tsx`); the
+alias `@/components/ui` maps to the standard shadcn-CLI install location.
+
+### Via one-shot init (showcase path)
+
+Running `npx shadcn add <init-url>` alone installs only the theme + `src/lib/utils.ts`. To install
+all showcase components, follow with per-component adds. The showcase
+(`www/src/components/marketing/showcase/cards.tsx`) uses 37 distinct UI modules; the minimal set to
+render `<Cards />` is:
+
+accordion, avatar, badge, button, calendar, card, checkbox, checkbox-group, color-area, color-editor,
+color-field, color-slider, color-thumb, disclosure, drop-zone, field, file-trigger, group, input, kbd,
+link, list-box, loader, otp-field, popover, progress-bar, radio-group, select, separator, slider,
+switch, table, tabs, tag-group, text, text-field, time-field, toggle-button, toggle-button-group
+
+One-liner to install all showcase components after the init:
+
+```bash
+npx shadcn add \
+  https://dotui.com/r/accordion?preset=ENCODED \
+  https://dotui.com/r/avatar?preset=ENCODED \
+  https://dotui.com/r/badge?preset=ENCODED \
+  https://dotui.com/r/button?preset=ENCODED \
+  https://dotui.com/r/calendar?preset=ENCODED \
+  https://dotui.com/r/card?preset=ENCODED \
+  https://dotui.com/r/checkbox?preset=ENCODED \
+  https://dotui.com/r/checkbox-group?preset=ENCODED \
+  https://dotui.com/r/color-area?preset=ENCODED \
+  https://dotui.com/r/color-editor?preset=ENCODED \
+  https://dotui.com/r/color-field?preset=ENCODED \
+  https://dotui.com/r/color-slider?preset=ENCODED \
+  https://dotui.com/r/color-thumb?preset=ENCODED \
+  https://dotui.com/r/disclosure?preset=ENCODED \
+  https://dotui.com/r/drop-zone?preset=ENCODED \
+  https://dotui.com/r/field?preset=ENCODED \
+  https://dotui.com/r/file-trigger?preset=ENCODED \
+  https://dotui.com/r/group?preset=ENCODED \
+  https://dotui.com/r/input?preset=ENCODED \
+  https://dotui.com/r/kbd?preset=ENCODED \
+  https://dotui.com/r/link?preset=ENCODED \
+  https://dotui.com/r/list-box?preset=ENCODED \
+  https://dotui.com/r/loader?preset=ENCODED \
+  https://dotui.com/r/otp-field?preset=ENCODED \
+  https://dotui.com/r/popover?preset=ENCODED \
+  https://dotui.com/r/progress-bar?preset=ENCODED \
+  https://dotui.com/r/radio-group?preset=ENCODED \
+  https://dotui.com/r/select?preset=ENCODED \
+  https://dotui.com/r/separator?preset=ENCODED \
+  https://dotui.com/r/slider?preset=ENCODED \
+  https://dotui.com/r/switch?preset=ENCODED \
+  https://dotui.com/r/table?preset=ENCODED \
+  https://dotui.com/r/tabs?preset=ENCODED \
+  https://dotui.com/r/tag-group?preset=ENCODED \
+  https://dotui.com/r/text?preset=ENCODED \
+  https://dotui.com/r/text-field?preset=ENCODED \
+  https://dotui.com/r/time-field?preset=ENCODED \
+  https://dotui.com/r/toggle-button?preset=ENCODED \
+  https://dotui.com/r/toggle-button-group?preset=ENCODED
+```
+
+Replace `ENCODED` with the actual encoded preset string from `encodePreset(designSystem)`.
+`shadcn add` follows `registryDependencies` recursively, so installing `button` automatically
+pulls `loader` and `focus-styles` (bundled via init). The transitive rewrite in `publish.ts:83-104`
+ensures every recursive fetch carries the same preset.
+
+---
+
+## 5. Theme in globals.css
+
+`npx shadcn add <init-url>` merges the `registry:base` item produced by
+`emitInitItem` (`www/src/publisher/emit-theme.ts:71`) into the consumer's Tailwind CSS entry file.
+The resulting file contains, in order:
+
+```css
+/* 1. Imports and plugins — from base/base.css, constant across presets */
+@import "tailwindcss";
+@import "tw-animate-css";
+@plugin "tailwindcss-react-aria-components";
+@plugin "tailwindcss-autocontrast" { cssfile: "<this-file>"; }
+@plugin "tailwindcss-with";
+@custom-variant dark (&:is(.dark *));
+
+/* 2. Utility blocks — from base/base.css, constant */
+@utility focus-ring { … }
+@utility focus-input { … }
+@utility focus-reset { … }
+@utility no-highlight { … }
+
+/* 3. Layer base resets — constant */
+@layer base {
+  * { @apply border-border; }
+  body { @apply bg-bg font-sans text-fg; }
+  html { @apply font-sans; }
+}
+
+/* 4. @theme inline — semantic color tokens + radius scale, from base/theme.css, CONSTANT across presets */
+@theme inline {
+  --radius-md: calc(0.375rem * var(--radius-factor));
+  --color-bg: var(--neutral-50);
+  --color-accent: var(--accent-500);
+  --color-fg-on-accent: var(--on-accent-500);
+  /* ... all ~80 semantic tokens ... */
+}
+
+/* 5. :root — PRESET-SPECIFIC OKLCH primitive ramps */
+:root {
+  --radius-factor: 1;
+  --neutral-50: oklch(0.985 0 0);   /* ← user's chosen neutral seed, OKLCH-generated */
+  --neutral-100: oklch(0.953 0 0);
+  /* ... --neutral-* through --info-* (6 palettes × 11 steps = 66 vars) ... */
+  --accent-50: oklch(0.96 0.012 242.44);   /* ← user's chosen accent seed */
+  /* ... */
+  /* --dotui-density: comfortable;  ← only if density != "compact" */
+}
+
+/* 6. .dark — reversed ramps (same palettes, 50↔950 lightness swap) */
+.dark {
+  --neutral-50: oklch(0.13 0 0);
+  /* ... */
+}
+/* --on-accent-500 etc. are NOT emitted here — tailwindcss-autocontrast injects them at build */
+```
+
+The `@theme inline` block (section 4) is identical for every preset — it contains semantic
+indirections only (`--color-accent: var(--accent-500)`, etc.). Only sections 5 and 6 change per
+preset; `mergePresetCssFields` in `emit-theme.ts:145-170` handles this: when `preset.color` is
+present it calls `resolveColorConfig(preset.color)` then `rampsToVars(resolved.light/dark)` to
+override those 66 vars per palette. When `preset.color` is absent, the static default ramps from
+`__generated__/base-css.ts` are used unchanged.
+
+**Component-level CSS** (e.g. `--avatar-radius`, `@utility`-based skeleton animation) is emitted
+per-component — each `npx shadcn add @dotui/<name>` call merges the component's `css`/`cssVars`
+fields from its `/r/<name>?preset=<encoded>` response.
+
+---
+
+## 6. The showcase as first view
+
+The showcase `<Cards />` is not a route or page that Cursor can directly navigate to — it lives at
+`www/src/components/marketing/showcase/cards.tsx` as a React component. To make it the first view
+in the user's project:
+
+### Option A: copy showcase files into the generated project
+
+The showcase card files are plain React components (no server functions, no loaders, no routing).
+They can be copied verbatim from `www/src/components/marketing/showcase/*.tsx` into the user's
+project. dotUI must expose them for download — options:
+
+1. **Ship them as a registry item** — add a new `registry:page` (or `registry:component`) item
+   pointing at the showcase directory, fetchable via `npx shadcn add <url>`. The showcase files
+   themselves reference `@/registry/ui/*` imports that align with the shadcn-installed paths only
+   if the aliases are configured.
+2. **GitHub raw download** — link to the raw files on the main branch. Simpler but no preset
+   substitution.
+3. **Generated zip / template repo** — a new `/r/showcase.zip?preset=<encoded>` endpoint (see §7)
+   that bundles init + all showcase components + card files + a stub `App.tsx`.
+
+### Option B: document a one-step scaffold
+
+Until a showcase registry item or zip endpoint exists, the secondary button's copy-command output
+can include instructions:
+
+```
+# 1. Create project (example: Vite + React + TS)
+pnpm create vite my-dotui-app --template react-ts
+cd my-dotui-app
+
+# 2. Install dotUI theme + all showcase components
+npx shadcn init
+npx shadcn add https://dotui.com/r/init?preset=ENCODED
+npx shadcn add https://dotui.com/r/button?preset=ENCODED ...  (all 39 above)
+
+# 3. Copy showcase card files from dotUI source
+#    https://github.com/mehdibha/dotUI/tree/main/www/src/components/marketing/showcase/
+#    Place them at: src/components/marketing/showcase/
+
+# 4. Replace src/App.tsx with:
+#    import { Cards } from "@/components/marketing/showcase/cards";
+#    export default function App() { return <div className="p-8"><Cards /></div>; }
+
+# 5. Open in Cursor
+cursor my-dotui-app
+```
+
+The showcase requires these additional context files that are NOT installed by `shadcn add`:
+- `src/registry/lib/context/index.tsx` (`createContext`, `createVariantsContext`, `createScopedContext`)
+- `src/registry/hooks/use-image-loading-status.ts` (used by `avatar/base.tsx`)
+- `src/registry/__generated__/icons.tsx` (only `ExternalLinkIcon`; can be replaced with `import { ExternalLink } from "lucide-react"` directly)
+- `src/modules/core/styles.tsx` (`DesignSystemProvider`, `createStyles`)
+
+These are internal dotUI runtime files not yet shipped as separate registry items. They must be
+copied manually or added to a future registry item.
+
+### Provider wrapping
+
+The showcase needs a dark-mode class toggle (`class="dark"` on `<html>`). dotUI's own
+`ThemeProvider` from `packages/starter-themes` depends on `@tanstack/react-router`'s `ScriptOnce`
+and is not suited for arbitrary projects. Replace it with `next-themes` or any provider that
+toggles the `dark` class on `<html>`:
+
+```tsx
+// App.tsx (minimal, Vite)
+import { Cards } from "@/components/marketing/showcase/cards";
+
+export default function App() {
+  // DesignSystemProvider is optional — omit it for defaults
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg antialiased">
+      <main className="p-8">
+        <Cards />
+      </main>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. What dotUI must build
+
+### Blocker 1 — `/r/registry.json` index route (required for MCP)
+
+The shadcn `registry:mcp` subcommand needs a standard registry index at the `REGISTRY_URL`. Today
+`/r/registry.json` returns 404. A new TanStack Start server GET handler must be added:
+
+**File:** `www/src/routes/r/registry[.]json.tsx` (the `[.]` escapes the literal dot in file-based routing)
+
+**Shape to emit** (`www/src/registry/types.ts:80-82` — `Registry` = `{ name, homepage, items[] }`):
+
+```json
+{
+  "name": "dotui",
+  "homepage": "https://dotui.com",
+  "items": [
+    { "name": "accordion",  "type": "registry:ui",  "title": "Accordion",  "description": "..." },
+    { "name": "alert",      "type": "registry:ui",  "title": "Alert",      "description": "..." },
+    ...
+  ]
+}
+```
+
+The data is all available: `registryUi` + `registryLib` + `registryHooks` + `registryBase` from
+`www/src/registry/__generated__/registry-items.ts`. Strip `group`, `params`, `files[].content`
+(they don't belong in the index). The index does NOT need a preset — it is just a discovery
+manifest; the preset is wired per-item via the init step's `config.registries["@dotui"]`.
+
+**Cache headers:** follow the existing pattern from `$name.tsx:27-30`:
+`public, max-age=60, s-maxage=3600, stale-while-revalidate=86400`.
+
+### Blocker 2 — verify `shadcn registry:mcp` subcommand availability
+
+The `registry:mcp` subcommand was introduced in a shadcn canary/next build. Verify the exact
+version before shipping the button:
+
+```bash
+npx shadcn@latest registry:mcp --help
+# if unknown command, try:
+npx shadcn@canary registry:mcp --help
+```
+
+Update the `args` array in the server config (`"shadcn@latest"` vs `"shadcn@canary"`) accordingly.
+
+### Optional — showcase registry item or zip endpoint
+
+For the "showcase as first view" goal without requiring manual file copies:
+
+**Option A — registry:page item** for the showcase directory. Add a new item in
+`www/src/registry/` (e.g. `showcase/meta.ts`):
+
+```ts
+{
+  name: "showcase",
+  type: "registry:page",   // or "registry:component" — depends on shadcn schema version
+  files: [
+    { type: "registry:page", path: "components/marketing/showcase/cards.tsx",   target: "components/showcase/cards.tsx" },
+    { type: "registry:page", path: "components/marketing/showcase/booking.tsx", target: "components/showcase/booking.tsx" },
+    // ... all 17 card files ...
+  ],
+  registryDependencies: [/* all 39 components above */],
+}
+```
+
+Expose at `/r/showcase?preset=<encoded>`. Because the showcase imports `@/registry/ui/*` paths,
+the shadcn aliases in `components.json` must map `@/registry/ui/button` → `@/components/ui/button`
+etc. — this may require alias remapping in the emitted files. Significant work; evaluate whether
+it is in scope.
+
+**Option B — zip endpoint.** A new route `/r/showcase.zip?preset=<encoded>` that streams a zip
+containing: `globals.css` (from `emitInitItem`), all 39 component files (from `publish()`), the
+showcase card files, a stub `App.tsx`, `package.json`, and `vite.config.ts`. This is fully
+self-contained and requires no shadcn CLI on the consumer side, but it bypasses the `shadcn add`
+merge step for `globals.css` and must do the CSS merge server-side.
+
+### Non-blocking enhancements
+
+- **`tokens` round-trip through init**: `emit-theme.ts:62-68` documents the TODO — global tokens
+  (e.g. `--radius-factor` override) are not yet written to `:root`. Wire `preset.tokens` into
+  `emitPresetLightVars` and expand `PublishPreset` (`www/src/publisher/types.ts:79`) to carry `tokens`.
+- **Showcase context files as registry items**: extract `lib/context`, `hooks/use-image-loading-status`,
+  `modules/core/styles.tsx` as registered items so `shadcn add @dotui/showcase` can pull everything
+  transitively without manual copies.
+
+---
+
+## 8. Schema / meta.ts changes
+
+No changes to `RegistryItem` (`www/src/registry/types.ts:69`) are required for either button.
+
+If a showcase registry item is implemented (Option A above), add it to the registry with any of
+the existing `type` values supported by the shadcn schema. The build glob
+(`scripts/registry-build.ts:370`) will auto-discover a new `showcase/meta.ts` under
+`www/src/registry/`. Integrity guards only check `name` uniqueness, declared `registryDependencies`,
+and `files` — a showcase item with all its deps declared will pass.
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+| Issue | Impact | Fallback |
+|---|---|---|
+| `/r/registry.json` does not exist today | MCP button is fully blocked | Build the index route first (§7 Blocker 1) |
+| `registry:mcp` subcommand may require shadcn canary | MCP server install fails silently | Pin the working version in `args`; show version in tooltip |
+| `cursor://` deep-link only works if Cursor is installed | Click does nothing on machines without Cursor | Add `title` attribute: "Requires Cursor desktop app" |
+| `cursor://` deep-link does not open a specific file or folder | User lands in Cursor without the project open | Pair with the copy-command button for project setup |
+| MCP install alone does NOT pre-install components | User must run `shadcn add` commands manually or via agent | Document this clearly; the copy-command button handles it |
+| `tokens` not wired through init | `--radius-factor` overrides in user preset are lost | Acceptable gap; plain color + density + component params all work |
+| Showcase context files not in registry | `<Cards />` fails to compile without manual copies | Document the 4 extra files; or land §7 Optional before launch |
+| GitHub avatar CDN images in showcase | May fail in offline/restricted environments | `AvatarFallback` already handles missing images gracefully |
+| `DesignSystemProvider` from `starter-themes` depends on TanStack Router | Not portable to plain Vite/Next.js | Replace with `next-themes` or an inline `<script>` for dark mode |
+| Color `fixed` algorithm stripped by `sanitizeColor` | A preset with `algorithm:"fixed"` falls back to default colors | Codec fallback is intentional; document it |
+
+---
+
+## 10. Step-by-step implementation checklist
+
+### Phase 0 — Prerequisite (blocks MCP path)
+
+- [ ] **Create `/r/registry.json` route**
+  - File: `www/src/routes/r/registry[.]json.tsx`
+  - Import `registryUi`, `registryLib`, `registryHooks`, `registryBase` from their re-export barrels
+  - Emit `{ name: "dotui", homepage: "https://dotui.com", items: [...] }` stripping `group`, `params`, `files`
+  - Add the same `Cache-Control` headers as `$name.tsx:27-30`
+  - Verify: `curl https://dotui.com/r/registry.json | jq '.items | length'` should return 63+
+
+### Phase 1 — MCP install button
+
+- [ ] Verify `shadcn@latest registry:mcp` works (or determine the correct pinned version)
+- [ ] Build the server config JSON and base64-encode it:
+
+```ts
+const serverConfig = {
+  command: "npx",
+  args: ["-y", "shadcn@latest", "registry:mcp"],   // pin version if needed
+  env: { REGISTRY_URL: "https://dotui.com/r/registry.json" }
+};
+const configB64 = btoa(JSON.stringify(serverConfig));
+const deeplinkUrl = `cursor://anysphere.cursor-deeplink/mcp/install?name=dotUI-registry&config=${configB64}`;
+```
+
+- [ ] Add an `OpenInCursor` button component (e.g. `www/src/components/marketing/open-in-cursor.tsx`):
+  - Renders an `<a href={deeplinkUrl}>` with the Cursor icon
+  - No preset param needed in the deep-link URL (preset lives in the per-item URLs baked by init)
+  - Add `title="Requires Cursor desktop app"` for discoverability
+- [ ] Place button in the customizer panel (`www/src/modules/create/`) next to the existing `InstallCommand`
+- [ ] Manual test: click button on a machine with Cursor installed; confirm MCP panel shows the server
+
+### Phase 2 — Copy-command button (secondary, showcase-preinstalled)
+
+The `InstallCommand` component (`www/src/modules/create/install-command.tsx`) already computes
+`npx shadcn add <init-url?preset=encoded>`. The secondary button is essentially a styled version
+of this that also includes the per-component add commands for the full showcase set.
+
+- [ ] Create a `CopyShowcaseInstallCommand` component that builds a multi-line script:
+
+```ts
+function buildShowcaseScript(host: string, encoded: string | undefined): string {
+  const presetSuffix = encoded ? `?preset=${encoded}` : "";
+  const initUrl = `${host}/r/init${presetSuffix}`;
+  const componentUrls = SHOWCASE_COMPONENT_NAMES.map(
+    (name) => `  ${host}/r/${name}${presetSuffix} \\`
+  ).join("\n");
+  return [
+    `npx shadcn add ${initUrl}`,
+    `npx shadcn add \\`,
+    componentUrls,
+  ].join("\n");
+}
+
+const SHOWCASE_COMPONENT_NAMES = [
+  "accordion","avatar","badge","button","calendar","card","checkbox","checkbox-group",
+  "color-area","color-editor","color-field","color-slider","color-thumb","disclosure",
+  "drop-zone","field","file-trigger","group","input","kbd","link","list-box","loader",
+  "otp-field","popover","progress-bar","radio-group","select","separator","slider",
+  "switch","table","tabs","tag-group","text","text-field","time-field",
+  "toggle-button","toggle-button-group"
+];
+```
+
+- [ ] The button copies this script and shows a tooltip: "Installs all showcase components with your preset"
+
+### Phase 3 — Documentation
+
+- [ ] In the README / `/docs/open-in-cursor` page, explain:
+  - The MCP button installs an agent tool; it does not pre-install components
+  - Run the copy-command script in a new project first, then `cursor <dir>` to open it
+  - The 4 internal files that must be copied manually until they become registry items:
+    `src/registry/lib/context/index.tsx`, `src/registry/hooks/use-image-loading-status.ts`,
+    `src/registry/__generated__/icons.tsx`, `src/modules/core/styles.tsx`
+
+### Phase 4 — Optional polish
+
+- [ ] Wire `tokens` through init (`emit-theme.ts:62-68` TODO) so `--radius-factor` overrides land in `:root`
+- [ ] Extract `lib/context`, `hooks/use-image-loading-status`, and `modules/core/styles.tsx` as registered
+      items, so `shadcn add @dotui/context` and `@dotui/use-image-loading-status` work
+- [ ] Evaluate shipping a `showcase` registry item (§7 Option A) so a single
+      `npx shadcn add https://dotui.com/r/showcase?preset=<encoded>` installs everything
+
+---
+
+## Sources
+
+- Cursor MCP install deep-link: `cursor://anysphere.cursor-deeplink/mcp/install?name=...&config=...`
+  documented in Cursor's changelog and the shadcn registry docs (verify current version at
+  https://cursor.com/changelog and https://ui.shadcn.com/docs/registry/registry-json)
+- shadcn registry MCP server command: `npx shadcn registry:mcp` with `REGISTRY_URL` env var;
+  see https://ui.shadcn.com/docs/registry/registry-json for the registry index shape
+- shadcn `registry:base` item and `cssVars.light/.dark` merge behaviour: https://ui.shadcn.com/docs/registry/registry-json
+- dotUI preset codec: `www/src/modules/create/preset/codec.ts:75-126` (pako deflate + base64url)
+- dotUI init route: `www/src/routes/r/init.tsx` + `www/src/publisher/emit-theme.ts:71-170`
+- dotUI per-component route: `www/src/routes/r/$name.tsx` + `www/src/publisher/publish.ts:119-161`
+- dotUI install command (live): `www/src/modules/create/install-command.tsx:39-48`
+- Showcase component list: `www/src/components/marketing/showcase/cards.tsx`
+- Registry item types: `www/src/registry/types.ts:43-78`
+- Tailwind v4 cssVars limitation (shadcn issue #7119): colors must be in `cssVars.light/.dark`,
+  not `cssVars.theme` only, for shadcn CLI to write them to globals.css

--- a/docs/research/open-in/figma.md
+++ b/docs/research/open-in/figma.md
@@ -1,0 +1,446 @@
+# Open in Figma
+
+> Summary line: **possible (custom plugin, the realistic path)** · button type **plugin** · preset fidelity **full** · color fidelity **partial** (OKLCH → sRGB hex/RGBA, lossy at out-of-sRGB hues)
+
+Figma **cannot render React**, so the literal goal ("land in a working project that renders the showcase using themed installed components") is not achievable inside Figma. The faithful reinterpretation for a design tool is: **dynamically generate Figma Component Sets + a Variables collection from dotUI metadata + the chosen preset's tokens**, so a designer opens a Figma file whose first page is a *showcase frame* assembled from real dotUI component instances, all bound to Variables whose values are the user's preset. This is the deep design doc the user asked for: a new `figma` block on each `meta.ts`, a generator algorithm, and the OKLCH→RGB pipeline.
+
+This is **net-new dotUI work** (no Figma path consumes a shadcn registry today). The realistic mechanism is a **Figma plugin** (Plugin API runs in the file and can create nodes + variables); the Variables REST *write* API is Enterprise-only and is documented here only as a fallback.
+
+---
+
+## 1. User experience
+
+From the dotUI `/create` customizer (state lives in `?preset=<encoded>`, see `www/src/routes/_app/create.tsx:11-16`), the user clicks **"Open in Figma"**. Because a browser cannot push nodes into the Figma desktop/web canvas directly, the realistic flow is:
+
+1. The button opens Figma to the **dotUI Figma plugin** (deep link `figma://` / the plugin's community page) and hands it the preset. Two concrete handoffs:
+   - **Preferred:** copy a one-line command / token to the clipboard and instruct "run the dotUI plugin, paste". The plugin pulls everything from dotUI endpoints by preset.
+   - **Lower-friction:** a published plugin with a "Paste dotUI link" field; the user pastes `https://dotui.com/create?preset=<encoded>` (or just the `<encoded>` string).
+2. Inside Figma the plugin shows a short progress UI ("Reading dotUI registry… generating Variables… building component sets… assembling showcase"), then:
+   - Creates a **Variables collection** `dotui` with modes **Light** / **Dark**, populated from the preset's resolved ramps + semantic aliases (section 5).
+   - Creates one **Component Set** per dotUI component declared with a `figma` block (Button, Card, Input, Select, …), each with **variant properties** (`variant`, `size`, `state`) and fills/strokes/radii/text **bound to Variables** (section 8).
+   - Assembles a **"Showcase" page** as the first/active page: a frame mirroring `www/src/components/marketing/showcase/cards.tsx` (Login form, Booking, Notifications, …) built from **instances** of those component sets, so the showcase is what the designer sees on open — themed with their preset.
+
+What they land in: a Figma file (or the current file) where page 1 = the themed cards showcase, the component sets are reusable and variant-driven, and switching the collection's mode flips Light/Dark. "Components installed" becomes "component sets generated"; "theme in globals.css" becomes "Variables collection"; "their preset" is honored because every value is sourced from the decoded `?preset`.
+
+---
+
+## 2. Technical mechanism
+
+Figma's only in-canvas write surface that a third party can ship for free is a **plugin** using the **Plugin API** (runs in a sandbox inside Figma, full read/write to nodes + the Variables API). References:
+
+- Plugin API overview & `figma.createComponent` / `ComponentSetNode` (combine-as-variants): <https://www.figma.com/plugin-docs/api/properties/figma-createcomponent/> and <https://www.figma.com/plugin-docs/api/ComponentSetNode/>
+- Variables in plugins: `figma.variables.createVariableCollection`, `createVariable`, `setValueForMode`, `setBoundVariable`: <https://www.figma.com/plugin-docs/api/figma-variables/>
+- Component **properties** (variant + boolean/text/instance-swap): <https://www.figma.com/plugin-docs/api/ComponentProperties/>
+- Auto layout via plugin (`layoutMode`, `itemSpacing`, `paddingLeft`…): <https://www.figma.com/plugin-docs/api/properties/nodes-layoutmode/>
+
+**Entry point:** the plugin `main` (`code.ts`) running under `figma.*`. It fetches dotUI data over HTTPS (plugins may `fetch` with a `networkAccess.allowedDomains` manifest entry, e.g. `https://dotui.com`). The two pieces of dotUI data it needs:
+
+1. The **registry index** + per-item `figma` metadata → tells the plugin *what* to build and *how* (anatomy, variant→property map, token bindings). This is the new payload dotUI must serve (section 7).
+2. The **preset's resolved tokens** → the Variable values. Derived from the same `?preset` string via dotUI's codec + `resolveColorConfig` (section 3, 5).
+
+The REST **Variables write** endpoints (`POST /v1/files/:key/variables`) exist but are **Enterprise-only** and write to a file you already own — unusable as a public "open in" path. Documented as fallback in section 9. Source: <https://www.figma.com/developers/api#variables>.
+
+---
+
+## 3. Preset propagation
+
+The chosen preset never reaches Figma as React state; it reaches the plugin as the **same `?preset=<encoded>` string** dotUI already produces, and the plugin (or a dotUI endpoint it calls) decodes it with dotUI's existing codec.
+
+The wire format is fixed (from `www/src/modules/create/preset/codec.ts`): `encodePreset(ds)` diffs the `DesignSystem` against `DEFAULTS` (`www/src/modules/create/preset/defaults.ts`), `JSON.stringify`s the compact `{p,t,d,c}` (`www/src/modules/create/preset/types.ts:14-19`), `pako.deflateRaw(json,{level:9})`, then URL-safe base64 (`toBase64Url`, `codec.ts:12-21`). `decodePreset` is the exact inverse and merges back over `DEFAULTS`, returning a full `DesignSystem` `{ componentParams, tokens, density, color? }`.
+
+Two ways the plugin gets the decoded preset:
+
+- **Plugin decodes locally (recommended).** Reimplement the contract in the plugin: base64url → `pako.inflateRaw` → `JSON.parse` → merge over a copy of dotUI's `DEFAULTS`. `pako` is already a dotUI dependency (`www/package.json:46`) and runs fine in the plugin sandbox. The only field the plugin cares about for theming is `color: ColorConfig` (seeds + algorithm + knobs); `density` selects which auto-layout sizing block to read; `componentParams` selects enum variants / scalar radii.
+- **dotUI resolves server-side (simplest plugin).** The plugin calls a new endpoint `GET /r/figma/tokens?preset=<encoded>` (section 7) that runs `decodePreset` + `resolveColorConfig` and returns ready-to-bind RGB values. This keeps OKLCH→RGB math (and `colorjs.io`) on the server and out of the plugin bundle.
+
+Critical fidelity note: the preset is the **user's chosen** state, not the default. `encodePreset` returns `undefined` when the design system equals defaults (`codec.ts:84-89`), so the button must handle "no preset" by falling back to `DEFAULT_COLOR_CONFIG` (`www/src/registry/theme/color-config.ts:72-83`) — the plugin must generate the *default* palette in that case, never an empty collection.
+
+Also note the existing `/r/$name` route **drops `color`** from the preset (`www/src/routes/r/$name.tsx:113-121` returns only `{ density, componentParams }`); color only survives on `/r/init`. The Figma path must therefore source color from `/r/init`-style resolution or its own decode, **not** from the per-component route.
+
+---
+
+## 4. Components installed
+
+"Installed components" maps to **generated Component Sets**, one per dotUI ui item that declares a `figma` block. The plugin does not consume the React `base.tsx` (Figma can't run it); it consumes the **anatomy + bindings** from the new `figma` meta plus the registry's existing structure.
+
+How every needed component lands as a node tree:
+
+1. **Discovery.** The plugin fetches the registry index (the `/r/registry.json` dotUI must add, section 7) and filters to items whose descriptor has `figma`. The canonical name list already exists as `registryUi` (`www/src/registry/__generated__/registry-items.ts`, 60 items) — `registry.json` is generated from it (section 7).
+2. **Transitive deps.** The showcase needs composites (e.g. `Select` depends on `button, field, list-box, popover` per `www/src/registry/ui/select/meta.ts:14`; `LoginForm` uses `Card`, `TextField`/`Input`, `Button`, `Link`). The plugin must build dependencies **first** so a composite can place **instances** of its parts. Dependency order comes straight from each item's `registryDependencies` (a DAG); topologically sort it (the same names the publisher rewrites in `rewriteDeps`, `www/src/publisher/publish.ts:79-105`). For Figma the deps mean "child component instances", not file fetches.
+3. **Variant params from real metadata.** Enum params already encode the variant axes the publisher uses (`alert.style`, `loader.style`, etc., `www/src/registry/types.ts:43-49`). The Button's variant matrix is authoritative in `www/src/registry/ui/button/styles.ts` (`variant`: default/primary/quiet/link/warning/danger; `size`: xs/sm/md/lg; `isIconOnly`). The `figma` block restates these as Figma component properties (section 8) so a generated set has the same variant cells.
+4. **Result.** Each component becomes a `ComponentSetNode` (variants combined via `figma.combineAsVariants`), living on a "Components" page; the showcase page uses instances. This is the Figma analogue of "every needed component present under `ui/`".
+
+---
+
+## 5. Theme in globals.css → Figma Variables
+
+In a code project the preset's OKLCH tokens land in `globals.css` via `emitInitItem` (`www/src/publisher/emit-theme.ts:71-128`): primitive ramps in `:root`/`.dark` and the constant `@theme inline` semantic layer in `cssVars.theme`. **Figma has no CSS** — the equivalent is a **Variables collection** with two modes. The mapping is direct and lossless in *structure*, lossy only in *color space*.
+
+### 5a. What gets created
+
+A collection `dotui` with modes `Light` and `Dark`, and two tiers of variables that mirror dotUI's two CSS tiers:
+
+- **Primitive tier** — one `COLOR` variable per `--<palette>-<step>` (6 palettes × 11 steps = 66), e.g. `primitives/neutral/500`, `primitives/accent/500`. Light mode = `resolved.light`, Dark mode = `resolved.dark`. Source of the ramps: `resolveColorConfig(preset.color)` → `{ steps, light, dark }` (`www/src/registry/theme/primitives.ts:67-108`). The dark ramp is the reversed-lightness ladder dotUI already computes (`reverseRamp`, `primitives.ts:28-37`) — so Figma's dark mode matches the site exactly.
+- **Semantic tier** — one variable per `--color-*` token from `DEFAULT_SEMANTICS` (`www/src/registry/theme/semantics.ts:36-124`), e.g. `semantic/bg`, `semantic/accent`, `semantic/fg-on-accent`, **aliased** to the matching primitive variable (`setBoundVariable`/alias), reproducing dotUI's `--color-bg: var(--neutral-50)` indirection. Because the semantic layer is **constant across presets**, only the primitive values change per preset — exactly dotUI's model.
+
+### 5b. The `--on-*` (contrast foreground) problem
+
+In code, `--on-accent-500` etc. are **not shipped**; the consumer's `tailwindcss-autocontrast` plugin derives them at build (`emit-theme.ts:152-159`). Figma has no such plugin, so the plugin must **precompute** them. dotUI already has the exact replica: `onBlackWhite(background)` (`packages/colors/src/shared/on-color.ts:88-97`), kept in lockstep with the plugin via a parity test. The Figma generator computes `--on-<palette>-<step>` per step with `onBlackWhite` and stores them as primitive variables, so `semantic/fg-on-accent` aliases a real value.
+
+### 5c. OKLCH → RGB conversion (the hard requirement)
+
+dotUI emits **only `oklch()` strings** (`oklchCss`, `packages/colors/src/shared/color.ts:54-60`). The Figma Plugin API `RGB`/`RGBA` takes **0..1 sRGB channels** (<https://www.figma.com/plugin-docs/api/RGB/>). So every ramp value must be converted:
+
+```ts
+// dotUI already has the seam — packages/colors/src/shared/color.ts
+import { toSrgb } from "@dotui/colors/shared/color"; // toSrgb({l,c,h}|string) -> {r,g,b} in 0..1
+import { gamutMap, toOklch } from "@dotui/colors";
+
+function oklchToFigmaRGB(oklch: string): { r: number; g: number; b: number } {
+  const mapped = gamutMap(toOklch(oklch)); // CSS Color 4 chroma-reduce+clip into sRGB
+  return toSrgb(mapped);                   // already 0..1, exactly Figma's RGB shape
+}
+```
+
+`gamutMap` first is essential: vivid OKLCH at light/dark ends sits **outside sRGB**, and Figma stores sRGB — without gamut mapping the raw clip would shift hue. This is the documented lossiness: in-gamut steps are exact; out-of-gamut steps are perceptually nudged (same nudge dotUI's own swatches use). **`toSrgb` is currently NOT exported from the package barrel** (`packages/colors/src/index.ts:39` exports `gamutMap, oklchCss, toOklch, apca, wcag2` but not `toSrgb`) — dotUI must add it (one line) or expose a `toHex`/`toFigmaRGB` helper next to `oklchCss` (section 7).
+
+For HSL (if a swatch UI or fallback needs it) the same seam goes through `colorjs.io`'s `srgb→hsl`; centralize it behind `color.ts` rather than importing `colorjs.io` in the plugin.
+
+### 5d. Density / radius
+
+Density isn't a color. In code it's baked into class strings (`buttonStyles` has per-density `compact`/`default`/`comfortable` blocks, `www/src/registry/ui/button/styles.ts:40-74`). For Figma, the `figma` meta declares per-density auto-layout numbers (height/padding/gap) and the plugin reads the block for `preset.density`. Radius (`--radius-*` = `calc(base * --radius-factor)`, `www/src/registry/base/theme.css:8-17`) becomes a `FLOAT` Variable `radius/md` etc., bound to each node's `cornerRadius`, computed from the preset's `--radius-factor` if present in `tokens` (note: `tokens` currently doesn't reach the publisher, `emit-theme.ts:62-68`; the Figma path can read it directly from the decoded `DesignSystem.tokens`).
+
+---
+
+## 6. The showcase as first view
+
+The portable showcase entry is `www/src/components/marketing/showcase/cards.tsx` — a masonry of 17 cards (`Booking`, `TwoFactor`, `Notifications`, `LoginForm`, …). Figma can't import that React file, so the generator builds a **declarative mirror**: a "Showcase" page (set as `figma.currentPage` so it's the open view) containing a frame per card, each card frame assembled from **instances** of the generated component sets.
+
+Two ways to get the layout into the plugin:
+
+- **Hand-authored showcase manifest (recommended, accurate).** dotUI ships `www/src/registry/figma/showcase.ts`: a JSON description of each card (which components, props/variant values, sample text, layout). The plugin walks it and places instances. This mirrors `cards.tsx` 1:1 and is what the user sees first. Example card descriptor for `LoginForm` (mirrors `www/src/components/marketing/showcase/login-form.tsx`):
+
+  ```jsonc
+  {
+    "id": "login-form",
+    "component": "card",
+    "layout": { "direction": "vertical", "gap": 16, "padding": 24, "width": 320 },
+    "children": [
+      { "component": "text", "props": { "style": "title" }, "content": "Login to your account" },
+      { "component": "text", "props": { "style": "muted" }, "content": "Enter your email below to login" },
+      { "component": "text-field", "props": { "label": "Email address" } },
+      { "component": "button", "props": { "variant": "primary", "size": "md" }, "content": "Continue with email" }
+    ]
+  }
+  ```
+
+- **Auto-derived (lossy).** Parse `cards.tsx` at build with the same `ts-morph` already used in `scripts/registry-build.ts` to emit a rough manifest, then hand-correct. Cheaper to start, but JSX→layout inference is imperfect; the hand-authored manifest is the maintainable source.
+
+Providers/imports have no Figma analogue: there's no `ThemeProvider` — "dark mode" is the collection's Dark mode; there's no `cn`/react-aria runtime. The showcase frame simply consumes the generated sets and Variables. The result is showcase-first parity: the designer opens the file on the themed cards, exactly as the website's home (`www/src/routes/_app/index.tsx:51-53`) shows them.
+
+---
+
+## 7. What dotUI must build
+
+Concrete, referencing real paths/functions:
+
+1. **`/r/registry.json` index route** — `www/src/routes/r/registry[.]json.tsx` (literal dot). No such route exists today (confirmed: only `$name.tsx` + `init.tsx` under `www/src/routes/r/`). Import `registryBase`, `registryUi`, `registryLib`, `registryHooks` and emit the shadcn `Registry` shape (`www/src/registry/types.ts:80-82`). Needed both for shadcn MCP discovery and as the Figma plugin's component catalog. Cache headers as in `$name.tsx:27-30`.
+
+2. **Per-item `figma` metadata in the index.** Extend each `meta.ts` with an optional `figma` block (section 8) and surface it in `registry.json` descriptors (and/or a dedicated `GET /r/figma/manifest?preset=<encoded>`). This is the *what to build* payload.
+
+3. **`GET /r/figma/tokens?preset=<encoded>`** — a new server route that runs `decodePreset` (`www/src/modules/create/preset/codec.ts:111`) → `resolveColorConfig(ds.color ?? DEFAULT_COLOR_CONFIG)` (`www/src/registry/theme/primitives.ts:67`) → for every ramp step convert OKLCH→sRGB and compute `onBlackWhite` (`packages/colors/src/shared/on-color.ts:88`), returning:
+
+   ```jsonc
+   {
+     "modes": ["light", "dark"],
+     "primitives": {
+       "light": { "neutral-50": {"r":0.98,"g":0.98,"b":0.98}, "accent-500": {"r":0.26,"g":0.55,"b":0.84}, "...": {} },
+       "dark":  { "neutral-50": {"r":0.13,"g":0.13,"b":0.13}, "...": {} }
+     },
+     "on": { "light": { "accent-500": {"r":1,"g":1,"b":1} }, "dark": { "...": {} } },
+     "semantic": { "bg": "neutral-50", "accent": "accent-500", "fg-on-accent": "on/accent-500", "...": "" },
+     "radius": { "md": 6, "lg": 8 },
+     "density": "compact"
+   }
+   ```
+
+   `semantic` mirrors `DEFAULT_SEMANTICS` (`www/src/registry/theme/semantics.ts`) as primitive references → the plugin makes them aliases. This keeps `colorjs.io` server-side.
+
+4. **Export `toSrgb` (and ideally `toFigmaRGB`/`toHex`) from `@dotui/colors`.** `toSrgb` lives in `packages/colors/src/shared/color.ts:42` but is absent from the barrel (`packages/colors/src/index.ts:39`). Add it so both the new route and any client converter share one seam.
+
+5. **The showcase manifest** `www/src/registry/figma/showcase.ts` (section 6) describing `cards.tsx` declaratively, plus a small generator/validator test that asserts every `component` referenced exists in `registryUi`.
+
+6. **The Figma plugin** (separate package, e.g. `packages/figma-plugin`): `manifest.json` with `networkAccess.allowedDomains: ["https://dotui.com"]`, `code.ts` (the generator, section 8), and a minimal `ui.html` with the "paste dotUI link" field. Published to the Figma Community; the "Open in Figma" button deep-links to it.
+
+7. **The "Open in Figma" button** on `/create` (alongside the existing install command, `www/src/modules/create/install-command.tsx`): builds the deep link / clipboard payload from the current `encodePreset(designSystem)` value (`www/src/modules/create/preset/use-design-system.ts`).
+
+---
+
+## 8. Schema / meta.ts changes
+
+This is the core ask. Add an **optional `figma` field** to `RegistryItem` (`www/src/registry/types.ts:69-78`), dropped from emitted shadcn JSON exactly like `group`/`params`. It is purely declarative metadata read by the plugin.
+
+### 8a. The `figma` schema, field by field
+
+```ts
+// additions to www/src/registry/types.ts
+export type FigmaTokenBinding =
+  | { kind: "fill"; token: string }        // token = semantic name, e.g. "accent" / "bg" / "fg-on-accent"
+  | { kind: "stroke"; token: string }
+  | { kind: "text"; token: string }        // text color
+  | { kind: "radius"; token: string }      // e.g. "md"  -> radius/md FLOAT var
+  | { kind: "opacity"; value: number };
+
+export interface FigmaLayer {
+  /** Stable node name in the generated component. */
+  name: string;
+  /** "frame" => auto-layout container; "text"; "icon"; "instance" (swap-in another component set). */
+  type: "frame" | "text" | "icon" | "instance";
+  /** For type:"instance", the dotUI component name to place (must be in registryUi). */
+  component?: string;
+  /** Variable bindings applied to this layer. */
+  bind?: FigmaTokenBinding[];
+  /** Static fallback content for text layers / sample data. */
+  content?: string;
+  /** Nested layers (only meaningful for frames). */
+  children?: FigmaLayer[];
+  /** Which variant values hide/show this layer, e.g. only render when state="loading". */
+  showWhen?: Record<string, string>;
+}
+
+/** Maps a dotUI param (or synthetic axis) to a Figma component property. */
+export interface FigmaVariantMapping {
+  /** Figma property name shown in the right panel. */
+  property: string;
+  /** "VARIANT" (1-of-N), "BOOLEAN", "TEXT", or "INSTANCE_SWAP". */
+  propertyType: "VARIANT" | "BOOLEAN" | "TEXT" | "INSTANCE_SWAP";
+  /** Source of values: a dotUI enum param name, or "$state"/"$size"/"$variant" synthetic axes. */
+  source: string;
+  /** Explicit value list (defaults to the param's `values` when source is a real enum param). */
+  values?: readonly string[];
+  default?: string;
+}
+
+/** Per-density auto-layout numbers (sourced from the component's density tv block). */
+export interface FigmaDensitySizing {
+  height?: number;        // fixed height, px
+  paddingX?: number;
+  paddingY?: number;
+  gap?: number;           // itemSpacing
+}
+
+export interface FigmaMeta {
+  /** Root auto-layout. direction -> layoutMode; padding/gap default from density unless overridden. */
+  layout: {
+    direction: "horizontal" | "vertical" | "none";
+    align?: "min" | "center" | "max" | "space-between";
+    /** Per-density sizing; keys: "compact" | "default" | "comfortable". */
+    sizing?: Partial<Record<Density, FigmaDensitySizing>>;
+  };
+  /** The component's node tree (anatomy). */
+  anatomy: FigmaLayer[];
+  /** Variant axes -> Figma component properties. */
+  variants: FigmaVariantMapping[];
+  /** Default sample content if anatomy text layers omit `content`. */
+  sample?: Record<string, string>;
+  /** Whether to also generate state cells (hover/pressed/disabled) as variants. */
+  states?: readonly string[]; // e.g. ["default","hover","pressed","disabled"]
+}
+
+export type RegistryItem = ShadcnRegistryItem & {
+  group?: ComponentGroup | null;
+  params?: Record<string, ParamDef>;
+  figma?: FigmaMeta;   // NEW — declarative, dropped from emitted JSON
+};
+```
+
+Field rationale, tied to dotUI internals:
+
+- **`layout.direction` → `node.layoutMode`** (`"horizontal"|"vertical"`), `align` → `primaryAxisAlignItems`/`counterAxisAlignItems` (<https://www.figma.com/plugin-docs/api/properties/nodes-layoutmode/>). Buttons are `horizontal` + `center`.
+- **`layout.sizing` per density** comes from the tv density blocks. For Button, `compact.md = "h-7 px-2 gap-1"` (`styles.ts:47`), `default.md = "h-8 px-2.5 gap-1.5"` (`styles.ts:58`), `comfortable.md = "h-9 px-2.5"` (`styles.ts:69`). The plugin picks the block for `preset.density` and sets `node.itemSpacing` (gap), `paddingLeft/Right` (px), and a fixed height.
+- **`anatomy` (`FigmaLayer[]`)** is the node tree. Each `bind` entry is resolved to a **Variable alias** at generation: `kind:"fill", token:"accent"` → bind the layer's `fills[0]` to the `semantic/accent` variable (`setBoundVariable("fills", var)`); `kind:"text", token:"fg-on-accent"` → bind the text node's fill to `semantic/fg-on-accent`. The token names are exactly the `--color-*` suffixes in `DEFAULT_SEMANTICS` (`semantics.ts`), so bindings reuse dotUI's vocabulary verbatim.
+- **`variants` (`FigmaVariantMapping[]`)** maps dotUI enum params to Figma variant properties. When `source` is a real enum param (e.g. `style` on Alert/Loader), `values` defaults to the param's `values`. Synthetic axes `$variant`/`$size`/`$state` cover axes that live in `styles.ts` rather than `params` (Button's `variant`/`size` are tv variants, not customizer params). `INSTANCE_SWAP` covers icon slots.
+- **`states`** drives generation of interaction cells. `buttonStyles` encodes hover/pressed/disabled/pending via Tailwind state variants (`styles.ts:11-12,17-23`); Figma can't run those, so the generator materializes them as extra variant cells with the resolved hover/pressed *colors* (e.g. `bg-primary-hover` → `accent-600` via semantics).
+
+### 8b. Concrete example — Button
+
+Mirrors `www/src/registry/ui/button/styles.ts` exactly (6 variants × 4 sizes × icon-only, hover/pressed/disabled).
+
+```ts
+// www/src/registry/ui/button/meta.ts  (added figma block)
+const buttonMeta = {
+  name: "button",
+  type: "registry:ui",
+  group: "buttons",
+  files: [{ type: "registry:ui", path: "ui/button/base.tsx", target: "ui/button.tsx" }],
+  registryDependencies: ["loader", "focus-styles"],
+  figma: {
+    layout: {
+      direction: "horizontal",
+      align: "center",
+      sizing: {
+        compact:     { height: 28, paddingX: 8,  gap: 4 },   // h-7 px-2  gap-1   (md)
+        default:     { height: 32, paddingX: 10, gap: 6 },   // h-8 px-2.5 gap-1.5
+        comfortable: { height: 36, paddingX: 10, gap: 6 },   // h-9 px-2.5
+      },
+    },
+    anatomy: [
+      {
+        name: "Button", type: "frame",
+        bind: [{ kind: "fill", token: "neutral" }, { kind: "radius", token: "md" }],
+        children: [
+          { name: "Label", type: "text", content: "Button", bind: [{ kind: "text", token: "fg-on-neutral" }] },
+        ],
+      },
+    ],
+    variants: [
+      // Button's variant/size are tv variants (styles.ts), exposed as synthetic axes:
+      { property: "Variant", propertyType: "VARIANT", source: "$variant",
+        values: ["default","primary","quiet","link","warning","danger"], default: "default" },
+      { property: "Size", propertyType: "VARIANT", source: "$size",
+        values: ["xs","sm","md","lg"], default: "md" },
+      { property: "Icon only", propertyType: "BOOLEAN", source: "$iconOnly", default: "false" },
+    ],
+    states: ["default", "hover", "pressed", "disabled"],
+    sample: { Label: "Button" },
+  },
+} satisfies RegistryItem;
+```
+
+How the generator reads this for `variant=primary`: it overrides the root frame's fill binding to `semantic/accent` and the label to `semantic/fg-on-accent` (because `styles.ts:18-19` is `bg-primary text-fg-on-primary`, and `--color-primary` maps via semantics; primary in the showcase resolves through the accent ramp). For `state=hover` it binds to `semantic/accent-hover` (`bg-primary-hover`). The cell matrix = `variant × size × iconOnly × state`.
+
+### 8c. Concrete example — a complex component (Select)
+
+`Select` is composite: a trigger `Button` + `ChevronDown` icon + a `Popover` containing a `ListBox` (`www/src/registry/ui/select/base.tsx`; deps `button, field, list-box, popover`, `select/meta.ts:14`). It demonstrates `instance` layers (reuse the Button/ListBox sets) and a multi-part anatomy.
+
+```ts
+// www/src/registry/ui/select/meta.ts (added figma block)
+figma: {
+  layout: { direction: "vertical", gap: 4, align: "min",
+    sizing: { compact: { gap: 4 }, default: { gap: 6 }, comfortable: { gap: 6 } } },
+  anatomy: [
+    { name: "Field", type: "frame", children: [
+      { name: "Label", type: "text", content: "Label", bind: [{ kind: "text", token: "fg" }] },
+      // The trigger reuses the Button component set (instance swap):
+      { name: "Trigger", type: "instance", component: "button",
+        children: [
+          { name: "Value", type: "text", content: "Select an option", bind: [{ kind: "text", token: "fg-muted" }] },
+          { name: "Chevron", type: "icon", bind: [{ kind: "fill", token: "fg-muted" }] },
+        ] },
+      // Open state surfaces the popover + listbox as a sibling, shown only when state=open:
+      { name: "Popover", type: "instance", component: "popover", showWhen: { state: "open" },
+        bind: [{ kind: "fill", token: "popover" }, { kind: "radius", token: "md" }],
+        children: [ { name: "Options", type: "instance", component: "list-box" } ] },
+    ] },
+  ],
+  variants: [
+    { property: "State", propertyType: "VARIANT", source: "$state",
+      values: ["closed","open","disabled"], default: "closed" },
+    { property: "Size", propertyType: "VARIANT", source: "$size", values: ["sm","md","lg"], default: "md" },
+  ],
+  states: ["default", "disabled"],
+  sample: { Label: "Country", Value: "Select an option" },
+},
+```
+
+Generation consequences: because `Trigger`/`Popover`/`Options` are `type:"instance"`, the plugin **requires** the `button`, `popover`, `list-box` component sets to exist first (the topological order from `registryDependencies`, section 4). `showWhen:{state:"open"}` makes the popover visible only in the `open` variant cell. `bind` tokens (`popover`, `fg-muted`, `fg`) are the same semantic names as `DEFAULT_SEMANTICS` (`color-popover`, `color-fg-muted`, …).
+
+### 8d. The generation algorithm (plugin `code.ts`)
+
+```text
+INPUT: registry.json (filtered to items with `figma`), figma manifest, tokens payload (section 7).
+
+1. THEME → VARIABLES
+   collection = figma.variables.createVariableCollection("dotui")
+   light = collection.defaultModeId; dark = collection.addMode("Dark")
+   for each primitive p in tokens.primitives.light:
+     v = createVariable("primitives/"+p, collection, "COLOR")
+     v.setValueForMode(light, rgb(tokens.primitives.light[p]))
+     v.setValueForMode(dark,  rgb(tokens.primitives.dark[p]))
+   same for tokens.on -> "on/<palette>-<step>"
+   for each semantic s -> primitive ref in tokens.semantic:
+     v = createVariable("semantic/"+s, collection, "COLOR")
+     v.setValueForMode(light, ALIAS(varByName("primitives/"+ref or "on/"+ref)))   // alias both modes
+     v.setValueForMode(dark,  ALIAS(...))
+   for each radius r in tokens.radius: createVariable("radius/"+r, collection, "FLOAT").setValue(both modes, px)
+
+2. COMPONENT SETS  (topological order by registryDependencies; deps first)
+   for each item with figma, in dep order:
+     sizing = item.figma.layout.sizing[tokens.density]
+     cells = cartesian(item.figma.variants × item.figma.states)
+     for each cell:
+       node = buildLayer(item.figma.anatomy[0], cell, sizing)   // recursive (step 3)
+       name node "<prop1>=<val1>, <prop2>=<val2>, ..."          // Figma variant naming
+     set = figma.combineAsVariants(cellNodes, componentsPage)
+     register set.id under item.name (so instance layers can swap it)
+
+3. buildLayer(layer, cell, sizing):
+   switch layer.type:
+     frame: n = figma.createFrame(); n.layoutMode = dir(layout); n.itemSpacing = sizing.gap
+            n.paddingLeft/Right = sizing.paddingX; if sizing.height fixed-height
+     text:  n = figma.createText(); n.characters = layer.content ?? sample[layer.name]
+     icon:  n = placeholder vector / instance of icon set
+     instance: n = instanceOf(register[layer.component]); apply cell.size if relevant
+   for each bind in layer.bind:
+     resolve token -> variable (variantOverride(cell) e.g. primary->accent, hover->accent-hover)
+     fill   -> n.fills = [bound paint]; setBoundVariable("fills", var)
+     stroke -> setBoundVariable on strokes
+     text   -> setBoundVariable text fill
+     radius -> setBoundVariable("topLeftRadius"... or cornerRadius) to radius var
+   if layer.showWhen and !matches(cell): n.visible = false
+   recurse children
+   return n
+
+4. SHOWCASE PAGE  (first/active view)
+   page = figma.createPage("Showcase"); figma.currentPage = page
+   root = autolayout frame (columns, gap 16) bound semantic/bg
+   for each card in manifest.showcase:
+     cardNode = buildCard(card)   // walks card.children, instancing component sets, setting variant props + text
+     append to root
+```
+
+`variantOverride(cell)` is the one piece of dotUI-specific logic: it translates a variant cell into which semantic token a binding resolves to, reading the same intent as `styles.ts` (e.g. `$variant=primary` ⇒ root fill `accent`, label `fg-on-accent`; `state=hover` ⇒ `accent-hover`). Encoding this in the `figma` block (e.g. an optional `variantBindings: Record<axisValue, FigmaTokenBinding[]>`) keeps it data-driven rather than hardcoded per component.
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+- **No direct browser→canvas write.** A web button cannot inject nodes into Figma. *Fallback:* publish a Community plugin and deep-link to it with the preset on the clipboard / in a paste field (section 1). This is the standard pattern for "open in Figma" integrations.
+- **OKLCH is not sRGB (color fidelity = partial).** Figma stores sRGB; OKLCH steps outside sRGB are gamut-mapped (`gamutMap`, `color.ts:48`), so the most saturated light/dark steps shift slightly. In-gamut steps are exact. There is no fix — sRGB is Figma's only color space for Variables today. Document the mapping so designers know vivid swatches are nudged.
+- **Variables REST write API is Enterprise-only.** The "no plugin" path (`POST /v1/files/:key/variables`) needs an Enterprise org token and an existing file you own — not viable as a public button. *Fallback:* plugin (the primary path).
+- **No interactivity / no React semantics.** Figma component sets are static; hover/pressed/disabled become **separate variant cells** with precomputed colors, not live states. Behavior (focus rings, react-aria, pending spinners) cannot be represented; only the resolved visual states.
+- **Composite drift.** The `figma` anatomy is hand-authored and can drift from `base.tsx` / `styles.ts`. *Mitigation:* a CI test asserting every `figma.anatomy[].component` and `variants[].source` enum exists in `registryUi` / the item's `params`, plus the showcase manifest references only real components (section 7.5).
+- **`--on-*` parity.** Figma foregrounds are precomputed with `onBlackWhite` (`on-color.ts:88`). If dotUI ever changes the autocontrast formula, the plugin must track it — the existing parity test (`www/src/registry/theme/on-color-parity.spec.ts`) is the guard to extend.
+- **Plugin bundle weight if decoding client-side.** Shipping `colorjs.io` into the plugin is heavy. *Mitigation:* the `/r/figma/tokens` endpoint (section 7.3) keeps OKLCH→RGB on the server; the plugin only consumes RGB.
+- **`?preset` absent.** When the user hasn't customized, `encodePreset` returns `undefined` (`codec.ts:84-89`); the plugin must generate the **default** palette from `DEFAULT_COLOR_CONFIG`, not an empty file.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+1. **Add `/r/registry.json`** (`www/src/routes/r/registry[.]json.tsx`) emitting the shadcn `Registry` shape from `registryUi`/`registryLib`/`registryHooks`/`registryBase`. (Also unblocks shadcn MCP.)
+2. **Define the `figma` schema** in `www/src/registry/types.ts` (`FigmaMeta`, `FigmaLayer`, `FigmaVariantMapping`, `FigmaDensitySizing`, `FigmaTokenBinding`); add optional `figma?` to `RegistryItem`; ensure the publisher drops it (it already drops non-shadcn fields in `www/src/publisher/publish.ts:145-158`).
+3. **Author `figma` blocks** for the components the showcase needs first: `button`, `card`, `text`, `text-field`/`input`, `select`, `checkbox`, `switch`, `link`, `avatar`, `badge`, `tooltip`, `loader` — mirroring each `styles.ts`. Start with Button (section 8b) and Select (section 8c).
+4. **Export `toSrgb`** from `packages/colors/src/index.ts` (and optionally add `toFigmaRGB`/`toHex` next to `oklchCss` in `packages/colors/src/shared/color.ts`).
+5. **Build `GET /r/figma/tokens?preset=<encoded>`** (`www/src/routes/r/figma.tokens.tsx`): `decodePreset` → `resolveColorConfig(ds.color ?? DEFAULT_COLOR_CONFIG)` → convert ramps (`gamutMap`+`toSrgb`) + `onBlackWhite` → emit the JSON in section 7.3. Mirror `DEFAULT_SEMANTICS` into the `semantic` map.
+6. **Write the showcase manifest** `www/src/registry/figma/showcase.ts` from `cards.tsx`, plus a validator test (every referenced component exists in `registryUi`).
+7. **Build the Figma plugin** (`packages/figma-plugin`): `manifest.json` (`networkAccess.allowedDomains:["https://dotui.com"]`), `code.ts` implementing the algorithm in section 8d (Variables → component sets → showcase page), minimal `ui.html` (paste link / progress). Use `figma.variables.*`, `figma.combineAsVariants`, auto-layout APIs.
+8. **Publish** the plugin to the Figma Community; capture its deep link / id.
+9. **Add the "Open in Figma" button** on `/create` next to `install-command.tsx`, building the deep link + clipboard payload from `encodePreset(designSystem)` (handle `undefined` → default).
+10. **Round-trip test:** customize a preset (custom accent + comfortable density), Open in Figma, verify (a) the collection's accent matches the site swatch within gamut, (b) Dark mode matches the reversed ramp, (c) the showcase page is the open view and component variants/sizes match `styles.ts`.
+11. **CI guards:** anatomy↔registry validator (step 6), `onBlackWhite` parity (extend `on-color-parity.spec.ts`), and a snapshot of `/r/figma/tokens` for the default preset.
+
+---
+
+## Sources
+
+- Figma Plugin API — overview & node creation: <https://www.figma.com/plugin-docs/>
+- `figma.createComponent` / Component nodes: <https://www.figma.com/plugin-docs/api/properties/figma-createcomponent/>
+- `ComponentSetNode` / combine as variants: <https://www.figma.com/plugin-docs/api/ComponentSetNode/>
+- Component properties (variant / boolean / instance-swap / text): <https://www.figma.com/plugin-docs/api/ComponentProperties/>
+- Variables in plugins (`createVariableCollection`, `createVariable`, `setValueForMode`, aliases, `setBoundVariable`): <https://www.figma.com/plugin-docs/api/figma-variables/>
+- Auto layout properties (`layoutMode`, `itemSpacing`, padding): <https://www.figma.com/plugin-docs/api/properties/nodes-layoutmode/>
+- `RGB`/`RGBA` color type (0..1 sRGB channels): <https://www.figma.com/plugin-docs/api/RGB/>
+- Variables REST API (Enterprise-only write): <https://www.figma.com/developers/api#variables>
+- Plugin manifest `networkAccess`: <https://www.figma.com/plugin-docs/manifest/>
+- OKLCH / CSS Color 4 gamut mapping background: <https://www.w3.org/TR/css-color-4/#gamut-mapping>

--- a/docs/research/open-in/framer.md
+++ b/docs/research/open-in/framer.md
@@ -1,0 +1,482 @@
+# Open in Framer
+
+> Summary line: **feasible with significant dotUI-side build work** · button type **plugin** · preset fidelity **full** · color fidelity **partial** (OKLCH ramps converted to hex/sRGB; out-of-gamut hues clip predictably via gamut mapping)
+
+Framer uses React code components but has its own styling model: **no Tailwind, no CSS Modules, no CSS custom-property-based theming at build time**. The dotUI source stack (React Aria Components + tailwind-variants + OKLCH CSS vars) cannot run as-is in Framer. The realistic path is a **separate, purpose-built Framer code-component library** (re-implementing dotUI's visual layer in Framer's inline-style/MotionValue idiom) plus a **preset-driven token injection** step that writes the chosen OKLCH palette as hex/rgba CSS variables into Framer's Site Settings > Custom Code > `<head>`. This document is the full design for that path.
+
+---
+
+## 1. User experience
+
+From the dotUI `/create` customizer — whose state lives in `?preset=<encoded>` on `www/src/routes/_app/create.tsx:12-16` — the user clicks **"Open in Framer"**. The realistic UX is:
+
+1. Clicking the button opens the **Framer website** at a deep-link that loads the dotUI Framer package page (e.g. `https://framer.com/m/<package-id>`). Framer packages are published as npm-compatible code-component bundles; the deep link installs the package into the open Framer project.
+2. In parallel (or via a secondary step) the user is shown a **"Copy theme CSS"** snippet — a `<style>` block containing their preset's hex tokens as CSS custom properties — which they paste into Framer's **Site Settings > Custom Code > Start of `<head>`**.
+3. Framer reloads the canvas. All dotUI Framer components that reference `var(--accent-500)` etc. now reflect the chosen preset palette.
+4. The user drags the **dotUI Showcase** page component (a pre-built Framer component mirroring `www/src/components/marketing/showcase/cards.tsx`) onto the canvas, or it is the default landing frame of the installed package. This is the "first view".
+
+What the user lands in: a Framer project where (a) the dotUI component library is installed as a code-component package, (b) the palette matches their chosen preset (injected as CSS variables), and (c) the default canvas page contains the showcase layout.
+
+Limitations vs the shadcn path: preset-driven **component style choices** (density, enum params like `card.style`, `loader.style`) are not automatically applied to the Framer components — those require separate variant properties exposed on the Framer component. The theme (color palette) is fully propagated; per-component param choices are propagated only if the Framer components expose matching Framer variant controls.
+
+---
+
+## 2. Technical mechanism
+
+### 2a. Why the dotUI registry/RAC source is not reusable in Framer
+
+Framer code components must be valid React components with **no build-time dependencies** on Tailwind CSS v4 (which processes class strings and `@plugin` directives), `tailwind-variants`, or the dotUI `createStyles`/`DesignSystemProvider` runtime (`www/src/modules/core/styles.tsx`). Specifically:
+
+- `tailwind-variants` produces `className` strings that are meaningful only when Tailwind's generated stylesheet is present. Framer has no Tailwind runtime.
+- OKLCH color values (`oklch(L C H)`) are embedded in CSS custom properties and consumed by Tailwind utility classes. Framer renders inline styles; CSS `var()` references work only if the property is declared in a `<style>` tag that Framer injects (via Custom Code) — not from a generated stylesheet.
+- `react-aria-components` (RAC) uses `data-[state]` attributes that hook into `tailwindcss-react-aria-components`'s `@plugin` variants. Those variants are processed at Tailwind compile time and do not exist at runtime.
+- The dotUI `DesignSystemProvider` writes CSS vars to `document.documentElement` via `useLayoutEffect` (`styles.tsx:106-117`). This can be replicated inside Framer's Custom Code, but the per-component param selections (enum/scalar) would need to be re-plumbed through Framer's property controls.
+
+The conclusion: **a separate Framer component library is required**, written using inline styles or Framer-idiomatic CSS (`MotionValue`, `style` prop, CSS custom properties referenced via `var()` in inline style objects), and referencing the preset CSS variables that are injected via Custom Code.
+
+### 2b. Framer code-component delivery
+
+Framer supports **code components** distributed as npm packages. The recommended path for a reusable component library is:
+
+1. Publish a package (e.g. `@dotui/framer`) to npm or a private registry.
+2. Users install it in Framer via **Packages > Add package** → npm package name, or via a Framer-hosted deep link (`https://framer.com/m/<package-id>` if the package is submitted to the Framer Marketplace).
+3. Components appear in the left panel under the package name and can be dragged onto the canvas.
+
+Each component in `@dotui/framer` must:
+- Reference CSS custom properties (`var(--accent-500)`, `var(--neutral-50)`, etc.) in its `style` props — these resolve against the injected `<style>` block.
+- Expose **Framer Property Controls** (`addPropertyControls`, `ControlType`) for the equivalent of dotUI's enum params (e.g. `style: "default" | "tasnim"` for `card`, `thumb-style: "solid" | "outline" | "bar" | "faceted"` for `slider`).
+- NOT import `tailwind-variants`, `react-aria-components`, or any Tailwind-dependent utility.
+
+### 2c. Button type: plugin vs deep link vs copy-command
+
+The "Open in Framer" button is best implemented as a **two-part action** on the dotUI `/create` page:
+
+- Part 1: a **package deep link** (opens `https://framer.com/m/<package-id>` or a Framer-hosted page with an "Add to Project" button). Button type: `component-url` (an external URL the browser opens). No Framer plugin API is invoked.
+- Part 2: a **copy-command** — a "Copy theme CSS" button that copies the preset's hex token block to the clipboard for pasting into Framer's Custom Code. This is the mechanism for preset color propagation (see section 3).
+
+There is no Framer API that allows a third-party website to inject CSS or install packages programmatically. The split (deep link for components + clipboard copy for tokens) is the correct realistic mechanism.
+
+---
+
+## 3. Preset propagation
+
+### 3a. The encoding source
+
+The preset string is produced by `encodePreset(ds: DesignSystem): string | undefined` in `www/src/modules/create/preset/codec.ts:75`. The wire format is:
+
+```
+base64url( deflateRaw( JSON.stringify( DesignSystemState ), level=9 ) )
+```
+
+where `DesignSystemState` = `{ p?, t?, d?, c? }` (only fields differing from defaults). The color recipe lives in `c?: ColorConfig` — `{ algorithm, seeds: { neutral, accent, success, warning, danger, info }, knobs? }`.
+
+### 3b. Decoding and resolving to hex
+
+The dotUI server at `GET /r/init?preset=<encoded>` calls `resolveColorConfig(preset.color)` (`www/src/publisher/emit-theme.ts:156`), which invokes:
+
+1. `resolveColorConfig` (`www/src/registry/theme/primitives.ts:67-108`) — calls `@dotui/colors`'s `createTheme` with the seeds/algorithm/knobs.
+2. Returns `ResolvedPalettes { steps, light, dark }` where each palette is a `Record<step, oklch(L C H)>` string.
+
+For Framer, the OKLCH values must be converted to hex. The conversion seam is `packages/colors/src/shared/color.ts`:
+- `gamutMap(oklch): Oklch` — maps out-of-sRGB values into gamut (CSS Color 4 chroma reduction).
+- `toSrgb(oklch): {r,g,b}` (channels 0..1).
+- Hex: `#${[r,g,b].map(c => Math.round(c*255).toString(16).padStart(2,'0')).join('')}`.
+
+There is no exported `toHex` function today; a new helper should be added to the `@dotui/colors` package (or to `packages/colors/src/shared/color.ts:54+`) and exported via the barrel at `packages/colors/src/index.ts:39`.
+
+### 3c. The "Copy theme CSS" output
+
+The dotUI server (or a new API route, see section 7) produces a CSS block:
+
+```css
+/* dotUI preset — generated from ?preset=<encoded> */
+:root {
+  --neutral-50: #fafafa;
+  --neutral-100: #f4f4f5;
+  /* ... 11 steps × 6 palettes = 66 vars */
+  --accent-50: #eff6ff;
+  --accent-500: #3b82f6;
+  --accent-950: #172554;
+  /* success, warning, danger, info palettes ... */
+
+  /* Semantic aliases — constant across presets */
+  --dotui-bg: var(--neutral-50);
+  --dotui-accent: var(--accent-500);
+  --dotui-radius-factor: 1;
+  /* ... */
+}
+.dark {
+  --neutral-50: #0a0a0a;
+  /* reversed ramps ... */
+}
+```
+
+The Framer components reference `var(--accent-500)` etc. directly. The `.dark` block works with Framer's dark-mode mechanism when the class `dark` is on `<html>` (Framer's dark mode toggle adds this class).
+
+### 3d. Where density and component params land
+
+Framer components that mirror dotUI's enum params expose those as **Framer Property Controls** (`ControlType.Enum`). The chosen preset value (`DesignSystem.componentParams["card"]["style"]`, decoded from the `p` field of `DesignSystemState`) is not injected as a CSS variable — it is a component-level prop. The "Copy theme CSS" step cannot propagate these. Options:
+
+- The dotUI "Open in Framer" button generates a **preset summary JSON** that the user pastes into the Framer component's property panel (manual, not ideal).
+- A Framer plugin (future) reads the preset URL from the clipboard and sets default property values on newly-placed instances.
+- Document the gap clearly for the user: color fidelity is full; component variant fidelity is partial (manual).
+
+---
+
+## 4. Components installed
+
+### 4a. What "installed" means in Framer
+
+In Framer, components are not installed by running a CLI command. They come from a **code-component package** added via Packages. Once `@dotui/framer` is added to the project, all exported components are available in the left panel.
+
+### 4b. Which dotUI components the Showcase needs
+
+The `Cards` component (`www/src/components/marketing/showcase/cards.tsx:20-48`) consumes 37 registry UI items from `www/src/registry/ui/*/` (full list in the showcase internals map). The `@dotui/framer` package must include Framer-native reimplementations of at minimum:
+
+accordion, avatar, badge, button, calendar, card, checkbox, checkbox-group, color-area, color-editor, color-field, color-slider, color-thumb, disclosure, drop-zone, field, file-trigger, group, input, kbd, link, list-box, loader, otp-field, popover, progress-bar, radio-group, select, separator, slider, switch, table, tabs, tag-group, text, text-field, time-field, toggle-button, toggle-button-group.
+
+That is 39 components — a large but bounded set. Priority order for a first release: components used by the most showcase cards (button, card, input, field, avatar, separator, select, text-field, badge, list-box).
+
+### 4c. Dependency mapping
+
+The dotUI source components depend on:
+- `react-aria-components` — **not available in Framer**. Replace with Framer's own interaction model (`useTap`, `useHover`) or basic browser event handlers. Accessibility (ARIA roles, focus management) must be rebuilt manually.
+- `@base-ui/react/otp-field` (otp-field) — may work in Framer if it has no CSS module dependencies; test individually.
+- `@internationalized/date` (calendar, booking) — pure JS, works in Framer.
+- `lucide-react` — works in Framer (pure React SVG).
+- `tailwind-variants` — NOT used in `@dotui/framer`. Replace with plain style objects or a variant utility that produces inline style maps.
+
+### 4d. The `@dotui/framer` package structure
+
+```
+packages/framer/
+  src/
+    components/
+      button.tsx
+      card.tsx
+      input.tsx
+      # ... one file per component
+    theme.ts          # exports resolvePresetTokens(encodedPreset) → hex CSS vars string
+    showcase/
+      cards.tsx       # the showcase grid, using @dotui/framer components
+      booking.tsx
+      # ... mirrors www/src/components/marketing/showcase/*.tsx
+  package.json        # name: "@dotui/framer"; peerDeps: react, react-dom, lucide-react, @internationalized/date
+```
+
+---
+
+## 5. Theme in globals.css
+
+Framer has no `globals.css` file. The equivalent mechanism is **Site Settings > Custom Code > Start of `<head>`**, which accepts a raw HTML block including `<style>` tags. This is where the preset token block (section 3c) is injected.
+
+The `@dotui/framer` components must therefore:
+
+1. Reference only `var(--<palette>-<step>)` custom properties in their `style` props.
+2. NOT hardcode colors inline.
+3. Provide fallback values in case the Custom Code block is not present:
+   ```tsx
+   style={{ backgroundColor: 'var(--accent-500, #438cd6)' }}
+   ```
+   The fallback value `#438cd6` is the default `accent` seed from `DEFAULT_COLOR_CONFIG` (`www/src/registry/theme/color-config.ts:72-83`).
+
+The semantic layer (`--color-bg`, `--color-accent`, etc. from `www/src/registry/base/theme.css`) can optionally be included in the injected `<style>` block as well, so Framer components can reference semantic names rather than primitive steps. This makes them more resilient to palette changes:
+
+```css
+:root {
+  /* primitives — preset-specific */
+  --neutral-50: #fafafa; /* ... */
+  --accent-500: #3b82f6; /* ... */
+
+  /* semantics — constant structure, resolved via primitives */
+  --dotui-color-bg: var(--neutral-50);
+  --dotui-color-accent: var(--accent-500);
+  --dotui-color-fg: var(--neutral-950);
+  --dotui-color-border: var(--neutral-200);
+  /* ... mirroring www/src/registry/base/theme.css */
+}
+```
+
+Note: use a `--dotui-` prefix for semantic aliases in the Framer layer to avoid colliding with any other CSS variable conventions in the user's Framer project.
+
+---
+
+## 6. The showcase as first view
+
+### 6a. In the Framer package
+
+The `@dotui/framer` package exports a top-level **`Showcase`** component (mirroring `www/src/components/marketing/showcase/cards.tsx`) that renders the same masonry grid:
+
+```tsx
+// packages/framer/src/showcase/cards.tsx
+import { Booking } from "./booking";
+import { TwoFactor } from "./two-factor";
+// ... all 17 cards
+
+export function Cards(props: React.CSSProperties & { className?: string }) {
+  return (
+    <div style={{
+      columns: "4",
+      gap: "1rem",
+      // no Tailwind — explicit inline styles
+      ...props
+    }}>
+      <Booking />
+      <TwoFactor />
+      {/* ... 17 cards in same order as cards.tsx:29-46 */}
+    </div>
+  );
+}
+```
+
+The masonry layout (`columns-1 sm:columns-2 lg:columns-3 xl:columns-4` from `cards.tsx:25`) must be replicated with inline styles or a `@media`-query `<style>` block — no Tailwind.
+
+### 6b. The "first view" guarantee
+
+When the user clicks "Open in Framer" via the package deep link:
+- The package installs into the open Framer project.
+- The `@dotui/framer` package's **featured/default component** (set in the Framer Marketplace manifest) is `Cards` — the showcase grid.
+- The user drags `Cards` onto the canvas, or it is placed on a starter template page.
+
+There is no Framer API to automatically create a page and place components on it when a package is installed. The closest mechanism is a **Framer Template** (a `.framer` file exported from the Framer desktop app) that has the showcase pre-placed. The "Open in Framer" button could link to `https://framer.com/projects/new?template=<template-id>` which opens a new project from the template — but that template would contain a snapshot of the default preset, not the user's chosen one.
+
+Best realistic approach:
+1. The package deep link installs the code-component package.
+2. A starter template `.framer` file is published with the `Cards` component pre-placed and CSS variable references in place.
+3. The user pastes their Custom Code theme block from the "Copy theme CSS" step.
+4. Document this 3-step flow explicitly in the UI.
+
+---
+
+## 7. What dotUI must build
+
+### 7a. New server endpoint: `GET /r/framer-theme?preset=<encoded>`
+
+Returns a CSS text string (not a shadcn JSON item) — the full hex token block for injection into Framer Custom Code.
+
+Location: `www/src/routes/r/framer-theme.tsx` (new TanStack Start server GET handler).
+
+```ts
+// www/src/routes/r/framer-theme.tsx (pseudocode)
+import { decodePreset } from "@/modules/create/preset/codec";
+import { resolveColorConfig } from "@/registry/theme";
+import { gamutMap, toSrgb } from "@dotui/colors";
+import { PALETTE_ORDER } from "@/registry/theme/palettes";
+
+export const ServerRoute = createServerFileRoute("/r/framer-theme").methods({
+  GET: async ({ request }) => {
+    const url = new URL(request.url);
+    const encoded = url.searchParams.get("preset") ?? "";
+    const ds = encoded ? decodePreset(encoded) : null;
+    const color = ds?.color ?? undefined;
+
+    let lightVars: Record<string, string> = {};
+    let darkVars: Record<string, string> = {};
+
+    if (color) {
+      const resolved = resolveColorConfig(color);
+      // resolved.light and resolved.dark are Record<palette, Record<step, oklchString>>
+      lightVars = rampsToHex(resolved.light);
+      darkVars  = rampsToHex(resolved.dark);
+    } else {
+      // fall back to static base/colors.css vars (default palette)
+      // read from baseRegistryCss or a cached import of @/registry/__generated__/base-css
+    }
+
+    const css = buildFramerCssBlock(lightVars, darkVars);
+    return new Response(css, {
+      headers: {
+        "Content-Type": "text/css",
+        "Cache-Control": "public, max-age=60, s-maxage=3600",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  },
+});
+```
+
+`rampsToHex` converts each OKLCH string to hex:
+
+```ts
+function oklchToHex(oklchStr: string): string {
+  const oklch = toOklch(oklchStr);        // packages/colors/src/shared/color.ts:36
+  const mapped = gamutMap(oklch);         // color.ts:48
+  const { r, g, b } = toSrgb(mapped);    // color.ts:42
+  return "#" + [r, g, b]
+    .map(c => Math.round(c * 255).toString(16).padStart(2, "0"))
+    .join("");
+}
+```
+
+### 7b. New `toHex` helper in `@dotui/colors`
+
+Add to `packages/colors/src/shared/color.ts` (after `oklchCss` at line ~54):
+
+```ts
+/** Convert any CSS color string to a gamut-mapped sRGB hex string (#rrggbb). */
+export function toHex(input: string): string {
+  const mapped = gamutMap(toOklch(input));
+  const { r, g, b } = toSrgb(mapped);
+  return "#" + [r, g, b].map(c => Math.round(c * 255).toString(16).padStart(2, "0")).join("");
+}
+```
+
+Export via `packages/colors/src/index.ts:39+`.
+
+### 7c. New "Open in Framer" button on `/create`
+
+In `www/src/modules/create/install-command.tsx` (or a new `open-in-framer.tsx` component):
+
+```tsx
+// Derives encoded preset from useDesignSystem()
+const framerThemeUrl = `https://dotui.com/r/framer-theme?preset=${encodedPreset ?? ""}`;
+const packageDeepLink = `https://framer.com/m/<package-id>`;
+
+// Two-part UI:
+// 1. "Open in Framer" → opens packageDeepLink
+// 2. "Copy theme CSS" → fetches framerThemeUrl and writes to clipboard
+```
+
+### 7d. New `packages/framer/` workspace package
+
+Structure described in section 4d. Key constraints:
+- Zero Tailwind imports.
+- Zero `react-aria-components` imports. Use native HTML semantics + ARIA attributes.
+- Style via inline `style={{ color: 'var(--accent-500, #438cd6)' }}` — CSS custom property with hex fallback.
+- Expose Framer Property Controls for each dotUI enum param (`ControlType.Enum`).
+- Export `Cards` (the showcase) as the default/featured component.
+
+### 7e. New `figma`-style field on `meta.ts` for Framer mapping (optional)
+
+A `framer?: { componentId?: string; variants?: Record<string, string[]> }` field can be added to `RegistryItem` in `www/src/registry/types.ts:69-78` — one line addition — to carry Framer-specific metadata (e.g. the Framer Marketplace component ID for deep linking to a specific component). This is inert in the registry build (`registry-build.ts` spreads `{ ...rest }` in `metaForRuntime` at `build-publishables.ts:334`).
+
+---
+
+## 8. Schema / meta.ts changes
+
+### 8a. `RegistryItem` extension (optional)
+
+```ts
+// www/src/registry/types.ts
+export type RegistryItem = ShadcnRegistryItem & {
+  group?: ComponentGroup | null;
+  params?: Record<string, ParamDef>;
+  framer?: {
+    /** Framer Marketplace component ID for deep-linking. */
+    componentId?: string;
+    /** Maps dotUI enum param values to Framer variant names if they differ. */
+    variantMap?: Record<string, Record<string, string>>;
+  };
+};
+```
+
+This is a single-line addition, safe to add as it is inert in the build. It does not affect the emitted shadcn registry JSON (`publish.ts` drops unknown fields relative to the shadcn item schema).
+
+### 8b. No change to the codec
+
+The preset encoding/decoding in `www/src/modules/create/preset/codec.ts` is unchanged. The Framer theme endpoint decodes the same `?preset=<encoded>` string that every other `/r/*` endpoint uses.
+
+### 8c. No change to `/r/init` or `/r/$name`
+
+Those routes continue to serve the shadcn registry. The `/r/framer-theme` route is additive.
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### 9a. OKLCH → hex is lossy at wide-gamut hues
+
+The kernel (`packages/colors/src/producers/oklch.ts`) generates ramps that may include out-of-sRGB-gamut values at vivid mid-tones. `gamutMap` in `packages/colors/src/shared/color.ts:48` applies CSS Color 4 chroma reduction before converting to hex, so the result is the closest in-gamut color. For neutral and muted palettes the loss is imperceptible; for vivid `accent` colors at steps 400–600 it may be visible. Document this in the UI.
+
+### 9b. No automatic showcase placement
+
+Framer has no API for a third-party site to create pages or place components. The showcase-as-first-view is achieved only via a pre-published Framer template. If the user starts from a blank project, they must drag `Cards` manually.
+
+### 9c. RAC accessibility features are lost
+
+React Aria Components (`react-aria-components`) provides keyboard navigation, focus management, and ARIA role wiring. The Framer reimplementations in `@dotui/framer` will have basic keyboard and ARIA support at best. Not a blocker for the showcase demo use case but important to document for production use.
+
+### 9d. Component parity maintenance burden
+
+Every time a dotUI component (`www/src/registry/ui/*/base.tsx`) is updated, the corresponding `@dotui/framer` component must be manually updated. This is a significant ongoing maintenance cost. Consider automating a "style diff" check as part of CI.
+
+### 9e. Framer package publishing gating
+
+Submitting to the Framer Marketplace requires approval. During development, the deep-link mechanism is `https://framer.com/m/<package-id>` which requires a published (even draft) Framer package. The fallback during development is to distribute `@dotui/framer` as an npm package and document the manual import path in Framer.
+
+### 9f. Custom Code persistence
+
+Framer's Custom Code block is per-project. If the user changes their dotUI preset, they must repeat the "Copy theme CSS" and re-paste step. There is no webhook or live sync mechanism. Acknowledge this limitation in the UI copy.
+
+### 9g. Density and component params are not auto-applied
+
+As noted in section 3d, the `componentParams` from the preset (e.g. `card.style = "tasnim"`, `loader.style = "ring"`) cannot be automatically applied to Framer component instances. They must be set manually via property controls. Fallback: provide a preset summary panel in the "Open in Framer" flow that lists "Your chosen options: card style = tasnim, loader = ring, …" so the user can replicate them manually.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+**Phase 0: Infrastructure**
+
+- [ ] Add `toHex(input: string): string` to `packages/colors/src/shared/color.ts` (after `oklchCss` at line ~54) using `gamutMap` + `toSrgb`.
+- [ ] Export `toHex` via `packages/colors/src/index.ts`.
+- [ ] Add `framer?: { componentId?: string; variantMap?: ... }` to `RegistryItem` in `www/src/registry/types.ts:69`.
+
+**Phase 1: Server endpoint**
+
+- [ ] Create `www/src/routes/r/framer-theme.tsx` — TanStack Start GET handler that accepts `?preset=<encoded>`, calls `decodePreset` (same pattern as `www/src/routes/r/init.tsx:47-58`), calls `resolveColorConfig`, converts ramps to hex via `toHex`, and returns a CSS string.
+- [ ] For the default preset (no `?preset` param), serve the static ramps from `www/src/registry/__generated__/base-css.ts`'s `:root`/`.dark` entries converted to hex.
+- [ ] Add cache headers matching the pattern in `www/src/routes/r/$name.tsx:27-30`.
+- [ ] Add a `GET /r/framer-tokens.json?preset=<encoded>` variant returning the same data as JSON (`{ light: {}, dark: {} }`) for programmatic consumption.
+
+**Phase 2: `@dotui/framer` package skeleton**
+
+- [ ] Create `packages/framer/` workspace package with `package.json` (`name: "@dotui/framer"`, `peerDependencies: { react, react-dom }`).
+- [ ] Implement a `theme.ts` exporting `resolvePresetTokensToHex(encodedPreset: string): Promise<{ light: Record<string,string>, dark: Record<string,string> }>` that fetches `/r/framer-tokens.json?preset=…` (or re-implements conversion locally via `@dotui/colors`).
+- [ ] Implement the 10 highest-priority components (button, card, input, field, avatar, separator, select, text-field, badge, list-box) using inline styles and `var(--<palette>-<step>, <hex-fallback>)`.
+- [ ] For each component with dotUI enum params, expose a `ControlType.Enum` Framer property control.
+- [ ] Implement the `Cards` showcase grid component in `packages/framer/src/showcase/cards.tsx` using the above components, mirroring `www/src/components/marketing/showcase/cards.tsx:20-48`.
+- [ ] Implement remaining showcase card components iteratively until all 17 cards render.
+
+**Phase 3: Framer package publishing**
+
+- [ ] Publish `@dotui/framer` to npm.
+- [ ] Submit to Framer Marketplace (or use a Framer Community file with code-component imports).
+- [ ] Obtain the Framer deep-link URL (`https://framer.com/m/<package-id>`).
+
+**Phase 4: dotUI UI integration**
+
+- [ ] Add "Open in Framer" button to the `/create` page (near the existing install command in `www/src/modules/create/install-command.tsx`).
+  - Sub-button 1: "Open in Framer" → `window.open(framerDeepLink)`.
+  - Sub-button 2: "Copy theme CSS" → `fetch('/r/framer-theme?preset=...')` then `navigator.clipboard.writeText(css)`.
+- [ ] Show a callout explaining the 3-step flow: (1) install package, (2) paste theme CSS into Site Settings, (3) drag `Cards` onto canvas.
+- [ ] Optionally show a collapsible "Your preset summary" listing the non-default `componentParams` values the user must apply manually.
+
+**Phase 5: Template (optional, for first-view guarantee)**
+
+- [ ] Create a Framer template `.framer` file with the `Cards` component pre-placed and CSS variable references in place.
+- [ ] Publish the template to the Framer Marketplace or as a remixable Community file.
+- [ ] Update the "Open in Framer" button to point to `https://framer.com/projects/new?template=<template-id>` instead of (or in addition to) the package deep link.
+
+**Phase 6: Documentation and gaps**
+
+- [ ] Document OKLCH→hex color loss at vivid hues.
+- [ ] Document that density and component params are not auto-applied and must be set manually.
+- [ ] Document the Custom Code re-paste requirement when the preset changes.
+
+---
+
+## Sources
+
+- dotUI preset codec: `www/src/modules/create/preset/codec.ts:75-126`
+- dotUI preset types: `www/src/modules/create/preset/types.ts:14-41`
+- dotUI color resolution: `www/src/registry/theme/primitives.ts:67-108`
+- OKLCH→sRGB conversion seam: `packages/colors/src/shared/color.ts:36-81`
+- Init item assembly (template for `/r/framer-theme`): `www/src/publisher/emit-theme.ts:71-128`
+- Registry item type (for `framer?` field): `www/src/registry/types.ts:69-78`
+- Showcase component list: `www/src/components/marketing/showcase/cards.tsx:20-48`
+- Framer code components documentation: https://www.framer.com/developers/code-components/introduction
+- Framer Property Controls: https://www.framer.com/developers/code-components/property-controls
+- Framer Marketplace publishing: https://www.framer.com/marketplace/
+- Framer Custom Code (Site Settings): https://www.framer.com/academy/lessons/custom-code
+- CSS Color 4 gamut mapping (used by `gamutMap`): https://www.w3.org/TR/css-color-4/#css-gamut-mapping

--- a/docs/research/open-in/lovable.md
+++ b/docs/research/open-in/lovable.md
@@ -1,0 +1,501 @@
+# Open in Lovable
+
+> Feasible via repo-import, not a direct launch URL. · button type **repo-import** · preset fidelity **full** (baked into generated repo) · color fidelity **partial** (OKLCH shipped; HSL variant required for Lovable agent stability)
+
+---
+
+## 1. User experience
+
+The flow has three user-visible steps:
+
+1. **User customizes their design system** on `/create?preset=<encoded>`. The `?preset` encodes their chosen colors (`ColorConfig` seeds + algorithm), density, and per-component param choices (enum styles, scalar radius/spacing tokens).
+
+2. **dotUI generates a GitHub repo** from a server action. The repo is pre-populated with:
+   - `src/globals.css` — full OKLCH theme ramps for the chosen preset + all base at-rules.
+   - `src/components/ui/*` — all 60 published dotUI components, each with classes baked for the chosen preset.
+   - `src/components/showcase/` — the 17 showcase card files verbatim from `www/src/components/marketing/showcase/`.
+   - `src/App.tsx` — renders `<Cards />` as the home view.
+   - `lovable.md` or `.lovable/rules.md` — agent-context file that instructs Lovable to preserve React Aria and OKLCH.
+
+3. **User clicks "Open in Lovable"** → `https://lovable.dev/import?repo=<github-url>`. Lovable's GitHub import reads the repo, installs deps, and opens the project showing the showcase page as its first view.
+
+There is no component-URL or define API from Lovable that dotUI can call directly; the GitHub import path is the only realistic integration point as of the Lovable feature set available (enterprise-gated Design Systems feature excluded).
+
+---
+
+## 2. Technical mechanism
+
+### 2a. Button target
+
+```
+https://lovable.dev/import?repo=https://github.com/<dotui-org>/<generated-repo-name>
+```
+
+Lovable's GitHub import parses this and forks/imports the repo into a new Lovable project. The exact query-param name should be confirmed against Lovable's current import UI (`https://docs.lovable.dev`) but `?repo=` or `?github=` are the attested forms. The generated repo must be **public** or the Lovable user must have granted GitHub access.
+
+### 2b. Repo generation server action
+
+dotUI must implement a new server route, e.g. `POST /api/generate-repo?preset=<encoded>`, that:
+
+1. Decodes `?preset=` via `decodePreset` (`www/src/modules/create/preset/codec.ts:111`).
+2. Calls `emitInitItem` (`www/src/publisher/emit-theme.ts:71`) to produce the full `globals.css` content.
+3. Loops over all 60 `PUBLISHABLE_NAMES` calling `publish({ publishable, preset })` (`www/src/publisher/publish.ts:119`) to get each component's resolved file content.
+4. Assembles a GitHub repo via the GitHub REST API (`POST /orgs/{org}/repos` + `PUT /repos/{org}/{repo}/contents/{path}` or the Git Trees API for a single round-trip).
+5. Returns the new repo URL.
+
+The "Open in Lovable" button fires this action, waits for the URL, then navigates to `https://lovable.dev/import?repo=<url>`.
+
+### 2c. What publishables must exist first
+
+The publishables directory (`www/src/registry/__generated__/publishables/`) is git-ignored and only materialises after `pnpm build:registry` (`www/scripts/registry-build.ts`). The server action must run inside the deployed dotUI app where the registry has already been built, or the action triggers a build step.
+
+---
+
+## 3. Preset propagation
+
+The chosen `?preset=<encoded>` is a pako-deflated, base64url-encoded `DesignSystemState`:
+
+```
+DesignSystemState { p?, t?, d?, c? }  ←  codec.ts:14-19
+```
+
+**Decode path** (server action):
+
+```ts
+import { decodePreset } from "@/modules/create/preset/codec";
+// encoded = url.searchParams.get("preset")
+const ds = decodePreset(encoded);
+// ds.color     → ColorConfig with seeds + algorithm (e.g. accent: "#ef4444", algorithm: "oklch")
+// ds.density   → "compact" | "default" | "comfortable"
+// ds.componentParams → { button: { style: "outline" }, card: { style: "tasnim" }, ... }
+```
+
+**Narrowed to `PublishPreset`** for all publisher calls:
+
+```ts
+// publisher/types.ts:79-85
+const preset: PublishPreset = {
+  color: ds.color,
+  density: ds.density,
+  componentParams: ds.componentParams,
+};
+```
+
+**Into theme CSS**: `emitInitItem({ baseRegistryCss, preset, encodedPreset, registryRoot })` bakes:
+- `preset.color` → `resolveColorConfig(preset.color)` re-derives the OKLCH ramps; `rampsToVars(resolved.light)` / `rampsToVars(resolved.dark)` override `:root` / `.dark` in the item's `css` field (`emit-theme.ts:155-159`).
+- `preset.density` → `--dotui-density` written to `:root` if non-compact (`emit-theme.ts:58-68`).
+- The structured `css` / `cssVars` fields are then serialized into the generated `globals.css`.
+
+**Into component files**: for each of the 60 components, `publish({ publishable, preset })` folds density + enum param choices into the inlined `tv()` config (`flatten.ts`), rewrites scalar tokens to Tailwind suffixes (`resolve-classes.ts`), and splices the result into the `base.tsx` template via `%%TV_CONFIG%%` (`publish.ts:119-161`). These are written into `src/components/ui/<name>.tsx` in the generated repo.
+
+**Result**: the generated repo contains zero runtime preset references — all choices are baked in at generation time.
+
+---
+
+## 4. Components installed
+
+### 4a. What goes into `src/components/ui/`
+
+Every entry in `PUBLISHABLE_NAMES` (`www/src/registry/__generated__/publishables/index.ts`) gets one file, target path taken from `meta.files[0].target` (e.g. `"ui/button.tsx"` → `src/components/ui/button.tsx`).
+
+The loader component has two source files (`base.spinner.tsx` / `base.ring.tsx`). The `selectPublishable` logic currently inlined in `www/src/routes/r/$name.tsx:89-107` picks the right one based on `preset.componentParams["loader"]["style"]`. This function should be extracted to `www/src/publisher/publish.ts` for reuse in the repo-generation server action.
+
+### 4b. Support files
+
+Beyond the 60 `ui/*` files, the generated repo needs:
+
+| File | Source |
+|---|---|
+| `src/lib/utils.ts` | `CN_UTILS_TS` inline in `emit-theme.ts:41-47` |
+| `src/lib/context.tsx` | `www/src/registry/lib/context/index.tsx` (verbatim copy) |
+| `src/lib/focus-styles.ts` | `www/src/registry/lib/focus-styles/` |
+| `src/hooks/use-image-loading-status.ts` | `www/src/registry/hooks/use-image-loading-status.ts` |
+| `src/registry/__generated__/icons.tsx` | OR replace `ExternalLinkIcon` with a direct lucide import |
+
+These are the `BUNDLED_INTO_INIT` utilities plus the two `UNREGISTERED_DEP_ALLOWLIST` items (`context`, `use-image-loading-status`) that ship as raw copies rather than shadcn registry deps.
+
+### 4c. Showcase card files
+
+Copy all 17 files from `www/src/components/marketing/showcase/` verbatim:
+
+```
+showcase/account-menu.tsx   showcase/booking.tsx        showcase/color-editor.tsx
+showcase/cookie-preferences.tsx  showcase/faq.tsx        showcase/feedback.tsx
+showcase/filters.tsx         showcase/invite-members.tsx showcase/login-form.tsx
+showcase/notifications.tsx  showcase/payment.tsx        showcase/shortcuts.tsx
+showcase/storage.tsx         showcase/team-name.tsx      showcase/transactions.tsx
+showcase/two-factor.tsx      showcase/upload-avatar.tsx
+showcase/cards.tsx           ← the masonry grid container
+```
+
+These files contain only React state; no server functions, no loaders. They import from `@/registry/ui/*` and `@/registry/lib/utils`— the generated repo must configure the `@/` alias pointing at `src/`.
+
+### 4d. `package.json` dependencies
+
+From `emitInitItem`'s `DEFAULT_DEPENDENCIES` (`emit-theme.ts:31-39`) plus showcase transitive deps:
+
+```json
+{
+  "dependencies": {
+    "react-aria-components": "latest",
+    "react-aria": "latest",
+    "react-stately": "latest",
+    "tailwind-variants": "latest",
+    "clsx": "latest",
+    "tailwind-merge": "latest",
+    "tw-animate-css": "latest",
+    "tailwindcss-react-aria-components": "latest",
+    "tailwindcss-autocontrast": "latest",
+    "@internationalized/date": "latest",
+    "@base-ui/react": "latest",
+    "lucide-react": "latest",
+    "@fontsource-variable/geist": "latest",
+    "@fontsource/geist-mono": "latest"
+  },
+  "devDependencies": {
+    "tailwindcss": "^4.0.0",
+    "@tailwindcss/vite": "latest"
+  }
+}
+```
+
+`tailwindcss-autocontrast` and `tailwindcss-with` are workspace packages in the dotUI monorepo; they must be **published to npm** or bundled as vendored files in the generated repo before Lovable can install them. This is the largest infrastructure blocker (see §9).
+
+---
+
+## 5. Theme in globals.css
+
+The generated `src/globals.css` is assembled from the structured `css` and `cssVars` fields produced by `emitInitItem`. The conversion from registry fields back to raw CSS is:
+
+```
+cssVars.theme  →  @theme inline { --radius-md: calc(…); --color-bg: var(…); … }
+css["@import …"]  →  @import "tw-animate-css";
+css["@plugin …"]  →  @plugin "tailwindcss-react-aria-components"; etc.
+css["@utility …"] →  @utility focus-ring { … }
+css["@layer base"] →  @layer base { … }
+css["::selection"] →  ::selection { … }
+css[":root"]  →  :root { --radius-factor: 1; --neutral-50: oklch(…); … }   ← PRESET ramps
+css[".dark"]  →  .dark { --neutral-50: oklch(…); … }                       ← reversed ramps
+```
+
+For a **custom color preset** (`preset.color` is set), `resolveColorConfig(preset.color)` regenerates all 6 × 11 = 66 primitive OKLCH vars and overrides the defaults. For the **default preset** (`color: undefined`), the static ramps from `www/src/registry/base/colors.css` are used as-is (already in `baseRegistryCss`).
+
+**The `@theme inline` block is constant across all presets** — it only maps semantic tokens (`--color-bg → var(--neutral-50)`) and radius scales. Only the primitive ramps differ.
+
+**`--on-*` vars are NOT shipped** by dotUI. They are derived by the `tailwindcss-autocontrast` plugin at the consumer's Tailwind compile time by scanning `:root` and `.dark` for `--<name>-<shade>` vars and injecting `--on-<name>-<shade>: black | white`. Lovable's build pipeline must run Tailwind v4 with this plugin enabled for `fg-on-accent` and similar tokens to resolve.
+
+**Minimum complete `globals.css` shape**:
+
+```css
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "@fontsource-variable/geist";
+@import "@fontsource/geist-mono";
+
+@plugin "tailwindcss-react-aria-components";
+@plugin "tailwindcss-autocontrast" { cssfile: "./src/globals.css"; }
+@plugin "tailwindcss-with";
+
+@custom-variant dark (&:is(.dark *));
+
+@utility focus-ring { … }
+@utility focus-input { … }
+@utility focus-reset { … }
+@utility no-highlight { … }
+
+@layer base {
+  * { @apply border-border; }
+  body { @apply bg-bg font-sans text-fg; }
+  html { @apply font-sans; }
+}
+
+::selection { background-color: var(--accent-800); color: var(--on-accent-800); }
+
+@theme inline {
+  --radius-factor: 1;
+  --radius-sm: calc(0.25rem * var(--radius-factor));
+  --radius-md: calc(0.375rem * var(--radius-factor));
+  /* … full radius scale … */
+  --color-bg: var(--neutral-50);
+  --color-accent: var(--accent-500);
+  --color-fg-on-accent: var(--on-accent-500);
+  /* … full semantic token map from base/theme.css … */
+  --font-sans: "Geist Variable", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, monospace;
+}
+
+/* PRESET RAMPS — generated by resolveColorConfig(preset.color) + rampsToVars() */
+:root {
+  --neutral-50: oklch(0.985 0 0);
+  --neutral-100: oklch(0.955 0.004 264.05);
+  /* … 11 neutral steps … */
+  --accent-50: oklch(0.958 0.021 252.89);
+  /* … 11 accent steps … */
+  /* … success, warning, danger, info … */
+}
+
+.dark {
+  --neutral-50: oklch(0.13 0 0);   /* reversed: light's 950 value */
+  /* … reversed ramps … */
+}
+```
+
+---
+
+## 6. The showcase as first view
+
+### 6a. `App.tsx` / entry component
+
+The generated repo's home view renders `<Cards />` directly:
+
+```tsx
+// src/App.tsx
+import "./globals.css";
+import { Cards } from "./components/showcase/cards";
+
+export default function App() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg antialiased">
+      <main className="p-8">
+        <Cards />
+      </main>
+    </div>
+  );
+}
+```
+
+`Cards` (`cards.tsx:20-48`) is a CSS columns masonry grid (`columns-1 sm:columns-2 lg:columns-3 xl:columns-4 gap-4`) that renders all 17 showcase widgets inline. No routing is required; the component is pure React with local state only.
+
+### 6b. Dark-mode provider
+
+The showcase cards use class-based dark mode (`@custom-variant dark (&:is(.dark *))`). In Lovable's Vite+React scaffold, replace the dotUI `ThemeProvider` (which depends on TanStack Router's `ScriptOnce`) with a minimal inline script or `next-themes`:
+
+```tsx
+// minimal dark-mode bootstrap (no TanStack Router dep)
+function DarkModeScript() {
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `
+          (function(){
+            var stored = localStorage.getItem("theme");
+            var isDark = stored === "dark" || (!stored && window.matchMedia("(prefers-color-scheme: dark)").matches);
+            document.documentElement.classList.toggle("dark", isDark);
+          })();
+        `,
+      }}
+    />
+  );
+}
+```
+
+### 6c. `DesignSystemProvider`
+
+`DesignSystemProvider` from `www/src/modules/core/styles.tsx:61` is **optional** for the showcase. Its default context is `{ params: {}, tokens: {}, density: "default" }`, which gives every component its default visual variant. Since the preset choices are already baked into the component class strings (by `publish()`), the provider adds nothing for the generated repo's initial state. It can be omitted.
+
+### 6d. Avatar image fallbacks
+
+The showcase cards load GitHub CDN avatars (`https://github.com/mehdibha.png`, etc.) at runtime. These fall back gracefully via `AvatarFallback` when offline. No bundled image assets are needed.
+
+---
+
+## 7. What dotUI must build
+
+### 7a. Repo-generation server action
+
+New file: `www/src/routes/api/generate-repo.ts` (TanStack Start server function or server handler).
+
+Steps:
+1. Parse and validate `?preset=` → `decodePreset` → `PublishPreset`.
+2. Call `emitInitItem` for theme CSS fields.
+3. Serialize `css` + `cssVars` fields to raw CSS string (implement a `registryFieldsToCss(fields)` utility — the inverse of `cssToRegistryFields` in `www/src/publisher/build-time/css-to-registry-fields.ts`).
+4. Loop `PUBLISHABLE_NAMES`, call `publish({ publishable, preset })` per component, collect `{ target, content }` pairs.
+5. Collect support files (context, focus-styles, use-image-loading-status, icons).
+6. Copy showcase card files verbatim (embed them at build time via `import.meta.glob` or template strings).
+7. Generate `package.json`, `vite.config.ts`, `tsconfig.json`, `index.html`.
+8. Generate `.lovable/rules.md` (agent-context file, §7b).
+9. Create GitHub repo via REST API, commit all files via the Git Trees API in one request.
+10. Return repo URL.
+
+### 7b. Agent-context / rules file
+
+Create `.lovable/rules.md` (or `AGENTS.md`) in the generated repo. This is the primary mitigation for Lovable's HSL-overwrite and React-Aria refactor behaviours:
+
+```markdown
+# dotUI Design System — Agent Rules
+
+## Do not modify these files
+- `src/globals.css` — the full OKLCH theme; modifying it breaks the color system.
+- `src/components/ui/**` — installed dotUI components. Do not refactor them.
+- `src/lib/utils.ts`, `src/lib/context.tsx` — core helpers.
+
+## Color system
+This project uses **OKLCH** color variables (`--neutral-50 … --neutral-950`, `--accent-50 … --accent-950`, etc.).
+- Do NOT convert OKLCH values to HSL or hex. Lovable's editor may suggest HSL — reject these suggestions.
+- Do NOT add new `hsl()` or `#hex` color literals. Reference semantic tokens (`bg-bg`, `text-fg`, `bg-accent`, etc.) via Tailwind utilities instead.
+- The `--on-*` variables (e.g. `--on-accent-500`) are derived at build time by the `tailwindcss-autocontrast` plugin from the OKLCH ramps. Never set them manually.
+
+## UI components
+- All UI components in `src/components/ui/` use **React Aria Components** (`react-aria-components`).
+- Do NOT replace them with Radix UI, Shadcn UI, or any other component library.
+- Do NOT add `@radix-ui/*` dependencies.
+- When adding new interactive elements, use `react-aria-components` primitives and style them with Tailwind following the same patterns in `src/components/ui/`.
+
+## Styling
+- Use Tailwind utility classes. All semantic color tokens are available as utilities: `bg-bg`, `text-fg`, `bg-accent`, `text-fg-on-accent`, `border-border`, etc.
+- `bg-bg` = page background, `text-fg` = body text, `bg-accent` = primary brand color.
+- Dark mode is class-based: `.dark` on `<html>`. Do not use `prefers-color-scheme` media queries.
+```
+
+### 7c. HSL variant file (defensive fallback)
+
+Because Lovable's agent tends to overwrite OKLCH values with HSL on its own edits, dotUI should also generate an `hsl-theme.css` containing HSL equivalents of the preset's ramps:
+
+```
+:root {
+  --neutral-50-hsl: 0 0% 98.5%;
+  --accent-500-hsl: 210 65% 52%;
+  …
+}
+```
+
+This is generated from `resolveColorConfig(preset.color)` → `rampsToVars()` → OKLCH → `toSrgb()` → HSL conversion (`packages/colors/src/shared/color.ts:42`). The OKLCH primary file remains canonical; this file is a read-only reference the agent can use if it insists on HSL, rather than letting it hallucinate values.
+
+### 7d. `vite.config.ts` template
+
+```ts
+import path from "path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});
+```
+
+---
+
+## 8. Schema / meta.ts changes
+
+No changes to any `www/src/registry/ui/*/meta.ts` or `www/src/registry/types.ts` are required for this feature. The repo-generation action is entirely a new server route that consumes existing publisher APIs.
+
+**Optional addition** (`types.ts:69-78`): a `lovable?: { rules?: string }` field on `RegistryItem` could carry per-component agent guidance that the repo-generation action aggregates into the `.lovable/rules.md` file. Adding the field takes one line in the intersection type and is inert unless explicitly read:
+
+```ts
+export type RegistryItem = ShadcnRegistryItem & {
+  group?: ComponentGroup | null;
+  params?: Record<string, ParamDef>;
+  lovable?: { rules?: string }; // optional per-component agent guidance
+};
+```
+
+This is low-priority; the single top-level rules file (§7b) is sufficient.
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### 9a. OKLCH → HSL overwrite (primary Lovable risk)
+
+Lovable's AI agent is trained on HSL-heavy codebases and will tend to convert `oklch(…)` values to `hsl(…)` on any edit that touches `globals.css` or adds new color usage. Mitigations, in order of effectiveness:
+
+1. **`.lovable/rules.md`** with explicit "do not convert OKLCH" instructions (§7b). Rules files are read by Lovable's agent before generating edits.
+2. **HSL companion file** `hsl-theme.css` (§7c) gives the agent correct HSL values to use if it refuses OKLCH, preventing value hallucination.
+3. **Semantic utilities only** in showcase cards — cards use `bg-bg`, `text-fg`, `bg-accent`, not raw OKLCH vars. The agent sees no OKLCH in application code; only `globals.css` is exposed.
+4. **Acceptance**: for users who only want Lovable to build new pages (not modify the design system), OKLCH overwrite in `globals.css` is acceptable — the design system still renders correctly until they run `npx shadcn add <dotui-init-url>` again to restore it.
+
+### 9b. React Aria → Radix refactor (secondary Lovable risk)
+
+Lovable's agent has a strong prior toward Radix UI (Shadcn's default stack). It will suggest replacing RAC components with Radix equivalents when asked to "improve" or "refactor" a component.
+
+1. **Rules file** explicitly names `react-aria-components` as the required library and bans `@radix-ui/*` deps.
+2. **Do-not-touch paths** listed in rules (all of `src/components/ui/**`).
+3. **Structural separation**: showcase cards import from `@/components/ui/` not from `react-aria-components` directly, so the agent sees a higher-level abstraction layer and is less likely to drill down.
+
+### 9c. Workspace packages not on npm
+
+`tailwindcss-autocontrast` and `tailwindcss-with` are in `packages/` in the monorepo and not yet published to npm. Without them:
+- `tailwindcss-autocontrast`: `--on-*` vars are never injected → `text-fg-on-accent` etc. render as transparent. **Fallback**: inline pre-computed `--on-*` vars into the generated `:root` / `.dark` using `onBlackWhite` from `packages/colors/src/shared/on-color.ts:88-97` during repo generation (the `emitPrimitivesCss({onColors:true})` path at `primitives.ts:130-138` shows this pattern).
+- `tailwindcss-with`: removes `with-[...]` container variants. Most showcase cards do not use it; impact is low. **Fallback**: drop it from the generated `globals.css`'s `@plugin` line.
+
+**Resolution**: publish both packages to npm as part of the Open-in Lovable launch.
+
+### 9d. No live `?preset` sync
+
+Once the repo is generated, there is no live sync between the dotUI customizer and the Lovable project. The preset is baked in. To change the theme, the user must re-generate. This is expected — note it in the dotUI UI as "Your design system is baked in. Re-generate to apply a new preset."
+
+### 9e. GitHub repo quota / naming
+
+Each "Open in Lovable" click creates a new GitHub repo. dotUI must either:
+- Use a per-user repo (requires OAuth, reuses/updates the same repo), or
+- Create a fresh repo with a unique timestamped name under a dotUI org.
+
+The simplest v1: org repo `dotui-<random-6-char>`, public. Long-term: user OAuth → personal repo.
+
+### 9f. No shadcn MCP / registry.json index
+
+The generated Lovable project does not use the shadcn CLI workflow (no `components.json`, no MCP). The `/r/registry.json` 404 is irrelevant for this integration. All components are pre-installed as source files; no shadcn install commands run in Lovable.
+
+### 9g. Lovable's "Design Systems" feature
+
+Lovable has a bidirectional GitHub sync and an enterprise-gated "Design Systems" feature. The repo-import path used here is the **free tier** entry point and does not require enterprise access. The enterprise Design Systems feature (which would allow a more native token integration) is out of scope.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+**Phase 1: Infrastructure**
+
+- [ ] Publish `tailwindcss-autocontrast` and `tailwindcss-with` to npm from `packages/`.
+- [ ] Extract `selectPublishable` (currently at `www/src/routes/r/$name.tsx:89-107`) into `www/src/publisher/publish.ts` as an exported function.
+- [ ] Implement `registryFieldsToCss(fields: RegistryCssFields): string` in `www/src/publisher/emit-theme.ts` — converts the structured `css` + `cssVars` fields back to raw CSS text for writing to a file.
+- [ ] Pre-compute and inline `--on-*` vars as fallback: add `inlineOnColors: boolean` option to `mergePresetCssFields` (`emit-theme.ts:145`) that calls `onBlackWhite` (`packages/colors/src/shared/on-color.ts:88`) on each ramp step and writes `--on-<palette>-<step>` into `:root` / `.dark`. Enable this for repo generation.
+
+**Phase 2: Repo-generation server action**
+
+- [ ] Create `www/src/routes/api/generate-repo.ts` (TanStack Start server handler, `POST`).
+- [ ] Implement showcase-file embedding: use `import.meta.glob("../../components/marketing/showcase/*.tsx", { eager: true, query: "?raw" })` to get file contents as strings at build time.
+- [ ] Implement `buildRepoFiles(preset, encodedPreset): Record<filePath, string>` that assembles the full file tree (globals.css, ui/*, showcase/*, support files, package.json, vite.config.ts, App.tsx).
+- [ ] Generate `.lovable/rules.md` content from template (§7b).
+- [ ] Generate `hsl-theme.css` using `resolveColorConfig` → `toSrgb` → HSL conversion.
+- [ ] Implement GitHub repo creation via `POST /orgs/dotui-dev/repos` (REST API, server-side GitHub token).
+- [ ] Implement file commit via `POST /repos/dotui-dev/{repo}/git/trees` + `POST /repos/dotui-dev/{repo}/git/commits` + `PATCH /repos/dotui-dev/{repo}/git/refs/heads/main` (single round-trip for all files).
+- [ ] Return `{ repoUrl: "https://github.com/dotui-dev/<name>" }`.
+
+**Phase 3: UI button**
+
+- [ ] Add "Open in Lovable" button to the customizer panel (`www/src/modules/create/` UI area), next to the existing install command in `www/src/modules/create/install-command.tsx`.
+- [ ] On click: call `POST /api/generate-repo?preset=<encoded>`, show spinner, on success `window.open("https://lovable.dev/import?repo=" + repoUrl)`.
+- [ ] Handle errors: rate limit, GitHub API failure → toast with fallback copy-command.
+
+**Phase 4: Validation**
+
+- [ ] Test with default preset: no `?preset=` → default OKLCH ramps in `globals.css`.
+- [ ] Test with custom accent seed `#ef4444`: verify `:root` contains `--accent-50 … --accent-950` with red-shifted OKLCH values.
+- [ ] Test loader `style: "ring"` preset: verify `src/components/ui/loader.tsx` contains the ring template (not spinner).
+- [ ] Test Lovable import: generated repo imports correctly, first view shows the showcase cards.
+- [ ] Test agent rules: instruct the Lovable agent to "improve the color scheme" and verify it respects OKLCH, does not replace with Radix.
+
+---
+
+## Sources
+
+- dotUI preset codec: `www/src/modules/create/preset/codec.ts` — `encodePreset` (`:75`), `decodePreset` (`:111`)
+- dotUI init item builder: `www/src/publisher/emit-theme.ts` — `emitInitItem` (`:71`), `mergePresetCssFields` (`:145`), `rampsToVars` (`:135`)
+- dotUI init route: `www/src/routes/r/init.tsx` — `decodePresetForRoute` (`:47`)
+- dotUI color resolution: `www/src/registry/theme/primitives.ts` — `resolveColorConfig` (`:67`)
+- dotUI on-color fallback: `packages/colors/src/shared/on-color.ts` — `onBlackWhite` (`:88`)
+- dotUI install command: `www/src/modules/create/install-command.tsx:39-48`
+- dotUI showcase grid: `www/src/components/marketing/showcase/cards.tsx:20-48`
+- dotUI component publisher: `www/src/publisher/publish.ts:119-161`
+- dotUI publish preset type: `www/src/publisher/types.ts:79-85`
+- Lovable GitHub import: `https://docs.lovable.dev` (import path; verify `?repo=` param name before shipping)
+- Lovable agent behavior (HSL overwrite, Radix refactor prior): ground-truth facts provided in task specification
+- shadcn registry:base type: `https://ui.shadcn.com/docs/registry/registry-item-type`
+- tailwindcss-autocontrast (on-color plugin): `packages/tailwindcss-autocontrast/src/index.js:407-501`

--- a/docs/research/open-in/paper.md
+++ b/docs/research/open-in/paper.md
@@ -1,0 +1,397 @@
+# Open in Paper (paper.design)
+
+> Summary line: **lowest fidelity of the set; agent-mediated only today** · button type **none** (no native import; agent-driven clipboard/command flow) · preset fidelity **partial** (token values injected as inline styles; component semantics absent) · color fidelity **partial** (OKLCH ramps resolved to inline CSS; no utility class system)
+
+paper.design is an AI-first canvas tool built around an MCP server that exposes two write primitives: set styles on the canvas and write HTML markup. It does not speak React, Tailwind, shadcn registries, or npm packages. As of June 2026, themes and shadcn registry support are listed as roadmap items ("coming soon") on Paper's site — they are not shipped. The realistic integration path today is **agent-mediated**: an AI agent (Claude, Cursor, etc.) reads the user's dotUI preset, resolves it to flat token values, and calls Paper's MCP tools to paint an approximation of the showcase with inline styles. Set expectations plainly: the result is a styled flat-div layout, not a working React component tree. No component semantics, no Tailwind utilities, no interactive states, no RAC aria wiring.
+
+---
+
+## 1. User experience
+
+**Today (agent-mediated path)**
+
+From the dotUI `/create` customizer (URL state: `?preset=<encoded>`, route `www/src/routes/_app/create.tsx:12-16`), the user clicks **"Open in Paper"**. Because Paper has no URL import protocol and no registry hook, the flow is:
+
+1. dotUI copies a command (or JSON blob) to the clipboard describing the showcase layout + resolved preset tokens.
+2. The user opens Paper, activates an AI agent inside Paper (or uses Paper's MCP server from an external agent like Claude Code), and pastes / runs the command.
+3. The agent calls Paper's MCP tools — `set_styles` (to write the preset's OKLCH-derived hex tokens as Paper canvas styles) and `write_html` (to paint a flat div tree approximating the showcase card grid) — producing a low-fidelity visual on the Paper canvas.
+
+What the user lands in: a Paper canvas showing a static layout of colored divs and text labels representing the 17 showcase cards. Colors match the user's preset (accent, neutrals, status palettes). No interactivity, no variant logic, no component install. This is the honest ceiling for Paper today.
+
+**Future (when Paper ships themes/shadcn support)**
+
+Once Paper ships a shadcn registry import or a theme-import command, the flow can be upgraded to a button that opens Paper with the dotUI init URL baked in (section 10 covers the revisit plan). Until then, the agent-mediated path below is the only viable option.
+
+---
+
+## 2. Technical mechanism
+
+Paper's current external-integration surface is its **MCP server**. The server config (as documented on paper.design) is:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "paper-design-mcp@latest"],
+  "env": {}
+}
+```
+
+The MCP exposes (at minimum) two write tools relevant here:
+
+- `write_html` — accepts an HTML string with inline styles; Paper renders it as flat div nodes on the canvas.
+- `set_styles` — sets global canvas-level style variables (color tokens, font sizes, spacing).
+
+There is no `install_registry`, no `import_components`, no `run_shadcn` tool. Paper's canvas is **not** a React render tree. The agent produces markup; Paper displays it.
+
+The integration therefore has three parts:
+
+1. **Resolve the preset to flat values** (server-side, in dotUI).
+2. **Serialize the showcase as HTML with inline styles** (agent-generated from dotUI's card structure).
+3. **Call Paper MCP tools** to push styles + markup onto the canvas.
+
+dotUI must build a new server endpoint that performs step 1 + step 2 and returns a payload the agent can consume.
+
+---
+
+## 3. Preset propagation
+
+The user's preset (`?preset=<encoded>`) must be decoded and resolved before any data reaches Paper. The full decode path:
+
+```
+?preset=<base64url> 
+  → fromBase64Url() + inflateRaw() + JSON.parse()  [codec.ts:111-126]
+  → DesignSystemState { p?, t?, d?, c? }
+  → fromCompact() → DesignSystem { componentParams, tokens, density, color? }
+  → if color present: resolveColorConfig(color)    [primitives.ts:67-108]
+      → createTheme() → { steps, light, dark }     [@dotui/colors kernel]
+      → light: { neutral: oklch[], accent: oklch[], success[], warning[], danger[], info[] }
+      → dark:  same palettes, lightness reversed   [reverseRamp, primitives.ts:28-37]
+```
+
+For Paper's needs, the OKLCH strings must be converted to hex (Paper's MCP tools accept CSS color values; it is safest to use sRGB hex or `oklch()` literals and rely on Paper's rendering engine to handle OKLCH — but for maximum compatibility, convert to hex).
+
+The conversion seam is `packages/colors/src/shared/color.ts`:
+
+```ts
+// gamutMap clips out-of-sRGB vivid OKLCH colors; toSrgb returns {r,g,b} in 0..1
+import { gamutMap, toSrgb } from "@dotui/colors/shared/color";
+
+function oklchToHex(oklchStr: string): string {
+  // oklchStr e.g. "oklch(0.6543 0.1892 256.12)"
+  const [l, c, h] = oklchStr.replace("oklch(","").replace(")","").split(" ").map(Number);
+  const mapped = gamutMap({ l, c, h });
+  const { r, g, b } = toSrgb(mapped);
+  const toHex = (v: number) => Math.round(v * 255).toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+```
+
+The result is a flat token map:
+
+```ts
+// Produced once per preset, for all 6 palettes × 11 steps = 66 light + 66 dark vars
+const lightTokens: Record<string, string> = {}; // "--neutral-50": "#f9f9f9", ...
+const darkTokens: Record<string, string> = {};
+
+for (const [palette, steps] of Object.entries(resolved.light)) {
+  for (let i = 0; i < resolved.steps.length; i++) {
+    lightTokens[`--${palette}-${resolved.steps[i]}`] = oklchToHex(steps[i]);
+  }
+}
+// same for dark using resolved.dark
+```
+
+Additionally, the semantic `--color-*` layer (from `www/src/registry/base/theme.css` / `www/src/registry/theme/semantics.ts:36-124`) can be derived by substituting the palette step references into the semantic aliases. Key mappings needed to paint the showcase (from `DEFAULT_SEMANTICS`):
+
+```
+--color-bg        → --neutral-50  (light) / --neutral-950 (dark)
+--color-fg        → --neutral-950 (light) / --neutral-50  (dark)
+--color-border    → --neutral-200 (light) / --neutral-800 (dark)
+--color-accent    → --accent-500
+--color-card      → --neutral-100 (light) / --neutral-900 (dark)
+--color-muted     → --neutral-100 (light) / --neutral-900 (dark)
+--color-fg-muted  → --neutral-500
+```
+
+Density (`compact | default | comfortable`) affects Tailwind class suffix selection inside component TVs but has no analog in Paper's flat-div model. It can be noted as a label in the Paper canvas header but cannot be rendered structurally.
+
+**What is NOT propagated:** per-component `componentParams` (e.g. `alert.style = "sousse"`, `card.style = "tasnim"`). These drive `tv()` class selection in `publisher/flatten.ts:148-170` and `publisher/resolve-classes.ts`. Paper receives no component tree, so param choices are invisible. The best approximation is a text annotation on the canvas listing the non-default params.
+
+---
+
+## 4. Components installed
+
+**Paper: none.** Paper has no concept of installing components into a project's `ui/` folder. The canvas holds markup, not a file system.
+
+The agent-mediated path can paint a visual representation of the 17 showcase cards from `www/src/components/marketing/showcase/cards.tsx` using HTML divs with inline styles. The 37 registry UI components the cards depend on (accordion, avatar, badge, button, calendar, card, checkbox, color-area, color-editor, color-field, color-slider, color-thumb, combobox, disclosure, drop-zone, field, file-trigger, group, input, kbd, link, list-box, loader, otp-field, popover, progress-bar, radio-group, select, separator, slider, switch, table, tabs, tag-group, text, text-field, time-field, toggle-button, toggle-button-group) are **not installed anywhere** — they are painted as visual approximations.
+
+When Paper ships shadcn/component support, the install path will be:
+
+```
+npx shadcn add <dotui-init-url>?preset=<encoded>
+```
+
+where `<dotui-init-url>` = `https://dotui.com/r/init` (the `registry:base` item produced by `emitInitItem` in `www/src/publisher/emit-theme.ts:71-128`). That URL delivers every dotUI dependency, the `cn()` helper, and the `config.registries["@dotui"]` baked with the encoded preset so subsequent `shadcn add @dotui/<name>` calls hit per-component endpoints with the correct preset. But Paper is not there yet.
+
+---
+
+## 5. Theme in globals.css
+
+**Paper: no globals.css.** Paper does not have a Tailwind project or a CSS entry file.
+
+The theme is approximated via Paper's `set_styles` MCP tool. The agent calls it with the resolved flat token map (section 3) as CSS custom property assignments. This gives Paper's canvas a color system, but it is cosmetic — Paper does not run a Tailwind build, does not process `@theme inline` blocks, and does not invoke `tailwindcss-autocontrast` to derive `--on-*` foreground values.
+
+For the agent-mediated path, `--on-*` foregrounds are derived using the same `onBlackWhite` heuristic the autocontrast plugin uses (WCAG relative luminance, black or white pick) from `packages/colors/src/shared/on-color.ts:88-97`. This is the deliberate replica of `tailwindcss-autocontrast`'s `getContrastColor` kept in lockstep by `www/src/registry/theme/on-color-parity.spec.ts`. The result is adequate for painting foreground text on colored cards.
+
+What the `set_styles` call looks like:
+
+```json
+{
+  "tool": "set_styles",
+  "arguments": {
+    "styles": {
+      "--neutral-50":  "#f9f9f9",
+      "--neutral-100": "#f2f2f2",
+      "--accent-500":  "#438cd6",
+      "--color-bg":    "#f9f9f9",
+      "--color-fg":    "#0a0a0a",
+      "--color-accent":"#438cd6",
+      "--color-card":  "#f2f2f2",
+      "--color-border":"#e5e5e5"
+    }
+  }
+}
+```
+
+The full init-item equivalent (what `https://dotui.com/r/init?preset=<encoded>` would write to a real `globals.css` via shadcn) includes:
+- `@import "tw-animate-css"` — not applicable in Paper
+- `@plugin "tailwindcss-react-aria-components"` — not applicable in Paper
+- `@plugin "tailwindcss-autocontrast" { cssfile: ... }` — not applicable in Paper
+- `@theme inline` semantic layer — approximated via `set_styles`
+- `:root { --neutral-50: ...; ... }` / `.dark { ... }` — approximated via `set_styles` (light values only; dark is unavailable in Paper's current model)
+
+---
+
+## 6. The showcase as first view
+
+`www/src/components/marketing/showcase/cards.tsx:20-48` renders a `columns-1 sm:columns-2 lg:columns-3 xl:columns-4` masonry grid of 17 self-contained card widgets. The agent must translate this into HTML markup that Paper's `write_html` tool can accept.
+
+The translation rules:
+
+| React pattern | Paper HTML approximation |
+|---|---|
+| `<Card>` with `cn("bg-card border-border rounded-lg p-4")` | `<div style="background:var(--color-card); border:1px solid var(--color-border); border-radius:8px; padding:16px">` |
+| `<Button>` (accent variant) | `<button style="background:var(--color-accent); color:var(--on-accent-500); border-radius:6px; padding:8px 16px; font-size:14px">` |
+| `<Avatar>` | `<img style="border-radius:50%; width:32px; height:32px">` + fallback `<span style="background:var(--color-muted)">` |
+| `<Badge>` | `<span style="background:var(--color-accent); color:var(--on-accent-500); border-radius:4px; padding:2px 8px; font-size:12px">` |
+| `<Separator>` | `<hr style="border:none; border-top:1px solid var(--color-border)">` |
+| `<ProgressBar>` | `<div style="height:8px; background:var(--color-muted); border-radius:4px"><div style="width:{value}%; height:100%; background:var(--color-accent)"></div></div>` |
+| `<Tabs>` | `<div>` row of tab labels + active underline in accent color |
+| `<Switch>` checked | `<div style="width:36px; height:20px; background:var(--color-accent); border-radius:10px; ...">` |
+| Lucide icons | `<svg>` pass-through (inline the icon path from lucide's source) |
+| `@fontsource-variable/geist` | `font-family: "Geist Variable", system-ui, sans-serif` inline on the root `<div>` |
+
+The agent-generated HTML output is a single `<div>` with a 4-column CSS grid (or flex-wrap) containing 17 card sub-trees, each approximating one of: Booking, TwoFactor, Filters, Storage, Notifications, CookiePreferences, InviteMembers, Shortcuts, Payment, Transactions, AccountMenu, Faq, ColorEditorCard, UploadAvatar, TeamName, Feedback, LoginForm.
+
+Remote avatar images (`https://github.com/mehdibha.png`, `https://github.com/shadcn.png`, etc.) can be included as `<img src="...">` tags — they are publicly accessible and Paper renders remote images.
+
+The inline SVG sign-in icons in `login-form.tsx` (Google, X, GitHub) can be embedded verbatim in the HTML string.
+
+**Key constraint:** the masonry layout (`columns-*` CSS multi-column) must be replaced with a flat CSS grid or flex-wrap since Paper does not run Tailwind. Use:
+
+```html
+<div style="display:grid; grid-template-columns:repeat(4,1fr); gap:16px; padding:32px; background:var(--color-bg); font-family:'Geist Variable',system-ui,sans-serif">
+  <!-- 17 card divs -->
+</div>
+```
+
+---
+
+## 7. What dotUI must build
+
+For the agent-mediated path, dotUI needs one new server endpoint and one button component:
+
+### 7a. New endpoint: `GET /r/paper?preset=<encoded>`
+
+Route file: `www/src/routes/r/paper.tsx` (new, following the pattern of `www/src/routes/r/init.tsx`).
+
+Responsibilities:
+1. Decode `?preset=` via `decodePreset` from `www/src/modules/create/preset/codec.ts:111`.
+2. Resolve color ramps: `resolveColorConfig(preset.color)` from `www/src/registry/theme/primitives.ts:67` (falls back to default ramps if `color` is absent).
+3. Convert all 66 light + 66 dark OKLCH values to hex via `gamutMap` + `toSrgb` from `packages/colors/src/shared/color.ts:42-60`.
+4. Build the semantic flat-token map by substituting primitive hex values into the `DEFAULT_SEMANTICS` step references (`www/src/registry/theme/semantics.ts:36-124`).
+5. Derive `--on-*` foregrounds using `onBlackWhite` from `packages/colors/src/shared/on-color.ts:88-97`.
+6. Return a JSON payload:
+
+```json
+{
+  "preset": "<encoded>",
+  "density": "compact",
+  "tokens": {
+    "light": {
+      "--neutral-50": "#f9f9f9",
+      "--accent-500": "#438cd6",
+      "--color-bg": "#f9f9f9",
+      "--color-fg": "#0a0a0a",
+      "--on-accent-500": "#ffffff"
+    },
+    "dark": { ... }
+  },
+  "componentParams": {
+    "card": { "style": "default" },
+    "alert": { "style": "default" }
+  },
+  "mcpInstructions": {
+    "set_styles": { ... },
+    "write_html": "<div style=...><!-- showcase HTML --></div>"
+  }
+}
+```
+
+The `mcpInstructions` block is optional but useful: it pre-serializes the exact tool calls so a dumb copy-paste workflow also works (user pastes the `write_html` value into Paper's own AI chat).
+
+### 7b. New button in the install panel
+
+In `www/src/modules/create/install-command.tsx` (the panel that already renders the `npx shadcn add ...` command), add an "Open in Paper" row. Since no URL protocol exists, the button:
+- Fetches `/r/paper?preset=<encoded>` (or constructs the payload client-side using the codec).
+- Copies the `mcpInstructions.write_html` string to the clipboard.
+- Shows a tooltip: "Copied showcase HTML. In Paper, open the AI assistant and paste — it will call Paper's MCP tools to paint the showcase with your theme."
+
+No `openUrl` / `window.open` needed. The button type is `copy-command`.
+
+### 7c. Agent prompt template
+
+For users running Claude Code or Cursor with Paper's MCP configured, dotUI can expose an agent prompt at `GET /r/paper-prompt?preset=<encoded>` that returns a plain-text instruction:
+
+```
+You have Paper's MCP server available. Do the following:
+
+1. Call set_styles with these tokens (light mode):
+   --neutral-50: #f9f9f9
+   --accent-500: #438cd6
+   --color-bg: #f9f9f9
+   --color-fg: #0a0a0a
+   [... full list ...]
+
+2. Call write_html with the following markup:
+   <div style="display:grid; grid-template-columns:repeat(4,1fr); gap:16px; background:#f9f9f9; font-family:'Geist Variable',system-ui,sans-serif; padding:32px">
+     [... 17 card divs ...]
+   </div>
+```
+
+This prompt can be copied from the dotUI UI and pasted into any agent that has Paper's MCP connected.
+
+---
+
+## 8. Schema / meta.ts changes
+
+Unlike the Figma path (which requires a `figma` field on every `meta.ts`), the Paper path requires **no meta.ts changes**. The agent-mediated flow does not consume component anatomy metadata — it only needs the resolved token map and a static HTML template of the showcase.
+
+However, if Paper ships component support in the future, a `paper` field on `RegistryItem` could carry a Paper component ID or style template:
+
+```ts
+// www/src/registry/types.ts (hypothetical future addition)
+export type RegistryItem = ShadcnRegistryItem & {
+  group?: ComponentGroup | null;
+  params?: Record<string, ParamDef>;
+  figma?: string;
+  paper?: string; // Paper component ID or template key, e.g. "button-primary"
+};
+```
+
+Adding this field is one line in `www/src/registry/types.ts:69-78` (the intersection type). It becomes inert until code reads it, and propagates automatically into internal publishable meta via the `{ ...rest }` spread in `www/src/publisher/build-time/build-publishables.ts:334` (`metaForRuntime`).
+
+**For today's agent-mediated path: no meta.ts changes are required.**
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### Fidelity ceiling (structural)
+
+Paper's `write_html` produces flat div nodes. dotUI's showcase components use:
+- **React Aria Components** for all interactive states (`data-focused`, `data-hovered`, `data-selected`, `data-disabled`) — invisible in a static HTML snapshot.
+- **`tailwind-variants`** for slot-based class composition — the HTML approximation must inline equivalent styles by hand.
+- **`tailwindcss-autocontrast`** for `--on-*` foreground derivation at Tailwind build time — must be pre-computed server-side (section 3).
+- **`tailwindcss-react-aria-components`** for `data-[...]` variants — not applicable.
+- **`tailwindcss-with`** for `with-[...]` container variants — not applicable.
+
+The resulting Paper canvas is a **wireframe approximation**, not a runnable component tree. Do not promise designers that the Paper canvas is the "same" as the dotUI showcase.
+
+### OKLCH gamut risk
+
+dotUI emits `oklch()` strings. High-chroma OKLCH colors (especially vivid accent hues at mid-lightness) may lie outside the sRGB gamut. `gamutMap` from `packages/colors/src/shared/color.ts:48` uses the CSS Color 4 chroma-reduction method to clip them to sRGB before hex conversion. This is lossy at vivid hues — the Paper hex will be less saturated than the browser-rendered OKLCH. Document this in the button tooltip.
+
+### Paper MCP API surface (unstable)
+
+Paper's MCP server is undocumented beyond what Paper's own AI agent uses. Tool names (`set_styles`, `write_html`) and argument shapes may change without notice. Build the `/r/paper` endpoint to return the resolved token map and showcase HTML as data fields, not pre-serialized MCP calls — this way the agent can adapt to Paper's current API shape without a dotUI deployment.
+
+### Dark mode
+
+Paper (as of June 2026) does not expose a canvas-level dark/light mode switch via MCP. The agent-mediated path delivers light-mode tokens only. Dark ramps are included in the `/r/paper` response payload so an agent can inject a `.dark` override if Paper's API gains mode support.
+
+### No /r/registry.json index (existing limitation)
+
+dotUI currently has no `/r/registry.json` index route (it returns 404). This is a known gap noted in the ground-truth facts. The Paper integration does not depend on this index — it uses the `/r/paper` endpoint directly — so this is not a blocker. But when the shadcn MCP discovery path becomes relevant (if Paper ships shadcn import), the registry.json index must be built. The implementation would be a new route `www/src/routes/r/registry[.]json.tsx` importing `registryUi`, `registryLib`, `registryHooks`, `registryBase` from `www/src/registry/__generated__/registry-items.ts` and emitting the shadcn `Registry` shape (`{ name: "dotui", homepage: "...", items: [...] }`).
+
+### Preset round-trip correctness
+
+The `/r/paper` endpoint decodes the preset exactly as `/r/init` does (`decodePreset`, `codec.ts:111-126`), with the same fallback to `defaultPreset()` on any malformed input. The `tokens` field of `DesignSystem` (global CSS vars set via `setToken`) is not yet wired into the publisher's `PublishPreset` (documented TODO at `emit-theme.ts:62-68`) — this means user-set `--radius-factor` overrides, for example, are silently dropped. The Paper path inherits this limitation.
+
+### Paper themes roadmap
+
+Paper's public roadmap mentions "themes" and "shadcn" as forthcoming features. When they ship, revisit: (a) whether Paper can consume a `registry:base` item from `https://dotui.com/r/init?preset=<encoded>` directly (shadcn CLI integration), and (b) whether Paper exposes a URL protocol (`paper://import?registry=...`) or deeplink that enables a real button-type `component-url` or `mcp-install` flow. Until then, the agent-mediated path is the only option.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+### Phase 0: resolve + serialize (server-side, no UI)
+
+- [ ] **Create `www/src/routes/r/paper.tsx`** as a TanStack Start server GET handler, mirroring the structure of `www/src/routes/r/init.tsx:22-59`.
+  - Read `url.searchParams.get("preset")`, decode via `decodePreset` (`www/src/modules/create/preset/codec.ts:111`), fall back to `defaultPreset()`.
+  - If `preset.color` is defined, call `resolveColorConfig(preset.color)` (`www/src/registry/theme/primitives.ts:67`); otherwise use the static ramps from `baseRegistryCss` (`www/src/registry/__generated__/base-css.ts`).
+  - Convert all ramp OKLCH strings to hex using `gamutMap` + `toSrgb` from `packages/colors/src/shared/color.ts:42-60` (implement `oklchToHex` as a small utility in `www/src/publisher/`).
+  - Derive `--on-*` using `onBlackWhite` from `packages/colors/src/shared/on-color.ts:88-97`.
+  - Build the semantic alias map by substituting resolved hex values into `DEFAULT_SEMANTICS` step references (`www/src/registry/theme/semantics.ts:36-124`).
+  - Return JSON: `{ preset, density, tokens: { light, dark }, componentParams, showcaseHtml }` with cache headers matching the `/r/$name` pattern (`www/src/routes/r/$name.tsx:27-30`).
+
+- [ ] **Implement `buildShowcaseHtml(tokens)`** in `www/src/publisher/paper-showcase.ts` (new file). This function takes the resolved light token map and returns the HTML string approximation of the 17 showcase cards from `www/src/components/marketing/showcase/cards.tsx:20-48`. Use hardcoded layout values (the card content is static data). Include remote avatar `<img>` tags using the GitHub CDN URLs embedded in the showcase files.
+
+### Phase 1: UI button
+
+- [ ] **Add "Open in Paper" button** to the install panel in `www/src/modules/create/install-command.tsx`.
+  - On click: fetch `GET /r/paper?preset=<encoded>` (or construct payload in-browser).
+  - Extract `showcaseHtml` and copy to clipboard.
+  - Show tooltip: "HTML copied. Open Paper, activate the AI assistant, and paste to paint the showcase with your theme."
+  - Button type: `copy-command` (no URL open).
+
+- [ ] **Run `pnpm exec oxfmt`** on every touched file before pushing (MEMORY: `reference_oxfmt_import_order.md` — CI `pnpm check` enforces import order via oxfmt).
+
+### Phase 2: agent prompt endpoint (optional)
+
+- [ ] **Create `www/src/routes/r/paper-prompt.tsx`** returning a plain-text instruction string for agents that have Paper's MCP configured. Include the `set_styles` token list and the `write_html` markup as plain text.
+
+### Phase 3: revisit triggers (when Paper ships themes/shadcn)
+
+- [ ] Watch Paper's changelog for a registry import feature or URL deeplink protocol.
+- [ ] When available: replace the `copy-command` button with a `mcp-install` or `component-url` button that opens Paper directly with `https://dotui.com/r/init?preset=<encoded>` as the registry root.
+- [ ] If Paper ships component semantics: add `paper?: string` to `RegistryItem` (`www/src/registry/types.ts:69-78`) and populate it in each `ui/*/meta.ts` with the matching Paper component ID.
+- [ ] If Paper ships a shadcn MCP discovery path: build the `/r/registry.json` index route (new `www/src/routes/r/registry[.]json.tsx`, imports from `__generated__/registry-items.ts`) so Paper's MCP can discover all dotUI items.
+
+---
+
+## Sources
+
+- Paper MCP server: <https://paper.design> (MCP integration docs, "coming soon" themes/shadcn as of June 2026)
+- dotUI preset codec: `www/src/modules/create/preset/codec.ts:75-126`
+- dotUI init item emission: `www/src/publisher/emit-theme.ts:71-128`
+- OKLCH color seam: `packages/colors/src/shared/color.ts:36-81`
+- on-black/white heuristic (autocontrast parity): `packages/colors/src/shared/on-color.ts:88-97`; parity test `www/src/registry/theme/on-color-parity.spec.ts`
+- Showcase card list: `www/src/components/marketing/showcase/cards.tsx:20-48`
+- Semantic token vocabulary: `www/src/registry/theme/semantics.ts:36-124`
+- RegistryItem type (where to add `paper` field): `www/src/registry/types.ts:69-78`
+- metaForRuntime spread (auto-propagation of new fields): `www/src/publisher/build-time/build-publishables.ts:334`
+- shadcn registry MCP config shape: <https://ui.shadcn.com/docs/registry/mcp> (requires `/r/registry.json` index, currently 404 on dotUI)
+- tailwindcss-autocontrast plugin (on-* derivation): `packages/tailwindcss-autocontrast/src/index.js:339-351`
+- tokens TODO (not yet wired into PublishPreset): `www/src/publisher/emit-theme.ts:62-68`

--- a/docs/research/open-in/replit.md
+++ b/docs/research/open-in/replit.md
@@ -1,0 +1,472 @@
+# Open in Replit
+
+> Summary line: **feasible via two paths (generated-repo import or base-template agent install)** · button type **repo-import** (primary) or **copy-command** (secondary) · preset fidelity **full** · color fidelity **full** (OKLCH ramps written to globals.css by `npx shadcn add /r/init?preset=…`)
+
+---
+
+## 1. User experience
+
+From the dotUI `/create` customizer — state lives in `?preset=<encoded>` via `www/src/routes/_app/create.tsx:11-16`, encoded by `encodePreset` from `www/src/modules/create/preset/codec.ts:75` — the user clicks **"Open in Replit"**.
+
+Two practical flows exist. The primary flow is cleaner but requires dotUI to maintain a GitHub template repo:
+
+### Primary path: GitHub import (generated-repo)
+
+1. Clicking "Open in Replit" triggers a server action (or client-side redirect) that:
+   - Calls dotUI's backend to generate (or update) a GitHub repo seeded with the user's preset.
+   - Redirects the browser to `https://replit.com/github.com/<owner>/<repo>`.
+2. Replit clones the repo, detects it as a Node/Vite project, and opens an IDE session with the app already runnable.
+3. The user sees the showcase (`<Cards />` from `www/src/components/marketing/showcase/cards.tsx`) as the first view, with `globals.css` already containing their OKLCH ramp, and every needed dotUI component already installed under `src/components/ui/`.
+
+### Secondary path: base template + agent install (copy-command)
+
+1. Clicking "Open in Replit" opens a fixed public Replit template (a bare Vite + React + Tailwind v4 repo that already has `components.json` configured and `shadcn` available).
+2. The button also copies a one-line command to the clipboard — the same command `InstallCommand` produces at `www/src/modules/create/install-command.tsx:39-48`:
+   ```
+   npx shadcn add https://dotui.com/r/init?preset=<encoded>
+   ```
+3. The user opens the Replit shell and pastes the command. The shadcn CLI fetches `/r/init?preset=<encoded>` (the `registry:base` item), writes the OKLCH theme into `globals.css`, installs `src/lib/utils.ts`, and bakes the `@dotui` registry alias with the preset into `components.json`. The user then adds components individually via `npx shadcn add @dotui/button` etc., or dotUI can provide a second command that adds all at once.
+
+The primary path is better UX (zero manual commands); the secondary path requires zero dotUI backend work beyond what already exists.
+
+---
+
+## 2. Technical mechanism
+
+### Replit GitHub import URL format
+
+Replit's programmatic project-creation surface for public use is the GitHub import URL:
+
+```
+https://replit.com/github.com/<owner>/<repo>
+```
+
+Note the literal string `github.com/` embedded in the Replit URL (not `github/`). Examples:
+
+```
+https://replit.com/github.com/dotui-org/showcase-template
+```
+
+This URL causes Replit to:
+- Fork/clone the repo into the user's account.
+- Detect the run command from `.replit` or `package.json`.
+- Present the live preview and IDE immediately.
+
+There is no Replit API for programmatic project creation available to third parties without OAuth or a Replit Teams plan. The GitHub import URL is the practical public path.
+
+### Runtime environment
+
+Replit runs real Linux VMs (Nix-based). Node.js, `pnpm`, and `npx` are all available. Vite dev server starts fine. The app runs as a normal Vite + React SPA.
+
+### shadcn CLI availability
+
+`npx shadcn@latest` works on Replit exactly as on a developer's laptop. There is no sandbox restriction. The template repo can include shadcn in `devDependencies` so the install skips the network resolution step.
+
+---
+
+## 3. Preset propagation
+
+The preset is the string produced by `encodePreset(ds)` (`www/src/modules/create/preset/codec.ts:75`). Its wire format:
+
+1. Build the compact `DesignSystemState` `{p?,t?,d?,c?}` (`www/src/modules/create/preset/types.ts:14-19`) by diffing `DesignSystem` against `DEFAULTS` (`www/src/modules/create/preset/defaults.ts:5`).
+2. `JSON.stringify` the compact state.
+3. `pako.deflateRaw(json, { level: 9 })` — raw DEFLATE, no zlib header.
+4. URL-safe base64 (`toBase64Url`, `codec.ts:12-21`): `btoa(String.fromCharCode(...bytes))` then `+→-`, `/→_`, strip trailing `=`.
+5. `encodePreset` returns `undefined` when the design system equals defaults — the button must handle this case by omitting `?preset=` entirely.
+
+The init URL is therefore:
+
+```ts
+// mirrors www/src/modules/create/install-command.tsx:39-48
+const encoded = encodePreset(designSystem); // undefined if default
+const initUrl = encoded
+  ? `https://dotui.com/r/init?preset=${encoded}`
+  : `https://dotui.com/r/init`;
+```
+
+### Primary path: baking the preset at repo-generation time
+
+For the generated-repo path, the server action does not redirect to a Replit URL immediately. It:
+
+1. Decodes the preset server-side using `decodePreset(encoded)` (`codec.ts:111`).
+2. Runs `npx shadcn add <initUrl>` inside a temporary Node process (or calls `emitInitItem` + `publish` directly — see section 5) to produce the full `globals.css` content and component files.
+3. Commits those files into a new branch or repo (via GitHub API or `git`).
+4. Redirects the user to `https://replit.com/github.com/<owner>/<generated-or-updated-repo>`.
+
+This keeps the preset baked statically — Replit never calls a dotUI endpoint; the preset lives as literal CSS and TS source in the repo.
+
+### Secondary path: live install
+
+The secondary path keeps it simple: the user runs `npx shadcn add <initUrl>` in the Replit shell. The shadcn CLI fetches `/r/init?preset=<encoded>` from `www/src/routes/r/init.tsx`, which calls `decodePresetForRoute(encoded)` (`init.tsx:47-58`) and then `emitInitItem({ baseRegistryCss, preset, encodedPreset, registryRoot })` (`www/src/publisher/emit-theme.ts:71-128`). The returned `registry:base` JSON item is merged into the project's `globals.css` by the shadcn CLI.
+
+The `?preset=` string is intentionally NOT URL-encoded again in the command — `install-command.tsx:41` concatenates it raw. The encoded string is already URL-safe base64.
+
+---
+
+## 4. Components installed
+
+### What "installed" means in a target project
+
+After `npx shadcn add https://dotui.com/r/init?preset=<encoded>` the project has:
+- `src/lib/utils.ts` — the `cn()` helper (ships inline in the init item's `files[]`, `emit-theme.ts:41-47`, because shadcn's own `cn` is 4xx-gated under Tailwind v4).
+- `components.json` updated with `registries["@dotui"] = "https://dotui.com/r/{name}?preset=<encoded>"` (`emit-theme.ts:130-132`). This bakes the preset so all subsequent `shadcn add @dotui/<name>` calls hit the right endpoint.
+
+To install the full component set needed to render the showcase, shadcn add must be called for each component the showcase uses. From the transitive import graph (`showcase/cards.tsx` imports all 17 cards which collectively use 37 registry items):
+
+```bash
+npx shadcn add @dotui/accordion @dotui/avatar @dotui/badge @dotui/button \
+  @dotui/calendar @dotui/card @dotui/checkbox @dotui/checkbox-group \
+  @dotui/color-area @dotui/color-editor @dotui/color-field @dotui/color-slider \
+  @dotui/color-thumb @dotui/disclosure @dotui/drop-zone @dotui/field \
+  @dotui/file-trigger @dotui/group @dotui/input @dotui/kbd @dotui/link \
+  @dotui/list-box @dotui/loader @dotui/otp-field @dotui/popover \
+  @dotui/progress-bar @dotui/radio-group @dotui/select @dotui/separator \
+  @dotui/slider @dotui/switch @dotui/table @dotui/tabs @dotui/tag-group \
+  @dotui/text @dotui/text-field @dotui/time-field @dotui/toggle-button \
+  @dotui/toggle-button-group
+```
+
+Each `@dotui/<name>` resolves via the baked `registries` alias to `/r/<name>?preset=<encoded>`. The per-component route `www/src/routes/r/$name.tsx` applies `density` and `componentParams` from the preset, rewriting Tailwind class strings and serializing the `tv()` config (`publish.ts:119-161`). Transitive deps (e.g. `button → loader → focus-styles`) are resolved as absolute URLs with the same preset appended (`rewriteDeps`, `publish.ts:79-105`), so the full graph installs with the correct preset.
+
+### For the primary (generated-repo) path
+
+The repo is pre-populated. All 39 component files (37 ui items + `utils` + `focus-styles` bundled into init) are committed as resolved TypeScript under `src/components/ui/`. Their content is exactly what `publish({ publishable, preset })` would emit for the user's preset: density-adjusted class strings, scalar-resolved Tailwind suffixes, enum-with-files variants (e.g. `loader` ships `base.spinner.tsx` or `base.ring.tsx` depending on `componentParams.loader.style`). The `selectPublishable` logic at `www/src/routes/r/$name.tsx:89-107` determines which file variant ships.
+
+---
+
+## 5. Theme in globals.css
+
+### What `/r/init?preset=<encoded>` writes
+
+The `emitInitItem` function (`www/src/publisher/emit-theme.ts:71-128`) returns a `registry:base` item. When shadcn processes it, the following is merged into the consumer's `globals.css`:
+
+**At-rules (constant across presets, from `baseRegistryCss`):**
+```css
+@import "tw-animate-css";
+@plugin "tailwindcss-react-aria-components";
+@plugin "tailwindcss-autocontrast" { cssfile: "<this-file>"; }
+@plugin "tailwindcss-with";
+@custom-variant dark (&:is(.dark *));
+@utility focus-ring { … }
+@utility focus-reset { … }
+@utility focus-input { … }
+@utility no-highlight { … }
+@layer base { * { @apply border-border } body { @apply bg-bg font-sans text-fg } html { @apply font-sans } }
+::selection { background-color: var(--accent-800); color: var(--on-accent-800); }
+```
+
+**`@theme inline` block (constant, from `cssVars.theme`, `base-css.ts:179-278`):**
+```css
+@theme inline {
+  --radius-md: calc(0.375rem * var(--radius-factor));
+  --color-bg: var(--neutral-50);
+  --color-accent: var(--accent-500);
+  --color-fg-on-accent: var(--on-accent-500);
+  /* ... all ~80 semantic color tokens + radius scale + cursors + eases */
+}
+```
+
+**`:root` block (preset-specific):**
+```css
+:root {
+  --radius-factor: 1;
+  /* 6 palettes × 11 steps = 66 OKLCH primitive ramp vars for the USER'S chosen seeds */
+  --neutral-50: oklch(0.985 0 0);
+  --neutral-100: oklch(0.9562 0 0);
+  /* ... */
+  --accent-50: oklch(…);  /* derived from user's accent seed via resolveColorConfig */
+  /* ... all 66 vars for neutral/accent/success/warning/danger/info */
+}
+```
+
+**`.dark` block:** the reversed ramp (each palette's steps 50↔950 swapped, `reverseRamp`, `primitives.ts:28-37`).
+
+The color ramps are generated by `resolveColorConfig(preset.color)` (`emit-theme.ts:155-159`) when `preset.color` is present, or taken from the static `baseRegistryCss` (built from `DEFAULT_COLOR_CONFIG`) otherwise. `resolveColorConfig` is at `www/src/registry/theme/primitives.ts:67-108`; it calls `@dotui/colors` kernel `createTheme` with the user's seeds and algorithm. `rampsToVars` (`emit-theme.ts:134-143`) flattens the resolved ramp to `--<palette>-<step>` OKLCH strings.
+
+`--on-*` foreground variables are NOT emitted into the init item. The `tailwindcss-autocontrast` plugin generates them at Tailwind compile time from the `--<palette>-<step>` values in `:root`/`.dark` (`emit-theme.ts:152-159`). The template repo must therefore include a Tailwind config that loads the autocontrast plugin.
+
+**Density:**
+- `density === "compact"` (the dotUI default, `registry/types.ts:7`): nothing written to `:root`; the compact class strings are already baked into component files.
+- `density !== "compact"`: `--dotui-density: <value>` is written to `:root` (`emit-theme.ts:53-69`). Note: this var is informational only; no CSS selector currently reads it. Density actually bakes into component class strings at publish time via `flatten` (`publisher/flatten.ts:148-170`) — the class strings in the installed `.tsx` files already reflect the chosen density.
+
+### For the primary (generated-repo) path
+
+`globals.css` is committed with the preset fully resolved. The server-side generation step calls `emitInitItem` directly, taking its `css` and `cssVars` output and serializing it into the committed `globals.css`. No runtime shadcn install is needed in the Replit session itself.
+
+---
+
+## 6. The showcase as first view
+
+### What the showcase is
+
+`Cards` (`www/src/components/marketing/showcase/cards.tsx:20-48`) renders 17 self-contained widgets in a responsive masonry grid (`columns-1 sm:columns-2 lg:columns-3 xl:columns-4`). All state is local (no loaders, no server functions, no routing). The full component list: Booking, TwoFactor, Filters, Storage, Notifications, CookiePreferences, InviteMembers, Shortcuts, Payment, Transactions, AccountMenu, Faq, ColorEditorCard, UploadAvatar, TeamName, Feedback, LoginForm.
+
+### Showcase dependencies (what the Replit project must include)
+
+Beyond the 37 ui registry items, the showcase needs:
+
+**Runtime modules to copy verbatim:**
+- `www/src/registry/lib/utils/index.ts` → `src/lib/utils.ts` (the `cn()` helper; already shipped by init)
+- `www/src/registry/lib/context/index.tsx` → `src/lib/context.tsx` (used by avatar, tabs, toggle-button, button)
+- `www/src/registry/hooks/use-image-loading-status.ts` → `src/hooks/use-image-loading-status.ts` (used by avatar)
+- `www/src/modules/core/styles.tsx` → `src/modules/core/styles.tsx` (DesignSystemProvider + createStyles)
+
+**Showcase card source files:**
+All files under `www/src/components/marketing/showcase/*.tsx` — 17 cards plus `cards.tsx` itself.
+
+**External npm packages** (must be in `package.json`):
+```json
+{
+  "dependencies": {
+    "react": "^19",
+    "react-dom": "^19",
+    "react-aria-components": "latest",
+    "react-aria": "latest",
+    "react-stately": "latest",
+    "@internationalized/date": "latest",
+    "@base-ui/react": "latest",
+    "lucide-react": "latest",
+    "tailwind-variants": "latest",
+    "clsx": "latest",
+    "tailwind-merge": "latest",
+    "@fontsource-variable/geist": "latest",
+    "@fontsource/geist-mono": "latest",
+    "tw-animate-css": "latest",
+    "tailwindcss-react-aria-components": "latest"
+  }
+}
+```
+
+`tailwindcss-autocontrast` and `tailwindcss-with` are workspace packages in dotUI. They must be published to npm or vendored in the template repo before the "Open in Replit" path can work without manual steps. This is a hard prerequisite (see section 9).
+
+### App.tsx / entry point
+
+```tsx
+// src/App.tsx
+import "./globals.css";
+import { Cards } from "./components/marketing/showcase/cards";
+
+export default function App() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg antialiased">
+      <main className="p-8">
+        <Cards />
+      </main>
+    </div>
+  );
+}
+```
+
+No `DesignSystemProvider` is required for the showcase to render — the default context (`{ params: {}, tokens: {}, density: "default" }`) gives every component its default visual variant. The preset's visual effect comes entirely from the installed component files (density-baked class strings) and `globals.css` (OKLCH ramps), not from a runtime provider.
+
+For dark-mode support, wrap with a tiny inline script or a `next-themes`-style provider that toggles `class="dark"` on `<html>`. `ThemeProvider` from `packages/starter-themes` depends on `@tanstack/react-router`'s `ScriptOnce` and should not be used in a plain Vite project.
+
+### Path aliases
+
+The showcase and component files use the `@/` alias rooted at `src/`. The Vite config must include:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "./src") },
+  },
+});
+```
+
+### Remote avatar images
+
+The showcase cards load GitHub CDN avatars at runtime (e.g. `https://github.com/mehdibha.png`). Replit VMs have outbound internet access, so this works without any configuration. `AvatarFallback` handles the offline case gracefully.
+
+---
+
+## 7. What dotUI must build
+
+### Minimal viable (secondary path — copy-command only)
+
+Nothing new is required. The install command already exists (`InstallCommand` component, `www/src/modules/create/install-command.tsx`). The "Open in Replit" button on the secondary path is:
+
+1. A link to the fixed Replit template URL.
+2. A clipboard copy of `npx shadcn add https://dotui.com/r/init?preset=<encoded>`.
+
+The template repo itself (a bare Vite + React + Tailwind v4 project with `components.json` pre-configured) is a one-time manual setup.
+
+### Full-fidelity (primary path — generated-repo import)
+
+**New server action** (e.g. `www/src/routes/api/open-in/replit.ts` or an API route):
+
+```ts
+// pseudocode for the generation endpoint
+GET /api/open-in/replit?preset=<encoded>
+
+1. const encodedPreset = url.searchParams.get("preset") ?? undefined;
+2. const preset = encodedPreset ? decodePreset(encodedPreset) : defaultPreset();
+3. // Generate globals.css
+   const initItem = emitInitItem({ baseRegistryCss, preset, encodedPreset, registryRoot });
+   const globalsCss = serializeInitItemToCss(initItem); // expand css/cssVars to real CSS text
+4. // Generate component files for all 37 showcase-needed items
+   setKnownDotuiNames(PUBLISHABLE_NAMES);
+   setDotuiDepResolver(origin, encodedPreset ? `?preset=${encodedPreset}` : "");
+   const componentFiles: Record<string, string> = {};
+   for (const name of SHOWCASE_COMPONENT_NAMES) { // the 37-item subset
+     const mod = await publishables[name]();
+     const publishable = selectPublishable(mod, preset);  // handles loader enum-with-files
+     const { item } = publish({ publishable, preset });
+     for (const f of item.files) {
+       componentFiles[`src/components/${f.target}`] = f.content;
+     }
+   }
+5. // Commit to GitHub (or push to a preset-keyed branch of the template repo)
+   await commitToGitHub({ globalsCss, componentFiles, preset: encodedPreset });
+6. // Redirect
+   return Response.redirect(`https://replit.com/github.com/dotui-org/showcase-template`);
+```
+
+`selectPublishable` logic is currently private in `www/src/routes/r/$name.tsx:89-107` and must be extracted to `www/src/publisher/publish.ts` or a shared utility for reuse here.
+
+**Key functions to reuse:**
+- `emitInitItem` — `www/src/publisher/emit-theme.ts:71`
+- `publish` — `www/src/publisher/publish.ts:119`
+- `setKnownDotuiNames` / `setDotuiDepResolver` — `www/src/publisher/publish.ts`
+- `publishables` / `PUBLISHABLE_NAMES` — `www/src/registry/__generated__/publishables/index.ts` (present after `pnpm build:registry`)
+
+**The GitHub template repo** (`dotui-org/showcase-template`) must contain:
+- `package.json` with all peer deps listed in section 6.
+- `vite.config.ts` with `@tailwindcss/vite` and the `@/` alias.
+- `src/App.tsx` rendering `<Cards />`.
+- `src/components/marketing/showcase/*.tsx` — all 17 card files + `cards.tsx`.
+- `src/modules/core/styles.tsx`, `src/lib/context.tsx`, `src/hooks/use-image-loading-status.ts`.
+- `src/registry/__generated__/icons.tsx` (or inline the one Lucide import `ExternalLinkIcon`).
+- `.replit` file: `run = "pnpm dev --host 0.0.0.0"` (Replit requires `--host 0.0.0.0` to expose the port).
+- `components.json` pre-configured for shadcn (for the secondary path).
+
+For the primary path, `globals.css` and `src/components/ui/*.tsx` are overwritten per preset at generation time.
+
+---
+
+## 8. Schema / meta.ts changes
+
+No changes to `www/src/registry/types.ts` or any `meta.ts` file are required for the Replit path.
+
+The Replit open-in logic operates entirely on data already available:
+- `encodePreset` / `decodePreset` from `www/src/modules/create/preset/codec.ts`
+- `emitInitItem` from `www/src/publisher/emit-theme.ts`
+- `publish` + `PUBLISHABLE_NAMES` from `www/src/publisher/publish.ts` and `__generated__/publishables`
+- The 37 component names needed for the showcase (a static constant derived from `showcase/cards.tsx`'s import graph)
+
+If a future iteration wants to serve a `/r/registry.json` index for shadcn MCP discovery (so Replit's AI agent can discover all dotUI components), add a new route `www/src/routes/r/registry[.]json.tsx` (or `registry%5B.%5Djson.tsx` for the literal dot in TanStack Start). That route imports `registryUi`, `registryLib`, `registryHooks`, `registryBase` from the generated manifests and emits the shadcn `Registry` shape:
+
+```jsonc
+{
+  "name": "dotui",
+  "homepage": "https://dotui.com",
+  "items": [
+    { "name": "button", "type": "registry:ui", "title": "Button", ... },
+    ...
+  ]
+}
+```
+
+Per item: strip `group` and `params` (dotUI-only), omit `files[].content` (point `files[].path` at `/r/<name>`). Names come from `registry-items.ts:70-129`. This is blocked today (returns 404) and is a separate prerequisite for the shadcn MCP route — not required for the GitHub import path.
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### Programmatic Replit project creation is not a public API
+
+Replit does not expose a public REST API for creating new projects on behalf of arbitrary users. The only no-auth path is `https://replit.com/github.com/<owner>/<repo>`, which imports from a GitHub repo into the visiting user's account. A persistent generated-repo-per-preset approach would require GitHub API credentials and could result in many repos. Mitigation: use a single template repo with a preset-keyed branch, or generate the repo on-the-fly and delete it after the redirect (TTL-based cleanup).
+
+### `tailwindcss-autocontrast` and `tailwindcss-with` are not on npm
+
+These are workspace packages (`packages/tailwindcss-autocontrast`, `packages/tailwindcss-with`). The Replit template cannot install them via `npm install` today. Options:
+- Publish both to npm (the correct long-term fix; required for any "open in" path that installs dotUI into an external project).
+- Vendor the packages inline in the template repo under `src/plugins/` and reference them via relative path in the Tailwind config.
+- In the interim, use the `css` field override in `emitInitItem` to inline the autocontrast output directly into `:root`/`.dark` (this is what `emitPrimitivesCss({onColors:true})` does for the live preview at `primitives.ts:130-138`). This replaces the plugin-at-build approach with statically baked `--on-*` values.
+
+### `--on-*` variables require the autocontrast plugin at Tailwind compile time
+
+If `tailwindcss-autocontrast` is absent, `--on-accent-500` etc. are never generated, and semantic tokens like `--color-fg-on-accent` (which point at `--on-accent-500`) resolve to empty. The workaround for the generated-repo path: call `onBlackWhite` (`packages/colors/src/shared/on-color.ts:88-97`) for each ramp step and write the `--on-*` values directly into `:root`/`.dark` at generation time, bypassing the plugin. This matches the live-preview behavior exactly (`primitives.ts:140-148`).
+
+### `registry.json` index is absent
+
+`/r/registry.json` returns 404 today. Replit's AI agents (or the shadcn MCP server) cannot auto-discover dotUI components without it. This only affects the secondary flow if the user expects AI-assisted component discovery; it does not affect the GitHub import path or the manual `npx shadcn add @dotui/<name>` flow.
+
+### Branch-per-preset GitHub strategy has repo sprawl risk
+
+A new repo (or branch) per preset means potentially thousands of repos/branches over time. Use a content-addressed branch name (e.g. `preset/<first-16-chars-of-encoded>`) and enforce a TTL cleanup job. Alternatively: generate the full file content in memory, push to a gist or ephemeral GitHub App installation, and redirect to the import URL immediately.
+
+### Replit `--host 0.0.0.0` is mandatory
+
+Vite's default `localhost` binding is not accessible from Replit's public URL. The template's `.replit` run command must be `pnpm dev --host 0.0.0.0`; otherwise the user sees a blank preview.
+
+### `pako` must be available server-side for the generation endpoint
+
+`pako` is already a dep at `www/package.json:46`. The generation endpoint runs in the same TanStack Start server, so `decodePreset` (which calls `pako.inflateRaw`) is available without any additional install.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+### Phase 0: prerequisites
+
+- [ ] Publish `tailwindcss-autocontrast` to npm (or decide to inline `--on-*` values at generation time).
+- [ ] Publish `tailwindcss-with` to npm (or vendor it in the template).
+- [ ] Create the GitHub template repo `dotui-org/showcase-template` (see section 7 for required contents).
+- [ ] Add `.replit` file to the template: `run = "pnpm dev --host 0.0.0.0"`.
+- [ ] Verify `https://replit.com/github.com/dotui-org/showcase-template` opens correctly.
+
+### Phase 1: secondary path (copy-command, zero backend work)
+
+- [ ] Add an "Open in Replit" button to the `/create` page (next to the existing install command in `www/src/modules/create/install-command.tsx` or as a sibling component).
+- [ ] The button opens the fixed template URL in a new tab: `window.open("https://replit.com/github.com/dotui-org/showcase-template")`.
+- [ ] The button also copies `npx shadcn add https://dotui.com/r/init?preset=<encoded>` to the clipboard (reuse the `encodePreset(designSystem)` + `getRegistryHost()` logic already in `install-command.tsx:17-48`).
+- [ ] Add a tooltip/label: "Opens the Replit template. Paste the copied command in the Replit shell to install your preset."
+
+### Phase 2: primary path (full-fidelity generated-repo import)
+
+- [ ] Extract `selectPublishable` from `www/src/routes/r/$name.tsx:89-107` into `www/src/publisher/publish.ts` (or a new `www/src/publisher/select-publishable.ts`) so the generation endpoint can call it.
+- [ ] Write the server action at `www/src/routes/api/open-in/replit.ts` (TanStack Start API route):
+  - [ ] Parse `?preset=` from the query.
+  - [ ] Call `decodePreset` → `PublishPreset`.
+  - [ ] Call `emitInitItem({ baseRegistryCss, preset, encodedPreset, registryRoot })` to get the init item.
+  - [ ] Serialize the init item's `css` / `cssVars` to real CSS text (the reverse of `cssToRegistryFields` — write a `registryFieldsToCss` helper or use the already-serialized blocks from `baseRegistryCss` directly).
+  - [ ] Loop over `SHOWCASE_COMPONENT_NAMES` (define this constant as the 37 names from the showcase's import graph): call `publishables[name]()`, `selectPublishable`, `publish`, collect `item.files`.
+  - [ ] Use GitHub API (with a dotUI bot token) to commit the generated files to a branch `preset/<encoded-prefix>` of `dotui-org/showcase-template`.
+  - [ ] Redirect `302` to `https://replit.com/github.com/dotui-org/showcase-template/tree/preset/<encoded-prefix>` (Replit's GitHub import URL supports branch refs via `/tree/<branch>`).
+- [ ] Add TTL cleanup: a cron job or GitHub Actions workflow that deletes `preset/*` branches older than 7 days.
+- [ ] Update the button from phase 1 to hit the new API route instead of opening the template directly.
+
+### Phase 3: registry.json index (enables shadcn MCP + AI agent discovery)
+
+- [ ] Add route `www/src/routes/r/registry[.]json.tsx` that imports `registryUi`, `registryLib`, `registryHooks`, `registryBase` and emits the shadcn `Registry` shape (see section 8).
+- [ ] Verify the shadcn MCP server config works: `{ command: "npx", args: ["-y", "shadcn@latest", "registry:mcp"], env: { REGISTRY_URL: "https://dotui.com/r/registry.json" } }`.
+- [ ] Update dotUI's documentation to advertise the MCP endpoint.
+
+---
+
+## Sources
+
+- dotUI preset codec: `www/src/modules/create/preset/codec.ts:75-126` — `encodePreset`, `decodePreset`, pako + base64url wire format.
+- dotUI install command: `www/src/modules/create/install-command.tsx:17-48` — live URL construction from preset.
+- dotUI init route: `www/src/routes/r/init.tsx:22-59` — `GET /r/init?preset=` handler.
+- dotUI init item emitter: `www/src/publisher/emit-theme.ts:71-170` — `emitInitItem`, color ramp merge, density var, `@dotui` registry alias.
+- dotUI component publisher: `www/src/publisher/publish.ts:119-161` — `publish`, `rewriteDeps`.
+- dotUI base CSS generated: `www/src/registry/__generated__/base-css.ts` — structured at-rules + semantic `@theme inline` + default ramps.
+- dotUI showcase: `www/src/components/marketing/showcase/cards.tsx:20-48` — the 17-card masonry grid.
+- Replit GitHub import URL format: `https://replit.com/github.com/<owner>/<repo>` — documented in Replit's "Import from GitHub" feature (https://docs.replit.com/getting-started/creating-a-repl).
+- Replit `.replit` run config: https://docs.replit.com/programming-ide/configuring-repl — `run` command must bind to `0.0.0.0`.
+- shadcn `registry:base` item type and `shadcn add <url>`: https://ui.shadcn.com/docs/registry/registry-item-type — describes how `registry:base` + `config.registries` is consumed.
+- shadcn `config.registries` baking pattern: `emit-theme.ts:130-132` — writes `@dotui` alias with preset-baked URL into `components.json`.
+- Transitive dep rewrite with preset: `www/src/publisher/publish.ts:79-105` — `rewriteDeps` + `setDotuiDepResolver`.
+- `tailwindcss-autocontrast` `--on-*` generation: `packages/tailwindcss-autocontrast/src/index.js:407-501` — scans `:root`/`.dark` for `--<name>-<shade>`, injects `--on-<name>-<shade>`.
+- OKLCH ramp reversal for dark mode: `www/src/registry/theme/primitives.ts:28-37` — `reverseRamp`.
+- `resolveColorConfig` + `rampsToVars`: `www/src/registry/theme/primitives.ts:67-108`; `emit-theme.ts:134-143`.
+- Static `--on-*` bake (live preview path, workaround for absent plugin): `www/src/registry/theme/primitives.ts:130-148`.
+- `pako` dependency: `www/package.json:46` — `"pako": "^2.1.0"`.

--- a/docs/research/open-in/shadcn-cli.md
+++ b/docs/research/open-in/shadcn-cli.md
@@ -1,0 +1,805 @@
+# Open in shadcn CLI
+
+> The universal substrate. One `npx shadcn add <url>?preset=…` command installs every dotUI component into the target project's `ui/` folder and writes the full OKLCH theme into `globals.css`, all reflecting the user's chosen preset. Button type: **copy-command** · Preset fidelity: **full** · Color fidelity: **full**
+
+---
+
+## 1. User experience
+
+The user lands on the dotUI customizer (`/_app/create`), tweaks colors, density, and per-component
+params, then sees a live-updating command in the customizer footer:
+
+```
+npx shadcn add https://dotui.com/r/init?preset=<base64url>
+```
+
+That single command, pasted into any existing Next.js / Vite / TanStack Start project that already
+has a `components.json`, does the following in one shot:
+
+1. Fetches `https://dotui.com/r/init?preset=<encoded>` — a `registry:base` item.
+2. Merges its `cssVars.theme` (the `@theme inline` block with semantic tokens and radius scale) and
+   its `css` (at-rules, plugins, `::selection`, `:root` / `.dark` OKLCH ramps) into the project's
+   globals CSS file.
+3. Writes `src/lib/utils.ts` (the `cn()` helper).
+4. Installs npm dependencies: `tailwind-variants`, `clsx`, `tailwind-merge`,
+   `react-aria-components`, `tailwindcss-react-aria-components`, `tw-animate-css`,
+   `tailwindcss-autocontrast`.
+5. Registers `@dotui` as a named registry in `components.json` so subsequent
+   `npx shadcn add @dotui/<name>` calls hit the matching per-component endpoint with the
+   **same preset baked in**.
+
+After `init`, the user runs a second command — either a curated subset or the "all components"
+aggregate — to install every component file into `src/components/ui/`.
+
+For the full showcase experience (components + showcase files + theme in one command), see §7.
+
+---
+
+## 2. Technical mechanism
+
+### 2a. The existing `install-command.tsx`
+
+`www/src/modules/create/install-command.tsx:39-47` already builds and copies this command:
+
+```ts
+const encoded = encodePreset(designSystem);   // codec.ts:75
+const url = encoded
+  ? `${host}/r/init?preset=${encoded}`
+  : `${host}/r/init`;
+return `npx shadcn add ${url}`;
+```
+
+`encodePreset` (`www/src/modules/create/preset/codec.ts:75`) diffs the `DesignSystem` against
+`DEFAULTS` (`www/src/modules/create/preset/defaults.ts:5`), pako-deflates (`level:9`) the compact
+JSON (`DesignSystemState`), and base64url-encodes it. If nothing differs from defaults the function
+returns `undefined` and the `?preset=` param is omitted.
+
+### 2b. The `/r/init` route
+
+`www/src/routes/r/init.tsx` is a TanStack Start server GET handler. It:
+
+1. Reads `url.searchParams.get("preset")` (`init.tsx:27`).
+2. Calls `decodePresetForRoute(encoded)` (`init.tsx:47`) which dynamically imports
+   `decodePreset` from `@/modules/create/preset/codec` and narrows the result to
+   `PublishPreset` (`publisher/types.ts:79`): `{ color?, density, componentParams }`.
+3. Calls `emitInitItem({ baseRegistryCss, preset, encodedPreset, registryRoot })`
+   (`publisher/emit-theme.ts:71`).
+4. Returns `JSON.stringify(item, null, 2)` with cache headers
+   `public, max-age=60, s-maxage=3600, stale-while-revalidate=86400`.
+
+### 2c. Per-component `/r/$name` route
+
+`www/src/routes/r/$name.tsx` handles `GET /r/button?preset=<encoded>` etc. It:
+
+1. Looks up `publishables[name]` from `__generated__/publishables/index.ts`. Missing → 404.
+2. Decodes the preset (density + componentParams only; color is dropped at `$name.tsx:117`).
+3. Calls `setDotuiDepResolver(origin, "?preset=<encoded>")` so all `registryDependencies`
+   emitted in the response become absolute URLs **with the same preset** (e.g.
+   `https://dotui.com/r/loader?preset=…`).
+4. Calls `publish({ publishable, preset })` (`publisher/publish.ts:119`) — the five-step
+   pipeline (flatten → resolveClasses → serialize → substitute → assemble).
+5. Runs the result through `oxfmt` (printWidth 120, useTabs).
+
+### 2d. shadcn CLI flow end-to-end
+
+```
+User pastes:  npx shadcn add https://dotui.com/r/init?preset=<encoded>
+                                │
+              shadcn fetches the URL → registry:base item
+                                │
+              shadcn merges css/cssVars → globals.css
+              shadcn writes files[]   → src/lib/utils.ts
+              shadcn installs deps[]
+              shadcn writes config{}  → components.json
+                  └── registries["@dotui"] = "https://dotui.com/r/{name}?preset=<encoded>"
+                                │
+User runs:    npx shadcn add @dotui/button  (or the aggregate "all" item, see §7)
+                                │
+              shadcn expands @dotui/button →
+                  https://dotui.com/r/button?preset=<encoded>
+                                │
+              /r/button response contains:
+                  registryDependencies: ["https://dotui.com/r/loader?preset=<encoded>"]
+                                │
+              shadcn recursively fetches loader, focus-styles (dropped), utils (dropped)
+```
+
+---
+
+## 3. Preset propagation
+
+Preset fidelity is **full** for color, density, and per-component params. Here is precisely how
+each dimension travels:
+
+### 3a. Color
+
+The `?preset=` value, when decoded, yields `ds.color: ColorConfig | undefined`.
+`decodePresetForRoute` (`init.tsx:47-59`) passes `color` through to `PublishPreset`.
+`emitInitItem` calls `mergePresetCssFields` (`emit-theme.ts:145`), which — when `preset.color` is
+set — calls `resolveColorConfig(preset.color)` (`registry/theme/primitives.ts:67`) to generate
+full OKLCH ramps for all six palettes (`neutral, accent, success, warning, danger, info`) in both
+modes, then overwrites `:root` and `.dark` in the item's `css` field via `rampsToVars`.
+
+The consumer's `tailwindcss-autocontrast` plugin re-derives `--on-*` foreground vars from the
+shipped ramps at Tailwind build time (these are intentionally not shipped in the registry item —
+`emit-theme.ts:152-159`).
+
+Result: the user's custom seed colors appear in `globals.css` as 66 OKLCH primitive vars (6
+palettes × 11 steps) for both light and dark modes.
+
+### 3b. Density
+
+`preset.density` propagates two ways:
+
+- **Into component class strings**: `/r/$name` uses `density` in the `flatten` step
+  (`publisher/flatten.ts`) — the merge order `base ← density[selected] ← params[name][value]`
+  bakes the density tier's tv override into the shipped component source. So installing
+  `@dotui/button` at density `comfortable` gives a component with the `comfortable` class
+  strings hardcoded.
+- **Into `:root` vars**: `emitPresetLightVars` (`emit-theme.ts:58`) writes
+  `--dotui-density: <value>` to `:root` only when density ≠ `"compact"` (the default).
+
+Note: `--dotui-density` is informational only today. No CSS selector reads it. The real effect
+of density is the baked class strings.
+
+### 3c. Per-component params (enum + scalar)
+
+`componentParams` travel with the preset encoded in `?preset=`.
+
+For **enum params**: `flatten` merges the selected value's tv override into the class strings.
+Example: `alert.style = "sousse"` → the alert component ships with Sousse-style class lists
+hardcoded.
+
+For **scalar params**: `resolveClasses` / `buildScalarVarMap` (`publisher/resolve-classes.ts:30`)
+rewrites Tailwind suffix expressions. Example: `avatar.radius = "--radius-full"` → the class
+`rounded-(--avatar-radius)` is rewritten to `rounded-full` in the shipped source.
+
+For **enum-with-files params** (only `loader`): `selectPublishable` (`$name.tsx:89`) picks the
+correct base file (`base.spinner.tsx` vs `base.ring.tsx`) before publish runs.
+
+`componentParams` are NOT written to CSS — they live entirely in the component `.tsx` source.
+
+### 3d. Global tokens (`t` field in DesignSystemState)
+
+`tokens` round-trip through the codec (key `t` in `DesignSystemState`) but `PublishPreset` does
+not carry a `tokens` field, so they currently have **no effect on emitted output**. This is an
+explicit TODO at `emit-theme.ts:62-68`. The value `--radius-factor` (the most important global
+token) is unaffected today; it defaults to `1` in `:root` from `base/colors.css`.
+
+---
+
+## 4. Components installed
+
+### 4a. Per-component add (current behavior)
+
+After `shadcn init` (which writes `components.json` with the `@dotui` registry entry), the user
+installs each component individually:
+
+```bash
+npx shadcn add @dotui/button
+npx shadcn add @dotui/card
+# etc.
+```
+
+Each command fetches `/r/<name>?preset=<encoded>`, writes the resolved `.tsx` source to
+`src/components/ui/<name>.tsx`, and recursively fetches transitive deps (which arrive as absolute
+URLs in `registryDependencies` — see §2c). The deps `focus-styles`, `theme`, and `utils` are
+dropped (`BUNDLED_INTO_INIT`, `publish.ts:52`) because they were already installed by init.
+
+### 4b. Full component list (60 ui items)
+
+From `www/src/registry/__generated__/registry-items.ts:70-129`, all 60 registered UI items:
+
+accordion, alert, avatar, badge, breadcrumbs, button, calendar, card, checkbox, checkbox-group,
+color-area, color-editor, color-field, color-picker, color-slider, color-swatch,
+color-swatch-picker, color-thumb, combobox, command, date-field, date-picker, dialog, disclosure,
+drawer, drop-zone, empty, field, file-trigger, group, input, kbd, link, list-box, loader, menu,
+modal, number-field, otp-field, overlay, popover, progress-bar, radio-group, scroll-fade,
+search-field, select, separator, skeleton, slider, switch, table, tabs, tag-group, text,
+text-field, time-field, toast, toggle-button, toggle-button-group, tooltip.
+
+Plus 2 lib items: `utils` (shipped inline by init), `focus-styles` (shipped via init CSS).
+Plus 1 hook: `use-mobile`.
+
+WIP / excluded: `context-menu`, `sidebar`, `react-hook-form`, `tanstack-form` (all in
+`ORPHAN_ALLOWLIST`, `registry-build.ts:356`).
+
+### 4c. Install path
+
+shadcn installs each item at the `target` declared in the registry item's `files[]`. For
+ui items the target is `ui/<name>.tsx`, which resolves via the `@/components/ui` alias
+(from `config.aliases.ui = "@/components/ui"` in the init item) to
+`src/components/ui/<name>.tsx`.
+
+---
+
+## 5. Theme in globals.css
+
+`shadcn add <init-url>` merges the `registry:base` item's `css` and `cssVars` into the project's
+CSS entry point. The result looks like:
+
+```css
+/* ---- merged by shadcn into globals.css ---- */
+@import "tw-animate-css";
+@plugin "tailwindcss-react-aria-components";
+@plugin "tailwindcss-autocontrast" { cssfile: "<this-file>"; }
+@plugin "tailwindcss-with";
+@custom-variant dark (&:is(.dark *));
+@utility focus-reset { … }
+@utility focus-ring  { … }
+@utility focus-input { … }
+@utility no-highlight { … }
+@layer base {
+  * { @apply border-border; }
+  body { @apply bg-bg font-sans text-fg; }
+  html { @apply font-sans; }
+}
+::selection { background-color: var(--accent-800); color: var(--on-accent-800); }
+
+@theme inline {
+  /* constant semantic + radius layer — same across all presets */
+  --radius-sm:  calc(0.125rem * var(--radius-factor));
+  --radius-md:  calc(0.375rem * var(--radius-factor));
+  --radius-lg:  calc(0.5rem   * var(--radius-factor));
+  --radius-xl:  calc(0.75rem  * var(--radius-factor));
+  --radius-2xl: calc(1rem     * var(--radius-factor));
+  --radius-full: 9999px;
+  --color-bg:   var(--neutral-50);
+  --color-accent: var(--accent-500);
+  --color-fg-on-accent: var(--on-accent-500);
+  --color-border-focus: var(--accent-500);
+  /* … all 100+ semantic tokens from registry/base/theme.css … */
+}
+
+/* PRESET-SPECIFIC: OKLCH primitive ramps (6 palettes × 11 steps = 66 vars each) */
+:root {
+  --radius-factor: 1;
+  --neutral-50:  oklch(0.985 0 0);
+  --neutral-100: oklch(0.945 0.005 240.14);
+  /* … */
+  --accent-50:   oklch(0.96 0.018 251.3);
+  /* … */
+  --info-950:    oklch(0.175 0.052 258.6);
+  /* For a custom color preset, all 66 vars here are regenerated from the seed */
+}
+.dark {
+  --neutral-50:  oklch(0.13 0 0);   /* reversed from light */
+  /* … 65 more dark-mode primitives … */
+}
+/* --on-accent-500 etc. injected by tailwindcss-autocontrast at Tailwind build time */
+```
+
+The `cssVars.theme` field (→ `@theme inline`) is **constant across presets**; only the `:root` /
+`.dark` primitive ramps change per preset. This is by design: the semantic layer (`--color-*`)
+always points at primitive vars, and only the primitives are overridden.
+
+Source of the `@theme inline` content: `www/src/registry/base/theme.css` (hand-authored),
+typed source `www/src/registry/theme/semantics.ts:36-124`, structured form
+`www/src/registry/__generated__/base-css.ts:179-278`.
+
+Source of the at-rules / utilities: `www/src/registry/base/base.css`.
+
+Source of the default ramps: `www/src/registry/base/colors.css` (auto-generated by
+`pnpm build:registry` from `DEFAULT_COLOR_CONFIG`). For a custom preset, these are overridden at
+request time by `resolveColorConfig(preset.color)` → `rampsToVars()` in `emit-theme.ts:155-159`.
+
+---
+
+## 6. The showcase as first view
+
+The showcase (`www/src/components/marketing/showcase/cards.tsx`) is 17 self-contained card
+widgets in a `columns-1 sm:columns-2 lg:columns-3 xl:columns-4` masonry grid. It has no server
+functions, no loaders, and no routing dependencies — all state is client-side.
+
+### What "showcase as first view" requires
+
+1. **Component files present** under `src/components/ui/` — 37 distinct ui items are consumed
+   by the cards (accordion, avatar, badge, button, calendar, card, checkbox, checkbox-group,
+   color-area, color-editor, color-field, color-slider, color-thumb, disclosure, drop-zone, field,
+   file-trigger, group, input, kbd, link, list-box, loader, otp-field, popover, progress-bar,
+   radio-group, select, separator, slider, switch, table, tabs, tag-group, text, text-field,
+   time-field, toggle-button, toggle-button-group).
+
+2. **Theme in globals.css** — already achieved by the `init` command (§5).
+
+3. **Showcase source files** — `www/src/components/marketing/showcase/*.tsx` (18 files) must
+   be present in the target project, verbatim or via the registry.
+
+4. **Providers** — a dark-mode class toggle on `<html>` (the `class="dark"` pattern shadcn uses)
+   and optionally `DesignSystemProvider` for live param customization. The showcase renders
+   correctly with defaults even without `DesignSystemProvider`.
+
+5. **Fonts** — `@fontsource-variable/geist` and `@fontsource/geist-mono` (installed as npm deps
+   or via CDN; the registry item's `dependencies[]` should list them).
+
+6. **Runtime aliases** — all imports use `@/` rooted at `src/`. shadcn writes the aliases into
+   `components.json`; the target project's bundler must honor them.
+
+### Why the showcase files must be a registry item
+
+The shadcn CLI installs only what is declared in registry items. The showcase files live under
+`www/src/components/marketing/showcase/` and are not currently in any registry item. To deliver
+them via `shadcn add`, they must be added to a new registry item or bundled into the "all"
+aggregate described in §7.
+
+---
+
+## 7. What dotUI must build
+
+### 7a. The `/r/registry.json` index (required for shadcn MCP)
+
+No index route exists today (`/r/registry.json` returns 404). For shadcn MCP discovery the
+config is `{ command:'npx', args:['-y','shadcn@latest','registry:mcp'], env:{ REGISTRY_URL: 'https://dotui.com/r/registry.json' } }`.
+
+Add a new route `www/src/routes/r/registry[.]json.tsx`:
+
+```ts
+// www/src/routes/r/registry[.]json.tsx
+import { createFileRoute } from "@tanstack/react-router";
+import { registryUi, registryLib } from "@/registry/__generated__/registry-items";
+import { registryBase } from "@/registry/base/registry";
+import { registryHooks } from "@/registry/hooks/registry";
+
+export const Route = createFileRoute("/r/registry[.]json")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const origin = new URL(request.url).origin;
+        const items = [
+          // lightweight descriptors: name, type, title?, description?
+          // strip group/params/files.content; point consumers at /r/<name>
+          ...registryUi.map((item) => ({
+            name: item.name,
+            type: item.type,
+            ...(item.title       ? { title:       item.title       } : {}),
+            ...(item.description ? { description: item.description } : {}),
+          })),
+          ...registryLib.map((item) => ({ name: item.name, type: item.type })),
+          ...registryHooks.map((item) => ({ name: item.name, type: item.type })),
+          ...registryBase.map((item) => ({ name: item.name, type: item.type })),
+        ];
+        const registry = { name: "dotui", homepage: origin, items };
+        return new Response(JSON.stringify(registry, null, 2), {
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Cache-Control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+          },
+        });
+      },
+    },
+  },
+});
+```
+
+Note: TanStack Start route files use `[.]` to escape literal dots in filenames.
+
+### 7b. The "all components" aggregate item — the key deliverable
+
+The central problem: installing all 60 components one by one is impractical for "open in one
+command". The solution is a single aggregate `registry:base` item served at `/r/all?preset=<encoded>`
+that bundles every component file inline, the full theme, and the showcase files.
+
+**Shape of the item:**
+
+```jsonc
+{
+  "name": "dotui-all",
+  "type": "registry:base",
+  "extends": "none",
+  "dependencies": [
+    /* DEFAULT_DEPENDENCIES from emit-theme.ts:31 */
+    "tailwind-variants", "clsx", "tailwind-merge",
+    "react-aria-components", "tailwindcss-react-aria-components",
+    "tw-animate-css", "tailwindcss-autocontrast",
+    /* additional deps needed by 60 components */
+    "react-aria", "react-stately",
+    "@base-ui/react",
+    "@internationalized/date",
+    "lucide-react",
+    "@fontsource-variable/geist",
+    "@fontsource/geist-mono"
+  ],
+  "registryDependencies": [],  /* everything is inline — no external deps needed */
+  "css":     { /* full theme css — identical to /r/init output */ },
+  "cssVars": { "theme": { /* full @theme inline block */ } },
+  "files": [
+    /* lib/utils.ts — the cn() helper */
+    { "type": "registry:lib", "path": "lib/utils.ts", "target": "src/lib/utils.ts", "content": "…" },
+    /* all 60 component .tsx files */
+    { "type": "registry:ui", "path": "ui/button/base.tsx", "target": "ui/button.tsx", "content": "/* resolved */" },
+    /* … 59 more component files … */
+    /* showcase card files */
+    { "type": "registry:component", "path": "components/marketing/showcase/cards.tsx",
+      "target": "components/showcase/cards.tsx", "content": "/* verbatim */" },
+    /* … 17 more showcase files … */
+    /* main page file */
+    { "type": "registry:page", "path": "app/showcase-page.tsx",
+      "target": "app/page.tsx", "content": "/* imports <Cards /> */" }
+  ],
+  "config": {
+    "style": "default",
+    "tailwind": { "cssVariables": true },
+    "aliases": {
+      "components": "@/components", "ui": "@/components/ui",
+      "utils": "@/lib/utils",      "lib": "@/lib", "hooks": "@/hooks"
+    },
+    "registries": { "@dotui": "https://dotui.com/r/{name}?preset=<encodedPreset>" }
+  }
+}
+```
+
+All `registryDependencies` are intentionally empty because every file is inline. The consumer
+needs nothing from `components.json` registries to render the showcase.
+
+**The install command becomes:**
+
+```bash
+npx shadcn add "https://dotui.com/r/all?preset=<encoded>"
+```
+
+### 7c. New route `www/src/routes/r/all.tsx`
+
+```ts
+// www/src/routes/r/all.tsx
+import { createFileRoute } from "@tanstack/react-router";
+import { emitInitItem } from "@/publisher/emit-theme";
+import { baseRegistryCss } from "@/registry/__generated__/base-css";
+import { publishables, PUBLISHABLE_NAMES } from "@/registry/__generated__/publishables";
+import { publish, setKnownDotuiNames, setDotuiDepResolver } from "@/publisher/publish";
+import { format } from "oxfmt";
+// showcase source files (raw strings imported via ?raw or read at build time):
+import * as showcaseFiles from "@/components/marketing/showcase/__registry__";
+
+setKnownDotuiNames(PUBLISHABLE_NAMES);
+
+export const Route = createFileRoute("/r/all")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const url = new URL(request.url);
+        const encodedPreset = url.searchParams.get("preset") ?? undefined;
+        const preset = encodedPreset
+          ? await decodePresetForRoute(encodedPreset)
+          : { density: "compact", componentParams: {} };
+
+        const origin = `${url.protocol}//${url.host}`;
+        // For the all-bundle, dep rewriting is irrelevant (no registryDependencies emitted),
+        // but prime it anyway so the publish() pipeline doesn't error.
+        setDotuiDepResolver(origin, "");
+
+        // 1. Theme half (identical to /r/init)
+        const themeItem = emitInitItem({
+          baseRegistryCss, preset, encodedPreset,
+          registryRoot: origin,
+        });
+
+        // 2. Component files half
+        const componentFiles = [];
+        for (const name of PUBLISHABLE_NAMES) {
+          const mod = await publishables[name]();
+          const publishable = selectPublishable(mod, preset);   // same logic as $name.tsx:89
+          const { item, rawContent } = publish({ publishable, preset });
+          let content = rawContent;
+          try {
+            const r = await format(publishable.meta.files?.[0]?.target ?? "ui.tsx", rawContent, {
+              printWidth: 120, useTabs: true,
+            });
+            content = r.code;
+          } catch { /* use raw */ }
+          for (const f of (item.files ?? [])) {
+            componentFiles.push({ ...f, content, registryDependencies: undefined });
+          }
+        }
+
+        // 3. Showcase files (pre-read strings)
+        const showcaseItems = buildShowcaseFiles(showcaseFiles);
+
+        // 4. Assemble the aggregate item
+        const allItem = {
+          ...themeItem,
+          name: "dotui-all",
+          files: [
+            ...(themeItem.files ?? []),
+            ...componentFiles,
+            ...showcaseItems,
+          ],
+          registryDependencies: [],
+          dependencies: [
+            ...(themeItem.dependencies ?? []),
+            "react-aria", "react-stately", "@base-ui/react",
+            "@internationalized/date", "lucide-react",
+            "@fontsource-variable/geist", "@fontsource/geist-mono",
+          ],
+        };
+
+        return new Response(JSON.stringify(allItem, null, 2), {
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Cache-Control": "public, max-age=60, s-maxage=300, stale-while-revalidate=3600",
+          },
+        });
+      },
+    },
+  },
+});
+```
+
+The `selectPublishable` helper from `$name.tsx:89-107` needs to be extracted into
+`publisher/select-publishable.ts` and imported by both `$name.tsx` and `all.tsx`.
+
+### 7d. Showcase files as registry entries
+
+The 18 showcase files (`www/src/components/marketing/showcase/*.tsx`) need to be declared in a
+new registry descriptor so the `all.tsx` route can read them. Simplest approach: a static map in
+`www/src/components/marketing/showcase/__registry__.ts`:
+
+```ts
+// www/src/components/marketing/showcase/__registry__.ts
+// Vite raw imports — each value is the file's string content
+export { default as cards } from "./cards.tsx?raw";
+export { default as booking } from "./booking.tsx?raw";
+// … all 18 files …
+```
+
+Or, for the server route, read them via `fs.readFileSync` at request time from the source tree
+(only works in dev/SSR; use `?raw` imports for the Vite build).
+
+The target path for each showcase file in the consumer project:
+
+| Source | Consumer target |
+|---|---|
+| `cards.tsx` | `src/components/showcase/cards.tsx` |
+| `booking.tsx` | `src/components/showcase/booking.tsx` |
+| … | … |
+
+The consumer's `src/app/page.tsx` (or equivalent) renders `<Cards />`:
+
+```tsx
+// src/app/page.tsx — generated by the "all" item
+import { Cards } from "@/components/showcase/cards";
+
+export default function Page() {
+  return (
+    <main className="min-h-screen bg-bg py-12">
+      <div className="container">
+        <Cards />
+      </div>
+    </main>
+  );
+}
+```
+
+This file is shipped as a `registry:page` type in the `all` item's `files[]`.
+
+### 7e. Adjusting showcase imports
+
+The showcase files currently import from `@/registry/ui/*`, `@/registry/lib/*`,
+`@/modules/core/styles`, and `@/registry/__generated__/icons`. In the consumer project, the
+installed paths are `@/components/ui/*`, `@/lib/utils`, and `lucide-react`.
+
+Options:
+
+1. **Path rewrite at publish time**: add a transform step in `all.tsx` that rewrites
+   `@/registry/ui/` → `@/components/ui/`, `@/registry/lib/utils` → `@/lib/utils`, and
+   `@/registry/__generated__/icons` → `lucide-react` in every showcase file string before
+   embedding it in the registry item. This is the cleanest approach.
+
+2. **Pre-rewritten source**: maintain a separate `showcase-standalone/` directory with
+   consumer-ready imports. Higher maintenance cost.
+
+3. **Alias delegation**: ship a `components.json` alias `"showcase": "@/components/showcase"`
+   and keep the `@/registry/` imports, relying on the consumer to set up matching aliases.
+   Fragile — only works if the consumer's bundler and `tsconfig.json` are set up correctly.
+
+Option 1 is recommended. The rewrite is purely mechanical (string replace on known import paths)
+and can be implemented in ~20 lines alongside the `all.tsx` route.
+
+---
+
+## 8. Schema / meta.ts changes
+
+### 8a. No changes required for core behavior
+
+The existing `RegistryItem` type (`www/src/registry/types.ts:69`), the codec
+(`www/src/modules/create/preset/codec.ts`), `emitInitItem` (`emit-theme.ts:71`), and the
+`/r/$name` route all work today without schema changes.
+
+### 8b. Optional: a `showcaseFiles` field on meta.ts
+
+If you want the build step to drive showcase inclusion (rather than the `__registry__.ts` map),
+add an optional field to `RegistryItem`:
+
+```ts
+// www/src/registry/types.ts
+export type RegistryItem = ShadcnRegistryItem & {
+  group?: ComponentGroup | null;
+  params?: Record<string, ParamDef>;
+  showcaseFile?: string;   // source path of the showcase card for this component group
+};
+```
+
+One line change. `registry-build.ts` ignores unknown fields (they flow through `metaForRuntime`'s
+spread, `build-publishables.ts:334`). Only `all.tsx` reads it — no integrity guard needed.
+
+### 8c. `tokens` wiring (optional but valuable)
+
+`PublishPreset` (`publisher/types.ts:79`) does not carry `tokens`. The TODO at `emit-theme.ts:62-68`
+describes threading `preset.tokens` into the `:root` block of the init item. This would let
+`--radius-factor` (and future global tokens) propagate correctly. Until then, radius-factor
+customizations from the `t`-key of the encoded preset are silently dropped.
+
+To wire it: extend `PublishPreset` with `tokens?: Record<string, string>`, thread it through
+`decodePresetForRoute` in both `init.tsx` and `all.tsx`, and in `emitPresetLightVars` spread
+`preset.tokens` into the `:root` vars object.
+
+### 8d. `registry.json` shape
+
+The `/r/registry.json` response uses `Registry` from `www/src/registry/types.ts:80`:
+
+```ts
+export type Registry = Omit<ShadcnRegistry, "items"> & {
+  items: RegistryItem[];
+};
+```
+
+For the index endpoint, `RegistryItem` entries need only `name`, `type`, and optionally `title` /
+`description`. Full `files`, `params`, `group`, `css`, `cssVars` should be omitted to keep the
+index lightweight.
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### 9a. Response size of the "all" bundle
+
+60 component files × ~5–20 KB each = roughly 300–1 200 KB of uncompressed JSON. With Brotli or
+gzip compression from the CDN this is typically 60–150 KB on the wire — acceptable for a one-time
+install command. Add a lower cache TTL (`max-age=60, s-maxage=300`) compared to per-component
+endpoints (`s-maxage=3600`) to allow faster invalidation after a dotUI release.
+
+### 9b. `tailwindcss-autocontrast` cssfile path
+
+The init item ships `@plugin "tailwindcss-autocontrast" { cssfile: "./src/styles.css"; }` (from
+`base.css`). In the consumer project this must point at the project's Tailwind entry CSS file.
+The path `./src/styles.css` is correct for a standard Next.js app dir layout but may be wrong
+for Vite projects (often `./src/index.css`). shadcn detects the CSS entry from `tailwind.config`
+or `components.json`; the `config.tailwind` block in the init item deliberately omits `css` to
+let shadcn auto-detect. If the path is wrong, `--on-*` foreground vars will not be injected at
+Tailwind build time, causing invisible text on colored backgrounds.
+
+Mitigation: document that after `shadcn add <init-url>` the user must verify the `cssfile` path
+in their globals CSS matches their actual CSS entry point.
+
+### 9c. `registry:mcp` subcommand availability
+
+The shadcn MCP server requires `npx shadcn@latest registry:mcp` and a `/r/registry.json` index.
+As of early 2026 the `registry:mcp` subcommand may require the canary build
+(`npx shadcn@canary registry:mcp`). Check the shadcn changelog before documenting MCP support.
+The registry.json index (§7a) is a prerequisite regardless.
+
+### 9d. Showcase import path rewriting correctness
+
+The mechanical import rewrite (§7e option 1) must handle:
+- `@/registry/ui/<name>` → `@/components/ui/<name>`
+- `@/registry/ui/<name>/index` → `@/components/ui/<name>`
+- `@/registry/lib/utils` → `@/lib/utils`
+- `@/registry/lib/context` → shipped inline in the all-bundle (context is not a registered item
+  today; it is in `ORPHAN_ALLOWLIST`)
+- `@/registry/__generated__/icons` → `lucide-react` (only `ExternalLinkIcon` is needed by the
+  showcase, `invite-members.tsx:6`)
+- `@/modules/core/styles` → shipped inline or re-exported
+
+The `context` lib (`registry/lib/context/index.tsx`) is an `UNREGISTERED_DEP_ALLOWLIST` item
+(`registry-build.ts:464`) — it does not have a `/r/context` endpoint. It must be bundled inline
+in the `all` item's `files[]` alongside the component files.
+
+### 9e. `tokens` field not yet propagated
+
+As noted in §3d, `--radius-factor` and other global tokens customized in the create page are
+silently dropped by the publisher. Until `tokens` is threaded into `PublishPreset`, any user who
+has adjusted the radius factor will get the default (`1`) in the installed project. This is the
+highest-priority gap for full preset fidelity.
+
+### 9f. No `shadcn init` equivalent yet
+
+`install-command.tsx` currently emits `npx shadcn add <url>` (not `npx shadcn init <url>`).
+The comment at `install-command.tsx:43-46` explains why: `shadcn add` works on any project that
+already has a `components.json`, merging theme fields and installing files. `shadcn init` starts
+a new project from scratch and may prompt interactively. The `add` invocation is correct for the
+"already have a project, install dotUI into it" flow. For the "brand new project" flow, the user
+should run `npx shadcn init` first (to generate `components.json`), then `npx shadcn add <url>`.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+### Phase 1 — registry.json index (unblocks MCP)
+
+- [ ] Add route `www/src/routes/r/registry[.]json.tsx` that imports `registryUi`, `registryLib`,
+      `registryHooks`, `registryBase` and returns the lightweight `Registry` JSON (§7a).
+- [ ] Verify: `curl https://dotui.com/r/registry.json | jq '.items | length'` returns 64
+      (60 ui + 2 lib + 1 hook + 1 base).
+
+### Phase 2 — extract `selectPublishable`
+
+- [ ] Move the `selectPublishable` function from `www/src/routes/r/$name.tsx:89-107` to
+      `www/src/publisher/select-publishable.ts` and export it.
+- [ ] Import it back in `$name.tsx`. No behavior change.
+
+### Phase 3 — wire `tokens` into `PublishPreset`
+
+- [ ] Extend `PublishPreset` (`publisher/types.ts:79`) with `tokens?: Record<string, string>`.
+- [ ] Thread it through `decodePresetForRoute` in `init.tsx:47` and the future `all.tsx`.
+- [ ] In `emitPresetLightVars` (`emit-theme.ts:58`), spread `preset.tokens ?? {}` into the
+      returned vars object.
+- [ ] Verify: encode a preset with `--radius-factor: 1.5`, run `shadcn add`, confirm `:root`
+      in globals.css contains `--radius-factor: 1.5`.
+
+### Phase 4 — showcase files registry map
+
+- [ ] Create `www/src/components/marketing/showcase/__registry__.ts` with raw `?raw` imports
+      of all 18 showcase files (or use `fs.readFileSync` in the SSR route).
+- [ ] Define target paths for each file (e.g. `cards.tsx` → `components/showcase/cards.tsx`).
+
+### Phase 5 — `/r/all` route
+
+- [ ] Create `www/src/routes/r/all.tsx`:
+  - Decode `?preset=` (same as `init.tsx`).
+  - Call `emitInitItem` for the theme half.
+  - Loop `PUBLISHABLE_NAMES`, call `publish()` for each, collect formatted file objects.
+  - Apply import path rewrite to showcase files (§7e option 1).
+  - Assemble the aggregate item (§7b) with all files, merged deps, empty
+    `registryDependencies`.
+  - Return `JSON.stringify(item, null, 2)` with appropriate cache headers.
+- [ ] Add a "page" file (`src/app/page.tsx` or equivalent) to the aggregate item's `files[]`
+      that imports and renders `<Cards />`.
+
+### Phase 6 — update `install-command.tsx`
+
+- [ ] Add a second command variant for "install everything + showcase":
+  ```ts
+  const fullCommand = `npx shadcn add ${host}/r/all?preset=${encoded}`;
+  ```
+- [ ] Surface it in the customizer UI alongside the existing `init` command — or replace the
+      existing command depending on UX decision.
+
+### Phase 7 — testing
+
+- [ ] Create a fresh Next.js 15 app dir project.
+- [ ] Run `npx shadcn add "https://dotui.com/r/all?preset=<custom-encoded>"`.
+- [ ] Verify: `src/components/ui/` contains all 60 `.tsx` files.
+- [ ] Verify: `globals.css` contains the custom OKLCH ramps (not defaults) in `:root`.
+- [ ] Verify: `src/app/page.tsx` renders `<Cards />` and the page loads with the correct theme.
+- [ ] Verify: `components.json` contains `registries["@dotui"]` with the correct preset URL.
+- [ ] Run `npx shadcn add @dotui/button` in the same project — it should already be installed
+      (shadcn skips installed items) but if overwrite is chosen, the button should arrive
+      with the correct preset-baked classes.
+
+---
+
+## Sources
+
+- `www/src/modules/create/install-command.tsx` — live command generation (`:17-48`)
+- `www/src/modules/create/preset/codec.ts` — `encodePreset` (`:75`), `decodePreset` (`:111`)
+- `www/src/modules/create/preset/types.ts` — `DesignSystem` (`:24`), `DesignSystemState` (`:14`)
+- `www/src/modules/create/preset/defaults.ts` — `DEFAULTS` (`:5`)
+- `www/src/publisher/emit-theme.ts` — `emitInitItem` (`:71`), `mergePresetCssFields` (`:145`)
+- `www/src/publisher/publish.ts` — `publish` (`:119`), `rewriteDeps` (`:79`), `BUNDLED_INTO_INIT` (`:52`)
+- `www/src/publisher/types.ts` — `PublishPreset` (`:79`), `Publishable` (`:61`)
+- `www/src/publisher/flatten.ts` — density + enum merge pipeline
+- `www/src/publisher/resolve-classes.ts` — scalar param rewriting (`:30`)
+- `www/src/routes/r/init.tsx` — GET handler (`:22-59`)
+- `www/src/routes/r/$name.tsx` — GET handler + `selectPublishable` (`:32-121`)
+- `www/src/registry/types.ts` — `RegistryItem`, `Density`, `ParamDef` (`:7-83`)
+- `www/src/registry/theme/primitives.ts` — `resolveColorConfig` (`:67`), `reverseRamp` (`:28`)
+- `www/src/registry/theme/color-config.ts` — `DEFAULT_COLOR_CONFIG` (`:72`), `ColorConfig` (`:58`)
+- `www/src/registry/theme/semantics.ts` — `DEFAULT_SEMANTICS` (`:36`)
+- `www/src/registry/__generated__/base-css.ts` — structured base CSS (whole file)
+- `www/src/registry/__generated__/registry-items.ts` — `registryUi` (`:69-130`)
+- `www/src/registry/base/base.css`, `colors.css`, `theme.css` — source of globals CSS content
+- `www/src/components/marketing/showcase/cards.tsx` — `<Cards />` component (`:20-48`)
+- `www/scripts/registry-build.ts` — `ORPHAN_ALLOWLIST` (`:356`), `BUNDLED_INTO_INIT` (`:454`)
+- `packages/tailwindcss-autocontrast/src/index.js` — `getContrastColor` (`:339`)
+- shadcn registry docs: https://ui.shadcn.com/docs/registry
+- shadcn registry:base type: https://ui.shadcn.com/docs/registry/registry-item-type
+- pako: https://github.com/nodeca/pako

--- a/docs/research/open-in/stackblitz.md
+++ b/docs/research/open-in/stackblitz.md
@@ -1,0 +1,564 @@
+# Open in StackBlitz
+
+> Viable · button type **sandbox-define** · preset fidelity **full** · color fidelity **full**
+
+StackBlitz's programmatic project definition API lets dotUI construct an exact in-memory file tree at button-click time — components already resolved to the chosen preset, globals.css carrying the correct OKLCH ramps, and the showcase as `App.tsx`. This is the strongest "Open in" integration available: no GitHub import lag, no default-preset fallback, no shadcn CLI network round-trip at first render.
+
+---
+
+## 1. User experience
+
+1. User lands on the dotUI `/create` page and customises their design system (accent seed, density, component params).
+2. They click **Open in StackBlitz**. The button fires `sdk.openProject(payload, { openFile: "src/App.tsx" })` in the same tab (or new tab via `newWindow: true`).
+3. StackBlitz boots a WebContainers environment with the provided file tree. Vite starts automatically (`startScript: "dev"`). The browser tab shows the showcase cards running under the chosen theme — no install step required by the user.
+4. From that point the project is fully editable: the user can modify card components, swap tokens in `globals.css`, or run `npx shadcn add @dotui/<name>?preset=<encoded>` inside the StackBlitz terminal to fetch additional components with preset fidelity preserved.
+
+---
+
+## 2. Technical mechanism
+
+### Primary: `@stackblitz/sdk` — `openProject`
+
+```ts
+import sdk from "@stackblitz/sdk";
+
+sdk.openProject(project, {
+  openFile: "src/App.tsx",
+  newWindow: true,
+});
+```
+
+`project` is a plain JS object (`Project` type from the SDK):
+
+```ts
+interface Project {
+  title: string;
+  description?: string;
+  template: "node";           // WebContainers: Node runtime
+  files: Record<string, string>; // path → file content (strings)
+  dependencies?: Record<string, string>;
+  settings?: { compile?: { trigger?: "auto" | "keystroke" } };
+}
+```
+
+All files are **strings embedded in the JS bundle** — they are transmitted as part of the POST payload the SDK constructs. No network call to dotUI's registry is made before StackBlitz boots; the preset is already baked into every file.
+
+### Alternative: POST form to `https://stackblitz.com/run`
+
+For use cases where the SDK cannot be imported (a plain `<form>`, server-side render, email links):
+
+```html
+<form method="POST" action="https://stackblitz.com/run" target="_blank">
+  <input type="hidden" name="project[title]" value="dotUI Showcase" />
+  <input type="hidden" name="project[template]" value="node" />
+  <input type="hidden" name="project[files][package.json]" value="..." />
+  <input type="hidden" name="project[files][src/App.tsx]" value="..." />
+  <!-- one hidden input per file -->
+  <button type="submit">Open in StackBlitz</button>
+</form>
+```
+
+This is the same mechanism the SDK uses internally. It is limited by browser URL/POST-body size but works fine for the dotUI showcase payload (all files are source; no binary assets).
+
+### Runtime environment
+
+StackBlitz WebContainers runs a browser-native Node.js. Vite + React + Tailwind CSS v4 work without modification. The `@plugin` directives in `globals.css` (including `tailwindcss-autocontrast`) run through Vite's Tailwind v4 plugin at dev-server startup — the `--on-*` foreground variables are derived at that point from the shipped OKLCH ramps.
+
+---
+
+## 3. Preset propagation
+
+The chosen preset is a `DesignSystem` object in the browser, encoded via `encodePreset` from `www/src/modules/create/preset/codec.ts:75`.
+
+```ts
+// Encoding contract (codec.ts:75-94)
+// 1. diff against DEFAULTS (www/src/modules/create/preset/defaults.ts:5)
+// 2. JSON.stringify the compact DesignSystemState
+// 3. pako.deflateRaw(json, { level: 9 })
+// 4. base64url (+ → -, / → _, strip =)
+const encoded: string | undefined = encodePreset(designSystem);
+```
+
+For the StackBlitz integration, **the encoded string is only needed to construct the file tree** — it is not passed as a URL parameter to StackBlitz. Instead:
+
+- `globals.css` is built by calling the same `emitInitItem` logic that powers `GET /r/init?preset=<encoded>` (`www/src/publisher/emit-theme.ts:71`). The returned `{ css, cssVars }` fields are serialised to a CSS string and written directly into the StackBlitz file tree.
+- Each component file under `src/ui/` is built by calling `publish({ publishable, preset })` (`www/src/publisher/publish.ts:119`) for each name in `PUBLISHABLE_NAMES`, exactly as `GET /r/<name>?preset=<encoded>` does at request time.
+
+This means preset fidelity is **full and offline**: the user's exact OKLCH seeds, density setting, and component-param choices are baked into the files before the StackBlitz tab opens.
+
+The encoded preset string is also written into a comment at the top of `src/globals.css` (e.g. `/* dotUI preset: <encoded> */`) so the user can reconstruct the dotUI customiser URL later:
+
+```
+https://dotui.com/create?preset=<encoded>
+```
+
+---
+
+## 4. Components installed
+
+All 60 registered UI items from `registryUi` (`www/src/registry/__generated__/registry-items.ts:70-129`) are installed. For the showcase specifically, the required subset is the 38 components listed in the transitive import graph of `Cards` (`www/src/components/marketing/showcase/cards.tsx`). However, shipping all 60 is simpler and costs little — each component is a single ~1–5 KB `.tsx` file.
+
+Each file is produced by the same pipeline as `GET /r/<name>?preset=<encoded>`:
+
+```ts
+// Pseudocode — runs server-side, inside the dotUI www app
+import { publishables, PUBLISHABLE_NAMES } from "@/registry/__generated__/publishables";
+import { publish, setKnownDotuiNames, setDotuiDepResolver } from "@/publisher/publish";
+import { format } from "oxfmt";
+
+setKnownDotuiNames(PUBLISHABLE_NAMES);
+// No dep-rewriting needed: all files ship inline, cross-component deps resolved locally
+setDotuiDepResolver("", "");
+
+const uiFiles: Record<string, string> = {};
+for (const name of PUBLISHABLE_NAMES) {
+  const mod = await publishables[name]();
+  const publishable = selectPublishable(mod, preset); // handles loader spinner/ring swap
+  const { item } = publish({ publishable, preset });
+  for (const file of item.files) {
+    // target is e.g. "ui/button.tsx" → install at src/components/ui/button.tsx
+    const formatted = (await format(file.target, file.content, {
+      printWidth: 120,
+      useTabs: true,
+    })).code;
+    uiFiles[`src/components/${file.target}`] = formatted;
+  }
+}
+```
+
+The resulting entries look like:
+
+```
+src/components/ui/button.tsx
+src/components/ui/card.tsx
+src/components/ui/calendar.tsx
+... (58 more)
+src/lib/utils.ts         ← cn() helper from emitInitItem
+```
+
+The `registryDependencies` rewriting step (`publish.ts:79-105`) is not needed here because all files are already local. Items in `BUNDLED_INTO_INIT` (`focus-styles`, `theme`, `utils`) are already covered by `globals.css` and `src/lib/utils.ts`.
+
+The **`loader` component** uses an enum-with-files param (`ui/loader/meta.ts:14-36`, values `["spinner","ring"]`). `selectPublishable` (currently private in `www/src/routes/r/$name.tsx:89-107`) reads `preset.componentParams.loader?.style` and returns the correct `publishable` from `mod.publishableByPath`. This logic must be extracted into a shared utility before the StackBlitz builder can reuse it.
+
+---
+
+## 5. Theme in globals.css
+
+`globals.css` is assembled by reusing `emitInitItem` (`www/src/publisher/emit-theme.ts:71`) and serialising its structured output back to a CSS string.
+
+### What `emitInitItem` produces (for a custom preset)
+
+`mergePresetCssFields` (`emit-theme.ts:145-170`) takes `baseRegistryCss` (`www/src/registry/__generated__/base-css.ts`, the structured form of `registry/base/base.css` + `colors.css` + `theme.css` + `fonts.css`) and merges:
+
+- **Static at-rules**: `@import "tw-animate-css"`, `@plugin "tailwindcss-react-aria-components"`, `@plugin "tailwindcss-autocontrast" { cssfile: "./src/globals.css" }`, `@plugin "tailwindcss-with"`, `@custom-variant dark (&:is(.dark *))`, `@utility focus-ring/focus-reset/focus-input/no-highlight`, `@layer base` resets, `::selection` rule. These are constant across presets.
+- **`css[":root"]`**: `--radius-factor: 1` plus the **full light OKLCH ramp** (6 palettes × 11 steps = 66 vars). When `preset.color` is set, `resolveColorConfig(preset.color)` (`www/src/registry/theme/primitives.ts:67`) regenerates the ramps and overrides these entries via `rampsToVars(resolved.light)` (`emit-theme.ts:135-143`). `--dotui-density: <density>` is added when density ≠ `"compact"`.
+- **`css[".dark"]`**: the reversed dark ramp (each palette's step-50 gets step-950's oklch value, etc.) via `rampsToVars(resolved.dark)` (`emit-theme.ts:158`; reversal in `primitives.ts:28-37`).
+- **`cssVars.theme`**: the constant semantic `@theme inline` block — `--radius-*` (calc with `--radius-factor`), `--color-bg`, `--color-accent`, `--color-fg-on-accent`, all 80+ semantic tokens from `www/src/registry/base/theme.css`. Never changes per preset.
+
+### Serialising the structured fields to a CSS string
+
+`emitInitItem` returns a `RegistryItem` with `{ css, cssVars }` in shadcn's structured format (as produced by `cssToRegistryFields`, `www/src/publisher/build-time/css-to-registry-fields.ts:30`). Shadcn's own CLI converts these back to a CSS string when it writes `globals.css`. For the StackBlitz builder, a small serialiser is needed:
+
+```ts
+function registryItemToCss(item: RegistryItem): string {
+  const parts: string[] = ["@import 'tailwindcss';"];
+  // cssVars.theme → @theme inline { ... }
+  if (item.cssVars?.theme) {
+    const themeDecls = Object.entries(item.cssVars.theme)
+      .map(([k, v]) => `  ${k}: ${v};`)
+      .join("\n");
+    parts.push(`@theme inline {\n${themeDecls}\n}`);
+  }
+  // css keys → at-rules and selectors
+  if (item.css) {
+    for (const [selector, body] of Object.entries(item.css)) {
+      if (typeof body === "object" && body !== null) {
+        const decls = Object.entries(body as Record<string, string>)
+          .map(([k, v]) => `  ${k}: ${v};`)
+          .join("\n");
+        parts.push(`${selector} {\n${decls}\n}`);
+      } else if (typeof body === "string") {
+        parts.push(body);
+      }
+    }
+  }
+  return parts.join("\n\n");
+}
+```
+
+The `tailwindcss-autocontrast` plugin's `cssfile` option must point at the same `globals.css` so it finds the `:root`/`.dark` ramp vars to derive `--on-*` foregrounds. In the StackBlitz project this is `./src/globals.css`.
+
+### The autocontrast gap
+
+`--on-accent-500`, `--on-neutral-200`, etc. are **not shipped in the init item** — they are derived at Tailwind compile time by `tailwindcss-autocontrast` scanning `:root`/`.dark` for `--<palette>-<step>` vars. In StackBlitz, Vite runs the Tailwind plugin when the dev server starts, so `--on-*` are injected correctly into the compiled CSS. The showcase will render correctly after Vite's first transform pass.
+
+---
+
+## 6. The showcase as first view
+
+`App.tsx` in the generated project renders `<Cards />` directly. The `Cards` component (`www/src/components/marketing/showcase/cards.tsx:20-48`) is the masonry grid of 17 showcase widgets.
+
+Because the showcase files import from `@/components/ui/*`, `@/registry/lib/utils`, and `@/registry/__generated__/icons`, the StackBlitz project must replicate these paths under `src/`. The path alias `@/ → src/` is configured in `vite.config.ts`.
+
+The showcase card files (`www/src/components/marketing/showcase/*.tsx`) are copied verbatim — they contain no server functions, no TanStack Router loaders, and no SSR dependencies. All state is local React state. The only runtime network calls are to GitHub CDN for avatar images (`https://github.com/mehdibha.png` etc.), which degrade gracefully via `AvatarFallback`.
+
+`ThemeProvider` from `packages/starter-themes` depends on `@tanstack/react-router`'s `ScriptOnce`. In the StackBlitz project, replace it with a minimal inline dark-mode script:
+
+```tsx
+// src/main.tsx
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./globals.css";
+import App from "./App";
+
+// Class-based dark mode: dotUI uses `@custom-variant dark (&:is(.dark *))`
+// Toggle by adding/removing class="dark" on <html>.
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+document.documentElement.classList.toggle("dark", prefersDark);
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);
+```
+
+```tsx
+// src/App.tsx
+import { Cards } from "./components/marketing/showcase/cards";
+
+export default function App() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-fg antialiased">
+      <main className="p-8">
+        <Cards />
+      </main>
+    </div>
+  );
+}
+```
+
+`DesignSystemProvider` (`www/src/modules/core/styles.tsx:61`) is **not needed** in the StackBlitz project. The provider's only runtime job is to write CSS vars to `document.documentElement` reflecting the active preset selection. In the StackBlitz project the preset is already baked into every component's `tv()` class strings (by `publish`/`flatten`) and into `globals.css`. The default context value (`{ params: {}, tokens: {}, density: "default" }`) is sufficient.
+
+---
+
+## 7. What dotUI must build
+
+### 7.1 New server route: `GET /r/stackblitz?preset=<encoded>`
+
+This endpoint is the core new piece. It runs entirely server-side inside the dotUI www app, reuses existing publisher infrastructure, and returns a JSON payload the client-side `openProject` call consumes.
+
+```ts
+// www/src/routes/r/stackblitz.tsx (new file)
+import { createFileRoute } from "@tanstack/react-router";
+import { emitInitItem } from "@/publisher/emit-theme";
+import { baseRegistryCss } from "@/registry/__generated__/base-css";
+import { publishables, PUBLISHABLE_NAMES } from "@/registry/__generated__/publishables";
+import { publish, setKnownDotuiNames } from "@/publisher/publish";
+import { showcaseFiles } from "@/registry/__generated__/showcase-bundle"; // see §7.3
+import { buildStackBlitzProject } from "@/modules/open-in/stackblitz";
+
+export const Route = createFileRoute("/r/stackblitz")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const url = new URL(request.url);
+        const encodedPreset = url.searchParams.get("preset") ?? undefined;
+        const preset = encodedPreset
+          ? await decodePresetForRoute(encodedPreset)
+          : { density: "compact", componentParams: {} };
+
+        setKnownDotuiNames(PUBLISHABLE_NAMES);
+        const project = await buildStackBlitzProject({
+          preset, encodedPreset, publishables, PUBLISHABLE_NAMES,
+          baseRegistryCss, showcaseFiles,
+        });
+
+        return new Response(JSON.stringify(project), {
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    },
+  },
+});
+```
+
+### 7.2 New module: `www/src/modules/open-in/stackblitz.ts`
+
+```ts
+// www/src/modules/open-in/stackblitz.ts
+import { emitInitItem } from "@/publisher/emit-theme";
+import { publish } from "@/publisher/publish";
+import { format } from "oxfmt";
+import type { PublishPreset } from "@/publisher/types";
+import type { RegistryItem } from "@/registry/types";
+
+export async function buildStackBlitzProject(opts: {
+  preset: PublishPreset;
+  encodedPreset: string | undefined;
+  publishables: Record<string, () => Promise<{ publishable: Publishable; publishableByPath?: Record<string, Publishable> }>>;
+  PUBLISHABLE_NAMES: string[];
+  baseRegistryCss: Pick<RegistryItem, "css" | "cssVars">;
+  showcaseFiles: Record<string, string>;  // path → content, pre-read at build time
+}): Promise<StackBlitzProject> {
+  const { preset, encodedPreset, publishables, PUBLISHABLE_NAMES, baseRegistryCss, showcaseFiles } = opts;
+
+  // 1. Globals CSS
+  const initItem = emitInitItem({
+    baseRegistryCss,
+    preset,
+    encodedPreset,
+    registryRoot: "https://dotui.com",
+  });
+  const globalsCss = registryItemToCss(initItem, encodedPreset);
+
+  // 2. Component files
+  const uiFiles: Record<string, string> = {};
+  for (const name of PUBLISHABLE_NAMES) {
+    const mod = await publishables[name]();
+    const publishable = selectPublishableForPreset(mod, preset, name);
+    const { item } = publish({ publishable, preset });
+    for (const file of item.files) {
+      const result = await format(file.target, file.content, { printWidth: 120, useTabs: true });
+      uiFiles[`src/components/${file.target}`] = result.code;
+    }
+  }
+
+  // 3. Support files
+  const libUtils = initItem.files?.find((f) => f.target === "src/lib/utils.ts");
+
+  return {
+    title: "dotUI Showcase",
+    description: "dotUI component showcase — customised design system",
+    template: "node",
+    files: {
+      "package.json":        PACKAGE_JSON,
+      "vite.config.ts":      VITE_CONFIG,
+      "tsconfig.json":       TSCONFIG,
+      "index.html":          INDEX_HTML,
+      "src/main.tsx":        MAIN_TSX,
+      "src/App.tsx":         APP_TSX,
+      "src/globals.css":     globalsCss,
+      "src/lib/utils.ts":    libUtils?.content ?? CN_UTILS_TS,
+      "src/registry/lib/context/index.tsx": CONTEXT_LIB,        // see §7.3
+      "src/registry/hooks/use-image-loading-status.ts": USE_IMAGE_HOOK,
+      "src/registry/__generated__/icons.tsx": ICONS_GENERATED,
+      "src/modules/core/styles.tsx": DESIGN_SYSTEM_RUNTIME,      // stripped-down (see §7.3)
+      ...uiFiles,
+      ...showcaseFiles,   // src/components/marketing/showcase/*.tsx
+    },
+  };
+}
+```
+
+### 7.3 Pre-bundled showcase source
+
+The showcase card files (`www/src/components/marketing/showcase/*.tsx`) are **static source files** — they don't change per preset. They should be read once at build time and emitted as `www/src/registry/__generated__/showcase-bundle.ts` (a `Record<string, string>` mapping path → file content), so the server route does not do filesystem I/O per request.
+
+Add a step to `scripts/registry-build.ts` (after the existing publishables build):
+
+```ts
+// scripts/registry-build.ts (addition)
+async function buildShowcaseBundle() {
+  const files = await glob("src/components/marketing/showcase/*.tsx", { cwd: WWW_SRC });
+  const entries = await Promise.all(
+    files.map(async (f) => [
+      f.replace("src/", "src/"),   // keep full relative path as key
+      await readFile(path.join(WWW_SRC, f), "utf-8"),
+    ])
+  );
+  const src = `export const showcaseFiles: Record<string, string> = ${JSON.stringify(Object.fromEntries(entries), null, 2)};\n`;
+  await writeFile(path.join(WWW_SRC, "registry/__generated__/showcase-bundle.ts"), src);
+}
+```
+
+### 7.4 `selectPublishable` extraction
+
+`selectPublishable` is currently private in `www/src/routes/r/$name.tsx:89-107`. It must be extracted to `www/src/publisher/select-publishable.ts` and exported so both the route handler and the StackBlitz builder can call it.
+
+### 7.5 Client-side button
+
+```tsx
+// www/src/modules/create/open-in-stackblitz.tsx (new file)
+import sdk from "@stackblitz/sdk";
+import { useDesignSystem } from "./preset";
+import { encodePreset } from "./preset/codec";
+
+export function OpenInStackBlitzButton() {
+  const { designSystem } = useDesignSystem();
+
+  async function handleClick() {
+    const encoded = encodePreset(designSystem);
+    const qs = encoded ? `?preset=${encoded}` : "";
+    const host = typeof window !== "undefined" ? window.location.origin : "https://dotui.com";
+    // Fetch the pre-built project definition from the server
+    const resp = await fetch(`${host}/r/stackblitz${qs}`);
+    const project = await resp.json();
+    sdk.openProject(project, { openFile: "src/App.tsx", newWindow: true });
+  }
+
+  return (
+    <button onClick={handleClick}>
+      Open in StackBlitz
+    </button>
+  );
+}
+```
+
+The `fetch` + `sdk.openProject` pattern keeps the heavy publisher work on the server. If a fully client-side approach is preferred (e.g. to avoid the extra network round-trip), the builder can be rewritten to run in the browser — but it requires shipping the codec, pako, and publishables loader to the client bundle, which is a larger footprint.
+
+---
+
+## 8. Schema / meta.ts changes
+
+No `meta.ts` changes are required. The StackBlitz builder reuses the same `PublishPreset` shape (`www/src/publisher/types.ts:79-85`) and the same `publish` / `emitInitItem` pipeline.
+
+If dotUI later wants to annotate which components are "showcase-required" (for generating a minimal bundle), an optional `showcaseRequired?: boolean` field can be added to `RegistryItem` (`www/src/registry/types.ts:69-78`) — one line, inert until read. `metaForRuntime` (`www/src/publisher/build-time/build-publishables.ts:334`) spreads `...rest`, so it propagates automatically to the generated publishable meta literal.
+
+No changes to the shadcn registry JSON shape are needed.
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### Bundle size
+
+The complete file tree (60 component files + showcase cards + globals.css + support files) is roughly 300–600 KB of uncompressed text. This is well within StackBlitz's limits (the SDK POST is gzip-compressed). No concern in practice.
+
+### `publishables` must be built
+
+`www/src/registry/__generated__/publishables/` is generated by `pnpm build:registry` and is git-ignored. The server route `/r/stackblitz` imports from it, so it must exist in the deployed bundle. The existing Vercel build already runs `build:registry`; no change needed for production. Local dev requires `pnpm build:registry` first (same requirement as the existing `/r/$name` and `/r/init` routes).
+
+### `selectPublishable` is currently private
+
+Until it is extracted (§7.4), the StackBlitz builder cannot correctly handle the `loader` component's spinner/ring file swap. A short-term workaround is to hardcode `spinner` as the default loader style (always ship `base.spinner.tsx`) when no `componentParams.loader.style` is set.
+
+### `tokens` field is not yet wired into emitted CSS
+
+`www/src/publisher/emit-theme.ts:62-68` has an explicit TODO: the `tokens` key of `DesignSystem` (e.g. `--radius-factor`) is not yet threaded through `PublishPreset` to `:root`. This is a dotUI-wide limitation, not specific to StackBlitz. When it is fixed (Phase: "tokens in PublishPreset"), the StackBlitz builder inherits it for free because it calls `emitInitItem`.
+
+### `DesignSystemProvider` / runtime CSS-var writes
+
+The StackBlitz project ships without a live `DesignSystemProvider`. If the user edits a component's `tv()` call directly in StackBlitz, scalar param CSS vars (e.g. `--alert-radius: var(--radius-md)`) will not be set by the provider. Workaround: inline the scalar var declarations in `globals.css` during build. For each component with scalar params, iterate `meta.params` and emit `--<cssVar>: <resolvedValue>` into `:root` (using the same `resolveCssValue` logic from `www/src/modules/core/styles.tsx:49`).
+
+### `tailwindcss-autocontrast` path
+
+The `cssfile` option in `@plugin "tailwindcss-autocontrast"` must point at the project's own Tailwind entry file. In the StackBlitz project this is `./src/globals.css`. The `base.css` source has `./src/styles.css` — this must be adjusted in the serialiser.
+
+### No live preset editing in StackBlitz
+
+The StackBlitz project is a static snapshot. If the user wants to change the accent color, they must return to `dotui.com/create`, update the preset, and click Open in StackBlitz again. Alternatively, they can edit the OKLCH ramps directly in `globals.css`. An advanced enhancement would be to include a small `setPreset(encoded)` utility in the generated project that accepts a new preset string and regenerates `globals.css` + component files via the dotUI registry endpoints — but this is out of scope for v1.
+
+### `@base-ui/react` dependency
+
+`otp-field/base.tsx` imports from `@base-ui/react/otp-field` and `toast/base.tsx` from `@base-ui/react/toast`. Both must be in `package.json`. The toast component is not used in the showcase cards but ships as part of the full component bundle.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+- [ ] **Extract `selectPublishable`** from `www/src/routes/r/$name.tsx:89-107` into `www/src/publisher/select-publishable.ts` and export it. Update the route to import from the new location.
+- [ ] **Add showcase bundle generator** to `scripts/registry-build.ts`: glob `www/src/components/marketing/showcase/*.tsx`, emit `www/src/registry/__generated__/showcase-bundle.ts`.
+- [ ] **Write `registryItemToCss` serialiser** in `www/src/modules/open-in/stackblitz.ts`. Handle `cssVars.theme` → `@theme inline`, `css` keys → at-rules and `:root`/`.dark`/selector blocks. Adjust `tailwindcss-autocontrast` `cssfile` option to `./src/globals.css`.
+- [ ] **Write scalar-var emitter**: for each component with `kind:"scalar"` params, emit `--<cssVar>: <resolvedDefault>` into `:root` in `globals.css` (so the showcase renders correctly without `DesignSystemProvider`).
+- [ ] **Write `buildStackBlitzProject`** in `www/src/modules/open-in/stackblitz.ts` following the shape in §7.2. Include all static file templates (`PACKAGE_JSON`, `VITE_CONFIG`, `INDEX_HTML`, etc.).
+- [ ] **Write the static file templates** (see §10a below).
+- [ ] **Add server route** `www/src/routes/r/stackblitz.tsx` (GET handler, decode preset, call builder, return JSON).
+- [ ] **Add client button** `www/src/modules/create/open-in-stackblitz.tsx`. Wire into the customiser panel alongside the install command (`www/src/modules/create/install-command.tsx`).
+- [ ] **Add `@stackblitz/sdk`** to `www/package.json` dependencies.
+- [ ] **Test locally**: `pnpm build:registry && pnpm dev`, navigate to `/create`, open a custom preset, click the button.
+- [ ] **Verify in StackBlitz**: confirm `vite dev` boots, the showcase renders with the correct accent color and density, `--on-*` vars are present after Tailwind compile.
+
+### 10a. Static file templates
+
+```json
+// PACKAGE_JSON (template)
+{
+  "name": "dotui-showcase",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-aria-components": "^1.4.0",
+    "react-aria": "^3.36.0",
+    "react-stately": "^3.34.0",
+    "tailwind-variants": "^0.3.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.5.4",
+    "lucide-react": "^0.469.0",
+    "@internationalized/date": "^3.6.0",
+    "@base-ui/react": "^1.0.0",
+    "@fontsource-variable/geist": "^5.1.1",
+    "@fontsource/geist-mono": "^5.0.3",
+    "tailwindcss": "^4.0.0",
+    "tw-animate-css": "^1.3.0",
+    "tailwindcss-react-aria-components": "^2.1.0",
+    "tailwindcss-autocontrast": "^1.0.0",
+    "tailwindcss-with": "^1.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "@tailwindcss/vite": "^4.0.0",
+    "typescript": "~5.7.2",
+    "vite": "^6.0.5"
+  }
+}
+```
+
+```ts
+// VITE_CONFIG
+import path from "node:path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "./src") },
+  },
+});
+```
+
+```html
+<!-- INDEX_HTML -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>dotUI Showcase</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+The `tailwindcss-autocontrast` and `tailwindcss-with` package names in `package.json` must match their published npm names. Verify versions at publish time against the workspace `packages/` versions.
+
+---
+
+## Sources
+
+- StackBlitz SDK `openProject` API: https://developer.stackblitz.com/platform/api/javascript-sdk-options
+- StackBlitz POST form mechanism: https://developer.stackblitz.com/platform/api/post-api
+- StackBlitz WebContainers Vite + React support: https://developer.stackblitz.com/guides/user-guide/importing-projects
+- shadcn `registry:base` item type and `shadcn add` merge behaviour: https://ui.shadcn.com/docs/registry/registry-item-types
+- shadcn `cssVars.light/dark` writing behaviour (Tailwind v4, issue #7119): https://github.com/shadcn-ui/ui/issues/7119
+- dotUI codec: `www/src/modules/create/preset/codec.ts:75` (`encodePreset`), `codec.ts:111` (`decodePreset`)
+- dotUI init item builder: `www/src/publisher/emit-theme.ts:71` (`emitInitItem`), `emit-theme.ts:145` (`mergePresetCssFields`)
+- dotUI component publisher: `www/src/publisher/publish.ts:119` (`publish`), `publish.ts:79` (`rewriteDeps`)
+- dotUI init route: `www/src/routes/r/init.tsx:22`
+- dotUI per-component route: `www/src/routes/r/$name.tsx:35`
+- dotUI showcase entry: `www/src/components/marketing/showcase/cards.tsx:20`
+- dotUI base CSS structured output: `www/src/registry/__generated__/base-css.ts`
+- dotUI color resolution kernel: `www/src/registry/theme/primitives.ts:67` (`resolveColorConfig`)
+- pako (DEFLATE compression): https://nodeca.github.io/pako/

--- a/docs/research/open-in/v0.md
+++ b/docs/research/open-in/v0.md
@@ -1,0 +1,577 @@
+# Open in v0 (Vercel)
+
+> Feasible with workarounds · button type **component-url** · preset fidelity **full** (via file embedding) · color fidelity **full** (via files[], not cssVars)
+
+---
+
+## 1. User experience
+
+The user has customized their design system on `dotui.com/create?preset=<encoded>`. They click
+"Open in v0". v0 opens at `https://v0.app` showing the showcase layout (the 17-card masonry grid
+from `www/src/components/marketing/showcase/cards.tsx`) as the first view, rendered with the full
+dotUI component library already installed under `components/ui/` and the user's chosen OKLCH
+palette already written into `app/globals.css`. Dark mode, radius scale, density, and per-component
+style choices all reflect the preset — not the dotUI default.
+
+What happens under the hood: a single deeplink URL is constructed that points to a special
+"showcase bundle" registry item served by dotUI at `/r/showcase-bundle?preset=<encoded>`. That item
+is a `registry:style` (or `registry:ui`) type carrying:
+- all 60 component source files inline under `files[]`
+- the full theme as an actual CSS file in `files[]` targeting `app/globals.css`
+- the showcase page (`app/page.tsx` for Next.js App Router) in `files[]`
+
+v0 fetches that URL, materializes all files into a new sandbox, and opens the showcase page.
+
+---
+
+## 2. Technical mechanism
+
+### The deeplink URL
+
+v0 (formerly v0.dev, rebranded to v0.app in Jan 2026) exposes a single button deeplink:
+
+```
+https://v0.app/chat/api/open?url=<URL-ENCODED registry-item JSON URL>
+```
+
+dotUI constructs:
+
+```
+https://v0.app/chat/api/open?url=https%3A%2F%2Fdotui.com%2Fr%2Fshowcase-bundle%3Fpreset%3D<encURL>
+```
+
+where `<encURL>` is the `encodeURIComponent`-encoded value of the already-URL-safe preset string
+produced by `encodePreset` (`www/src/modules/create/preset/codec.ts:75`).
+
+v0 fetches `https://dotui.com/r/showcase-bundle?preset=<encoded>`, receives the registry item JSON,
+and writes all `files[].content` into the sandbox project.
+
+### What v0 strips (the central problem)
+
+v0's deeplink processor strips the following registry item fields before writing files:
+- `cssVars` (light / dark / theme) — the OKLCH palette does NOT travel this way
+- `css` — the structured at-rules and `:root` / `.dark` blocks do NOT travel this way
+- `envVars`, namespaced registries, advanced auth tokens
+
+This is the core obstacle. The entire dotUI color system (66 primitive ramps per mode, the `@theme
+inline` semantic layer, `@plugin` declarations) lives in `css` and `cssVars` on the init item. If
+dotUI relies on those fields the preset colors will be silently absent in the v0 sandbox.
+
+### The workaround: ship the theme as an actual file
+
+The workaround is to ship the theme as a real entry in `files[]` with the preset-resolved CSS
+as `content`. A file targeting `app/globals.css` (Next.js App Router) or `src/app/globals.css`
+travels through the deeplink intact because v0 writes every `files[]` entry verbatim. This is the
+Vercel registry-starter pattern: a registry:style/theme item whose `files[]` includes a CSS file
+targeting `app/globals.css`.
+
+---
+
+## 3. Preset propagation
+
+The preset string comes from `encodePreset(designSystem)` (`www/src/modules/create/preset/codec.ts:75`).
+It is the URL-safe base64 of pako raw-DEFLATE of `JSON.stringify(DesignSystemState)`, where
+`DesignSystemState` carries only the delta from defaults:
+
+```ts
+// types.ts:14
+{ p?: Record<string, Record<string, string>>;  // componentParams delta
+  t?: Record<string, string>;                   // tokens delta (not yet wired to publisher)
+  d?: Density;                                  // only if != "compact"
+  c?: ColorConfig;                              // full color recipe if != DEFAULT_COLOR_CONFIG }
+```
+
+The deeplink URL carries this string as a query parameter on the item URL:
+
+```
+https://dotui.com/r/showcase-bundle?preset=<encoded>
+```
+
+The server route reads `url.searchParams.get("preset")`, passes it through
+`decodePreset(encoded)` (`codec.ts:111`) to reconstruct the full `DesignSystem`, then narrows to
+`PublishPreset` (`www/src/publisher/types.ts:79-85`):
+
+```ts
+{ density: Density;
+  componentParams: Record<string, Record<string, string>>;
+  color?: ColorConfig; }
+```
+
+`color` is used by `resolveColorConfig(preset.color)` (`www/src/registry/theme/primitives.ts:67`)
+to regenerate the OKLCH ramps. These ramps are written into the CSS file content (not `cssVars`),
+so they survive the v0 strip.
+
+---
+
+## 4. Components installed
+
+Because v0 strips `registryDependencies` resolution (undocumented, treat as unreliable), the
+showcase bundle must ship **all** component files inline in a single item's `files[]`.
+
+The full set of files needed to render `<Cards />` (from the showcase internals map) is the union
+of these registry items (all 60 ui items cover more than needed; the exact showcase subset is
+documented in the showcase internals map):
+
+accordion, avatar, badge, button, calendar, card, checkbox, checkbox-group, color-area,
+color-editor, color-field, color-slider, color-thumb, disclosure, drop-zone, field, file-trigger,
+group, input, kbd, link, list-box, loader, otp-field, popover, progress-bar, radio-group, select,
+separator, slider, switch, table, tabs, tag-group, text, text-field, time-field, toggle-button,
+toggle-button-group
+
+Plus the lib/hook items: `registry/lib/utils`, `registry/lib/focus-styles` (CSS-only),
+`registry/hooks/use-image-loading-status`.
+
+Each component file is generated by `publish({ publishable, preset })` (`www/src/publisher/publish.ts:119`).
+The preset's `density` and `componentParams` bake into each component's `tv()` config inline at
+request time (flatten + resolveClasses pipeline), so the emitted source files already contain the
+correct class strings for the chosen preset — no runtime CSS var plumbing needed per component.
+
+All files land under `components/ui/<name>.tsx` in the v0 sandbox, matching the shadcn default
+`ui` alias (`@/components/ui`).
+
+---
+
+## 5. Theme in globals.css
+
+### Why cssVars fails here
+
+`emitInitItem` (`www/src/publisher/emit-theme.ts:71`) builds the theme as `css` and `cssVars`
+fields. For a preset with custom color, `mergePresetCssFields` (`emit-theme.ts:145`) overrides
+`:root` and `.dark` with `rampsToVars(resolved.light)` / `rampsToVars(resolved.dark)`. But v0
+strips these fields before writing files.
+
+### The files[] approach
+
+Instead, dotUI's showcase-bundle route assembles the full theme as a CSS string and puts it in
+`files[]` targeting `app/globals.css`:
+
+```ts
+// Pseudo-code for the new route handler
+const themeContent = buildGlobalsCssContent({ preset, baseRegistryCss });
+files.push({
+  type: "registry:ui",   // any type works; "registry:ui" is safe
+  path: "app/globals.css",
+  target: "app/globals.css",
+  content: themeContent,
+});
+```
+
+`buildGlobalsCssContent` renders the same structure that shadcn would have written from `css` /
+`cssVars`, but as a raw string:
+
+```css
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "@fontsource-variable/geist";
+@import "@fontsource/geist-mono";
+
+@plugin "tailwindcss-react-aria-components";
+@plugin "tailwindcss-autocontrast" { cssfile: "./app/globals.css"; }
+@plugin "tailwindcss-with";
+
+@custom-variant dark (&:is(.dark *));
+
+@utility focus-reset { ... }
+@utility focus-ring { ... }
+@utility focus-input { ... }
+@utility no-highlight { ... }
+
+@layer base {
+  * { @apply border-border; }
+  body { @apply bg-bg font-sans text-fg; }
+  html { @apply font-sans; }
+}
+
+::selection { background-color: var(--accent-800); color: var(--on-accent-800); }
+
+@theme inline {
+  --radius-md: calc(0.375rem * var(--radius-factor));
+  /* ... full semantic color token mapping from base/theme.css ... */
+  --color-bg: var(--neutral-50);
+  --color-accent: var(--accent-500);
+  /* ... */
+}
+
+@theme {
+  --font-sans: "Geist Variable", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, monospace;
+}
+
+/* PRESET PRIMITIVE RAMPS — generated by resolveColorConfig(preset.color) */
+:root {
+  --radius-factor: 1;
+  --neutral-50: oklch(0.985 0 0);
+  --neutral-100: oklch(0.945 0.003 264);
+  /* ... 66 vars for 6 palettes x 11 steps ... */
+  --accent-500: oklch(0.558 0.142 229.5);
+  /* ... */
+}
+.dark {
+  --neutral-50: oklch(0.13 0 0);
+  /* ... reversed ramps ... */
+}
+```
+
+The data for this comes from:
+- At-rules / utilities / layer blocks: `baseRegistryCss.css` (`__generated__/base-css.ts`) — the
+  structured object is serialized back to CSS text.
+- `@theme inline` semantic tokens: `baseRegistryCss.cssVars.theme` serialized to a `@theme inline`
+  block. This section is constant across presets.
+- `:root` / `.dark` primitive ramps: `rampsToVars(resolved.light)` / `rampsToVars(resolved.dark)`
+  from `emit-theme.ts:134-143` logic, but written as CSS text instead of structured objects.
+- Density var: `--dotui-density: <value>` in `:root` only when density != `"compact"`.
+
+The `tailwindcss-autocontrast` plugin (`@plugin "tailwindcss-autocontrast" { cssfile: "./app/globals.css"; }`)
+must point at this same file. It will inject `--on-accent-500` etc. at Tailwind compile time from
+the shipped ramps, filling in `--color-fg-on-accent` etc. This means the v0 sandbox Tailwind build
+will produce the correct foreground colors without dotUI needing to ship `--on-*` vars explicitly.
+
+---
+
+## 6. The showcase as first view
+
+### What the showcase is
+
+`www/src/components/marketing/showcase/cards.tsx:20-48` renders a `columns-1 sm:columns-2 lg:columns-3 xl:columns-4`
+masonry div with 17 self-contained card widgets (Booking, TwoFactor, Filters, Storage,
+Notifications, CookiePreferences, InviteMembers, Shortcuts, Payment, Transactions, AccountMenu,
+Faq, ColorEditorCard, UploadAvatar, TeamName, Feedback, LoginForm). All widgets are static
+client-side components — no server functions, no loaders, no routing dependencies.
+
+### What files[] must include for the showcase
+
+The showcase-bundle item's `files[]` must include:
+
+1. **`app/globals.css`** — the theme file described in §5.
+2. **`app/page.tsx`** — the Next.js App Router page that renders `<Cards />`. Content:
+   ```tsx
+   import { Cards } from "@/components/marketing/showcase/cards";
+
+   export default function Page() {
+     return (
+       <div className="min-h-screen bg-bg font-sans text-fg antialiased p-8">
+         <Cards />
+       </div>
+     );
+   }
+   ```
+3. **`app/layout.tsx`** — minimal root layout that applies dark-mode toggling and fonts:
+   ```tsx
+   import type { Metadata } from "next";
+   import "./globals.css";
+
+   export const metadata: Metadata = { title: "dotUI Showcase" };
+
+   export default function RootLayout({ children }: { children: React.ReactNode }) {
+     return (
+       <html lang="en">
+         <body>{children}</body>
+       </html>
+     );
+   }
+   ```
+4. **All component files** — one file per component under `components/ui/<name>.tsx` (see §4).
+5. **`components/marketing/showcase/*.tsx`** — the 17 card files plus `cards.tsx` itself.
+   These are copied verbatim from `www/src/components/marketing/showcase/`. They are static
+   (no TanStack Router, no server imports).
+6. **`lib/utils.ts`** — the `cn()` helper (`emit-theme.ts:CN_UTILS_TS`).
+7. **`lib/focus-styles.ts`** — if any component imports it directly (most consume it via CSS).
+8. **`hooks/use-image-loading-status.ts`** — used by `avatar/base.tsx`; must ship as a file.
+9. **`lib/context.tsx`** — `createContext` / `createVariantsContext` / `createScopedContext` used
+   by avatar, tabs, toggle-button, button.
+
+### Why the showcase doesn't need a special framework provider
+
+`DesignSystemProvider` (`www/src/modules/core/styles.tsx`) is optional for rendering the showcase.
+Its default context value gives every component its default visual variant. If preset
+`componentParams` are all at default values (which is likely for most users), omitting the provider
+is safe. If the preset contains non-default enum choices, the provider must be rendered in
+`app/layout.tsx` and fed the decoded params.
+
+However, `DesignSystemProvider` depends on `www/src/modules/core/styles.tsx` which in turn imports
+`createStyles`, `useStyles`, `createDynamicComponent` — a substantial module. The cleanest path for
+v0 is to **not include the runtime provider** and instead rely entirely on the preset being baked
+into each component's source file by the publisher pipeline (the `publish()` function already bakes
+density and enum choices into class strings at request time). Scalar params are baked as Tailwind
+suffixes via `resolveClasses`. This means the v0 project is preset-correct without needing the
+runtime provider at all.
+
+---
+
+## 7. What dotUI must build
+
+### 7.1 New server route: `/r/showcase-bundle`
+
+New file: `www/src/routes/r/showcase-bundle.tsx`
+
+A TanStack Start server GET handler that:
+
+1. Reads `?preset=` from the URL, decodes to `PublishPreset` via `decodePresetForRoute`
+   (same pattern as `www/src/routes/r/$name.tsx:113-121` and `init.tsx:47-58`).
+
+2. Builds the theme globals CSS string:
+   - Import `baseRegistryCss` from `@/registry/__generated__/base-css`.
+   - Call `mergePresetCssFields(baseRegistryCss, preset)` from `emit-theme.ts:145` to get
+     the structured `css` / `cssVars` with preset ramps merged in.
+   - Serialize the structured fields back to a CSS string (new helper `registryCssFieldsToString`,
+     see §7.3).
+
+3. Builds all component files:
+   - Import `publishables`, `PUBLISHABLE_NAMES` from `@/registry/__generated__/publishables`.
+   - For each component name in the showcase subset (or all 60): load publishable, call
+     `selectPublishable(mod, preset)`, call `publish({ publishable, preset })`, run through
+     `format()` (oxfmt).
+   - Also load and inline the showcase card source files from
+     `www/src/components/marketing/showcase/*.tsx` (these are not publishables; they must be
+     read from disk at build time and shipped as static content, OR included as pre-bundled
+     strings in a generated artifact similar to `base-css.ts`).
+
+4. Assembles the registry item:
+   ```ts
+   {
+     name: "dotui-showcase",
+     type: "registry:ui",
+     dependencies: [
+       "react-aria-components", "react-aria", "react-stately",
+       "tailwind-variants", "clsx", "tailwind-merge",
+       "lucide-react", "@internationalized/date", "@base-ui/react",
+       "@fontsource-variable/geist", "@fontsource/geist-mono",
+       "tw-animate-css", "tailwindcss-react-aria-components",
+       "tailwindcss-autocontrast", "tailwindcss-with"
+     ],
+     registryDependencies: [],
+     files: [
+       { type:"registry:ui", path:"app/globals.css",   target:"app/globals.css",   content: themeCss },
+       { type:"registry:ui", path:"app/layout.tsx",    target:"app/layout.tsx",    content: layoutContent },
+       { type:"registry:ui", path:"app/page.tsx",      target:"app/page.tsx",      content: pageContent },
+       { type:"registry:lib", path:"lib/utils.ts",     target:"src/lib/utils.ts",  content: cnHelper },
+       { type:"registry:lib", path:"lib/context.tsx",  target:"src/lib/context.tsx", content: contextContent },
+       { type:"registry:hook", path:"hooks/use-image-loading-status.ts",
+         target:"src/hooks/use-image-loading-status.ts", content: hookContent },
+       // 17 showcase card files
+       { type:"registry:ui", path:"components/marketing/showcase/cards.tsx",
+         target:"src/components/marketing/showcase/cards.tsx", content: cardsContent },
+       // ... 16 more card files ...
+       // 60 component files
+       { type:"registry:ui", path:"components/ui/button.tsx",
+         target:"src/components/ui/button.tsx", content: buttonContent },
+       // ... 59 more ...
+     ]
+   }
+   ```
+
+5. Returns `JSON.stringify(item, null, 2)` with `Cache-Control: public, max-age=60, s-maxage=3600,
+   stale-while-revalidate=86400` (same pattern as `$name.tsx:27-30`).
+
+### 7.2 The "Open in v0" button
+
+New UI component (e.g. `www/src/components/marketing/open-in-v0.tsx`):
+
+```tsx
+import { encodePreset } from "@/modules/create/preset/codec";
+import { useDesignSystem } from "@/modules/create/preset";
+
+export function OpenInV0Button() {
+  const { designSystem } = useDesignSystem();
+  const encoded = encodePreset(designSystem);
+  const itemUrl = encoded
+    ? `https://dotui.com/r/showcase-bundle?preset=${encoded}`
+    : `https://dotui.com/r/showcase-bundle`;
+  const href = `https://v0.app/chat/api/open?url=${encodeURIComponent(itemUrl)}`;
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      Open in v0
+    </a>
+  );
+}
+```
+
+`encodePreset` returns `undefined` when nothing differs from defaults (`codec.ts:75`); in that case
+the bundle URL omits the preset param and the route handler falls back to `defaultPreset()`.
+
+### 7.3 New helper: `registryCssFieldsToString`
+
+New file: `www/src/publisher/css-fields-to-string.ts`
+
+Serializes the structured `{ css, cssVars }` fields produced by `mergePresetCssFields` back to a
+raw CSS string suitable for writing as a file. This is the inverse of `cssToRegistryFields`
+(`www/src/publisher/build-time/css-to-registry-fields.ts:30`).
+
+Key rules:
+- `cssVars.theme` entries → emit as `@theme inline { <decls> }` block.
+- `css["@import \"tw-animate-css\""]`, `css["@plugin ..."]`, `css["@utility ..."]` etc. →
+  reconstruct at-rule syntax from the structured object keys.
+- `css[":root"]`, `css[".dark"]` → emit as selector blocks with declarations.
+
+### 7.4 Showcase card files as static artifacts
+
+The 17 showcase card files (`www/src/components/marketing/showcase/*.tsx`) are not registry items
+and have no publishable. They must be shipped as-is. Options:
+- Read them from disk at request time using `fs.readFileSync` (works in TanStack Start SSR context).
+- Generate a `__generated__/showcase-cards.ts` artifact at build time (similar to `base-css.ts`)
+  that exports each file's content as a const string.
+
+The second option is preferable for cold-start performance and avoids filesystem reads in a
+serverless/edge context. Add a step to `scripts/registry-build.ts` that globs
+`www/src/components/marketing/showcase/*.tsx` and emits
+`www/src/registry/__generated__/showcase-cards.ts`.
+
+---
+
+## 8. Schema / meta.ts changes
+
+No `meta.ts` changes are needed. The showcase-bundle item is a synthetic item assembled entirely at
+request time; it has no `ui/*/meta.ts` counterpart and is not registered in `registryUi`.
+
+The only schema consideration: `RegistryItem` (`www/src/registry/types.ts:69-78`) already allows
+any `ShadcnRegistryItem` type. The bundle item uses `type: "registry:ui"` which is valid.
+
+Optional: add an `openInV0?: boolean` field to `RegistryItem` as a future capability flag on
+individual items (e.g. to flag which items support single-component "Open in v0"). This requires
+one line in `types.ts:69-78`. It is inert unless code reads it:
+
+```ts
+export type RegistryItem = ShadcnRegistryItem & {
+  group?: ComponentGroup | null;
+  params?: Record<string, ParamDef>;
+  openInV0?: boolean;   // opt-in flag for single-component open-in deeplinks
+};
+```
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### cssVars stripping (the main constraint)
+**Confirmed behavior**: v0's deeplink strips `cssVars`, `css`, `envVars`. This is why the theme
+must travel as an actual `files[]` entry. No workaround exists without v0 Platform API (paid).
+The file-based approach is the canonical solution and is confirmed to work by the Vercel
+registry-starter pattern.
+
+### registryDependencies via deeplink
+**Status**: undocumented; treat as unreliable. The showcase-bundle avoids this entirely by shipping
+all component files inline in one item (no transitive dep resolution needed).
+
+### Response size
+60 component files inline + 17 showcase card files + the theme CSS = a large JSON payload.
+Rough estimate: each component file is ~2–8 KB formatted; 60 components = ~180–480 KB of component
+source; 17 showcase cards = ~50–100 KB; theme CSS = ~6 KB. Total: ~250–600 KB uncompressed.
+v0's fetch of the item URL will receive this as a single JSON response. Mitigations:
+- Apply `pnpm exec oxfmt` (print-width 120, useTabs) to keep files compact.
+- HTTP `Content-Encoding: gzip` (TanStack Start / Vercel serve gzip by default) reduces the
+  wire size by ~70–80%.
+- Cache headers `public, max-age=60, s-maxage=3600` (same as `/r/$name`) let CDN cache the
+  response per preset.
+
+### Showcase cards import from `@/registry/__generated__/icons.tsx`
+`www/src/components/marketing/showcase/invite-members.tsx:6` imports `ExternalLinkIcon` from
+`@/registry/__generated__/icons.tsx`. This generated file is large (all icons). Options:
+- Rewrite the import in the shipped file content to import directly from `lucide-react`:
+  `import { ExternalLink as ExternalLinkIcon } from "lucide-react"`.
+- Ship the relevant slice of `icons.tsx` as a separate file. The simpler option is the rewrite.
+
+### `context/index.tsx` is allowlisted-out (not a registered item)
+`registry/lib/context` is in `ORPHAN_ALLOWLIST` (`registry-build.ts:356`) and has no publishable.
+Its source must be read from disk and shipped inline in the bundle's `files[]`. Once context is
+promoted to a registered item (tracked in the registry reorg project), this becomes a normal
+publishable.
+
+### `tailwindcss-autocontrast` cssfile path
+The `@plugin "tailwindcss-autocontrast" { cssfile: "..." }` option in the shipped globals.css must
+point at the correct path in the v0 sandbox. For a Next.js App Router project this is
+`"./app/globals.css"`. If v0 scaffolds a different project structure (e.g. `src/app/globals.css`),
+the path must be adjusted. Inspect v0's default project template to confirm the correct path.
+
+### `tokens` field not yet wired to publisher
+`DesignSystemState.t` (global tokens, e.g. `--radius-factor`) round-trips in the preset URL but is
+not yet threaded to `PublishPreset` or `emitInitItem` (`emit-theme.ts:62-68` TODO). Custom radius
+factor will not propagate to the v0 project until this is resolved. Workaround: manually add
+`--radius-factor: <value>` to the `:root` block in the shipped CSS file.
+
+### v0 Platform API (paid alternative)
+For full programmatic control (custom project scaffolding, deterministic file placement,
+multi-turn chat seeding), use the v0 Platform API. This requires a paid v0 plan and an API key.
+The file-based deeplink approach described here is free and works with the public deeplink.
+
+### Dark mode provider
+`packages/starter-themes` depends on `@tanstack/react-router`'s `ScriptOnce`. The shipped
+`app/layout.tsx` must use a plain `next-themes` or inline `<script>` approach instead. The
+simplest inline version adds `class="dark"` to `<html>` by default or uses a tiny `<script>` in
+`<head>` to set the class from `localStorage`.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+- [ ] **Build artifact for showcase cards**: Add a step to `scripts/registry-build.ts` that globs
+  `www/src/components/marketing/showcase/*.tsx`, reads each file, and emits
+  `www/src/registry/__generated__/showcase-cards.ts` exporting a `Record<string, string>` map of
+  filename → content. This mirrors the `base-css.ts` pattern.
+
+- [ ] **`registryCssFieldsToString` helper**: Create
+  `www/src/publisher/css-fields-to-string.ts` that serializes `{ css, cssVars }` (the output of
+  `mergePresetCssFields`) to a raw CSS string. Unit-test round-trip against `base-css.ts`.
+
+- [ ] **`/r/showcase-bundle` route**: Create `www/src/routes/r/showcase-bundle.tsx`.
+  - Read `?preset=`, decode via `decodePresetForRoute` (pattern from `init.tsx:47-58`).
+  - Import `baseRegistryCss`, call `mergePresetCssFields(baseRegistryCss, preset)`,
+    call `registryCssFieldsToString(fields)` to get `themeCss`.
+  - Import `publishables`, `PUBLISHABLE_NAMES`; loop the showcase subset, call
+    `selectPublishable` + `publish` + `format` per component (pattern from `$name.tsx`).
+  - Import `SHOWCASE_CARDS` from `__generated__/showcase-cards.ts`; add each card file to
+    `files[]` with `target: "src/components/marketing/showcase/<name>.tsx"`.
+  - Rewrite the `ExternalLinkIcon` import in `invite-members` content before adding to files.
+  - Read `context/index.tsx` content (from disk or a generated artifact) and add to `files[]`.
+  - Assemble and return the registry item JSON.
+
+- [ ] **`encodePreset` guard**: Confirm `encodePreset` (`codec.ts:75`) returns `undefined` for
+  the default design system (verified by `codec.spec.ts:9-11`); the route must handle absent
+  preset gracefully via `defaultPreset()`.
+
+- [ ] **"Open in v0" button component**: Create
+  `www/src/components/marketing/open-in-v0.tsx` using `useDesignSystem` +
+  `encodePreset` to build the deeplink URL (see §7.2). Hook into the landing page
+  (`www/src/routes/_app/index.tsx`).
+
+- [ ] **Cache headers on the bundle route**: Apply the same `public, max-age=60, s-maxage=3600,
+  stale-while-revalidate=86400` headers as `$name.tsx:27-30` and `init.tsx:17-20`.
+
+- [ ] **Test the deeplink end-to-end**: Navigate to
+  `https://v0.app/chat/api/open?url=https://dotui.com/r/showcase-bundle?preset=<encoded>` and
+  confirm:
+  - All `components/ui/*.tsx` files are present.
+  - `app/globals.css` contains the preset OKLCH ramps (not defaults).
+  - `app/page.tsx` renders `<Cards />` as the first view.
+  - No console errors from missing deps or broken imports.
+
+- [ ] **`tokens` TODO follow-up**: Once `preset.tokens` is threaded through `PublishPreset` and
+  `emitInitItem` (tracked TODO at `emit-theme.ts:62-68`), add `--radius-factor` and any other
+  global token vars to the `:root` block in the shipped globals.css.
+
+- [ ] **Confirm v0 sandbox project structure**: Check whether v0 uses `app/globals.css` or
+  `src/app/globals.css` and adjust the `target` and `cssfile` plugin path accordingly.
+
+---
+
+## Sources
+
+- v0 deeplink format: `https://v0.app/chat/api/open?url=<encoded>` — Vercel v0 docs (Jan 2026
+  rebrand confirmed); registry-starter pattern for cssVars workaround.
+- shadcn `cssVars` / `css` stripping by the v0 deeplink: confirmed in the feature ground-truth
+  supplied to this document (Jan 2026).
+- shadcn `npx shadcn add <url>` merges `cssVars.light`/`.dark` for any item type:
+  https://ui.shadcn.com/docs/registry/registry-item-type
+- shadcn Tailwind v4 `cssVars.theme` note (dotUI issue #7119 reference): raw unwrapped OKLCH in
+  `cssVars` (not `cssVars.theme`) for v4 `:root` writes.
+- dotUI codec: `www/src/modules/create/preset/codec.ts:75-126`
+- dotUI init item assembly: `www/src/publisher/emit-theme.ts:71-170`
+- dotUI per-component publish pipeline: `www/src/publisher/publish.ts:119-161`
+- dotUI `/r/init` route: `www/src/routes/r/init.tsx:22-59`
+- dotUI `/r/$name` route: `www/src/routes/r/$name.tsx:32-122`
+- dotUI install command: `www/src/modules/create/install-command.tsx:39-48`
+- dotUI showcase cards component: `www/src/components/marketing/showcase/cards.tsx:20-48`
+- dotUI registry types: `www/src/registry/types.ts:69-78`
+- dotUI color resolution: `www/src/registry/theme/primitives.ts:67-108`
+- dotUI ramps-to-vars: `www/src/publisher/emit-theme.ts:134-143`
+- dotUI ORPHAN_ALLOWLIST (context not yet registered): `www/scripts/registry-build.ts:356`
+- tailwindcss-autocontrast plugin: `packages/tailwindcss-autocontrast/src/index.js:407-501`

--- a/docs/research/open-in/webflow.md
+++ b/docs/research/open-in/webflow.md
@@ -1,0 +1,420 @@
+# Open in Webflow
+
+> Token-export only — not a React/Tailwind target · button type **copy-command** · preset fidelity **partial** (tokens only; component classes not applicable) · color fidelity **partial** (OKLCH values exported; Webflow Designer does not parse OKLCH natively)
+
+---
+
+## 1. User experience
+
+The user is on `https://dotui.com/create` with a custom preset active (e.g. a teal accent, compact density, card style "tasnim"). They click **"Copy for Webflow"**.
+
+What they should land in:
+
+1. A modal (or fly-out panel) appears showing a ready-to-paste CSS block — the user's **preset color tokens** expressed as a `:root { … }` rule containing every `--<palette>-<step>` primitive and every `--color-*` semantic var, all computed to static `oklch(…)` values from the chosen preset.
+2. The user copies the block, opens **Webflow Site Settings → Custom Code → Head Code**, pastes it, and saves.
+3. Their Webflow site now has the dotUI OKLCH ramps available as CSS custom properties. Any raw HTML embed, Custom Code block, or Webflow CMS-driven element can reference them via `var(--color-accent)`, `var(--neutral-300)`, etc.
+4. A secondary **"Copy Tailwind theme"** option exports a JSON/CSS snippet for designers who also use a local Tailwind build alongside Webflow (e.g. via Webflow's Code Embed for components).
+
+What they do NOT get: React components installed under `ui/`, shadcn-style imports, `globals.css` written into a Next.js project, or any live component code. Webflow does not execute npm installs; its Designer works with visual blocks, not source files.
+
+**The button is therefore `copy-command` (copy-to-clipboard), not `repo-import`, `sandbox-define`, or `mcp-install`.**
+
+---
+
+## 2. Technical mechanism
+
+Webflow is a **visual website builder** with a proprietary runtime. It is not a React or Tailwind project. Its architecture differs from every other "Open in" target in this repo:
+
+- No Node.js environment at design time — there is no npm, no shadcn CLI, no `pnpm add`.
+- The Designer generates CSS and HTML from its own visual model; it does not parse a `globals.css`.
+- **DevLink** (Webflow's React export) goes in the opposite direction: Webflow Designer → React components. It cannot import dotUI components.
+- **Webflow Code Components** (currently in beta/limited access) allow embedding custom React components via a proprietary Webflow CLI, but they require a Webflow-managed hosting environment and are not equivalent to `shadcn add`.
+- Pasting a `:root { --neutral-50: oklch(…); … }` block into **Site Settings → Custom Code → Head Code** is the one universally supported path. It applies at runtime to every page and overrides nothing Webflow generates — it only adds new custom properties that Webflow's built-in color system ignores.
+
+OKLCH support in browsers is universal as of 2023 (Chrome 111+, Safari 15.4+, Firefox 113+). Webflow's *Designer* preview may not render OKLCH swatches in its native swatch palette, but the published site renders them correctly.
+
+---
+
+## 3. Preset propagation
+
+Preset propagation for Webflow bypasses the shadcn machinery entirely and goes directly through the color kernel.
+
+### The preset encode/decode contract (summary)
+
+The `?preset=` query parameter carried on `https://dotui.com/create?preset=<encoded>` is a URL-safe base64 of raw-DEFLATE (pako level 9) of `JSON.stringify(DesignSystemState)` — see `www/src/modules/create/preset/codec.ts:75-126`. The compact state shape:
+
+```ts
+// DesignSystemState — www/src/modules/create/preset/types.ts:14-19
+{ p?: Record<string, Record<string, string>>;  // componentParams diff vs DEFAULTS
+  t?: Record<string, string>;                   // tokens diff
+  d?: Density;                                  // only if !== "compact"
+  c?: ColorConfig;                              // full color recipe if !== DEFAULT_COLOR_CONFIG
+}
+```
+
+For Webflow, only `c` (ColorConfig) matters — the color seeds and algorithm. The `p` (component params) and `d` (density) fields affect React component class strings and are meaningless to Webflow's Designer.
+
+### Extracting the color ramps for Webflow
+
+The server-side path already exists at `GET /r/init?preset=<encoded>` (`www/src/routes/r/init.tsx`). That endpoint calls `emitInitItem({ baseRegistryCss, preset, encodedPreset, registryRoot })` (`www/src/publisher/emit-theme.ts:71-128`), which:
+
+1. Calls `resolveColorConfig(preset.color)` (`www/src/registry/theme/primitives.ts:67-108`) — runs the chosen algorithm (default `oklch`) over the seed hex values.
+2. Calls `rampsToVars(resolved.light)` and `rampsToVars(resolved.dark)` (`emit-theme.ts:134-143`) to produce two flat maps of `--<palette>-<step> → "oklch(L C H)"` strings.
+3. Writes them into `css[":root"]` and `css[".dark"]` of the `registry:base` item.
+
+For a new Webflow-export endpoint, the dotUI team should **add a dedicated server route** (e.g. `GET /r/webflow-export?preset=<encoded>`) that reuses the same kernel path and returns a raw CSS string instead of shadcn JSON:
+
+```ts
+// www/src/routes/r/webflow-export.tsx  (new file)
+import { decodePreset } from "@/modules/create/preset/codec";
+import { resolveColorConfig } from "@/registry/theme";
+
+export const ServerRoute = createServerFileRoute("/r/webflow-export").methods({
+  GET: async ({ request }) => {
+    const url = new URL(request.url);
+    const encoded = url.searchParams.get("preset") ?? undefined;
+    const preset = encoded ? decodePreset(encoded) : undefined;
+
+    let lightVars: Record<string, string>;
+    let darkVars:  Record<string, string>;
+
+    if (preset?.color) {
+      const resolved = resolveColorConfig(preset.color);
+      // rampsToVars is not currently exported; inline equivalent:
+      lightVars = Object.fromEntries(
+        resolved.steps.flatMap(step =>
+          Object.keys(resolved.light).map(palette => [
+            `--${palette}-${step}`,
+            resolved.light[palette][step]
+          ])
+        )
+      );
+      darkVars = Object.fromEntries(/* reversed ramps, same pattern */);
+    } else {
+      // fall back to static default ramps from base-css.ts
+      // import { baseRegistryCss } from "@/registry/__generated__/base-css";
+      lightVars = baseRegistryCss.css[":root"];
+      darkVars  = baseRegistryCss.css[".dark"];
+    }
+
+    const block = buildWebflowCssBlock(lightVars, darkVars);
+    return new Response(block, {
+      headers: { "Content-Type": "text/css", "Cache-Control": "public, max-age=60, s-maxage=3600" }
+    });
+  }
+});
+```
+
+`rampsToVars` is internal to `emit-theme.ts` — it iterates `resolved.light[palette][step]` pairs. The Webflow endpoint can duplicate that four-line loop rather than exporting it.
+
+### The `:root` / `.dark` block shape
+
+```css
+/* Generated by dotUI — preset: <encoded> */
+/* Paste into Webflow: Site Settings → Custom Code → Head Code  */
+
+:root {
+  --neutral-50:  oklch(0.985 0 0);
+  --neutral-100: oklch(0.960 0.003 247.86);
+  /* …66 primitive vars total (6 palettes × 11 steps) … */
+  --accent-500:  oklch(0.596 0.152 237.18);
+  /* … */
+
+  /* Semantic layer (constant across presets — maps palette steps to role names) */
+  --color-bg:              var(--neutral-50);
+  --color-fg:              var(--neutral-950);
+  --color-accent:          var(--accent-500);
+  --color-border:          var(--neutral-200);
+  /* … full DEFAULT_SEMANTICS from www/src/registry/theme/semantics.ts:36-124 … */
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --neutral-50:  oklch(0.13 0 0);   /* reversed ramp */
+    /* … */
+  }
+}
+
+/* Class-based dark mode (mirrors dotUI's @custom-variant dark (&:is(.dark *)) ) */
+.dark {
+  --neutral-50:  oklch(0.13 0 0);
+  /* … */
+}
+```
+
+The semantic layer (`--color-bg`, `--color-fg`, `--color-accent`, etc.) comes from `DEFAULT_SEMANTICS` in `www/src/registry/theme/semantics.ts:36-124` and is constant — it does not change with the preset. Include it in the export so Webflow elements can use role-based names rather than raw step numbers.
+
+The `--on-*` foreground vars (e.g. `--on-accent-500`) are **not emitted by the init pipeline** — they are derived by the `tailwindcss-autocontrast` plugin at Tailwind-compile time. For Webflow, include them statically by computing black/white via the same `onBlackWhite` logic (`packages/colors/src/shared/on-color.ts:88-97`) inside the export endpoint:
+
+```ts
+// For each palette step, determine whether black or white has higher WCAG contrast
+import { onBlackWhite } from "@dotui/colors/shared/on-color";
+
+// resolved.light[palette][step] is an oklch string
+const onVars: Record<string, string> =
+  Object.entries(lightVars)
+    .filter(([k]) => k.match(/^--(neutral|accent|success|warning|danger|info)-\d+$/))
+    .reduce((acc, [k, v]) => {
+      acc[`--on-${k.slice(2)}`] = onBlackWhite(v);  // returns "black" or "white"
+      return acc;
+    }, {} as Record<string, string>);
+```
+
+This mirrors the plugin's `getContrastColor` exactly (parity test: `www/src/registry/theme/on-color-parity.spec.ts`).
+
+---
+
+## 4. Components installed
+
+**None.** This is the central limitation of the Webflow target.
+
+Webflow is not a React project. There is no `ui/` folder, no `shadcn add`, no `components.json`. The dotUI registry exports — powered by `GET /r/$name?preset=<encoded>` (`www/src/routes/r/$name.tsx`) — produce TypeScript source files containing `tailwind-variants` configs and React Aria Components usage. None of that is usable in Webflow's Designer.
+
+The gap is architectural, not a missing feature:
+
+| dotUI publish step | Applicable to Webflow? |
+|---|---|
+| `flatten.ts` — density + enum param → tv class strings | No — tv requires a React build |
+| `resolve-classes.ts` — scalar params → Tailwind suffix rewrite | No — no Tailwind build in Webflow |
+| `serialize.ts` — tv config → TS literal | No |
+| `emit-theme.ts` — OKLCH ramps → `:root` CSS vars | **Yes — this is the Webflow path** |
+| `config.registries["@dotui"]` — preset-bound per-component URL | Not applicable |
+
+The closest Webflow analog would be Webflow's **Code Components** (beta), which embed arbitrary React components as iframes inside the Designer. However, Code Components require a Webflow organization plan, the Webflow CLI, and a Webflow-hosted build server — they are not equivalent to simply installing files from a registry. If/when Code Components are stable and accessible, the bolt.new or StackBlitz patterns (a pre-built Vite bundle) could be adapted.
+
+**Realistic recommendation:** Document the component gap explicitly in the Webflow export UI. The copy block installs the design tokens; it does not install components.
+
+---
+
+## 5. Theme in globals.css
+
+There is no `globals.css` in a Webflow project. The analog is the **Head Code** block in Site Settings, which injects a `<style>` tag into every page's `<head>`.
+
+The CSS block described in §3 — the `:root` rule with OKLCH primitive ramps + semantic layer + `--on-*` vars — replaces what `shadcn add https://dotui.com/r/init?preset=<encoded>` would write into `globals.css` for a React project.
+
+**Limitations compared to a full `globals.css`:**
+
+| globals.css feature | Webflow Head Code equivalent |
+|---|---|
+| `@import "tailwindcss"` | Not applicable |
+| `@plugin "tailwindcss-react-aria-components"` | Not applicable |
+| `@plugin "tailwindcss-autocontrast"` | Replaced by static `--on-*` vars computed server-side |
+| `@utility focus-ring { … }` | Not applicable — Webflow has its own focus handling |
+| `@theme inline { --radius-md: calc(…); --color-bg: var(…); }` | Replace with plain `:root` vars (no `@theme`; browsers don't parse `@theme inline`) |
+| `@layer base { body { @apply bg-bg text-fg } }` | Not applicable — use Webflow's Body style |
+| `--dotui-density` var | Not applicable — no tv to read it |
+
+The `@theme inline` block must be flattened to plain `:root` custom property declarations for Webflow. The mapping is straightforward:
+
+```css
+/* @theme inline equivalent for Webflow */
+:root {
+  --radius-xs:  calc(0.125rem * var(--radius-factor, 1));
+  --radius-sm:  calc(0.25rem  * var(--radius-factor, 1));
+  --radius-md:  calc(0.375rem * var(--radius-factor, 1));
+  --radius-lg:  calc(0.5rem   * var(--radius-factor, 1));
+  --radius-xl:  calc(0.75rem  * var(--radius-factor, 1));
+  --radius-2xl: calc(1rem     * var(--radius-factor, 1));
+  --radius-full: 9999px;
+  /* --color-bg, --color-fg, etc. from DEFAULT_SEMANTICS */
+}
+```
+
+The semantic layer is sourced from `DEFAULT_SEMANTICS` at `www/src/registry/theme/semantics.ts:36-124` and is constant across presets.
+
+---
+
+## 6. The showcase as first view
+
+The dotUI showcase (`www/src/components/marketing/showcase/cards.tsx`) is a React component tree that requires:
+
+- React 18+
+- react-aria-components (`@base-ui/react` for `otp-field`)
+- tailwind-variants
+- Tailwind CSS v4 (`@theme inline`, utility classes, RAC data-attribute variants)
+- `tailwindcss-react-aria-components` plugin
+- `tailwindcss-autocontrast` plugin
+- Specific providers: `DesignSystemProvider`, a dark-mode class toggle
+
+None of these exist in Webflow's native runtime.
+
+**The showcase cannot be the first view in Webflow Designer.** Webflow renders its own visual blocks; it does not render arbitrary React component trees as pages.
+
+**Best available workaround — an iframe embed:**
+
+1. Deploy the dotUI showcase as a standalone static site (Vite build) with the user's preset baked into its `globals.css`. This is identical to the bolt.new/StackBlitz payload: a `src/App.tsx` that renders `<Cards />` wrapped in minimal providers.
+2. Deploy that build to a public URL (e.g. a Vercel preview URL generated per-preset, or a static CDN path keyed by the encoded preset string).
+3. The Webflow export block includes an optional `<iframe>` snippet the user can paste into a Webflow **HTML Embed** element:
+
+```html
+<!-- Paste into a Webflow HTML Embed element -->
+<iframe
+  src="https://dotui.com/preview/showcase?preset=<encoded>"
+  style="width:100%;height:100vh;border:none;"
+  title="dotUI showcase preview"
+></iframe>
+```
+
+The `GET /preview/showcase?preset=<encoded>` route would serve a server-rendered or pre-built HTML page of `<Cards />` with the preset's ramps inline. This requires a new server route in `www/src/routes/preview/showcase.tsx` — see §7.
+
+This is a preview only, not a working Webflow page. The tokens in the Head Code block (§3) do not affect the iframe; the iframe carries its own styles.
+
+---
+
+## 7. What dotUI must build
+
+### 7.1 New server endpoint: `GET /r/webflow-export?preset=<encoded>`
+
+File: `www/src/routes/r/webflow-export.tsx`
+
+Responsibilities:
+- Decode `?preset=` via `decodePreset` (`www/src/modules/create/preset/codec.ts:111`).
+- If `preset.color` is set: call `resolveColorConfig(preset.color)` (`www/src/registry/theme/primitives.ts:67`); iterate `resolved.steps`, `resolved.light[palette]`, `resolved.dark[palette]` to build `lightVars` and `darkVars` maps.
+- If no preset color: fall back to the static `baseRegistryCss.css[":root"]` and `baseRegistryCss.css[".dark"]` from `www/src/registry/__generated__/base-css.ts`.
+- Compute `--on-*` vars using `onBlackWhite` from `packages/colors/src/shared/on-color.ts:88-97`.
+- Append the semantic layer from `DEFAULT_SEMANTICS` (`www/src/registry/theme/semantics.ts:36-124`) as plain `:root` vars (not `@theme inline`).
+- Append the radius scale as plain `:root` `calc()` vars (no `@theme`).
+- Return `Content-Type: text/css` with standard cache headers (`public, max-age=60, s-maxage=3600, stale-while-revalidate=86400`).
+
+### 7.2 UI: "Copy for Webflow" button on `/create`
+
+Location: `www/src/modules/create/` — alongside the existing install command UI (`www/src/modules/create/install-command.tsx:39-48`).
+
+Behavior:
+1. Read the current encoded preset from `useDesignSystem()` (`www/src/modules/create/preset/use-design-system.ts:18`).
+2. Fetch `GET /r/webflow-export?preset=<encoded>` (or generate the CSS block client-side using the same kernel — see §7.3).
+3. Write the CSS string to the clipboard via `navigator.clipboard.writeText(css)`.
+4. Show a toast confirming the copy.
+
+### 7.3 (Optional) Client-side generation
+
+The color kernel (`@dotui/colors`) is a pure JS package with no Node.js dependencies. The Webflow CSS block could be generated entirely on the client in the `/create` page:
+
+```ts
+import { createTheme } from "@dotui/colors";
+import { resolveColorConfig } from "@/registry/theme";
+
+const resolved = resolveColorConfig(designSystem.color ?? DEFAULT_COLOR_CONFIG);
+// build lightVars, darkVars, onVars from resolved — same as §3
+// build semanticVars from DEFAULT_SEMANTICS
+// serialize to a CSS string
+```
+
+This avoids a network round-trip and works offline. The tradeoff is that `@dotui/colors` bundle cost is paid in the `/create` page bundle (it is already imported there for the live preview, so no net addition).
+
+### 7.4 (Optional) Showcase preview route
+
+File: `www/src/routes/preview/showcase.tsx`
+
+A server-rendered page that:
+- Decodes `?preset=`.
+- Inlines the computed CSS ramps in a `<style>` tag in `<head>`.
+- Renders `<Cards />` with appropriate providers.
+- Can be embedded as an iframe in Webflow.
+
+This reuses `www/src/components/marketing/showcase/cards.tsx` directly. No new component files needed.
+
+---
+
+## 8. Schema / meta.ts changes
+
+No changes to `www/src/registry/types.ts` or any `ui/*/meta.ts` are required for the Webflow feature.
+
+The Webflow export reads from:
+- The preset codec (`codec.ts`) — no changes.
+- The color kernel (`primitives.ts`, `palettes.ts`) — no changes.
+- The semantics layer (`semantics.ts`) — read-only, no changes.
+- `baseRegistryCss` (`__generated__/base-css.ts`) — read-only, no changes.
+- `onBlackWhite` (`on-color.ts`) — read-only, no changes.
+
+The `RegistryItem` type extension pattern (described in `meta.md §3`) would only be needed if the Webflow export URL were tracked per component (e.g. a `webflow?: string` field on each `meta.ts`). That is not needed for a token-only export.
+
+If a future "Webflow Code Components" path is pursued, a `webflowComponentId?: string` field could be added as a single line in `www/src/registry/types.ts:69-78` — it would auto-propagate through `metaForRuntime`'s spread (`www/src/publisher/build-time/build-publishables.ts:334`).
+
+---
+
+## 9. Limitations, risks, fallbacks
+
+### L1 — OKLCH not visible in Webflow Designer color swatches
+Webflow Designer does not parse OKLCH for its native swatch panel. Colors defined in Head Code as `--neutral-500: oklch(…)` are valid CSS and render correctly in the published site, but the Designer's color picker will not show them as swatches.
+
+**Fallback:** Add an OKLCH → hex conversion step to the export. `gamutMap` + `toSrgb` from `packages/colors/src/shared/color.ts:42-48` converts any OKLCH primitive to a hex value. The export block could include a second `:root` rule with `--neutral-500-hex: #6b7280;` alongside the OKLCH value, giving the Designer a usable swatch while keeping the OKLCH value for runtime use.
+
+### L2 — No component parity
+The 37 showcase components (accordion, avatar, badge, button, calendar, card, checkbox, color-area, color-editor, color-field, color-slider, color-thumb, disclosure, drop-zone, field, file-trigger, group, input, kbd, link, list-box, loader, otp-field, popover, progress-bar, radio-group, select, separator, slider, switch, table, tabs, tag-group, text, text-field, time-field, toggle-button, toggle-button-group — and their transitive deps) cannot be installed in Webflow. The OKLCH tokens are available but not the React component implementations.
+
+**No full workaround exists.** A designer using Webflow must re-implement components visually in the Webflow Designer using the token values as raw CSS custom properties.
+
+### L3 — Density and component params have no effect
+The `p` (componentParams) and `d` (density) fields of the preset encode component-level class string decisions (via `flatten.ts` and `resolve-classes.ts`). These are Tailwind-variants concerns — they have no mapping to Webflow's visual model.
+
+**Fallback:** Strip these from the Webflow export silently. Document in the UI that "component customizations apply to React projects only."
+
+### L4 — `tailwindcss-autocontrast` plugin is not available
+The `--on-*` foreground vars are normally computed at Tailwind-compile time by `packages/tailwindcss-autocontrast/src/index.js`. They are never emitted by the init pipeline (`emit-theme.ts:152-159`).
+
+**Mitigation:** The Webflow export endpoint must compute them statically using `onBlackWhite` (see §3). This is safe — the parity test at `www/src/registry/theme/on-color-parity.spec.ts` confirms `onBlackWhite` produces the same output as the plugin's `getContrastColor`.
+
+### L5 — `tokens` field not wired
+The `t` / `tokens` field of `DesignSystemState` (global CSS vars like `--radius-factor: 1.25`) is not yet threaded into the publisher output — there is an explicit TODO at `www/src/publisher/emit-theme.ts:62-68` and `PublishPreset` (`www/src/publisher/types.ts:79-85`) does not carry `tokens`. This means a user who has adjusted `--radius-factor` via the customizer will not see that change reflected in any export, including the Webflow block.
+
+**Fallback:** Read `tokens` directly from `DesignSystem` (not `PublishPreset`) in the Webflow export endpoint, since the endpoint bypasses the publisher pipeline.
+
+### L6 — Cache keying
+The existing `/r/$name` route uses `public, max-age=60, s-maxage=3600, stale-while-revalidate=86400` headers and the encoded preset is part of the URL query string so the CDN keys on it. The new `/r/webflow-export` route should use identical headers.
+
+---
+
+## 10. Step-by-step implementation checklist
+
+### Phase 1 — Backend endpoint (1–2 days)
+
+- [ ] Create `www/src/routes/r/webflow-export.tsx` as a TanStack Start server GET handler.
+- [ ] Import `decodePreset` from `@/modules/create/preset/codec`, `resolveColorConfig` from `@/registry/theme`, `onBlackWhite` from `packages/colors/src/shared/on-color`, `DEFAULT_SEMANTICS` from `@/registry/theme/semantics`, `baseRegistryCss` from `@/registry/__generated__/base-css`.
+- [ ] Implement the ramp resolution: if `preset.color` present → `resolveColorConfig`; else → `baseRegistryCss.css[":root"]` / `baseRegistryCss.css[".dark"]`.
+- [ ] Implement `--on-*` computation via `onBlackWhite` over every `--<palette>-<step>` key.
+- [ ] Read `tokens` from the decoded `DesignSystem` (not `PublishPreset`) and include any non-default entries in the `:root` block (workaround for L5).
+- [ ] Serialize the radius scale as plain `:root` `calc(var(--radius-factor, 1) * …rem)` declarations (no `@theme`).
+- [ ] Serialize `DEFAULT_SEMANTICS` as plain `:root` `var(--<palette>-<step>)` declarations.
+- [ ] Write the `.dark` / `@media (prefers-color-scheme: dark)` blocks for the reversed ramps.
+- [ ] Add cache headers: `public, max-age=60, s-maxage=3600, stale-while-revalidate=86400`.
+- [ ] Add a `Content-Disposition: inline; filename="dotui-tokens.css"` header.
+- [ ] Write a unit test: default preset → output matches static `base-css.ts` ramps; custom preset → output differs only in `--accent-*` values.
+
+### Phase 2 — UI button on `/create` (half day)
+
+- [ ] In `www/src/modules/create/` add a `webflow-export-button.tsx` component (or extend `install-command.tsx`).
+- [ ] Read `encodedPreset` from `useDesignSystem()` (`use-design-system.ts:18`).
+- [ ] On click: fetch `/r/webflow-export?preset=<encoded>` → copy to clipboard via `navigator.clipboard.writeText`.
+- [ ] Show a success toast and a "How to paste in Webflow" helper link.
+- [ ] Add a secondary "Download .css" link (`<a href="/r/webflow-export?preset=<encoded>" download="dotui-tokens.css">`).
+
+### Phase 3 — Optional hex fallback export (half day)
+
+- [ ] In the endpoint, also compute `gamutMap(toOklch(v))` → `toSrgb` → hex for every primitive var.
+- [ ] Emit a second `:root` block (or a CSS comment block) with `--neutral-500-hex: #…` values so Webflow's Designer can display swatches.
+- [ ] Make this opt-in via `?format=hex` or a UI toggle.
+
+### Phase 4 — Optional showcase preview iframe (1 day)
+
+- [ ] Create `www/src/routes/preview/showcase.tsx`.
+- [ ] Render `<Cards />` wrapped in providers; inline preset ramps as a `<style>` tag.
+- [ ] Expose at `GET /preview/showcase?preset=<encoded>`.
+- [ ] Include an `<iframe>` snippet in the Webflow export modal.
+
+### Phase 5 — Documentation
+
+- [ ] Add a Webflow section to `docs/open-in/README.md` (or the architecture doc).
+- [ ] Document the OKLCH-swatch limitation and the hex fallback.
+- [ ] Document that component params and density are silently dropped from the Webflow export.
+
+---
+
+## Sources
+
+- dotUI internals: `www/src/publisher/emit-theme.ts` (ramp emission), `www/src/registry/theme/primitives.ts` (color kernel), `www/src/registry/theme/semantics.ts` (semantic layer), `www/src/modules/create/preset/codec.ts` (encode/decode), `packages/colors/src/shared/on-color.ts` (onBlackWhite), `packages/tailwindcss-autocontrast/src/index.js` (contrast parity)
+- Webflow Custom Code (Head Code injection): https://university.webflow.com/lesson/custom-code-in-the-head-and-body-tags
+- Webflow Code Components (beta): https://developers.webflow.com/data/docs/code-components
+- Webflow DevLink (reverse direction — Webflow → React): https://university.webflow.com/lesson/devlink
+- OKLCH browser support (Baseline 2023): https://caniuse.com/css-oklch
+- CSS Color 4 gamut mapping: https://www.w3.org/TR/css-color-4/#css-gamut-mapping


### PR DESCRIPTION
## What

Replaces the boilerplate CLAUDE.md (three pointers to `docs/agents/*.md`, `CONTEXT.md`, and `docs/adr/` — all removed in e3e301db or never existed) with content agents can actually act on:

- **Intro** — what dotUI is and the stack (RAC, Tailwind v4 + tailwind-variants, OKLCH color engine, shadcn-compatible registry on TanStack Start).
- **Product direction** — the builder vision (every visual decision becomes a user-configurable axis: color system, typography, icons, density, per-component style variants, synced component groups, more export targets), explicitly marked as goal-not-current-state, plus the four invariants it implies for code written today.
- **Layout** — monorepo map, including the `tailwindcss-react-aria-components` patch warning.
- **Commands** — dev/check/typecheck/test, with the fresh-clone `build:registry` requirement and the oxfmt-before-push rule.
- **Generated files** — the registry-drift CI contract, the showcase-bundle `themeStub()` blind spot, the never-regenerate-API-references rule, routeTree.gen.ts.
- **Conventions & gotchas** — commit style, the `:root` token-freeze constraint, RAC SSR crashes.

Every line traces to a verified fact or a real past incident in this repo — no template filler.

## Also: docs/research/

Adds `docs/research/` as the home for date-prefixed (`YYYY-MM-DD-topic.md`), point-in-time research and assessment reports (multi-file topics get a subfolder), pointed at from CLAUDE.md's Layout section so agents check it before re-researching a settled topic. When a report's open question gets decided, a dated `> Decision:` line is appended to its status header — a low-ceremony alternative to ADRs.

First report: `2026-06-11-autocontrast-assessment.md` — design assessment + industry survey of `tailwindcss-autocontrast`. Headline findings: build-time scanning of authored CSS is a pattern no surveyed design system uses (they ship explicit foreground pairs, compute at theme-generation time from structured input, or compute at runtime); and the plugin's WCAG2 max-contrast rule measurably picks black text on blue-500/indigo-500-class accents where Mantine, MUI, Material 3, and APCA-aligned thresholds pick white. Includes an options ladder; assessment only, no decision made.

Also restores `docs/open-in/` verbatim (deleted in e419f2fa as stale planning docs) into `docs/research/open-in/` — the per-tool "Open in ‹tool›" integration research and bundle-engine architecture, kept as reference for the export-targets roadmap.

## Note

The Layout and Commands sections anticipate `starter-themes` / `tailwindcss-autocontrast` / `tailwindcss-with` moving to standalone repos (phrased as "are moving"). After the extraction lands, verify the fresh-clone recipe still holds and tighten that wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
