### PR TITLE
ci: match slashed base branches in PR triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 
 on:
   pull_request:
-    branches: ['*']
+    branches: ['**']
   merge_group:
 
 jobs:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -6,7 +6,7 @@ name: PR Checks
 
 on:
   pull_request_target:
-    branches: ['*']
+    branches: ['**']
     types: ['opened', 'edited', 'synchronize']
 
 jobs:


### PR DESCRIPTION
Fixes the gap reported in https://github.com/mehdibha/dotUI/pull/239#issuecomment-4693620179: no GitHub Actions ran on that PR because it was stacked on `claude/pensive-keller-c680ef`.

In GitHub Actions branch filters, `*` does not match `/`, so `branches: ['*']` silently excludes any PR whose **base** branch contains a slash — i.e. every stacked PR. `**` matches across slashes.

Changed in both workflows:

- `ci.yml` (`pull_request`) — checks, typecheck, tests, registry-drift guard
- `pr-labeler.yml` (`pull_request_target`) — PR title lint and labeler, skipped on stacked PRs for the same reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)