### PR TITLE
chore: remove .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,6 +1,0 @@
-# Commits that git blame should skip (mass mechanical changes).
-# GitHub's blame view honors this file automatically. Locally, run once:
-#   git config blame.ignoreRevsFile .git-blame-ignore-revs
-
-# style: reformat repo with oxfmt
-ccd5c0442be89b7bc7b5eb7ef486bb0853db8e49


### PR DESCRIPTION
## What

Deletes `.git-blame-ignore-revs`, which hid the repo-wide oxfmt reformat commit (`ccd5c044`) from blame.

## Why

The blame-ignore mechanism is no longer wanted; blame will now attribute reformatted lines to the reformat commit directly.

## Reviewer notes

- Nothing else in the repo references the file.
- Anyone who set the local config from the file's old header should unset it, or `git blame` will hard-fail on the missing file: `git config --unset blame.ignoreRevsFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)