### PR TITLE
feat(www): add state tables to component API references

### DIFF
--- a/docs/research/2026-06-12-render-prop-state-tables.md
+++ b/docs/research/2026-06-12-render-prop-state-tables.md
@@ -1,0 +1,55 @@
+# Render prop / CSS selector / Tailwind state tables for component docs
+
+**Status:** Research + proposal, 2026-06-12. Awaiting approval before implementation.
+
+> Decision (2026-06-12): Approved and implemented. States table is embedded in `Reference` (no separate Styling section). Resolution is className-param based with a `RENDER_PROPS_SOURCES` override map in the generator config (first entry: ColorThumbProps). `getTypeId` in type-to-ast.ts was also fixed to emit machine-independent typeLinks ids, making regeneration deterministic across checkouts.
+>
+> Decision (2026-06-12, revised): only stylable states make the table — render props with no `@selector` (the `state` object, `percentage`, `selectedItems`, value getters, …) are omitted, reversing the earlier "show with `—`" call. A "CSS selector / Tailwind selector" table should not carry rows that are dashes in both columns. Components left with nothing stylable (color-swatch, field-error) get no states table. This also covers **Base UI** components (drawer, otp-field): their state object carries no selectors, so the table is built from the sibling `*DataAttributes` enum (`DrawerPopupState` → `DrawerPopupDataAttributes`) — name / `[data-*]` selector / native `data-*:` Tailwind variant / JSDoc description — and the column header reads "Data attribute" (via `renderPropsKind`) instead of "Render prop". Base UI parts with no such enum (DrawerIndent, DrawerIndentBackground) get no table.
+
+## Question
+
+Add React Aria–style "Render Prop / CSS Selector" tables to all component docs, plus a third column for the Tailwind variant (via `tailwindcss-react-aria-components`). Where does React Aria pull this data from, and what is the cleanest way to do it here?
+
+## How React Aria's docs do it (verified)
+
+- Source of truth: `@selector` JSDoc tags on the properties of each `*RenderProps` interface in react-aria-components source, e.g. `ButtonRenderProps.isHovered` → `@selector [data-hovered]`. The prop description doubles as the table description.
+- Their docs build (Parcel transformer, `packages/dev/parcel-transformer-docs`) parses the TS + JSDoc into a `docs` object; MDX pages render `<StateTable properties={docs.exports.ButtonRenderProps.properties} />` (e.g. `packages/react-aria-components/docs/Button.mdx:367`).
+- `StateTable` (old site: `packages/dev/docs/src/StateTable.js`; new site: `packages/dev/s2-docs/src/StateTable.tsx`) renders Render Prop / CSS Selector columns with the description underneath, filters `optional` render props by default, and shows `—` for render props that have no selector (e.g. `ProgressBarRenderProps.percentage`).
+- Key fact for us: the `@selector` tags **survive in the published package** — 287 of them across `react-aria-components/dist/types/src/*.d.ts` in our installed 1.18.0. No need to vendor or scrape anything.
+
+## What dotUI already has (surprising amount)
+
+- `www/scripts/api-docs-builder/src/componentHandler.ts` → `extractRenderProps()` already mines `@selector` tags through the TS type checker (the program includes RAC's d.ts), emitting `renderProps: { isPressed: { selector, description } }` into the reference JSONs.
+- 55 of 183 generated JSONs (`www/src/modules/references/generated/`) already carry populated `renderProps` (button, checkbox, select, slider parts, tabs, toast, …).
+- The field is typed (`ComponentApiReference.renderProps`, `www/src/modules/references/types.ts:48`) but **dropped** by `transformReference()` (`www/src/modules/references/transform.ts:144`) and never rendered in `www/src/modules/docs/reference.tsx`. So today it is extracted, committed, and invisible.
+
+## Gaps in the current extraction
+
+Resolution is by name convention: `XxxProps` → search the whole program for an interface named `XxxRenderProps`. This fails both ways:
+
+- Misses on renames: `ComboboxProps` (RAC is `ComboBoxRenderProps`, capital B), `TableRowProps` (RAC `RowRenderProps`), `TableCellProps`/`TableColumnProps`, `accordion` (RAC `DisclosureGroup`), the renamed `*-content` parts (`select-content`, `menu-content`, `combobox-content`, `tooltip-content` → RAC `PopoverRenderProps`/`TooltipRenderProps`), `text-area`, `time-field`, etc.
+- False positives: dotUI `TooltipProps` is the trigger root (renders no element) yet gets `TooltipRenderProps` attached by name collision; `TooltipContentProps` — the part that actually carries `data-placement` — gets nothing.
+- Render props without a selector are skipped entirely (RA shows them with `—`; they are still available in `className`/`children` functions).
+
+The fix that matches the type system: resolve the render-props type from the **`className` prop's function parameter** (`string | (values: T) => string` — the checker already prints `(values: ButtonRenderProps) => string` in button.json). Parts whose `className` is a plain string (plain HTML subcomponents) correctly get no table. Keep name convention as fallback plus a tiny override map in `api-docs-builder/src/config.ts` for stragglers.
+
+## Tailwind column
+
+- We register the plugin unprefixed (`@plugin 'tailwindcss-react-aria-components';` in `www/src/registry/base/base.css`), patched at v2.1.1 (`patches/`) for the upstream `not-*` bug.
+- The plugin's whole mapping lives in `node_modules/tailwindcss-react-aria-components/src/index.js`: boolean attrs (with renames `data-hovered`→`hover`, `data-focused`→`focus`, `data-readonly`→`read-only`, `data-placeholder`→`placeholder-shown`) and enum attrs with short names (`selection-mode`→`selection-*`, `resizable-direction`→`resizable-*`, `sort-direction`→`sort-*`).
+- Cleanest derivation: at build-references time, invoke the (patched) plugin with a stub `addVariant` to harvest `variant → selector(s)`, regex the `data-*` attribute out of each selector, build the reverse index. Zero drift with plugin updates/patches, no vendored table.
+- Per-selector mapping rule: plugin-covered boolean → `pressed:`/`hover:`/…; plugin-covered enum → `placement-left:` …; data attribute not covered by the plugin (`data-today`, `data-inert`, `data-level`, `data-channel=…`) → native Tailwind v4 `data-today:` / `data-[channel=hue]:`; non-data selectors (`:not([aria-valuenow])`, `[aria-valuetext]`) → `—`.
+
+## Proposal
+
+1. **Generator** (`www/scripts/api-docs-builder/`): switch render-props resolution to className-param with name-convention fallback + config overrides; include selector-less render props; compute and emit a `tailwind` field next to `selector` (plugin harvest above). Mapping lives only in the generator; JSON stays the single artifact.
+2. **Pipeline/UI**: carry `renderProps` through `transformReference()` (highlight selector/tailwind strings); render a states table inside `Reference` (`reference.tsx`) below the prop groups — columns Render Prop / CSS Selector / Tailwind, description underneath like RA. Because docs pages already render `<Reference>` per part, every part gets its correct table with **zero MDX churn** across ~60 pages. Optionally also export a standalone `<StateTable name="…"/>` MDX component for dedicated Styling sections later.
+3. **Regenerate**: one dedicated commit for the JSON regen (full `build:references` run — expect the known generator-drift noise across ~121 files; keep it separate from the source commit).
+
+Rejected alternatives: hand-written tables per MDX page (drifts, ~60 pages); vendoring RA's docs transformer (Parcel-specific, heavy); hardcoding the tailwind mapping table (drifts from the patched plugin).
+
+## Open questions
+
+- Show selector-less render props (RA does, with `—`) or keep state-only rows?
+- Embed in `Reference` (recommended) vs a separate "Styling" docs section per page?
+- dotUI-specific data attributes (`data-icon-only`, …) are not render props; documenting them would need its own `@selector`-style convention on our types — separate decision, out of scope here.

--- a/www/scripts/api-docs-builder/src/componentHandler.ts
+++ b/www/scripts/api-docs-builder/src/componentHandler.ts
@@ -12,6 +12,7 @@ import {
   RESOLVABLE_TYPE_PATTERNS,
   SKIP_RESOLVE_TYPES,
 } from './config'
+import { extractRenderProps } from './render-props'
 import {
   buildTypeAstFromString,
   type ConversionContext,
@@ -554,11 +555,6 @@ interface FormattedProp {
   description?: string
 }
 
-interface RenderPropInfo {
-  selector: string
-  description?: string
-}
-
 const registryDir = path.resolve(process.cwd(), 'src/registry')
 
 /**
@@ -633,8 +629,10 @@ export async function formatComponentData(
     extendsElement,
   )
 
-  // Extract render props (CSS state selectors)
-  const renderProps = extractRenderProps(exportNode.name, context)
+  // Extract the styling-state table (RAC render props or Base UI data attrs)
+  const states = extractRenderProps(exportNode.name, context)
+  const renderProps = states.props
+  const hasRenderProps = Object.keys(renderProps).length > 0
 
   // Collect type links for the component (sorted for deterministic output)
   const linkKeys = Object.keys(astContext.links).sort()
@@ -649,8 +647,13 @@ export async function formatComponentData(
     // Add extendsElement field if component extends an HTML element
     ...(extendsElement && { extendsElement }),
     props, // Keep natural TypeScript declaration order (like react-aria)
-    // Add renderProps field (only if not empty)
-    ...(Object.keys(renderProps).length > 0 && { renderProps }),
+    // Add the styling-state table (only if non-empty); flag Base UI tables so
+    // the docs can label the column "Data attribute" instead of "Render prop".
+    ...(hasRenderProps && { renderProps }),
+    ...(hasRenderProps &&
+      states.kind === 'data-attribute' && {
+        renderPropsKind: states.kind,
+      }),
     // Add type links for popover navigation
     ...(typeLinks && { typeLinks }),
   } as Record<string, unknown>
@@ -903,61 +906,6 @@ async function getPropsWithTypeChecker(
   // Local props come first (in ts-morph declaration order), then React Aria events
   // in their standard order, then remaining props
   return sortByDeclarationOrder(result, declarationOrder, originalOrder)
-}
-
-/**
- * Extract render props from component render props interfaces.
- * Looks for @selector JSDoc tags in properties of render props types
- * (e.g., ButtonRenderProps from ButtonProps).
- */
-function extractRenderProps(
-  propsTypeName: string,
-  context: ParserContext,
-): Record<string, RenderPropInfo> {
-  const { program, checker } = context
-  const result: Record<string, RenderPropInfo> = {}
-
-  // Derive render props type name from props type name
-  // e.g., "ButtonProps" -> "ButtonRenderProps"
-  const renderPropsTypeName = propsTypeName.replace(/Props$/, 'RenderProps')
-
-  // Search for the render props interface in all source files (including declaration files)
-  for (const sourceFile of program.getSourceFiles()) {
-    sourceFile.forEachChild((node) => {
-      if (
-        (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) &&
-        node.name.text === renderPropsTypeName
-      ) {
-        const symbol = checker.getSymbolAtLocation(node.name)
-        if (!symbol) return
-
-        const type = checker.getDeclaredTypeOfSymbol(symbol)
-        const properties = [...checker.getPropertiesOfType(type)].sort((a, b) =>
-          a.name.localeCompare(b.name),
-        )
-
-        for (const prop of properties) {
-          // Get JSDoc tags
-          const jsDocTags = prop.getJsDocTags(checker)
-          const selectorTag = jsDocTags.find((tag) => tag.name === 'selector')
-
-          if (selectorTag) {
-            const selectorValue = ts.displayPartsToString(selectorTag.text)
-            const description = ts.displayPartsToString(
-              prop.getDocumentationComment(checker),
-            )
-
-            result[prop.name] = {
-              selector: selectorValue.trim(),
-              ...(description && { description }),
-            }
-          }
-        }
-      }
-    })
-  }
-
-  return result
 }
 
 /**

--- a/www/scripts/api-docs-builder/src/config.ts
+++ b/www/scripts/api-docs-builder/src/config.ts
@@ -66,6 +66,17 @@ export const ALWAYS_EXPAND_TYPES = new Set([
 ])
 
 /**
+ * Render-props sources that can't be resolved from the `className` prop.
+ * Maps a Props export name to the render-props interface to document
+ * instead, or `null` to suppress the states table for that component.
+ */
+export const RENDER_PROPS_SOURCES: Record<string, string | null> = {
+  // className is narrowed to a plain string, but the underlying React Aria
+  // element still carries the state data attributes.
+  ColorThumbProps: 'ColorThumbRenderProps',
+}
+
+/**
  * Standard order for React Aria event props.
  * This ensures consistent ordering regardless of TypeScript's internal caching.
  * Order matches the declaration order in React Aria's type definitions.

--- a/www/scripts/api-docs-builder/src/render-props.ts
+++ b/www/scripts/api-docs-builder/src/render-props.ts
@@ -1,0 +1,369 @@
+/**
+ * Render props / styling-state extraction (state selectors + Tailwind variants).
+ *
+ * Two libraries expose stylable state in different shapes, so the table is
+ * sourced two ways:
+ *
+ * - **React Aria Components** — resolves the render-props interface from the
+ *   `className` prop (`ClassNameOrFunction<ButtonRenderProps>` →
+ *   `ButtonRenderProps`) and reads the `@selector` JSDoc tags RAC maintains on
+ *   it for its own docs. Selectors map to the variants registered by the
+ *   installed tailwindcss-react-aria-components plugin.
+ * - **Base UI** — its state object carries no selectors; the stylable surface
+ *   is a sibling `*DataAttributes` enum (`DrawerPopupState` →
+ *   `DrawerPopupDataAttributes`) whose members map a name to a `data-*`
+ *   attribute with a JSDoc description. Base UI ships no Tailwind plugin, so
+ *   each attribute maps to the native `data-*:` variant Tailwind v4 provides.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import racPlugin from 'tailwindcss-react-aria-components'
+import ts from 'typescript'
+
+import { RENDER_PROPS_SOURCES } from './config'
+
+export interface RenderPropInfo {
+  selector?: string
+  tailwind?: string
+  description?: string
+}
+
+/**
+ * Whether the states table documents React Aria render props or Base UI data
+ * attributes — drives the column header in the docs.
+ */
+export type RenderPropsKind = 'render-prop' | 'data-attribute'
+
+export interface RenderPropsResult {
+  kind: RenderPropsKind
+  props: Record<string, RenderPropInfo>
+}
+
+const EMPTY_RESULT: RenderPropsResult = { kind: 'render-prop', props: {} }
+
+interface TypeCheckerContext {
+  program: ts.Program
+  checker: ts.TypeChecker
+}
+
+/**
+ * Variant lookup harvested from the installed (patched) Tailwind plugin: the
+ * plugin registers every variant through `addVariant`, so running its handler
+ * with a stub yields the exact `data-*` attribute → variant table without
+ * duplicating it here.
+ */
+let pluginVariants: Map<string, string> | undefined
+
+function getPluginVariants(): Map<string, string> {
+  if (pluginVariants) return pluginVariants
+
+  const variants = new Map<string, string>()
+  const addVariant = (name: string, selector: string | string[]) => {
+    const selectors = Array.isArray(selector) ? selector : [selector]
+    for (const value of selectors) {
+      for (const match of value.matchAll(
+        /\[data-([a-z-]+)(?:="([^"]+)")?\]/g,
+      )) {
+        const attribute = match[1]
+        if (!attribute) continue
+        const key =
+          match[2] === undefined ? attribute : `${attribute}=${match[2]}`
+        if (!variants.has(key)) variants.set(key, name)
+      }
+    }
+  }
+
+  const { handler } = racPlugin() as unknown as {
+    handler: (api: { addVariant: typeof addVariant }) => void
+  }
+  handler({ addVariant })
+
+  pluginVariants = variants
+  return variants
+}
+
+/**
+ * Values React Aria documents as placeholders rather than literal attribute
+ * values (e.g. `[data-level="number"]`).
+ */
+const PLACEHOLDER_VALUES = new Set(['number', '...', '…'])
+
+/**
+ * Map a documented CSS selector to the Tailwind variant(s) that target it.
+ * Attributes the plugin doesn't cover fall back to Tailwind's native data-*
+ * variants; non-data selectors (e.g. `:not([aria-valuenow])`) have none.
+ */
+function tailwindForSelector(
+  selector: string,
+  variants: Map<string, string>,
+): string | undefined {
+  const match = selector.match(/^\[data-([a-z-]+)(?:="([^"]+)")?\]$/)
+  const attribute = match?.[1]
+  if (!attribute) return undefined
+
+  const value = match[2]
+  if (value === undefined) {
+    return `${variants.get(attribute) ?? `data-${attribute}`}:`
+  }
+
+  const parts = value.split('|').map((part) => {
+    const trimmed = part.trim()
+    if (PLACEHOLDER_VALUES.has(trimmed)) return `data-[${attribute}=…]:`
+    const variant = variants.get(`${attribute}=${trimmed}`)
+    return `${variant ?? `data-[${attribute}=${trimmed}]`}:`
+  })
+
+  return [...new Set(parts)].join(' | ')
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  const modifiers = ts.canHaveModifiers(node)
+    ? ts.getModifiers(node)
+    : undefined
+  return modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false
+}
+
+interface DeclaredType {
+  node: ts.InterfaceDeclaration | ts.TypeAliasDeclaration
+  symbol: ts.Symbol
+}
+
+/**
+ * Find an exported interface or type alias by name. With `sourceOnly`,
+ * declaration files are skipped so the lookup only matches registry source
+ * (overrides search everywhere, including react-aria-components types).
+ */
+function findExportedTypeDeclaration(
+  typeName: string,
+  context: TypeCheckerContext,
+  { sourceOnly = false }: { sourceOnly?: boolean } = {},
+): DeclaredType | undefined {
+  const { program, checker } = context
+
+  for (const sourceFile of program.getSourceFiles()) {
+    if (
+      sourceOnly &&
+      sourceFile.isDeclarationFile &&
+      !sourceFile.fileName.includes('@dotui')
+    ) {
+      continue
+    }
+
+    let found: DeclaredType | undefined
+
+    sourceFile.forEachChild((node) => {
+      if (found) return
+      if (
+        (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) &&
+        node.name.text === typeName &&
+        hasExportModifier(node)
+      ) {
+        const symbol = checker.getSymbolAtLocation(node.name)
+        if (symbol) found = { node, symbol }
+      }
+    })
+
+    if (found) return found
+  }
+
+  return undefined
+}
+
+/**
+ * Resolve the render-props type from the `className` prop's function
+ * parameter. Components whose `className` is a plain string (or absent) have
+ * no render props — name-based lookups would mis-attach states from
+ * same-named react-aria interfaces (e.g. a Tooltip root vs its content).
+ */
+function resolveFromClassName(
+  propsType: ts.Type,
+  checker: ts.TypeChecker,
+  location: ts.Node,
+): ts.Type | undefined {
+  const classNameProp = propsType.getProperty('className')
+  if (!classNameProp) return undefined
+
+  const classNameType = checker.getTypeOfSymbolAtLocation(
+    classNameProp,
+    location,
+  )
+  const unionParts = classNameType.isUnion()
+    ? classNameType.types
+    : [classNameType]
+
+  for (const part of unionParts) {
+    const signature = checker.getSignaturesOfType(
+      part,
+      ts.SignatureKind.Call,
+    )[0]
+    const parameter = signature?.parameters[0]
+    const declaration =
+      parameter?.valueDeclaration ?? parameter?.declarations?.[0]
+    if (!parameter || !declaration) continue
+    return checker.getTypeOfSymbolAtLocation(parameter, declaration)
+  }
+
+  return undefined
+}
+
+/** A Base UI state type and the declaration file it lives in. */
+interface BaseUiState {
+  name: string
+  sourceFile: string
+}
+
+/**
+ * If a type is a Base UI state interface (declared in the Base UI package with
+ * a `*State` name), return its name and source file. Base UI's stylable
+ * surface is exposed not on this type but on a sibling `*DataAttributes` enum.
+ */
+function asBaseUiState(type: ts.Type): BaseUiState | undefined {
+  const symbol = type.aliasSymbol ?? type.getSymbol()
+  const sourceFile = symbol?.getDeclarations()?.[0]?.getSourceFile().fileName
+  const name = symbol?.getName()
+  if (!sourceFile?.includes('@base-ui') || !name?.endsWith('State')) {
+    return undefined
+  }
+  return { name, sourceFile }
+}
+
+/** Read the leading JSDoc description of a node (standalone AST, no checker). */
+function jsDocDescription(node: ts.Node): string {
+  for (const doc of ts.getJSDocCommentsAndTags(node)) {
+    if (ts.isJSDoc(doc) && doc.comment) {
+      return typeof doc.comment === 'string'
+        ? doc.comment
+        : doc.comment.map((part) => part.text).join('')
+    }
+  }
+  return ''
+}
+
+/**
+ * Build the states table from a Base UI `*DataAttributes` enum, which sits
+ * next to its `*State` type (e.g. `DrawerPopupState` →
+ * `DrawerPopupDataAttributes` in the same directory). These enum files aren't
+ * imported anywhere, so they're absent from the TS program — parse the file
+ * standalone. Each member maps a name to a `data-*` attribute; the JSDoc is
+ * the description, and the Tailwind variant is the native `data-*:` form
+ * (Tailwind v4 turns `data-open:` into `[data-open]`).
+ */
+function dataAttributesFromState(
+  state: BaseUiState,
+): Record<string, RenderPropInfo> {
+  const enumName = state.name.replace(/State$/, 'DataAttributes')
+  const enumPath = path.join(path.dirname(state.sourceFile), `${enumName}.d.ts`)
+  if (!fs.existsSync(enumPath)) return {}
+
+  const sourceFile = ts.createSourceFile(
+    enumPath,
+    fs.readFileSync(enumPath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  )
+
+  const result: Record<string, RenderPropInfo> = {}
+
+  sourceFile.forEachChild((node) => {
+    if (!ts.isEnumDeclaration(node) || node.name.text !== enumName) return
+    for (const member of node.members) {
+      if (
+        !member.initializer ||
+        !ts.isStringLiteral(member.initializer) ||
+        !ts.isIdentifier(member.name)
+      ) {
+        continue
+      }
+      const value = member.initializer.text
+      const description = jsDocDescription(member)
+      result[member.name.text] = {
+        selector: `[${value}]`,
+        tailwind: `${value}:`,
+        ...(description && { description }),
+      }
+    }
+  })
+
+  return result
+}
+
+/**
+ * Extract the styling-state table for a Props export: React Aria render props
+ * (with `@selector` tags) or Base UI data attributes, whichever the component
+ * is built on. Only stylable states make the table — render props with no
+ * selector (the `state` object, value getters, …) are omitted, so components
+ * with no stylable state (and Base UI parts with no `*DataAttributes` enum)
+ * get no table at all.
+ */
+export function extractRenderProps(
+  propsTypeName: string,
+  context: TypeCheckerContext,
+): RenderPropsResult {
+  const { checker } = context
+
+  const override = RENDER_PROPS_SOURCES[propsTypeName]
+  if (override === null) return EMPTY_RESULT
+
+  let renderPropsType: ts.Type | undefined
+
+  if (override) {
+    const declared = findExportedTypeDeclaration(override, context)
+    if (declared) {
+      renderPropsType = checker.getDeclaredTypeOfSymbol(declared.symbol)
+    }
+  } else {
+    const declared = findExportedTypeDeclaration(propsTypeName, context, {
+      sourceOnly: true,
+    })
+    if (declared) {
+      const propsType = checker.getDeclaredTypeOfSymbol(declared.symbol)
+      renderPropsType = resolveFromClassName(propsType, checker, declared.node)
+    }
+  }
+
+  if (!renderPropsType) return EMPTY_RESULT
+
+  // Base UI: the className state object carries no selectors. Read the sibling
+  // `*DataAttributes` enum instead (e.g. DrawerPopupState → the enum). Parts
+  // with no such enum (e.g. DrawerIndent) expose nothing stylable — no table.
+  const baseUiState = asBaseUiState(renderPropsType)
+  if (baseUiState) {
+    const props = dataAttributesFromState(baseUiState)
+    if (Object.keys(props).length === 0) return EMPTY_RESULT
+    return { kind: 'data-attribute', props }
+  }
+
+  // React Aria: render props carry `@selector` JSDoc tags. Only those with a
+  // selector are stylable states; the rest (the `state` object, `percentage`,
+  // `selectedItems`, …) are render-function data and have no place in a
+  // selector table — skip them.
+  const variants = getPluginVariants()
+  const props: Record<string, RenderPropInfo> = {}
+
+  for (const prop of checker.getPropertiesOfType(renderPropsType)) {
+    // `defaultClassName` rides along in the className function parameter
+    if (prop.name === 'defaultClassName') continue
+    if (prop.flags & ts.SymbolFlags.Optional) continue
+
+    const selectorTag = prop
+      .getJsDocTags(checker)
+      .find((tag) => tag.name === 'selector')
+    if (!selectorTag) continue
+    const selector = ts.displayPartsToString(selectorTag.text).trim()
+    if (!selector) continue
+
+    const tailwind = tailwindForSelector(selector, variants)
+    const description = ts.displayPartsToString(
+      prop.getDocumentationComment(checker),
+    )
+
+    props[prop.name] = {
+      selector,
+      ...(tailwind && { tailwind }),
+      ...(description && { description }),
+    }
+  }
+
+  return { kind: 'render-prop', props }
+}

--- a/www/src/modules/docs/reference.tsx
+++ b/www/src/modules/docs/reference.tsx
@@ -9,7 +9,9 @@ import type {
   TransformedProp,
   TransformedPropsData,
   TransformedReference,
+  TransformedRenderProp,
 } from '@/modules/docs/references/transform'
+import type { RenderPropsKind } from '@/modules/docs/references/types'
 
 const GRID_LAYOUT =
   'grid grid-cols-[minmax(120px,1fr)_1fr_2.5rem] md:grid-cols-[5fr_7fr_4.5fr_2.5rem]'
@@ -49,6 +51,13 @@ export function Reference({ data, ...props }: ReferenceProps) {
           componentName={data.name}
           defaultExpandedGroups={data.defaultExpandedGroups}
         />
+        {data.renderProps && data.renderProps.length > 0 && (
+          <StatesTable
+            renderProps={data.renderProps}
+            kind={data.renderPropsKind}
+            componentName={data.name}
+          />
+        )}
       </div>
     </TypeRendererProvider>
   )
@@ -225,6 +234,148 @@ function PropRows({ prop, componentName }: PropRowsProps) {
                       __html: prop.defaultHighlighted ?? prop.default,
                     }}
                   />
+                </DescriptionItem>
+              )}
+            </dl>
+          </td>
+        </tr>
+      )}
+    </React.Fragment>
+  )
+}
+
+interface StatesTableProps {
+  renderProps: TransformedRenderProp[]
+  kind?: RenderPropsKind
+  componentName: string
+}
+
+function StatesTable({ renderProps, kind, componentName }: StatesTableProps) {
+  const nameHeader =
+    kind === 'data-attribute' ? 'Data attribute' : 'Render prop'
+  return (
+    <div className="mt-4 w-full overflow-hidden rounded-md border text-sm">
+      <table className="w-full border-collapse [&>tbody:last-child>tr:last-child]:border-b-0 [&>tbody:last-child>tr:last-child>td]:border-b-0">
+        <thead className="border-b bg-card">
+          <tr className={GRID_LAYOUT}>
+            <th className="px-3 py-2 text-left font-medium text-fg-muted">
+              {nameHeader}
+            </th>
+            <th className="px-3 py-2 text-left font-medium text-fg-muted">
+              CSS selector
+            </th>
+            <th className="hidden px-3 py-2 text-left font-medium text-fg-muted md:table-cell">
+              Tailwind selector
+            </th>
+            <th className="w-10 px-3 py-2" />
+          </tr>
+        </thead>
+        <tbody className="bg-bg">
+          {renderProps.map((renderProp) => (
+            <StateRows
+              key={renderProp.name}
+              renderProp={renderProp}
+              componentName={componentName}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+interface StateRowsProps {
+  renderProp: TransformedRenderProp
+  componentName: string
+}
+
+function StateRows({ renderProp, componentName }: StateRowsProps) {
+  const [isOpen, setIsOpen] = React.useState(false)
+  const id = `${componentName}-state-${renderProp.name}`
+
+  return (
+    <React.Fragment>
+      <tr
+        className={`${GRID_LAYOUT} cursor-pointer border-b transition-colors hover:bg-card`}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <td className="overflow-hidden px-3 py-2.5">
+          <button
+            type="button"
+            id={id}
+            className="flex items-baseline gap-1 text-left"
+            aria-expanded={isOpen}
+          >
+            <code className="font-mono text-[0.8125rem] whitespace-nowrap text-fg">
+              {renderProp.name}
+            </code>
+          </button>
+        </td>
+
+        <td className="overflow-hidden px-3 py-2.5">
+          {renderProp.selector ? (
+            <code className="font-mono text-[0.8125rem] whitespace-nowrap text-fg-muted">
+              {renderProp.selector}
+            </code>
+          ) : (
+            <code className="font-mono text-[0.8125rem] text-fg-muted/50">
+              —
+            </code>
+          )}
+        </td>
+
+        <td className="hidden overflow-hidden px-3 py-2.5 md:table-cell">
+          {renderProp.tailwind ? (
+            <code className="font-mono text-[0.8125rem] whitespace-nowrap text-fg-muted">
+              {renderProp.tailwind}
+            </code>
+          ) : (
+            <code className="font-mono text-[0.8125rem] text-fg-muted/50">
+              —
+            </code>
+          )}
+        </td>
+
+        <td className="px-3 py-2.5 text-center">
+          <ChevronDownIcon
+            className={`inline-block size-4 text-fg-muted transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+          />
+        </td>
+      </tr>
+
+      {isOpen && (
+        <tr className="border-b bg-card">
+          <td colSpan={4} className="px-3 py-3">
+            <dl className={PANEL_GRID_LAYOUT}>
+              <DescriptionItem label="Name">
+                <a href={`#${id}`} className="hover:underline">
+                  <code className="font-mono text-[0.8125rem] text-fg-accent">
+                    {renderProp.name}
+                  </code>
+                </a>
+              </DescriptionItem>
+
+              {renderProp.description && (
+                <DescriptionItem label="Description" hasSeparator>
+                  <div className="leading-relaxed text-fg-muted">
+                    {renderProp.description}
+                  </div>
+                </DescriptionItem>
+              )}
+
+              {renderProp.selector && (
+                <DescriptionItem label="CSS selector" hasSeparator>
+                  <code className="font-mono text-[0.8125rem] text-fg-muted">
+                    {renderProp.selector}
+                  </code>
+                </DescriptionItem>
+              )}
+
+              {renderProp.tailwind && (
+                <DescriptionItem label="Tailwind selector" hasSeparator>
+                  <code className="font-mono text-[0.8125rem] text-fg-muted">
+                    {renderProp.tailwind}
+                  </code>
                 </DescriptionItem>
               )}
             </dl>

--- a/www/src/modules/docs/references/generated/accordion.json
+++ b/www/src/modules/docs/references/generated/accordion.json
@@ -253,6 +253,13 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the disclosure group is disabled."
+    }
+  },
   "typeLinks": {
     "DisclosureGroupRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/breadcrumb-item.json
+++ b/www/src/modules/docs/references/generated/breadcrumb-item.json
@@ -177,6 +177,18 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isCurrent": {
+      "selector": "[data-current]",
+      "tailwind": "current:",
+      "description": "Whether the breadcrumb is for the current page."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the breadcrumb is disabled."
+    }
+  },
   "typeLinks": {
     "BreadcrumbRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/breadcrumb-link.json
+++ b/www/src/modules/docs/references/generated/breadcrumb-link.json
@@ -724,6 +724,38 @@
       "description": "The target window for the link. See\n[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)."
     }
   },
+  "renderProps": {
+    "isCurrent": {
+      "selector": "[data-current]",
+      "tailwind": "current:",
+      "description": "Whether the link is the current item within a list."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the link is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the link is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the link is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the link is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the link is disabled."
+    }
+  },
   "typeLinks": {
     "HoverEvent": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/button.json
+++ b/www/src/modules/docs/references/generated/button.json
@@ -981,29 +981,35 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the button is disabled."
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the button is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the button is currently in a pressed state."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the button is focused, either via a mouse or keyboard."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the button is keyboard focused."
     },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the button is currently hovered with a mouse."
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the button is disabled."
     },
     "isPending": {
       "selector": "[data-pending]",
+      "tailwind": "pending:",
       "description": "Whether the button is currently in a pending state."
-    },
-    "isPressed": {
-      "selector": "[data-pressed]",
-      "description": "Whether the button is currently in a pressed state."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/calendar-cell.json
+++ b/www/src/modules/docs/references/generated/calendar-cell.json
@@ -240,57 +240,70 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the cell is disabled, according to the calendar's `minValue`, `maxValue`, and\n`isDisabled` props. Disabled dates are not focusable, and cannot be selected by the user. They\nare typically displayed with a dimmed appearance."
-    },
-    "isFocused": {
-      "selector": "[data-focused]",
-      "description": "Whether the cell is focused."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether the cell is keyboard focused."
-    },
     "isHovered": {
       "selector": "[data-hovered]",
+      "tailwind": "hover:",
       "description": "Whether the cell is currently hovered with a mouse."
-    },
-    "isInvalid": {
-      "selector": "[data-invalid]",
-      "description": "Whether the cell is part of an invalid selection."
-    },
-    "isOutsideMonth": {
-      "selector": "[data-outside-month]",
-      "description": "Whether the cell is outside the current month."
-    },
-    "isOutsideVisibleRange": {
-      "selector": "[data-outside-visible-range]",
-      "description": "Whether the cell is outside the visible range of the calendar.\nFor example, dates before the first day of a month in the same week."
     },
     "isPressed": {
       "selector": "[data-pressed]",
+      "tailwind": "pressed:",
       "description": "Whether the cell is currently being pressed."
     },
     "isSelected": {
       "selector": "[data-selected]",
+      "tailwind": "selected:",
       "description": "Whether the cell is selected."
-    },
-    "isSelectionEnd": {
-      "selector": "[data-selection-end]",
-      "description": "Whether the cell is the last date in a range selection."
     },
     "isSelectionStart": {
       "selector": "[data-selection-start]",
+      "tailwind": "selection-start:",
       "description": "Whether the cell is the first date in a range selection."
     },
-    "isToday": {
-      "selector": "[data-today]",
-      "description": "Whether the cell is today."
+    "isSelectionEnd": {
+      "selector": "[data-selection-end]",
+      "tailwind": "selection-end:",
+      "description": "Whether the cell is the last date in a range selection."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the cell is focused."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the cell is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the cell is disabled, according to the calendar's `minValue`, `maxValue`, and\n`isDisabled` props. Disabled dates are not focusable, and cannot be selected by the user. They\nare typically displayed with a dimmed appearance."
+    },
+    "isOutsideVisibleRange": {
+      "selector": "[data-outside-visible-range]",
+      "tailwind": "outside-visible-range:",
+      "description": "Whether the cell is outside the visible range of the calendar.\nFor example, dates before the first day of a month in the same week."
+    },
+    "isOutsideMonth": {
+      "selector": "[data-outside-month]",
+      "tailwind": "outside-month:",
+      "description": "Whether the cell is outside the current month."
     },
     "isUnavailable": {
       "selector": "[data-unavailable]",
+      "tailwind": "unavailable:",
       "description": "Whether the cell is unavailable, according to the calendar's `isDateUnavailable` prop.\nUnavailable dates remain focusable, but cannot be selected by the user. They should be\ndisplayed with a visual affordance to indicate they are unavailable, such as a different color\nor a strikethrough.\n\nNote that because they are focusable, unavailable dates must meet a 4.5:1 color contrast ratio,\n[as defined by WCAG](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the cell is part of an invalid selection."
+    },
+    "isToday": {
+      "selector": "[data-today]",
+      "tailwind": "data-today:",
+      "description": "Whether the cell is today."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/calendar.json
+++ b/www/src/modules/docs/references/generated/calendar.json
@@ -677,10 +677,12 @@
   "renderProps": {
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the calendar is disabled."
     },
     "isInvalid": {
       "selector": "[data-invalid]",
+      "tailwind": "invalid:",
       "description": "Whether the calendar is invalid."
     }
   },

--- a/www/src/modules/docs/references/generated/checkbox-control.json
+++ b/www/src/modules/docs/references/generated/checkbox-control.json
@@ -230,6 +230,58 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the checkbox is selected."
+    },
+    "isIndeterminate": {
+      "selector": "[data-indeterminate]",
+      "tailwind": "indeterminate:",
+      "description": "Whether the checkbox is indeterminate."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the checkbox is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the checkbox is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the checkbox is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the checkbox is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the checkbox is disabled."
+    },
+    "isReadOnly": {
+      "selector": "[data-readonly]",
+      "tailwind": "read-only:",
+      "description": "Whether the checkbox is read only."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the checkbox invalid."
+    },
+    "isRequired": {
+      "selector": "[data-required]",
+      "tailwind": "required:",
+      "description": "Whether the checkbox is required."
+    }
+  },
   "typeLinks": {
     "CheckboxButtonRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/checkbox-group.json
+++ b/www/src/modules/docs/references/generated/checkbox-group.json
@@ -489,19 +489,23 @@
   "renderProps": {
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the checkbox group is disabled."
-    },
-    "isInvalid": {
-      "selector": "[data-invalid]",
-      "description": "Whether the checkbox group is invalid."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the checkbox group is read only."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the checkbox group is required."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the checkbox group is invalid."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/checkbox.json
+++ b/www/src/modules/docs/references/generated/checkbox.json
@@ -743,45 +743,35 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the checkbox is disabled."
-    },
-    "isFocused": {
-      "selector": "[data-focused]",
-      "description": "Whether the checkbox is focused, either via a mouse or keyboard."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether the checkbox is keyboard focused."
-    },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the checkbox is currently hovered with a mouse."
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the checkbox is selected."
     },
     "isIndeterminate": {
       "selector": "[data-indeterminate]",
+      "tailwind": "indeterminate:",
       "description": "Whether the checkbox is indeterminate."
     },
-    "isInvalid": {
-      "selector": "[data-invalid]",
-      "description": "Whether the checkbox invalid."
-    },
-    "isPressed": {
-      "selector": "[data-pressed]",
-      "description": "Whether the checkbox is currently in a pressed state."
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the checkbox is disabled."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the checkbox is read only."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the checkbox invalid."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the checkbox is required."
-    },
-    "isSelected": {
-      "selector": "[data-selected]",
-      "description": "Whether the checkbox is selected."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/color-area.json
+++ b/www/src/modules/docs/references/generated/color-area.json
@@ -349,6 +349,7 @@
   "renderProps": {
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the color area is disabled."
     }
   },

--- a/www/src/modules/docs/references/generated/color-field.json
+++ b/www/src/modules/docs/references/generated/color-field.json
@@ -837,25 +837,30 @@
     }
   },
   "renderProps": {
-    "channel": {
-      "selector": "[data-channel=\"hex | hue | saturation | ...\"]",
-      "description": "The color channel that this field edits, or \"hex\" if no `channel` prop is set."
-    },
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the color field is disabled."
     },
     "isInvalid": {
       "selector": "[data-invalid]",
+      "tailwind": "invalid:",
       "description": "Whether the color field is invalid."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the color field is read only."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the color field is required."
+    },
+    "channel": {
+      "selector": "[data-channel=\"hex | hue | saturation | ...\"]",
+      "tailwind": "data-[channel=hex]: | data-[channel=hue]: | data-[channel=saturation]: | data-[channel=…]:",
+      "description": "The color channel that this field edits, or \"hex\" if no `channel` prop is set."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/color-slider-control.json
+++ b/www/src/modules/docs/references/generated/color-slider-control.json
@@ -211,6 +211,23 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the slider track is currently hovered with a mouse."
+    },
+    "orientation": {
+      "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
+      "description": "The orientation of the slider."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the slider is disabled."
+    }
+  },
   "typeLinks": {
     "HoverEvent": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/color-slider-output.json
+++ b/www/src/modules/docs/references/generated/color-slider-output.json
@@ -136,6 +136,18 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "orientation": {
+      "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
+      "description": "The orientation of the slider."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the slider is disabled."
+    }
+  },
   "typeLinks": {
     "SliderRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/color-slider.json
+++ b/www/src/modules/docs/references/generated/color-slider.json
@@ -340,13 +340,15 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the color slider is disabled."
-    },
     "orientation": {
       "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
       "description": "The orientation of the color slider."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the color slider is disabled."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/color-swatch-picker-item.json
+++ b/www/src/modules/docs/references/generated/color-swatch-picker-item.json
@@ -404,41 +404,35 @@
     }
   },
   "renderProps": {
-    "allowsDragging": {
-      "selector": "[data-allows-dragging]",
-      "description": "Whether the item allows dragging."
-    },
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the item is non-interactive, i.e. both selection and actions are disabled and the item\nmay not be focused. Dependent on `disabledKeys` and `disabledBehavior`."
     },
-    "isDragging": {
-      "selector": "[data-dragging]",
-      "description": "Whether the item is currently being dragged."
-    },
-    "isDropTarget": {
-      "selector": "[data-drop-target]",
-      "description": "Whether the item is currently an active drop target."
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the item is currently selected."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the item is currently focused."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the item is currently keyboard focused."
     },
     "isHovered": {
       "selector": "[data-hovered]",
+      "tailwind": "hover:",
       "description": "Whether the item is currently hovered with a mouse."
     },
     "isPressed": {
       "selector": "[data-pressed]",
+      "tailwind": "pressed:",
       "description": "Whether the item is currently in a pressed state."
-    },
-    "isSelected": {
-      "selector": "[data-selected]",
-      "description": "Whether the item is currently selected."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/color-swatch-picker.json
+++ b/www/src/modules/docs/references/generated/color-swatch-picker.json
@@ -229,25 +229,30 @@
     }
   },
   "renderProps": {
+    "orientation": {
+      "selector": "[data-orientation=\"vertical | horizontal\"]",
+      "tailwind": "orientation-vertical: | orientation-horizontal:",
+      "description": "The primary orientation of the items."
+    },
+    "layout": {
+      "selector": "[data-layout=\"stack | grid\"]",
+      "tailwind": "layout-stack: | layout-grid:",
+      "description": "Whether the items are arranged in a stack or grid."
+    },
     "isEmpty": {
       "selector": "[data-empty]",
+      "tailwind": "empty:",
       "description": "Whether the listbox has no items and should display its empty state."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the listbox is currently focused."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the listbox is currently keyboard focused."
-    },
-    "layout": {
-      "selector": "[data-layout=\"stack | grid\"]",
-      "description": "Whether the items are arranged in a stack or grid."
-    },
-    "orientation": {
-      "selector": "[data-orientation=\"vertical | horizontal\"]",
-      "description": "The primary orientation of the items."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/color-thumb.json
+++ b/www/src/modules/docs/references/generated/color-thumb.json
@@ -186,25 +186,30 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the thumb is disabled."
-    },
     "isDragging": {
       "selector": "[data-dragging]",
+      "tailwind": "dragging:",
       "description": "Whether this thumb is currently being dragged."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the thumb is currently hovered with a mouse."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the thumb is currently focused."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the thumb is keyboard focused."
     },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the thumb is currently hovered with a mouse."
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the thumb is disabled."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/combobox-value.json
+++ b/www/src/modules/docs/references/generated/combobox-value.json
@@ -247,6 +247,13 @@
       "description": "Overrides the default DOM element with a custom render function.\nThis allows rendering existing components with built-in styles and behaviors\nsuch as router links, animation libraries, and pre-styled components.\n\nRequirements:\n\n- You must render the expected element type (e.g. if `<button>` is expected, you cannot render an\n  `<a>`).\n- Only a single root DOM element can be rendered (no fragments).\n- You must pass through props and ref to the underlying DOM element, merging with your own prop\n  as appropriate."
     }
   },
+  "renderProps": {
+    "isPlaceholder": {
+      "selector": "[data-placeholder]",
+      "tailwind": "placeholder-shown:",
+      "description": "Whether the value is a placeholder."
+    }
+  },
   "typeLinks": {
     "react-aria-components/dist/types/src/ComboBox.d.ts:ComboBoxValueRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/combobox.json
+++ b/www/src/modules/docs/references/generated/combobox.json
@@ -1024,6 +1024,33 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isOpen": {
+      "selector": "[data-open]",
+      "tailwind": "open:",
+      "description": "Whether the combobox is currently open."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the combobox is disabled."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the combobox is invalid."
+    },
+    "isRequired": {
+      "selector": "[data-required]",
+      "tailwind": "required:",
+      "description": "Whether the combobox is required."
+    },
+    "isReadOnly": {
+      "selector": "[data-readonly]",
+      "tailwind": "read-only:",
+      "description": "Whether the combobox is read only."
+    }
+  },
   "typeLinks": {
     "ComboBoxRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/command-content.json
+++ b/www/src/modules/docs/references/generated/command-content.json
@@ -704,6 +704,38 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isEmpty": {
+      "selector": "[data-empty]",
+      "tailwind": "empty:",
+      "description": "Whether the listbox has no items and should display its empty state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the listbox is currently focused."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the listbox is currently keyboard focused."
+    },
+    "isDropTarget": {
+      "selector": "[data-drop-target]",
+      "tailwind": "drop-target:",
+      "description": "Whether the listbox is currently the active drop target."
+    },
+    "layout": {
+      "selector": "[data-layout=\"stack | grid\"]",
+      "tailwind": "layout-stack: | layout-grid:",
+      "description": "Whether the items are arranged in a stack or grid."
+    },
+    "orientation": {
+      "selector": "[data-orientation=\"vertical | horizontal\"]",
+      "tailwind": "orientation-vertical: | orientation-horizontal:",
+      "description": "The primary orientation of the items."
+    }
+  },
   "typeLinks": {
     "@types/react/index.d.ts:ReactPortal": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/command-input.json
+++ b/www/src/modules/docs/references/generated/command-input.json
@@ -1088,6 +1088,33 @@
       "default": "'search'"
     }
   },
+  "renderProps": {
+    "isEmpty": {
+      "selector": "[data-empty]",
+      "tailwind": "empty:",
+      "description": "Whether the search field is empty."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the search field is disabled."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the search field is invalid."
+    },
+    "isReadOnly": {
+      "selector": "[data-readonly]",
+      "tailwind": "read-only:",
+      "description": "Whether the search field is read only."
+    },
+    "isRequired": {
+      "selector": "[data-required]",
+      "tailwind": "required:",
+      "description": "Whether the search field is required."
+    }
+  },
   "typeLinks": {
     "SearchFieldRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/date-field.json
+++ b/www/src/modules/docs/references/generated/date-field.json
@@ -748,20 +748,24 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the date field is disabled."
-    },
     "isInvalid": {
       "selector": "[data-invalid]",
+      "tailwind": "invalid:",
       "description": "Whether the date field is invalid."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the date field is disabled."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the date field is read only."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the date field is required."
     }
   },

--- a/www/src/modules/docs/references/generated/date-input.json
+++ b/www/src/modules/docs/references/generated/date-input.json
@@ -145,24 +145,29 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the date input is disabled."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether an element within the date input is keyboard focused."
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the date input is currently hovered with a mouse."
     },
     "isFocusWithin": {
       "selector": "[data-focus-within]",
+      "tailwind": "focus-within:",
       "description": "Whether an element within the date input is focused, either via a mouse or keyboard."
     },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the date input is currently hovered with a mouse."
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether an element within the date input is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the date input is disabled."
     },
     "isInvalid": {
       "selector": "[data-invalid]",
+      "tailwind": "invalid:",
       "description": "Whether the date input is invalid."
     }
   },

--- a/www/src/modules/docs/references/generated/date-picker.json
+++ b/www/src/modules/docs/references/generated/date-picker.json
@@ -862,33 +862,40 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the date picker is disabled."
+    "isFocusWithin": {
+      "selector": "[data-focus-within]",
+      "tailwind": "focus-within:",
+      "description": "Whether an element within the date picker is focused, either via a mouse or keyboard."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether an element within the date picker is keyboard focused."
     },
-    "isFocusWithin": {
-      "selector": "[data-focus-within]",
-      "description": "Whether an element within the date picker is focused, either via a mouse or keyboard."
-    },
-    "isInvalid": {
-      "selector": "[data-invalid]",
-      "description": "Whether the date picker is invalid."
-    },
-    "isOpen": {
-      "selector": "[data-open]",
-      "description": "Whether the date picker's popover is currently open."
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the date picker is disabled."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the date picker is read only."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the date picker is invalid."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the date picker is required."
+    },
+    "isOpen": {
+      "selector": "[data-open]",
+      "tailwind": "open:",
+      "description": "Whether the date picker's popover is currently open."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/date-range-picker.json
+++ b/www/src/modules/docs/references/generated/date-range-picker.json
@@ -933,31 +933,38 @@
   "renderProps": {
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the date picker is disabled."
+    },
+    "isReadOnly": {
+      "selector": "[data-readonly]",
+      "tailwind": "read-only:",
+      "description": "Whether the date picker is read only."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the date picker is invalid."
+    },
+    "isRequired": {
+      "selector": "[data-required]",
+      "tailwind": "required:",
+      "description": "Whether the date picker is required."
+    },
+    "isOpen": {
+      "selector": "[data-open]",
+      "tailwind": "open:",
+      "description": "Whether the date picker's popover is currently open."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether an element within the date picker is keyboard focused."
     },
     "isFocusWithin": {
       "selector": "[data-focus-within]",
+      "tailwind": "focus-within:",
       "description": "Whether an element within the date picker is focused, either via a mouse or keyboard."
-    },
-    "isInvalid": {
-      "selector": "[data-invalid]",
-      "description": "Whether the date picker is invalid."
-    },
-    "isOpen": {
-      "selector": "[data-open]",
-      "description": "Whether the date picker's popover is currently open."
-    },
-    "isReadOnly": {
-      "selector": "[data-readonly]",
-      "description": "Whether the date picker is read only."
-    },
-    "isRequired": {
-      "selector": "[data-required]",
-      "description": "Whether the date picker is required."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/date-segment.json
+++ b/www/src/modules/docs/references/generated/date-segment.json
@@ -212,36 +212,44 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the date field is disabled."
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the segment is currently hovered with a mouse."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the segment is focused, either via a mouse or keyboard."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the segment is keyboard focused."
-    },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the segment is currently hovered with a mouse."
-    },
-    "isInvalid": {
-      "selector": "[data-invalid]",
-      "description": "Whether the date field is in an invalid state."
     },
     "isPlaceholder": {
       "selector": "[data-placeholder]",
+      "tailwind": "placeholder-shown:",
       "description": "Whether the value is a placeholder."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the segment is read only."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the date field is disabled."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the date field is in an invalid state."
     },
     "type": {
       "selector": "[data-type=\"...\"]",
+      "tailwind": "data-[type=…]:",
       "description": "The type of segment. Values include `literal`, `year`, `month`, `day`, etc."
     }
   },

--- a/www/src/modules/docs/references/generated/disclosure-panel.json
+++ b/www/src/modules/docs/references/generated/disclosure-panel.json
@@ -191,6 +191,7 @@
   "renderProps": {
     "isFocusVisibleWithin": {
       "selector": "[data-focus-visible-within]",
+      "tailwind": "data-focus-visible-within:",
       "description": "Whether keyboard focus is within the disclosure panel."
     }
   },

--- a/www/src/modules/docs/references/generated/disclosure-trigger.json
+++ b/www/src/modules/docs/references/generated/disclosure-trigger.json
@@ -918,6 +918,38 @@
       "description": "The value associated with the button's name when it's submitted with the form data."
     }
   },
+  "renderProps": {
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the button is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the button is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the button is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the button is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the button is disabled."
+    },
+    "isPending": {
+      "selector": "[data-pending]",
+      "tailwind": "pending:",
+      "description": "Whether the button is currently in a pending state."
+    }
+  },
   "typeLinks": {
     "ButtonRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/disclosure.json
+++ b/www/src/modules/docs/references/generated/disclosure.json
@@ -214,17 +214,20 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the disclosure is disabled."
-    },
     "isExpanded": {
       "selector": "[data-expanded]",
+      "tailwind": "expanded:",
       "description": "Whether the disclosure is expanded."
     },
     "isFocusVisibleWithin": {
       "selector": "[data-focus-visible-within]",
+      "tailwind": "data-focus-visible-within:",
       "description": "Whether the disclosure has keyboard focus."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the disclosure is disabled."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/drawer-swipe-area.json
+++ b/www/src/modules/docs/references/generated/drawer-swipe-area.json
@@ -146,6 +146,34 @@
       "description": "The swipe direction that opens the drawer.\nDefaults to the opposite of `Drawer.Root` `swipeDirection`."
     }
   },
+  "renderProps": {
+    "open": {
+      "selector": "[data-open]",
+      "tailwind": "data-open:",
+      "description": "Present when the drawer is open."
+    },
+    "closed": {
+      "selector": "[data-closed]",
+      "tailwind": "data-closed:",
+      "description": "Present when the drawer is closed."
+    },
+    "disabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "data-disabled:",
+      "description": "Present when the swipe area is disabled."
+    },
+    "swipeDirection": {
+      "selector": "[data-swipe-direction]",
+      "tailwind": "data-swipe-direction:",
+      "description": "Indicates the swipe direction."
+    },
+    "swiping": {
+      "selector": "[data-swiping]",
+      "tailwind": "data-swiping:",
+      "description": "Present when the drawer is being swiped."
+    }
+  },
+  "renderPropsKind": "data-attribute",
   "typeLinks": {
     "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/drawer.json
+++ b/www/src/modules/docs/references/generated/drawer.json
@@ -96,5 +96,58 @@
       },
       "description": "The content of the drawer."
     }
-  }
+  },
+  "renderProps": {
+    "open": {
+      "selector": "[data-open]",
+      "tailwind": "data-open:",
+      "description": "Present when the drawer is open."
+    },
+    "closed": {
+      "selector": "[data-closed]",
+      "tailwind": "data-closed:",
+      "description": "Present when the drawer is closed."
+    },
+    "startingStyle": {
+      "selector": "[data-starting-style]",
+      "tailwind": "data-starting-style:",
+      "description": "Present when the drawer is animating in."
+    },
+    "endingStyle": {
+      "selector": "[data-ending-style]",
+      "tailwind": "data-ending-style:",
+      "description": "Present when the drawer is animating out."
+    },
+    "expanded": {
+      "selector": "[data-expanded]",
+      "tailwind": "data-expanded:",
+      "description": "Present when the drawer is at the expanded (full-height) snap point."
+    },
+    "nestedDrawerOpen": {
+      "selector": "[data-nested-drawer-open]",
+      "tailwind": "data-nested-drawer-open:",
+      "description": "Present when a nested drawer is open."
+    },
+    "nestedDrawerSwiping": {
+      "selector": "[data-nested-drawer-swiping]",
+      "tailwind": "data-nested-drawer-swiping:",
+      "description": "Present when a nested drawer is being swiped."
+    },
+    "swipeDismiss": {
+      "selector": "[data-swipe-dismiss]",
+      "tailwind": "data-swipe-dismiss:",
+      "description": "Present when the drawer is dismissed by swiping."
+    },
+    "swipeDirection": {
+      "selector": "[data-swipe-direction]",
+      "tailwind": "data-swipe-direction:",
+      "description": "Indicates the swipe direction."
+    },
+    "swiping": {
+      "selector": "[data-swiping]",
+      "tailwind": "data-swiping:",
+      "description": "Present when the drawer is being swiped."
+    }
+  },
+  "renderPropsKind": "data-attribute"
 }

--- a/www/src/modules/docs/references/generated/drop-zone.json
+++ b/www/src/modules/docs/references/generated/drop-zone.json
@@ -443,25 +443,30 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the dropzone is disabled."
-    },
-    "isDropTarget": {
-      "selector": "[data-drop-target]",
-      "description": "Whether the dropzone is the drop target."
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the dropzone is currently hovered with a mouse."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the dropzone is focused, either via a mouse or keyboard."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the dropzone is keyboard focused."
     },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the dropzone is currently hovered with a mouse."
+    "isDropTarget": {
+      "selector": "[data-drop-target]",
+      "tailwind": "drop-target:",
+      "description": "Whether the dropzone is the drop target."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the dropzone is disabled."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/group.json
+++ b/www/src/modules/docs/references/generated/group.json
@@ -329,24 +329,29 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the group is disabled."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether an element within the group is keyboard focused."
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the group is currently hovered with a mouse."
     },
     "isFocusWithin": {
       "selector": "[data-focus-within]",
+      "tailwind": "focus-within:",
       "description": "Whether an element within the group is focused, either via a mouse or keyboard."
     },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the group is currently hovered with a mouse."
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether an element within the group is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the group is disabled."
     },
     "isInvalid": {
       "selector": "[data-invalid]",
+      "tailwind": "invalid:",
       "description": "Whether the group is invalid."
     }
   },

--- a/www/src/modules/docs/references/generated/input-group.json
+++ b/www/src/modules/docs/references/generated/input-group.json
@@ -332,6 +332,33 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the group is currently hovered with a mouse."
+    },
+    "isFocusWithin": {
+      "selector": "[data-focus-within]",
+      "tailwind": "focus-within:",
+      "description": "Whether an element within the group is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether an element within the group is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the group is disabled."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the group is invalid."
+    }
+  },
   "typeLinks": {
     "GroupRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/input.json
+++ b/www/src/modules/docs/references/generated/input.json
@@ -209,24 +209,29 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the input is disabled."
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the input is currently hovered with a mouse."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the input is focused, either via a mouse or keyboard."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the input is keyboard focused."
     },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the input is currently hovered with a mouse."
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the input is disabled."
     },
     "isInvalid": {
       "selector": "[data-invalid]",
+      "tailwind": "invalid:",
       "description": "Whether the input is invalid."
     }
   },

--- a/www/src/modules/docs/references/generated/link-button.json
+++ b/www/src/modules/docs/references/generated/link-button.json
@@ -786,6 +786,38 @@
       "description": "The target window for the link. See\n[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)."
     }
   },
+  "renderProps": {
+    "isCurrent": {
+      "selector": "[data-current]",
+      "tailwind": "current:",
+      "description": "Whether the link is the current item within a list."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the link is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the link is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the link is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the link is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the link is disabled."
+    }
+  },
   "typeLinks": {
     "HoverEvent": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/link.json
+++ b/www/src/modules/docs/references/generated/link.json
@@ -750,27 +750,33 @@
   "renderProps": {
     "isCurrent": {
       "selector": "[data-current]",
+      "tailwind": "current:",
       "description": "Whether the link is the current item within a list."
-    },
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the link is disabled."
-    },
-    "isFocused": {
-      "selector": "[data-focused]",
-      "description": "Whether the link is focused, either via a mouse or keyboard."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether the link is keyboard focused."
     },
     "isHovered": {
       "selector": "[data-hovered]",
+      "tailwind": "hover:",
       "description": "Whether the link is currently hovered with a mouse."
     },
     "isPressed": {
       "selector": "[data-pressed]",
+      "tailwind": "pressed:",
       "description": "Whether the link is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the link is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the link is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the link is disabled."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/list-box-item.json
+++ b/www/src/modules/docs/references/generated/list-box-item.json
@@ -750,44 +750,39 @@
     }
   },
   "renderProps": {
-    "allowsDragging": {
-      "selector": "[data-allows-dragging]",
-      "description": "Whether the item allows dragging."
-    },
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the item is non-interactive, i.e. both selection and actions are disabled and the item\nmay not be focused. Dependent on `disabledKeys` and `disabledBehavior`."
-    },
-    "isDragging": {
-      "selector": "[data-dragging]",
-      "description": "Whether the item is currently being dragged."
-    },
-    "isDropTarget": {
-      "selector": "[data-drop-target]",
-      "description": "Whether the item is currently an active drop target."
-    },
-    "isFocused": {
-      "selector": "[data-focused]",
-      "description": "Whether the item is currently focused."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether the item is currently keyboard focused."
-    },
     "isHovered": {
       "selector": "[data-hovered]",
+      "tailwind": "hover:",
       "description": "Whether the item is currently hovered with a mouse."
     },
     "isPressed": {
       "selector": "[data-pressed]",
+      "tailwind": "pressed:",
       "description": "Whether the item is currently in a pressed state."
     },
     "isSelected": {
       "selector": "[data-selected]",
+      "tailwind": "selected:",
       "description": "Whether the item is currently selected."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the item is currently focused."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the item is currently keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the item is non-interactive, i.e. both selection and actions are disabled and the item\nmay not be focused. Dependent on `disabledKeys` and `disabledBehavior`."
     },
     "selectionMode": {
       "selector": "[data-selection-mode=\"single | multiple\"]",
+      "tailwind": "selection-single: | selection-multiple:",
       "description": "The type of selection that is allowed in the collection."
     }
   },

--- a/www/src/modules/docs/references/generated/list-box.json
+++ b/www/src/modules/docs/references/generated/list-box.json
@@ -701,28 +701,34 @@
     }
   },
   "renderProps": {
-    "isDropTarget": {
-      "selector": "[data-drop-target]",
-      "description": "Whether the listbox is currently the active drop target."
-    },
     "isEmpty": {
       "selector": "[data-empty]",
+      "tailwind": "empty:",
       "description": "Whether the listbox has no items and should display its empty state."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the listbox is currently focused."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the listbox is currently keyboard focused."
+    },
+    "isDropTarget": {
+      "selector": "[data-drop-target]",
+      "tailwind": "drop-target:",
+      "description": "Whether the listbox is currently the active drop target."
     },
     "layout": {
       "selector": "[data-layout=\"stack | grid\"]",
+      "tailwind": "layout-stack: | layout-grid:",
       "description": "Whether the items are arranged in a stack or grid."
     },
     "orientation": {
       "selector": "[data-orientation=\"vertical | horizontal\"]",
+      "tailwind": "orientation-vertical: | orientation-horizontal:",
       "description": "The primary orientation of the items."
     }
   },

--- a/www/src/modules/docs/references/generated/loader.json
+++ b/www/src/modules/docs/references/generated/loader.json
@@ -284,6 +284,16 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "valueText": {
+      "selector": "[aria-valuetext]",
+      "description": "A formatted version of the value."
+    },
+    "isIndeterminate": {
+      "selector": ":not([aria-valuenow])",
+      "description": "Whether the progress bar is indeterminate."
+    }
+  },
   "typeLinks": {
     "ProgressBarRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/menu-content.json
+++ b/www/src/modules/docs/references/generated/menu-content.json
@@ -547,6 +547,13 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isEmpty": {
+      "selector": "[data-empty]",
+      "tailwind": "empty:",
+      "description": "Whether the menu has no items and should display its empty state."
+    }
+  },
   "typeLinks": {
     "@types/react/index.d.ts:ReactPortal": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/menu-item.json
+++ b/www/src/modules/docs/references/generated/menu-item.json
@@ -702,52 +702,49 @@
     }
   },
   "renderProps": {
-    "allowsDragging": {
-      "selector": "[data-allows-dragging]",
-      "description": "Whether the item allows dragging."
-    },
     "hasSubmenu": {
       "selector": "[data-has-submenu]",
+      "tailwind": "has-submenu:",
       "description": "Whether the item has a submenu."
-    },
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the item is non-interactive, i.e. both selection and actions are disabled and the item\nmay not be focused. Dependent on `disabledKeys` and `disabledBehavior`."
-    },
-    "isDragging": {
-      "selector": "[data-dragging]",
-      "description": "Whether the item is currently being dragged."
-    },
-    "isDropTarget": {
-      "selector": "[data-drop-target]",
-      "description": "Whether the item is currently an active drop target."
-    },
-    "isFocused": {
-      "selector": "[data-focused]",
-      "description": "Whether the item is currently focused."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether the item is currently keyboard focused."
-    },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the item is currently hovered with a mouse."
     },
     "isOpen": {
       "selector": "[data-open]",
+      "tailwind": "open:",
       "description": "Whether the item's submenu is open."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the item is currently hovered with a mouse."
     },
     "isPressed": {
       "selector": "[data-pressed]",
+      "tailwind": "pressed:",
       "description": "Whether the item is currently in a pressed state."
     },
     "isSelected": {
       "selector": "[data-selected]",
+      "tailwind": "selected:",
       "description": "Whether the item is currently selected."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the item is currently focused."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the item is currently keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the item is non-interactive, i.e. both selection and actions are disabled and the item\nmay not be focused. Dependent on `disabledKeys` and `disabledBehavior`."
     },
     "selectionMode": {
       "selector": "[data-selection-mode=\"single | multiple\"]",
+      "tailwind": "selection-single: | selection-multiple:",
       "description": "The type of selection that is allowed in the collection."
     }
   },

--- a/www/src/modules/docs/references/generated/menu.json
+++ b/www/src/modules/docs/references/generated/menu.json
@@ -53,11 +53,5 @@
       },
       "description": "Handler that is called when the overlay's open state changes."
     }
-  },
-  "renderProps": {
-    "isEmpty": {
-      "selector": "[data-empty]",
-      "description": "Whether the menu has no items and should display its empty state."
-    }
   }
 }

--- a/www/src/modules/docs/references/generated/modal-content.json
+++ b/www/src/modules/docs/references/generated/modal-content.json
@@ -265,6 +265,18 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isEntering": {
+      "selector": "[data-entering]",
+      "tailwind": "entering:",
+      "description": "Whether the modal is currently entering. Use this to apply animations."
+    },
+    "isExiting": {
+      "selector": "[data-exiting]",
+      "tailwind": "exiting:",
+      "description": "Whether the modal is currently exiting. Use this to apply animations."
+    }
+  },
   "typeLinks": {
     "ModalRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/modal-overlay.json
+++ b/www/src/modules/docs/references/generated/modal-overlay.json
@@ -265,6 +265,18 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isEntering": {
+      "selector": "[data-entering]",
+      "tailwind": "entering:",
+      "description": "Whether the modal is currently entering. Use this to apply animations."
+    },
+    "isExiting": {
+      "selector": "[data-exiting]",
+      "tailwind": "exiting:",
+      "description": "Whether the modal is currently exiting. Use this to apply animations."
+    }
+  },
   "typeLinks": {
     "ModalRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/modal.json
+++ b/www/src/modules/docs/references/generated/modal.json
@@ -268,10 +268,12 @@
   "renderProps": {
     "isEntering": {
       "selector": "[data-entering]",
+      "tailwind": "entering:",
       "description": "Whether the modal is currently entering. Use this to apply animations."
     },
     "isExiting": {
       "selector": "[data-exiting]",
+      "tailwind": "exiting:",
       "description": "Whether the modal is currently exiting. Use this to apply animations."
     }
   },

--- a/www/src/modules/docs/references/generated/number-field.json
+++ b/www/src/modules/docs/references/generated/number-field.json
@@ -815,18 +815,22 @@
   "renderProps": {
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the number field is disabled."
     },
     "isInvalid": {
       "selector": "[data-invalid]",
+      "tailwind": "invalid:",
       "description": "Whether the number field is invalid."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the number field is read only."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the number field is required."
     }
   },

--- a/www/src/modules/docs/references/generated/otp-field-separator.json
+++ b/www/src/modules/docs/references/generated/otp-field-separator.json
@@ -138,6 +138,14 @@
       "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
     }
   },
+  "renderProps": {
+    "orientation": {
+      "selector": "[data-orientation]",
+      "tailwind": "data-orientation:",
+      "description": "Indicates the orientation of the separator."
+    }
+  },
+  "renderPropsKind": "data-attribute",
   "typeLinks": {
     "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/otp-field.json
+++ b/www/src/modules/docs/references/generated/otp-field.json
@@ -419,6 +419,59 @@
       "description": "The OTP value."
     }
   },
+  "renderProps": {
+    "complete": {
+      "selector": "[data-complete]",
+      "tailwind": "data-complete:",
+      "description": "Present when all slots are filled."
+    },
+    "disabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "data-disabled:",
+      "description": "Present when the OTP field is disabled."
+    },
+    "readonly": {
+      "selector": "[data-readonly]",
+      "tailwind": "data-readonly:",
+      "description": "Present when the OTP field is readonly."
+    },
+    "required": {
+      "selector": "[data-required]",
+      "tailwind": "data-required:",
+      "description": "Present when the OTP field is required."
+    },
+    "valid": {
+      "selector": "[data-valid]",
+      "tailwind": "data-valid:",
+      "description": "Present when the OTP field is in a valid state (when wrapped in Field.Root)."
+    },
+    "invalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "data-invalid:",
+      "description": "Present when the OTP field is in an invalid state (when wrapped in Field.Root)."
+    },
+    "touched": {
+      "selector": "[data-touched]",
+      "tailwind": "data-touched:",
+      "description": "Present when the OTP field has been touched (when wrapped in Field.Root)."
+    },
+    "dirty": {
+      "selector": "[data-dirty]",
+      "tailwind": "data-dirty:",
+      "description": "Present when the OTP field's value has changed (when wrapped in Field.Root)."
+    },
+    "filled": {
+      "selector": "[data-filled]",
+      "tailwind": "data-filled:",
+      "description": "Present when the OTP field contains at least one character."
+    },
+    "focused": {
+      "selector": "[data-focused]",
+      "tailwind": "data-focused:",
+      "description": "Present when one of the OTP field inputs is focused."
+    }
+  },
+  "renderPropsKind": "data-attribute",
   "typeLinks": {
     "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/pagination-link.json
+++ b/www/src/modules/docs/references/generated/pagination-link.json
@@ -803,6 +803,38 @@
       "description": "The target window for the link. See\n[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)."
     }
   },
+  "renderProps": {
+    "isCurrent": {
+      "selector": "[data-current]",
+      "tailwind": "current:",
+      "description": "Whether the link is the current item within a list."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the link is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the link is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the link is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the link is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the link is disabled."
+    }
+  },
   "typeLinks": {
     "HoverEvent": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/pagination-next.json
+++ b/www/src/modules/docs/references/generated/pagination-next.json
@@ -777,6 +777,38 @@
       "default": "isActive ? 'default' : 'quiet'"
     }
   },
+  "renderProps": {
+    "isCurrent": {
+      "selector": "[data-current]",
+      "tailwind": "current:",
+      "description": "Whether the link is the current item within a list."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the link is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the link is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the link is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the link is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the link is disabled."
+    }
+  },
   "typeLinks": {
     "HoverEvent": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/pagination-previous.json
+++ b/www/src/modules/docs/references/generated/pagination-previous.json
@@ -777,6 +777,38 @@
       "default": "isActive ? 'default' : 'quiet'"
     }
   },
+  "renderProps": {
+    "isCurrent": {
+      "selector": "[data-current]",
+      "tailwind": "current:",
+      "description": "Whether the link is the current item within a list."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the link is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the link is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the link is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the link is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the link is disabled."
+    }
+  },
   "typeLinks": {
     "HoverEvent": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/popover.json
+++ b/www/src/modules/docs/references/generated/popover.json
@@ -499,21 +499,25 @@
     }
   },
   "renderProps": {
+    "trigger": {
+      "selector": "[data-trigger=\"...\"]",
+      "tailwind": "data-[trigger=…]:",
+      "description": "The name of the component that triggered the popover, e.g. \"DialogTrigger\" or \"ComboBox\"."
+    },
+    "placement": {
+      "selector": "[data-placement=\"left | right | top | bottom\"]",
+      "tailwind": "placement-left: | placement-right: | placement-top: | placement-bottom:",
+      "description": "The placement of the popover relative to the trigger."
+    },
     "isEntering": {
       "selector": "[data-entering]",
+      "tailwind": "entering:",
       "description": "Whether the popover is currently entering. Use this to apply animations."
     },
     "isExiting": {
       "selector": "[data-exiting]",
+      "tailwind": "exiting:",
       "description": "Whether the popover is currently exiting. Use this to apply animations."
-    },
-    "placement": {
-      "selector": "[data-placement=\"left | right | top | bottom\"]",
-      "description": "The placement of the popover relative to the trigger."
-    },
-    "trigger": {
-      "selector": "[data-trigger=\"...\"]",
-      "description": "The name of the component that triggered the popover, e.g. \"DialogTrigger\" or \"ComboBox\"."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/progress-bar.json
+++ b/www/src/modules/docs/references/generated/progress-bar.json
@@ -249,13 +249,13 @@
     }
   },
   "renderProps": {
-    "isIndeterminate": {
-      "selector": ":not([aria-valuenow])",
-      "description": "Whether the progress bar is indeterminate."
-    },
     "valueText": {
       "selector": "[aria-valuetext]",
       "description": "A formatted version of the value."
+    },
+    "isIndeterminate": {
+      "selector": ":not([aria-valuenow])",
+      "description": "Whether the progress bar is indeterminate."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/radio-control.json
+++ b/www/src/modules/docs/references/generated/radio-control.json
@@ -230,6 +230,53 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the radio is selected."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the radio is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the radio is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the radio is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the radio is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the radio is disabled."
+    },
+    "isReadOnly": {
+      "selector": "[data-readonly]",
+      "tailwind": "read-only:",
+      "description": "Whether the radio is read only."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the radio is invalid."
+    },
+    "isRequired": {
+      "selector": "[data-required]",
+      "tailwind": "required:",
+      "description": "Whether the checkbox is required."
+    }
+  },
   "typeLinks": {
     "HoverEvent": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/radio-group.json
+++ b/www/src/modules/docs/references/generated/radio-group.json
@@ -485,25 +485,30 @@
     }
   },
   "renderProps": {
+    "orientation": {
+      "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
+      "description": "The orientation of the radio group."
+    },
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the radio group is disabled."
-    },
-    "isInvalid": {
-      "selector": "[data-invalid]",
-      "description": "Whether the radio group is invalid."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the radio group is read only."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the radio group is required."
     },
-    "orientation": {
-      "selector": "[data-orientation=\"horizontal | vertical\"]",
-      "description": "The orientation of the radio group."
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the radio group is invalid."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/radio.json
+++ b/www/src/modules/docs/references/generated/radio.json
@@ -559,41 +559,30 @@
     }
   },
   "renderProps": {
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the radio is selected."
+    },
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the radio is disabled."
-    },
-    "isFocused": {
-      "selector": "[data-focused]",
-      "description": "Whether the radio is focused, either via a mouse or keyboard."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether the radio is keyboard focused."
-    },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the radio is currently hovered with a mouse."
-    },
-    "isInvalid": {
-      "selector": "[data-invalid]",
-      "description": "Whether the radio is invalid."
-    },
-    "isPressed": {
-      "selector": "[data-pressed]",
-      "description": "Whether the radio is currently in a pressed state."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the radio is read only."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the radio is invalid."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the checkbox is required."
-    },
-    "isSelected": {
-      "selector": "[data-selected]",
-      "description": "Whether the radio is selected."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/range-calendar.json
+++ b/www/src/modules/docs/references/generated/range-calendar.json
@@ -705,10 +705,12 @@
   "renderProps": {
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the calendar is disabled."
     },
     "isInvalid": {
       "selector": "[data-invalid]",
+      "tailwind": "invalid:",
       "description": "Whether the calendar is invalid."
     }
   },

--- a/www/src/modules/docs/references/generated/search-field.json
+++ b/www/src/modules/docs/references/generated/search-field.json
@@ -1081,24 +1081,29 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the search field is disabled."
-    },
     "isEmpty": {
       "selector": "[data-empty]",
+      "tailwind": "empty:",
       "description": "Whether the search field is empty."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the search field is disabled."
     },
     "isInvalid": {
       "selector": "[data-invalid]",
+      "tailwind": "invalid:",
       "description": "Whether the search field is invalid."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the search field is read only."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the search field is required."
     }
   },

--- a/www/src/modules/docs/references/generated/select-content.json
+++ b/www/src/modules/docs/references/generated/select-content.json
@@ -755,6 +755,38 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isEmpty": {
+      "selector": "[data-empty]",
+      "tailwind": "empty:",
+      "description": "Whether the listbox has no items and should display its empty state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the listbox is currently focused."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the listbox is currently keyboard focused."
+    },
+    "isDropTarget": {
+      "selector": "[data-drop-target]",
+      "tailwind": "drop-target:",
+      "description": "Whether the listbox is currently the active drop target."
+    },
+    "layout": {
+      "selector": "[data-layout=\"stack | grid\"]",
+      "tailwind": "layout-stack: | layout-grid:",
+      "description": "Whether the items are arranged in a stack or grid."
+    },
+    "orientation": {
+      "selector": "[data-orientation=\"vertical | horizontal\"]",
+      "tailwind": "orientation-vertical: | orientation-horizontal:",
+      "description": "The primary orientation of the items."
+    }
+  },
   "typeLinks": {
     "@types/react/index.d.ts:ReactPortal": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/select-value.json
+++ b/www/src/modules/docs/references/generated/select-value.json
@@ -242,6 +242,7 @@
   "renderProps": {
     "isPlaceholder": {
       "selector": "[data-placeholder]",
+      "tailwind": "placeholder-shown:",
       "description": "Whether the value is a placeholder."
     }
   },

--- a/www/src/modules/docs/references/generated/select.json
+++ b/www/src/modules/docs/references/generated/select.json
@@ -829,28 +829,34 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the select is disabled."
-    },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the select is focused, either via a mouse or keyboard."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the select is keyboard focused."
     },
-    "isInvalid": {
-      "selector": "[data-invalid]",
-      "description": "Whether the select is invalid."
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the select is disabled."
     },
     "isOpen": {
       "selector": "[data-open]",
+      "tailwind": "open:",
       "description": "Whether the select is currently open."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the select is invalid."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the select is required."
     }
   },

--- a/www/src/modules/docs/references/generated/sidebar-group-action.json
+++ b/www/src/modules/docs/references/generated/sidebar-group-action.json
@@ -918,6 +918,38 @@
       "description": "The value associated with the button's name when it's submitted with the form data."
     }
   },
+  "renderProps": {
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the button is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the button is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the button is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the button is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the button is disabled."
+    },
+    "isPending": {
+      "selector": "[data-pending]",
+      "tailwind": "pending:",
+      "description": "Whether the button is currently in a pending state."
+    }
+  },
   "typeLinks": {
     "ButtonRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/sidebar-menu-action.json
+++ b/www/src/modules/docs/references/generated/sidebar-menu-action.json
@@ -926,6 +926,38 @@
       "description": "The value associated with the button's name when it's submitted with the form data."
     }
   },
+  "renderProps": {
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the button is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the button is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the button is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the button is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the button is disabled."
+    },
+    "isPending": {
+      "selector": "[data-pending]",
+      "tailwind": "pending:",
+      "description": "Whether the button is currently in a pending state."
+    }
+  },
   "typeLinks": {
     "ButtonRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/sidebar-rail.json
+++ b/www/src/modules/docs/references/generated/sidebar-rail.json
@@ -918,6 +918,38 @@
       "description": "The value associated with the button's name when it's submitted with the form data."
     }
   },
+  "renderProps": {
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the button is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the button is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the button is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the button is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the button is disabled."
+    },
+    "isPending": {
+      "selector": "[data-pending]",
+      "tailwind": "pending:",
+      "description": "Whether the button is currently in a pending state."
+    }
+  },
   "typeLinks": {
     "ButtonRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/sidebar-trigger.json
+++ b/www/src/modules/docs/references/generated/sidebar-trigger.json
@@ -918,6 +918,38 @@
       "description": "The value associated with the button's name when it's submitted with the form data."
     }
   },
+  "renderProps": {
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the button is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the button is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the button is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the button is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the button is disabled."
+    },
+    "isPending": {
+      "selector": "[data-pending]",
+      "tailwind": "pending:",
+      "description": "Whether the button is currently in a pending state."
+    }
+  },
   "typeLinks": {
     "ButtonRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/slider-control.json
+++ b/www/src/modules/docs/references/generated/slider-control.json
@@ -211,6 +211,23 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the slider track is currently hovered with a mouse."
+    },
+    "orientation": {
+      "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
+      "description": "The orientation of the slider."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the slider is disabled."
+    }
+  },
   "typeLinks": {
     "HoverEvent": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/slider-fill.json
+++ b/www/src/modules/docs/references/generated/slider-fill.json
@@ -221,17 +221,20 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the slider is disabled."
-    },
     "isHovered": {
       "selector": "[data-hovered]",
+      "tailwind": "hover:",
       "description": "Whether the slider fill is currently hovered with a mouse."
     },
     "orientation": {
       "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
       "description": "The orientation of the slider."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the slider is disabled."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/slider-output.json
+++ b/www/src/modules/docs/references/generated/slider-output.json
@@ -136,6 +136,18 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "orientation": {
+      "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
+      "description": "The orientation of the slider."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the slider is disabled."
+    }
+  },
   "typeLinks": {
     "SliderRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/slider-thumb.json
+++ b/www/src/modules/docs/references/generated/slider-thumb.json
@@ -484,25 +484,30 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the thumb is disabled."
-    },
     "isDragging": {
       "selector": "[data-dragging]",
+      "tailwind": "dragging:",
       "description": "Whether this thumb is currently being dragged."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the thumb is currently hovered with a mouse."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the thumb is currently focused."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the thumb is keyboard focused."
     },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the thumb is currently hovered with a mouse."
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the thumb is disabled."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/slider-track.json
+++ b/www/src/modules/docs/references/generated/slider-track.json
@@ -10,19 +10,5 @@
       },
       "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
     }
-  },
-  "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the slider is disabled."
-    },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the slider track is currently hovered with a mouse."
-    },
-    "orientation": {
-      "selector": "[data-orientation=\"horizontal | vertical\"]",
-      "description": "The orientation of the slider."
-    }
   }
 }

--- a/www/src/modules/docs/references/generated/slider.json
+++ b/www/src/modules/docs/references/generated/slider.json
@@ -378,13 +378,15 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the slider is disabled."
-    },
     "orientation": {
       "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
       "description": "The orientation of the slider."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the slider is disabled."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/switch-control.json
+++ b/www/src/modules/docs/references/generated/switch-control.json
@@ -253,6 +253,53 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the switch invalid."
+    },
+    "isRequired": {
+      "selector": "[data-required]",
+      "tailwind": "required:",
+      "description": "Whether the switch is required."
+    },
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the switch is selected."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the switch is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the switch is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the switch is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the switch is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the switch is disabled."
+    },
+    "isReadOnly": {
+      "selector": "[data-readonly]",
+      "tailwind": "read-only:",
+      "description": "Whether the switch is read only."
+    }
+  },
   "typeLinks": {
     "HoverEvent": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/switch.json
+++ b/www/src/modules/docs/references/generated/switch.json
@@ -758,33 +758,30 @@
     }
   },
   "renderProps": {
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the switch is selected."
+    },
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the switch is disabled."
-    },
-    "isFocused": {
-      "selector": "[data-focused]",
-      "description": "Whether the switch is focused, either via a mouse or keyboard."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether the switch is keyboard focused."
-    },
-    "isHovered": {
-      "selector": "[data-hovered]",
-      "description": "Whether the switch is currently hovered with a mouse."
-    },
-    "isPressed": {
-      "selector": "[data-pressed]",
-      "description": "Whether the switch is currently in a pressed state."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the switch is read only."
     },
-    "isSelected": {
-      "selector": "[data-selected]",
-      "description": "Whether the switch is selected."
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the switch invalid."
+    },
+    "isRequired": {
+      "selector": "[data-required]",
+      "tailwind": "required:",
+      "description": "Whether the switch is required."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/tab-indicator.json
+++ b/www/src/modules/docs/references/generated/tab-indicator.json
@@ -144,6 +144,18 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isEntering": {
+      "selector": "[data-entering]",
+      "tailwind": "entering:",
+      "description": "Whether the element is currently entering."
+    },
+    "isExiting": {
+      "selector": "[data-exiting]",
+      "tailwind": "exiting:",
+      "description": "Whether the element is currently exiting."
+    }
+  },
   "typeLinks": {
     "SharedElementRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/tab-list.json
+++ b/www/src/modules/docs/references/generated/tab-list.json
@@ -272,6 +272,7 @@
   "renderProps": {
     "orientation": {
       "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
       "description": "The orientation of the tab list."
     }
   },

--- a/www/src/modules/docs/references/generated/tab-panel.json
+++ b/www/src/modules/docs/references/generated/tab-panel.json
@@ -187,25 +187,30 @@
     }
   },
   "renderProps": {
-    "isEntering": {
-      "selector": "[data-entering]",
-      "description": "Whether the tab panel is currently entering. Use this to apply animations."
-    },
-    "isExiting": {
-      "selector": "[data-exiting]",
-      "description": "Whether the tab panel is currently exiting. Use this to apply animations."
-    },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the tab panel is currently focused."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the tab panel is currently keyboard focused."
     },
     "isInert": {
       "selector": "[data-inert]",
+      "tailwind": "data-inert:",
       "description": "Whether the tab panel is currently non-interactive. This occurs when the\n`shouldForceMount` prop is true, and the corresponding tab is not selected."
+    },
+    "isEntering": {
+      "selector": "[data-entering]",
+      "tailwind": "entering:",
+      "description": "Whether the tab panel is currently entering. Use this to apply animations."
+    },
+    "isExiting": {
+      "selector": "[data-exiting]",
+      "tailwind": "exiting:",
+      "description": "Whether the tab panel is currently exiting. Use this to apply animations."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/tab.json
+++ b/www/src/modules/docs/references/generated/tab.json
@@ -649,29 +649,35 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the tab is disabled."
-    },
-    "isFocused": {
-      "selector": "[data-focused]",
-      "description": "Whether the tab is currently focused."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether the tab is currently keyboard focused."
-    },
     "isHovered": {
       "selector": "[data-hovered]",
+      "tailwind": "hover:",
       "description": "Whether the tab is currently hovered with a mouse."
     },
     "isPressed": {
       "selector": "[data-pressed]",
+      "tailwind": "pressed:",
       "description": "Whether the tab is currently in a pressed state."
     },
     "isSelected": {
       "selector": "[data-selected]",
+      "tailwind": "selected:",
       "description": "Whether the tab is currently selected."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the tab is currently focused."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the tab is currently keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the tab is disabled."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/table-body.json
+++ b/www/src/modules/docs/references/generated/table-body.json
@@ -302,13 +302,15 @@
     }
   },
   "renderProps": {
-    "isDropTarget": {
-      "selector": "[data-drop-target]",
-      "description": "Whether the Table is currently the active drop target."
-    },
     "isEmpty": {
       "selector": "[data-empty]",
+      "tailwind": "empty:",
       "description": "Whether the table body has no rows and should display its empty state."
+    },
+    "isDropTarget": {
+      "selector": "[data-drop-target]",
+      "tailwind": "drop-target:",
+      "description": "Whether the Table is currently the active drop target."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/table-cell.json
+++ b/www/src/modules/docs/references/generated/table-cell.json
@@ -170,6 +170,63 @@
       "description": "A string representation of the cell's contents, used for features like typeahead."
     }
   },
+  "renderProps": {
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the cell is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the cell is currently focused."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the cell is currently keyboard focused."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the cell is currently hovered with a mouse."
+    },
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the parent row is currently selected."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the parent row is non-interactive, i.e. both selection and actions are disabled and the\nitem may not be focused. Dependent on `disabledKeys` and `disabledBehavior`."
+    },
+    "isFocusVisibleWithinRow": {
+      "selector": "[data-focus-visible-within-row]",
+      "tailwind": "data-focus-visible-within-row:",
+      "description": "Whether keyboard focus is visible anywhere within the parent row."
+    },
+    "isTreeColumn": {
+      "selector": "[data-tree-column]",
+      "tailwind": "data-tree-column:",
+      "description": "Whether the column displays hierarchical data."
+    },
+    "isExpanded": {
+      "selector": "[data-expanded]",
+      "tailwind": "expanded:",
+      "description": "Whether the parent row is expanded."
+    },
+    "hasChildItems": {
+      "selector": "[data-has-child-items]",
+      "tailwind": "has-child-items:",
+      "description": "Whether the parent row has child rows."
+    },
+    "level": {
+      "selector": "[data-level]",
+      "tailwind": "data-level:",
+      "description": "What level the parent row has within the table."
+    }
+  },
   "typeLinks": {
     "CellRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/table-column.json
+++ b/www/src/modules/docs/references/generated/table-column.json
@@ -366,6 +366,43 @@
       "description": "The width of the column. This prop only applies when the `<Table>` is wrapped in a\n`<ResizableTableContainer>`."
     }
   },
+  "renderProps": {
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the column is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the column is currently in a pressed state."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the column is currently focused."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the column is currently keyboard focused."
+    },
+    "allowsSorting": {
+      "selector": "[data-allows-sorting]",
+      "tailwind": "allows-sorting:",
+      "description": "Whether the column allows sorting."
+    },
+    "sortDirection": {
+      "selector": "[data-sort-direction=\"ascending | descending\"]",
+      "tailwind": "sort-ascending: | sort-descending:",
+      "description": "The current sort direction."
+    },
+    "isResizing": {
+      "selector": "[data-resizing]",
+      "tailwind": "resizing:",
+      "description": "Whether the column is currently being resized."
+    }
+  },
   "typeLinks": {
     "ColumnRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/table-drop-indicator.json
+++ b/www/src/modules/docs/references/generated/table-drop-indicator.json
@@ -145,6 +145,13 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isDropTarget": {
+      "selector": "[data-drop-target]",
+      "tailwind": "drop-target:",
+      "description": "Whether the drop indicator is currently the active drop target."
+    }
+  },
   "typeLinks": {
     "DropIndicatorRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/table-header.json
+++ b/www/src/modules/docs/references/generated/table-header.json
@@ -324,6 +324,7 @@
   "renderProps": {
     "isHovered": {
       "selector": "[data-hovered]",
+      "tailwind": "hover:",
       "description": "Whether the table header is currently hovered with a mouse."
     }
   },

--- a/www/src/modules/docs/references/generated/table-row.json
+++ b/www/src/modules/docs/references/generated/table-row.json
@@ -635,6 +635,63 @@
       "description": "The object value that this row represents. When using dynamic collections, this is set\nautomatically."
     }
   },
+  "renderProps": {
+    "isFocusVisibleWithin": {
+      "selector": "[data-focus-visible-within]",
+      "tailwind": "data-focus-visible-within:",
+      "description": "Whether the row's children have keyboard focus."
+    },
+    "isExpanded": {
+      "selector": "[data-expanded]",
+      "tailwind": "expanded:",
+      "description": "Whether the row is expanded."
+    },
+    "hasChildItems": {
+      "selector": "[data-has-child-items]",
+      "tailwind": "has-child-items:",
+      "description": "Whether the row has child rows."
+    },
+    "level": {
+      "selector": "[data-level]",
+      "tailwind": "data-level:",
+      "description": "What level the row has within the table."
+    },
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the item is currently hovered with a mouse."
+    },
+    "isPressed": {
+      "selector": "[data-pressed]",
+      "tailwind": "pressed:",
+      "description": "Whether the item is currently in a pressed state."
+    },
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the item is currently selected."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the item is currently focused."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the item is currently keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the item is non-interactive, i.e. both selection and actions are disabled and the item\nmay not be focused. Dependent on `disabledKeys` and `disabledBehavior`."
+    },
+    "selectionMode": {
+      "selector": "[data-selection-mode=\"single | multiple\"]",
+      "tailwind": "selection-single: | selection-multiple:",
+      "description": "The type of selection that is allowed in the collection."
+    }
+  },
   "typeLinks": {
     "@types/react/index.d.ts:ReactPortal": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/table.json
+++ b/www/src/modules/docs/references/generated/table.json
@@ -516,17 +516,20 @@
     }
   },
   "renderProps": {
-    "isDropTarget": {
-      "selector": "[data-drop-target]",
-      "description": "Whether the table is currently the active drop target."
-    },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the table is currently focused."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the table is currently keyboard focused."
+    },
+    "isDropTarget": {
+      "selector": "[data-drop-target]",
+      "tailwind": "drop-target:",
+      "description": "Whether the table is currently the active drop target."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/tabs.json
+++ b/www/src/modules/docs/references/generated/tabs.json
@@ -304,6 +304,7 @@
   "renderProps": {
     "orientation": {
       "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
       "description": "The orientation of the tabs."
     }
   },

--- a/www/src/modules/docs/references/generated/tag-list.json
+++ b/www/src/modules/docs/references/generated/tag-list.json
@@ -262,14 +262,17 @@
   "renderProps": {
     "isEmpty": {
       "selector": "[data-empty]",
+      "tailwind": "empty:",
       "description": "Whether the tag list has no items and should display its empty state."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the tag list is currently focused."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the tag list is currently keyboard focused."
     }
   },

--- a/www/src/modules/docs/references/generated/tag.json
+++ b/www/src/modules/docs/references/generated/tag.json
@@ -591,35 +591,43 @@
   "renderProps": {
     "allowsRemoving": {
       "selector": "[data-allows-removing]",
+      "tailwind": "allows-removing:",
       "description": "Whether the tag group allows items to be removed."
     },
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the item is non-interactive, i.e. both selection and actions are disabled and the item\nmay not be focused. Dependent on `disabledKeys` and `disabledBehavior`."
+    },
+    "selectionMode": {
+      "selector": "[data-selection-mode=\"single | multiple\"]",
+      "tailwind": "selection-single: | selection-multiple:",
+      "description": "The type of selection that is allowed in the collection."
+    },
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the item is currently selected."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the item is currently focused."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the item is currently keyboard focused."
     },
     "isHovered": {
       "selector": "[data-hovered]",
+      "tailwind": "hover:",
       "description": "Whether the item is currently hovered with a mouse."
     },
     "isPressed": {
       "selector": "[data-pressed]",
+      "tailwind": "pressed:",
       "description": "Whether the item is currently in a pressed state."
-    },
-    "isSelected": {
-      "selector": "[data-selected]",
-      "description": "Whether the item is currently selected."
-    },
-    "selectionMode": {
-      "selector": "[data-selection-mode=\"single | multiple\"]",
-      "description": "The type of selection that is allowed in the collection."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/text-area.json
+++ b/www/src/modules/docs/references/generated/text-area.json
@@ -177,6 +177,33 @@
       "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
     }
   },
+  "renderProps": {
+    "isHovered": {
+      "selector": "[data-hovered]",
+      "tailwind": "hover:",
+      "description": "Whether the input is currently hovered with a mouse."
+    },
+    "isFocused": {
+      "selector": "[data-focused]",
+      "tailwind": "focus:",
+      "description": "Whether the input is focused, either via a mouse or keyboard."
+    },
+    "isFocusVisible": {
+      "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
+      "description": "Whether the input is keyboard focused."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the input is disabled."
+    },
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the input is invalid."
+    }
+  },
   "typeLinks": {
     "HoverEvent": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/text-field.json
+++ b/www/src/modules/docs/references/generated/text-field.json
@@ -1037,18 +1037,22 @@
   "renderProps": {
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the text field is disabled."
     },
     "isInvalid": {
       "selector": "[data-invalid]",
+      "tailwind": "invalid:",
       "description": "Whether the value is invalid."
     },
     "isReadOnly": {
       "selector": "[data-readonly]",
+      "tailwind": "read-only:",
       "description": "Whether the text field is read only."
     },
     "isRequired": {
       "selector": "[data-required]",
+      "tailwind": "required:",
       "description": "Whether the text field is required."
     }
   },

--- a/www/src/modules/docs/references/generated/time-field.json
+++ b/www/src/modules/docs/references/generated/time-field.json
@@ -711,6 +711,28 @@
       "description": "The current value (controlled)."
     }
   },
+  "renderProps": {
+    "isInvalid": {
+      "selector": "[data-invalid]",
+      "tailwind": "invalid:",
+      "description": "Whether the date field is invalid."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the date field is disabled."
+    },
+    "isReadOnly": {
+      "selector": "[data-readonly]",
+      "tailwind": "read-only:",
+      "description": "Whether the date field is read only."
+    },
+    "isRequired": {
+      "selector": "[data-required]",
+      "tailwind": "required:",
+      "description": "Whether the date field is required."
+    }
+  },
   "typeLinks": {
     "DateFieldRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/toast.json
+++ b/www/src/modules/docs/references/generated/toast.json
@@ -193,15 +193,5 @@
       },
       "description": "The type of the toast. Used to conditionally style the toast,\nincluding conditionally rendering elements based on the type."
     }
-  },
-  "renderProps": {
-    "isFocused": {
-      "selector": "[data-focused]",
-      "description": "Whether the toast is currently focused."
-    },
-    "isFocusVisible": {
-      "selector": "[data-focus-visible]",
-      "description": "Whether the toast is keyboard focused."
-    }
   }
 }

--- a/www/src/modules/docs/references/generated/toggle-button-group.json
+++ b/www/src/modules/docs/references/generated/toggle-button-group.json
@@ -384,13 +384,15 @@
     }
   },
   "renderProps": {
-    "isDisabled": {
-      "selector": "[data-disabled]",
-      "description": "Whether the toggle button group is disabled."
-    },
     "orientation": {
       "selector": "[data-orientation=\"horizontal | vertical\"]",
+      "tailwind": "orientation-horizontal: | orientation-vertical:",
       "description": "The orientation of the toggle button group."
+    },
+    "isDisabled": {
+      "selector": "[data-disabled]",
+      "tailwind": "disabled:",
+      "description": "Whether the toggle button group is disabled."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/toggle-button.json
+++ b/www/src/modules/docs/references/generated/toggle-button.json
@@ -836,29 +836,35 @@
     }
   },
   "renderProps": {
+    "isSelected": {
+      "selector": "[data-selected]",
+      "tailwind": "selected:",
+      "description": "Whether the button is currently selected."
+    },
     "isDisabled": {
       "selector": "[data-disabled]",
+      "tailwind": "disabled:",
       "description": "Whether the button is disabled."
     },
     "isFocused": {
       "selector": "[data-focused]",
+      "tailwind": "focus:",
       "description": "Whether the button is focused, either via a mouse or keyboard."
     },
     "isFocusVisible": {
       "selector": "[data-focus-visible]",
+      "tailwind": "focus-visible:",
       "description": "Whether the button is keyboard focused."
     },
     "isHovered": {
       "selector": "[data-hovered]",
+      "tailwind": "hover:",
       "description": "Whether the button is currently hovered with a mouse."
     },
     "isPressed": {
       "selector": "[data-pressed]",
+      "tailwind": "pressed:",
       "description": "Whether the button is currently in a pressed state."
-    },
-    "isSelected": {
-      "selector": "[data-selected]",
-      "description": "Whether the button is currently selected."
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/tooltip-content.json
+++ b/www/src/modules/docs/references/generated/tooltip-content.json
@@ -333,6 +333,23 @@
       "description": "The ref for the element which the tooltip positions itself with respect to.\n\nWhen used within a TooltipTrigger this is set automatically. It is only required when used\nstandalone."
     }
   },
+  "renderProps": {
+    "placement": {
+      "selector": "[data-placement=\"left | right | top | bottom\"]",
+      "tailwind": "placement-left: | placement-right: | placement-top: | placement-bottom:",
+      "description": "The placement of the tooltip relative to the trigger."
+    },
+    "isEntering": {
+      "selector": "[data-entering]",
+      "tailwind": "entering:",
+      "description": "Whether the tooltip is currently entering. Use this to apply animations."
+    },
+    "isExiting": {
+      "selector": "[data-exiting]",
+      "tailwind": "exiting:",
+      "description": "Whether the tooltip is currently exiting. Use this to apply animations."
+    }
+  },
   "typeLinks": {
     "TooltipRenderProps": {
       "type": "interface",

--- a/www/src/modules/docs/references/generated/tooltip.json
+++ b/www/src/modules/docs/references/generated/tooltip.json
@@ -97,19 +97,5 @@
       },
       "description": "Handler that is called when the overlay's open state changes."
     }
-  },
-  "renderProps": {
-    "isEntering": {
-      "selector": "[data-entering]",
-      "description": "Whether the tooltip is currently entering. Use this to apply animations."
-    },
-    "isExiting": {
-      "selector": "[data-exiting]",
-      "description": "Whether the tooltip is currently exiting. Use this to apply animations."
-    },
-    "placement": {
-      "selector": "[data-placement=\"left | right | top | bottom\"]",
-      "description": "The placement of the tooltip relative to the trigger."
-    }
   }
 }

--- a/www/src/modules/docs/references/transform.ts
+++ b/www/src/modules/docs/references/transform.ts
@@ -9,6 +9,7 @@ import { DEFAULT_EXPANDED, groupProps } from './groups'
 import type {
   ComponentApiReference,
   PropDefinition,
+  RenderPropsKind,
   TypeLinksRegistry,
 } from './types'
 import type { TType } from './types/type-ast'
@@ -38,6 +39,16 @@ export interface TransformedPropsData {
 }
 
 /**
+ * Transformed render prop (state) ready for rendering
+ */
+export interface TransformedRenderProp {
+  name: string
+  selector?: string
+  tailwind?: string
+  description?: string
+}
+
+/**
  * Fully transformed reference data ready for rendering
  */
 export interface TransformedReference {
@@ -45,6 +56,8 @@ export interface TransformedReference {
   description?: string
   extendsElement?: string
   data: TransformedPropsData
+  renderProps?: TransformedRenderProp[]
+  renderPropsKind?: RenderPropsKind
   typeLinks?: TypeLinksRegistry
   defaultExpandedGroups: string[]
 }
@@ -192,6 +205,13 @@ export function transformReference(
     description: data.description,
     extendsElement: data.extendsElement,
     data: transformedData,
+    renderProps: data.renderProps
+      ? Object.entries(data.renderProps).map(([name, renderProp]) => ({
+          name,
+          ...renderProp,
+        }))
+      : undefined,
+    renderPropsKind: data.renderPropsKind,
     typeLinks: data.typeLinks,
     defaultExpandedGroups: Array.from(DEFAULT_EXPANDED),
   }

--- a/www/src/modules/docs/references/types.ts
+++ b/www/src/modules/docs/references/types.ts
@@ -23,14 +23,23 @@ export interface PropDefinition {
 }
 
 /**
- * A render prop definition with CSS selector
+ * A render prop / data attribute definition with CSS selector
  */
 export interface RenderPropDefinition {
-  /** CSS selector for styling this state (e.g., "[data-hovered]") */
-  selector: string
+  /** CSS selector for styling this state (e.g., "[data-hovered]"); absent for render props without a DOM marker */
+  selector?: string
+  /** Tailwind variant(s) targeting the selector (e.g., "pressed:") */
+  tailwind?: string
   /** Description of the render prop */
   description?: string
 }
+
+/**
+ * What the styling-state table documents: React Aria render props or Base UI
+ * data attributes. Drives the table's first-column header. Defaults to
+ * "render-prop" when absent.
+ */
+export type RenderPropsKind = 'render-prop' | 'data-attribute'
 
 /**
  * The full API reference for a component
@@ -44,8 +53,10 @@ export interface ComponentApiReference {
   extendsElement?: string
   /** Map of prop name to prop definition */
   props: Record<string, PropDefinition>
-  /** Map of render prop name to render prop definition (CSS selectors) */
+  /** Map of render prop / data attribute name to its definition (CSS selectors) */
   renderProps?: Record<string, RenderPropDefinition>
+  /** Whether `renderProps` documents render props or data attributes (default: render props) */
+  renderPropsKind?: RenderPropsKind
   /** Type links registry for navigating to type definitions */
   typeLinks?: TypeLinksRegistry
 }


### PR DESCRIPTION
## Summary

Every `<Reference>` in the component docs now renders a styling-states table — name / CSS selector / Tailwind selector, with descriptions in an expandable panel. Two libraries are sourced natively:

- **React Aria Components** — render props from the `@selector` JSDoc tags RAC publishes in its type definitions (the data its own `StateTable` uses). Column header: **Render prop**. Selectors map to the variants registered by the installed `tailwindcss-react-aria-components` plugin, harvested at build time so the column stays in sync with the patched plugin (no vendored table).
- **Base UI** (drawer, otp-field) — its state object carries no selectors, so the table is built from the sibling `*DataAttributes` enum (`DrawerPopupState` → `DrawerPopupDataAttributes`), mapping each member to a `data-*` attribute with its JSDoc description. Column header: **Data attribute**. Tailwind variants use the native `data-*:` form (Tailwind v4 turns `data-open:` into `[data-open]`).

**Generator resolution.** Render props resolve from the `className` prop's function parameter (with a `RENDER_PROPS_SOURCES` override map) instead of the old `XxxProps` → `XxxRenderProps` name convention — fixing RAC misses (`Combobox`, table parts, `*-content` parts, `text-area`, `accordion`) and mis-attachments (`Tooltip`/`Menu` roots, `Toast`). When that parameter is a Base UI `*State` type, the generator reads the adjacent `*DataAttributes` enum file instead (parsed standalone, since those enum files aren't imported anywhere). Parts whose `className` is a plain string (e.g. `SidebarMenuButton`) correctly get no table, while sibling parts that inherit a render-prop `className` (e.g. `SidebarMenuAction`) do.

**Output.** 92 of 205 references carry a table — 88 RAC render-prop, 4 Base UI data-attribute (`drawer`, `drawer-swipe-area`, `otp-field`, `otp-field-separator`). The regenerated diff is states-only: every field outside `renderProps`/`renderPropsKind` is byte-identical across all changed files, so the generator stayed deterministic.

## Reviewer notes

- Selector-less render props (the `state` object, `percentage`, value getters…) are omitted — a CSS-selector table shouldn't carry rows that are dashes in both columns. Components with nothing stylable get no table at all.
- Sub-part tables (e.g. `checkbox-control`, `sidebar-menu-action`) are intentional: the registry mirrors RAC state data attributes onto sub-elements, and `className`-param resolution attaches them precisely.
- `pnpm check`, `pnpm typecheck`, and the references-drift check all pass; the generator is deterministic (re-running `build:references` produces no diff). The full data → `transformReference` → table path was exercised on the regenerated JSON: RAC pages keep the **Render prop** header and gain the Tailwind column; Base UI pages show **Data attribute** with `[data-*]` selectors and `data-*:` variants.
- Rebased onto current `main`: references live at `www/src/modules/docs/references/` after #257's restructure, the pagination component (#245) gains its render-prop table (`pagination-link`/`-next`/`-previous`), and the sidebar component (#252) is covered at the live path.

Research notes in `docs/research/2026-06-12-render-prop-state-tables.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
