### PR TITLE
fix: correct case in breadcrumbs demo reference

### DIFF
--- a/www/content/docs/components/breadcrumbs.mdx
+++ b/www/content/docs/components/breadcrumbs.mdx
@@ -142,7 +142,7 @@ const BreadcrumbLink = ({ className, ...props }: BreadcrumbLinkProps) => {
 
 <Examples className="sm:grid-cols-2">
   <Example title="With Menu" name="breadcrumbs/demos/menu" />
-  <Example title="Custom Separator" name="breadcrumbs/demos/custom-Separator" />
+  <Example title="Custom Separator" name="breadcrumbs/demos/custom-separator" />
 </Examples>
 
 ## API Reference


### PR DESCRIPTION
## What

`www/content/docs/components/breadcrumbs.mdx` referenced the demo as `custom-Separator` (capital S), but the file is `custom-separator.tsx`. The mismatch resolves on case-insensitive macOS but throws `ENOENT` in rehype-transform on Vercel's case-sensitive Linux, failing the production build.

## Why it surfaced now

Latent since #152 (May 22). Turbo's remote cache had been serving a cached `www:build`, so the bad reference was never reprocessed. A dependency change in #228 invalidated the cache key → first fresh `www:build` in a while → `ENOENT`. `main` is one cache-miss away from the same failure, so this fix stands on its own.

## Fix

One character: `custom-Separator` → `custom-separator`, matching the generated registry key `breadcrumbs/demos/custom-separator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)