### PR TITLE
fix: clean Base UI component API references

### DIFF
--- a/www/src/modules/references/generated/drawer-indent-background.json
+++ b/www/src/modules/references/generated/drawer-indent-background.json
@@ -3,14 +3,11 @@
   "description": "The dark layer behind the indented content.",
   "props": {
     "className": {
-      "type": "string | ((state: DrawerIndentBackgroundState) => string | undefined)",
-      "detailedType": "| string\n| ((\n    state: DrawerIndentBackgroundState,\n  ) => string | undefined)\n| undefined",
+      "type": "string | (values: DrawerIndentBackgroundState) => string",
+      "detailedType": "string | (values: DrawerIndentBackgroundState) => string | undefined",
       "typeAst": {
         "type": "union",
         "elements": [
-          {
-            "type": "undefined"
-          },
           {
             "type": "string"
           },
@@ -19,10 +16,10 @@
             "parameters": [
               {
                 "type": "parameter",
-                "name": "state",
+                "name": "values",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/indent-background/DrawerIndentBackground.d.ts:DrawerIndentBackgroundState",
+                  "id": "DrawerIndentBackgroundState",
                   "name": "DrawerIndentBackgroundState"
                 },
                 "optional": false,
@@ -30,66 +27,20 @@
               }
             ],
             "return": {
-              "type": "union",
-              "elements": [
-                {
-                  "type": "undefined"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "type": "string"
             },
             "typeParameters": []
           }
         ]
       },
-      "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
-    },
-    "render": {
-      "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, DrawerIndentBackgroundState>",
-      "detailedType": "| ReactElement<\n    unknown,\n    string | JSXElementConstructor<any>\n  >\n| ComponentRenderFn<\n    HTMLProps,\n    DrawerIndentBackgroundState\n  >\n| undefined",
-      "typeAst": {
-        "type": "union",
-        "elements": [
-          {
-            "type": "undefined"
-          },
-          {
-            "type": "identifier",
-            "name": "ReactElement"
-          },
-          {
-            "type": "application",
-            "base": {
-              "type": "identifier",
-              "name": "ComponentRenderFn"
-            },
-            "typeParameters": [
-              {
-                "type": "identifier",
-                "name": "HTMLProps"
-              },
-              {
-                "type": "link",
-                "id": "@base-ui/react/esm/drawer/indent-background/DrawerIndentBackground.d.ts:DrawerIndentBackgroundState",
-                "name": "DrawerIndentBackgroundState"
-              }
-            ]
-          }
-        ]
-      },
-      "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state."
     },
     "style": {
-      "type": "CSSProperties | ((state: DrawerIndentBackgroundState) => CSSProperties | undefined)",
-      "detailedType": "| CSSProperties\n| ((\n    state: DrawerIndentBackgroundState,\n  ) => CSSProperties | undefined)\n| undefined",
+      "type": "CSSProperties | (values: DrawerIndentBackgroundState) => CSSProperties",
+      "detailedType": "CSSProperties | (values: DrawerIndentBackgroundState) => CSSProperties | undefined",
       "typeAst": {
         "type": "union",
         "elements": [
-          {
-            "type": "undefined"
-          },
           {
             "type": "identifier",
             "name": "CSSProperties"
@@ -99,10 +50,10 @@
             "parameters": [
               {
                 "type": "parameter",
-                "name": "state",
+                "name": "values",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/indent-background/DrawerIndentBackground.d.ts:DrawerIndentBackgroundState",
+                  "id": "DrawerIndentBackgroundState",
                   "name": "DrawerIndentBackgroundState"
                 },
                 "optional": false,
@@ -110,30 +61,20 @@
               }
             ],
             "return": {
-              "type": "union",
-              "elements": [
-                {
-                  "type": "undefined"
-                },
-                {
-                  "type": "identifier",
-                  "name": "CSSProperties"
-                }
-              ]
+              "type": "identifier",
+              "name": "CSSProperties"
             },
             "typeParameters": []
           }
         ]
       },
-      "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+      "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the element. A function may be provided to compute the style based on component state."
     }
   },
   "typeLinks": {
-    "@base-ui/react/esm/drawer/indent-background/DrawerIndentBackground.d.ts:DrawerIndentBackgroundState": {
+    "DrawerIndentBackgroundState": {
       "type": "interface",
-      "id": "@base-ui/react/esm/drawer/indent-background/DrawerIndentBackground.d.ts:DrawerIndentBackgroundState",
       "name": "DrawerIndentBackgroundState",
-      "extends": [],
       "properties": {
         "active": {
           "type": "property",
@@ -145,9 +86,7 @@
           "readonly": false,
           "description": "Whether any drawer within the nearest <Drawer.Provider> is open."
         }
-      },
-      "typeParameters": [],
-      "description": ""
+      }
     }
   }
 }

--- a/www/src/modules/references/generated/drawer-indent.json
+++ b/www/src/modules/references/generated/drawer-indent.json
@@ -3,14 +3,11 @@
   "description": "Wraps page content; scales/translates while a drawer is open.",
   "props": {
     "className": {
-      "type": "string | ((state: DrawerIndentState) => string | undefined)",
-      "detailedType": "| string\n| ((state: DrawerIndentState) => string | undefined)\n| undefined",
+      "type": "string | (values: DrawerIndentState) => string",
+      "detailedType": "string | (values: DrawerIndentState) => string | undefined",
       "typeAst": {
         "type": "union",
         "elements": [
-          {
-            "type": "undefined"
-          },
           {
             "type": "string"
           },
@@ -19,10 +16,10 @@
             "parameters": [
               {
                 "type": "parameter",
-                "name": "state",
+                "name": "values",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/indent/DrawerIndent.d.ts:DrawerIndentState",
+                  "id": "DrawerIndentState",
                   "name": "DrawerIndentState"
                 },
                 "optional": false,
@@ -30,66 +27,20 @@
               }
             ],
             "return": {
-              "type": "union",
-              "elements": [
-                {
-                  "type": "undefined"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "type": "string"
             },
             "typeParameters": []
           }
         ]
       },
-      "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
-    },
-    "render": {
-      "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, DrawerIndentState>",
-      "detailedType": "| ReactElement<\n    unknown,\n    string | JSXElementConstructor<any>\n  >\n| ComponentRenderFn<HTMLProps, DrawerIndentState>\n| undefined",
-      "typeAst": {
-        "type": "union",
-        "elements": [
-          {
-            "type": "undefined"
-          },
-          {
-            "type": "identifier",
-            "name": "ReactElement"
-          },
-          {
-            "type": "application",
-            "base": {
-              "type": "identifier",
-              "name": "ComponentRenderFn"
-            },
-            "typeParameters": [
-              {
-                "type": "identifier",
-                "name": "HTMLProps"
-              },
-              {
-                "type": "link",
-                "id": "@base-ui/react/esm/drawer/indent/DrawerIndent.d.ts:DrawerIndentState",
-                "name": "DrawerIndentState"
-              }
-            ]
-          }
-        ]
-      },
-      "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state."
     },
     "style": {
-      "type": "CSSProperties | ((state: DrawerIndentState) => CSSProperties | undefined)",
-      "detailedType": "| CSSProperties\n| ((\n    state: DrawerIndentState,\n  ) => CSSProperties | undefined)\n| undefined",
+      "type": "CSSProperties | (values: DrawerIndentState) => CSSProperties",
+      "detailedType": "CSSProperties | (values: DrawerIndentState) => CSSProperties | undefined",
       "typeAst": {
         "type": "union",
         "elements": [
-          {
-            "type": "undefined"
-          },
           {
             "type": "identifier",
             "name": "CSSProperties"
@@ -99,10 +50,10 @@
             "parameters": [
               {
                 "type": "parameter",
-                "name": "state",
+                "name": "values",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/indent/DrawerIndent.d.ts:DrawerIndentState",
+                  "id": "DrawerIndentState",
                   "name": "DrawerIndentState"
                 },
                 "optional": false,
@@ -110,30 +61,20 @@
               }
             ],
             "return": {
-              "type": "union",
-              "elements": [
-                {
-                  "type": "undefined"
-                },
-                {
-                  "type": "identifier",
-                  "name": "CSSProperties"
-                }
-              ]
+              "type": "identifier",
+              "name": "CSSProperties"
             },
             "typeParameters": []
           }
         ]
       },
-      "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+      "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the element. A function may be provided to compute the style based on component state."
     }
   },
   "typeLinks": {
-    "@base-ui/react/esm/drawer/indent/DrawerIndent.d.ts:DrawerIndentState": {
+    "DrawerIndentState": {
       "type": "interface",
-      "id": "@base-ui/react/esm/drawer/indent/DrawerIndent.d.ts:DrawerIndentState",
       "name": "DrawerIndentState",
-      "extends": [],
       "properties": {
         "active": {
           "type": "property",
@@ -145,9 +86,7 @@
           "readonly": false,
           "description": "Whether any drawer within the nearest <Drawer.Provider> is open."
         }
-      },
-      "typeParameters": [],
-      "description": ""
+      }
     }
   }
 }

--- a/www/src/modules/references/generated/drawer-provider.json
+++ b/www/src/modules/references/generated/drawer-provider.json
@@ -1,5 +1,14 @@
 {
   "name": "DrawerProviderProps",
   "description": "Optional explicit visual-state scope. Most apps don't need this.",
-  "props": {}
+  "props": {
+    "children": {
+      "type": "ReactNode",
+      "typeAst": {
+        "type": "identifier",
+        "name": "ReactNode"
+      },
+      "description": "The content scoped to this drawer provider."
+    }
+  }
 }

--- a/www/src/modules/references/generated/drawer-swipe-area.json
+++ b/www/src/modules/references/generated/drawer-swipe-area.json
@@ -3,14 +3,11 @@
   "description": "An edge region that can open the drawer by swiping.",
   "props": {
     "className": {
-      "type": "string | ((state: DrawerSwipeAreaState) => string | undefined)",
-      "detailedType": "| string\n| ((state: DrawerSwipeAreaState) => string | undefined)\n| undefined",
+      "type": "string | (values: DrawerSwipeAreaState) => string",
+      "detailedType": "string | (values: DrawerSwipeAreaState) => string | undefined",
       "typeAst": {
         "type": "union",
         "elements": [
-          {
-            "type": "undefined"
-          },
           {
             "type": "string"
           },
@@ -19,10 +16,10 @@
             "parameters": [
               {
                 "type": "parameter",
-                "name": "state",
+                "name": "values",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState",
+                  "id": "DrawerSwipeAreaState",
                   "name": "DrawerSwipeAreaState"
                 },
                 "optional": false,
@@ -30,75 +27,20 @@
               }
             ],
             "return": {
-              "type": "union",
-              "elements": [
-                {
-                  "type": "undefined"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "type": "string"
             },
             "typeParameters": []
           }
         ]
       },
-      "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
-    },
-    "disabled": {
-      "type": "boolean",
-      "detailedType": "boolean | undefined",
-      "typeAst": {
-        "type": "boolean"
-      },
-      "description": "Whether the swipe area is disabled.",
-      "default": "false"
-    },
-    "render": {
-      "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, DrawerSwipeAreaState>",
-      "detailedType": "| ReactElement<\n    unknown,\n    string | JSXElementConstructor<any>\n  >\n| ComponentRenderFn<HTMLProps, DrawerSwipeAreaState>\n| undefined",
-      "typeAst": {
-        "type": "union",
-        "elements": [
-          {
-            "type": "undefined"
-          },
-          {
-            "type": "identifier",
-            "name": "ReactElement"
-          },
-          {
-            "type": "application",
-            "base": {
-              "type": "identifier",
-              "name": "ComponentRenderFn"
-            },
-            "typeParameters": [
-              {
-                "type": "identifier",
-                "name": "HTMLProps"
-              },
-              {
-                "type": "link",
-                "id": "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState",
-                "name": "DrawerSwipeAreaState"
-              }
-            ]
-          }
-        ]
-      },
-      "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state."
     },
     "style": {
-      "type": "CSSProperties | ((state: DrawerSwipeAreaState) => CSSProperties | undefined)",
-      "detailedType": "| CSSProperties\n| ((\n    state: DrawerSwipeAreaState,\n  ) => CSSProperties | undefined)\n| undefined",
+      "type": "CSSProperties | (values: DrawerSwipeAreaState) => CSSProperties",
+      "detailedType": "CSSProperties | (values: DrawerSwipeAreaState) => CSSProperties | undefined",
       "typeAst": {
         "type": "union",
         "elements": [
-          {
-            "type": "undefined"
-          },
           {
             "type": "identifier",
             "name": "CSSProperties"
@@ -108,10 +50,10 @@
             "parameters": [
               {
                 "type": "parameter",
-                "name": "state",
+                "name": "values",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState",
+                  "id": "DrawerSwipeAreaState",
                   "name": "DrawerSwipeAreaState"
                 },
                 "optional": false,
@@ -119,22 +61,23 @@
               }
             ],
             "return": {
-              "type": "union",
-              "elements": [
-                {
-                  "type": "undefined"
-                },
-                {
-                  "type": "identifier",
-                  "name": "CSSProperties"
-                }
-              ]
+              "type": "identifier",
+              "name": "CSSProperties"
             },
             "typeParameters": []
           }
         ]
       },
-      "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
+      "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the element. A function may be provided to compute the style based on component state."
+    },
+    "disabled": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the swipe area is disabled.",
+      "default": "false"
     },
     "swipeDirection": {
       "type": "SwipeDirection",
@@ -147,11 +90,9 @@
     }
   },
   "typeLinks": {
-    "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState": {
+    "DrawerSwipeAreaState": {
       "type": "interface",
-      "id": "@base-ui/react/esm/drawer/swipe-area/DrawerSwipeArea.d.ts:DrawerSwipeAreaState",
       "name": "DrawerSwipeAreaState",
-      "extends": [],
       "properties": {
         "disabled": {
           "type": "property",
@@ -194,9 +135,7 @@
           "readonly": false,
           "description": "Whether the swipe area is currently being swiped."
         }
-      },
-      "typeParameters": [],
-      "description": ""
+      }
     }
   }
 }

--- a/www/src/modules/references/generated/drawer.json
+++ b/www/src/modules/references/generated/drawer.json
@@ -81,13 +81,6 @@
       "description": "Whether pressing Escape is suppressed.",
       "default": "false"
     },
-    "className": {
-      "type": "string",
-      "typeAst": {
-        "type": "string"
-      },
-      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
-    },
     "children": {
       "type": "ReactNode",
       "typeAst": {
@@ -95,6 +88,164 @@
         "name": "ReactNode"
       },
       "description": "The content of the drawer."
+    },
+    "className": {
+      "type": "string | (values: DrawerPopupState) => string",
+      "detailedType": "string | (values: DrawerPopupState) => string | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "DrawerPopupState",
+                  "name": "DrawerPopupState"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "string"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state."
+    },
+    "style": {
+      "type": "CSSProperties | (values: DrawerPopupState) => CSSProperties",
+      "detailedType": "CSSProperties | (values: DrawerPopupState) => CSSProperties | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "identifier",
+            "name": "CSSProperties"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "DrawerPopupState",
+                  "name": "DrawerPopupState"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "identifier",
+              "name": "CSSProperties"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the element. A function may be provided to compute the style based on component state."
+    }
+  },
+  "typeLinks": {
+    "DrawerPopupState": {
+      "type": "interface",
+      "name": "DrawerPopupState",
+      "properties": {
+        "expanded": {
+          "type": "property",
+          "name": "expanded",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the active snap point is the full-height expanded state."
+        },
+        "nested": {
+          "type": "property",
+          "name": "nested",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the drawer is nested within a parent drawer."
+        },
+        "nestedDrawerOpen": {
+          "type": "property",
+          "name": "nestedDrawerOpen",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the drawer has nested drawers open."
+        },
+        "nestedDrawerSwiping": {
+          "type": "property",
+          "name": "nestedDrawerSwiping",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether a nested drawer is currently being swiped."
+        },
+        "open": {
+          "type": "property",
+          "name": "open",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the drawer is currently open."
+        },
+        "swipeDirection": {
+          "type": "property",
+          "name": "swipeDirection",
+          "value": {
+            "type": "identifier",
+            "name": "SwipeDirection"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The swipe direction used to dismiss the drawer."
+        },
+        "swiping": {
+          "type": "property",
+          "name": "swiping",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the drawer is being swiped."
+        },
+        "transitionStatus": {
+          "type": "property",
+          "name": "transitionStatus",
+          "value": {
+            "type": "identifier",
+            "name": "TransitionStatus"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The transition status of the component."
+        }
+      }
     }
   }
 }

--- a/www/src/modules/references/generated/otp-field-separator.json
+++ b/www/src/modules/references/generated/otp-field-separator.json
@@ -3,14 +3,11 @@
   "description": "A separator visually divides groups of inputs within the OTP field.",
   "props": {
     "className": {
-      "type": "string | ((state: SeparatorState) => string | undefined)",
-      "detailedType": "| string\n| ((state: SeparatorState) => string | undefined)\n| undefined",
+      "type": "string | (values: SeparatorState) => string",
+      "detailedType": "string | (values: SeparatorState) => string | undefined",
       "typeAst": {
         "type": "union",
         "elements": [
-          {
-            "type": "undefined"
-          },
           {
             "type": "string"
           },
@@ -19,10 +16,10 @@
             "parameters": [
               {
                 "type": "parameter",
-                "name": "state",
+                "name": "values",
                 "value": {
                   "type": "link",
-                  "id": "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState",
+                  "id": "SeparatorState",
                   "name": "SeparatorState"
                 },
                 "optional": false,
@@ -30,21 +27,48 @@
               }
             ],
             "return": {
-              "type": "union",
-              "elements": [
-                {
-                  "type": "undefined"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "type": "string"
             },
             "typeParameters": []
           }
         ]
       },
-      "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state."
+    },
+    "style": {
+      "type": "CSSProperties | (values: SeparatorState) => CSSProperties",
+      "detailedType": "CSSProperties | (values: SeparatorState) => CSSProperties | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "identifier",
+            "name": "CSSProperties"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "SeparatorState",
+                  "name": "SeparatorState"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "identifier",
+              "name": "CSSProperties"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the element. A function may be provided to compute the style based on component state."
     },
     "orientation": {
       "type": "Orientation",
@@ -55,95 +79,12 @@
       },
       "description": "The orientation of the separator.",
       "default": "'horizontal'"
-    },
-    "render": {
-      "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, SeparatorState>",
-      "detailedType": "| ReactElement<\n    unknown,\n    string | JSXElementConstructor<any>\n  >\n| ComponentRenderFn<HTMLProps, SeparatorState>\n| undefined",
-      "typeAst": {
-        "type": "union",
-        "elements": [
-          {
-            "type": "undefined"
-          },
-          {
-            "type": "identifier",
-            "name": "ReactElement"
-          },
-          {
-            "type": "application",
-            "base": {
-              "type": "identifier",
-              "name": "ComponentRenderFn"
-            },
-            "typeParameters": [
-              {
-                "type": "identifier",
-                "name": "HTMLProps"
-              },
-              {
-                "type": "link",
-                "id": "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState",
-                "name": "SeparatorState"
-              }
-            ]
-          }
-        ]
-      },
-      "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
-    },
-    "style": {
-      "type": "CSSProperties | ((state: SeparatorState) => CSSProperties | undefined)",
-      "detailedType": "| CSSProperties\n| ((state: SeparatorState) => CSSProperties | undefined)\n| undefined",
-      "typeAst": {
-        "type": "union",
-        "elements": [
-          {
-            "type": "undefined"
-          },
-          {
-            "type": "identifier",
-            "name": "CSSProperties"
-          },
-          {
-            "type": "function",
-            "parameters": [
-              {
-                "type": "parameter",
-                "name": "state",
-                "value": {
-                  "type": "link",
-                  "id": "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState",
-                  "name": "SeparatorState"
-                },
-                "optional": false,
-                "rest": false
-              }
-            ],
-            "return": {
-              "type": "union",
-              "elements": [
-                {
-                  "type": "undefined"
-                },
-                {
-                  "type": "identifier",
-                  "name": "CSSProperties"
-                }
-              ]
-            },
-            "typeParameters": []
-          }
-        ]
-      },
-      "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
     }
   },
   "typeLinks": {
-    "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState": {
+    "SeparatorState": {
       "type": "interface",
-      "id": "@base-ui/react/esm/separator/Separator.d.ts:SeparatorState",
       "name": "SeparatorState",
-      "extends": [],
       "properties": {
         "orientation": {
           "type": "property",
@@ -156,9 +97,7 @@
           "readonly": false,
           "description": "The orientation of the separator."
         }
-      },
-      "typeParameters": [],
-      "description": ""
+      }
     }
   }
 }

--- a/www/src/modules/references/generated/otp-field.json
+++ b/www/src/modules/references/generated/otp-field.json
@@ -59,6 +59,74 @@
       },
       "description": "Handler that is called when the OTP value changes."
     },
+    "className": {
+      "type": "string | (values: OTPFieldRootState) => string",
+      "detailedType": "string | (values: OTPFieldRootState) => string | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "OTPFieldRootState",
+                  "name": "OTPFieldRootState"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "string"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state."
+    },
+    "style": {
+      "type": "CSSProperties | (values: OTPFieldRootState) => CSSProperties",
+      "detailedType": "CSSProperties | (values: OTPFieldRootState) => CSSProperties | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "identifier",
+            "name": "CSSProperties"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "OTPFieldRootState",
+                  "name": "OTPFieldRootState"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "identifier",
+              "name": "CSSProperties"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the element. A function may be provided to compute the style based on component state."
+    },
     "autoComplete": {
       "type": "string",
       "detailedType": "string | undefined",
@@ -76,50 +144,6 @@
       },
       "description": "Whether to submit the owning form when the OTP becomes complete.",
       "default": "false"
-    },
-    "className": {
-      "type": "string | ((state: OTPFieldRootState) => string | undefined)",
-      "detailedType": "| string\n| ((state: OTPFieldRootState) => string | undefined)\n| undefined",
-      "typeAst": {
-        "type": "union",
-        "elements": [
-          {
-            "type": "undefined"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "function",
-            "parameters": [
-              {
-                "type": "parameter",
-                "name": "state",
-                "value": {
-                  "type": "link",
-                  "id": "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState",
-                  "name": "OTPFieldRootState"
-                },
-                "optional": false,
-                "rest": false
-              }
-            ],
-            "return": {
-              "type": "union",
-              "elements": [
-                {
-                  "type": "undefined"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "typeParameters": []
-          }
-        ]
-      },
-      "description": "CSS class applied to the element, or a function that\nreturns a class based on the component's state."
     },
     "defaultValue": {
       "type": "string",
@@ -294,41 +318,6 @@
       },
       "description": "Callback fired when entered text contains characters that are rejected by sanitization,\nbefore the OTP value updates.\n\nThe `value` argument is the attempted user-entered string before sanitization."
     },
-    "render": {
-      "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ComponentRenderFn<HTMLProps, OTPFieldRootState>",
-      "detailedType": "| ReactElement<\n    unknown,\n    string | JSXElementConstructor<any>\n  >\n| ComponentRenderFn<HTMLProps, OTPFieldRootState>\n| undefined",
-      "typeAst": {
-        "type": "union",
-        "elements": [
-          {
-            "type": "undefined"
-          },
-          {
-            "type": "identifier",
-            "name": "ReactElement"
-          },
-          {
-            "type": "application",
-            "base": {
-              "type": "identifier",
-              "name": "ComponentRenderFn"
-            },
-            "typeParameters": [
-              {
-                "type": "identifier",
-                "name": "HTMLProps"
-              },
-              {
-                "type": "link",
-                "id": "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState",
-                "name": "OTPFieldRootState"
-              }
-            ]
-          }
-        ]
-      },
-      "description": "Allows you to replace the component's HTML element\nwith a different tag, or compose it with another component.\n\nAccepts a `ReactElement` or a function that returns the element to render."
-    },
     "sanitizeValue": {
       "type": "((value: string) => string)",
       "detailedType": "((value: string) => string) | undefined",
@@ -354,52 +343,6 @@
       },
       "description": "Function for custom sanitization when `validationType` is set to `'none'`.\nThis function runs before updating the OTP value from user interactions."
     },
-    "style": {
-      "type": "CSSProperties | ((state: OTPFieldRootState) => CSSProperties | undefined)",
-      "detailedType": "| CSSProperties\n| ((\n    state: OTPFieldRootState,\n  ) => CSSProperties | undefined)\n| undefined",
-      "typeAst": {
-        "type": "union",
-        "elements": [
-          {
-            "type": "undefined"
-          },
-          {
-            "type": "identifier",
-            "name": "CSSProperties"
-          },
-          {
-            "type": "function",
-            "parameters": [
-              {
-                "type": "parameter",
-                "name": "state",
-                "value": {
-                  "type": "link",
-                  "id": "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState",
-                  "name": "OTPFieldRootState"
-                },
-                "optional": false,
-                "rest": false
-              }
-            ],
-            "return": {
-              "type": "union",
-              "elements": [
-                {
-                  "type": "undefined"
-                },
-                {
-                  "type": "identifier",
-                  "name": "CSSProperties"
-                }
-              ]
-            },
-            "typeParameters": []
-          }
-        ]
-      },
-      "description": "Style applied to the element, or a function that\nreturns a style object based on the component's state."
-    },
     "validationType": {
       "type": "OTPValidationType",
       "detailedType": "OTPValidationType | undefined",
@@ -420,17 +363,9 @@
     }
   },
   "typeLinks": {
-    "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState": {
+    "OTPFieldRootState": {
       "type": "interface",
-      "id": "@base-ui/react/esm/otp-field/root/OTPFieldRoot.d.ts:OTPFieldRootState",
       "name": "OTPFieldRootState",
-      "extends": [
-        {
-          "type": "link",
-          "id": "@base-ui/react/esm/field/root/FieldRoot.d.ts:FieldRootState",
-          "name": "FieldRootState"
-        }
-      ],
       "properties": {
         "complete": {
           "type": "property",
@@ -526,15 +461,8 @@
           "type": "property",
           "name": "valid",
           "value": {
-            "type": "union",
-            "elements": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "boolean"
-              }
-            ]
+            "type": "identifier",
+            "name": "boolean | null"
           },
           "optional": false,
           "readonly": false,
@@ -550,9 +478,7 @@
           "readonly": false,
           "description": "The OTP value."
         }
-      },
-      "typeParameters": [],
-      "description": ""
+      }
     }
   }
 }

--- a/www/src/modules/references/generated/toast.json
+++ b/www/src/modules/references/generated/toast.json
@@ -2,14 +2,6 @@
   "name": "ToastProps",
   "description": "Options for a toast, passed to the toast manager when adding it to the queue. These include the toast's title, description, type, timeout, and custom data.",
   "props": {
-    "id": {
-      "type": "string",
-      "detailedType": "string | undefined",
-      "typeAst": {
-        "type": "string"
-      },
-      "description": "The unique identifier for the toast. Adding a toast with an existing ID\nupdates it in place and refreshes its auto-dismiss timer."
-    },
     "actionProps": {
       "type": "Omit<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, \"ref\">",
       "detailedType": "| Omit<\n    DetailedHTMLProps<\n      ButtonHTMLAttributes<HTMLButtonElement>,\n      HTMLButtonElement\n    >,\n    'ref'\n  >\n| undefined",
@@ -79,6 +71,14 @@
         "name": "ReactNode"
       },
       "description": "The description of the toast."
+    },
+    "id": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The unique identifier for the toast. Adding a toast with an existing ID\nupdates it in place and refreshes its auto-dismiss timer."
     },
     "onClose": {
       "type": "(() => void)",
@@ -166,24 +166,6 @@
         "name": "ReactNode"
       },
       "description": "The title of the toast."
-    },
-    "transitionStatus": {
-      "type": "\"ending\" | \"starting\"",
-      "detailedType": "'ending' | 'starting' | undefined",
-      "typeAst": {
-        "type": "union",
-        "elements": [
-          {
-            "type": "stringLiteral",
-            "value": "ending"
-          },
-          {
-            "type": "stringLiteral",
-            "value": "starting"
-          }
-        ]
-      },
-      "description": "The transition status of the toast."
     },
     "type": {
       "type": "string",

--- a/www/src/registry/ui/drawer/types.ts
+++ b/www/src/registry/ui/drawer/types.ts
@@ -1,13 +1,25 @@
 import type * as React from 'react'
 import type { Drawer as DrawerPrimitive } from '@base-ui/react/drawer'
+import type { StyleRenderProps } from 'react-aria-components'
 
 export type DrawerPlacement = 'top' | 'bottom' | 'left' | 'right'
+
+/**
+ * Shared `className`/`style` for Base UI parts: a string/object, or a function
+ * that receives the part's state — matching the React Aria render-prop form.
+ */
+interface BaseUIRenderStyles<State> {
+  /** The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state. */
+  className?: StyleRenderProps<State>['className']
+  /** The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the element. A function may be provided to compute the style based on component state. */
+  style?: StyleRenderProps<State>['style']
+}
 
 /**
  * A React Aria compatible drawer overlay powered by Base UI's Drawer overlay
  * primitives.
  */
-export interface DrawerProps {
+export interface DrawerProps extends BaseUIRenderStyles<DrawerPrimitive.Popup.State> {
   /**
    * The side of the screen where the drawer appears.
    * @default 'bottom'
@@ -31,8 +43,6 @@ export interface DrawerProps {
   isDismissable?: boolean
   /** Whether pressing Escape is suppressed. @default false */
   isKeyboardDismissDisabled?: boolean
-  className?: DrawerPrimitive.Popup.Props['className']
-  style?: DrawerPrimitive.Popup.Props['style']
 
   /** The content of the drawer. */
   children?: React.ReactNode
@@ -42,14 +52,28 @@ export interface DrawerProps {
 export interface DrawerHandleProps extends React.ComponentProps<'div'> {}
 
 /** An edge region that can open the drawer by swiping. */
-export interface DrawerSwipeAreaProps extends DrawerPrimitive.SwipeArea.Props {}
+export interface DrawerSwipeAreaProps
+  extends
+    Omit<DrawerPrimitive.SwipeArea.Props, 'className' | 'style' | 'render'>,
+    BaseUIRenderStyles<DrawerPrimitive.SwipeArea.State> {}
 
 /** Optional explicit visual-state scope. Most apps don't need this. */
-export interface DrawerProviderProps extends DrawerPrimitive.Provider.Props {}
+export interface DrawerProviderProps extends DrawerPrimitive.Provider.Props {
+  /** The content scoped to this drawer provider. */
+  children?: React.ReactNode
+}
 
 /** Wraps page content; scales/translates while a drawer is open. */
-export interface DrawerIndentProps extends DrawerPrimitive.Indent.Props {}
+export interface DrawerIndentProps
+  extends
+    Omit<DrawerPrimitive.Indent.Props, 'className' | 'style' | 'render'>,
+    BaseUIRenderStyles<DrawerPrimitive.Indent.State> {}
 
 /** The dark layer behind the indented content. */
 export interface DrawerIndentBackgroundProps
-  extends DrawerPrimitive.IndentBackground.Props {}
+  extends
+    Omit<
+      DrawerPrimitive.IndentBackground.Props,
+      'className' | 'style' | 'render'
+    >,
+    BaseUIRenderStyles<DrawerPrimitive.IndentBackground.State> {}

--- a/www/src/registry/ui/otp-field/types.ts
+++ b/www/src/registry/ui/otp-field/types.ts
@@ -1,13 +1,34 @@
 import type * as React from 'react'
 import type { OTPFieldPreview as OTPFieldPrimitive } from '@base-ui/react/otp-field'
+import type { StyleRenderProps } from 'react-aria-components'
+
+/**
+ * Shared `className`/`style` for Base UI parts: a string/object, or a function
+ * that receives the part's state — matching the React Aria render-prop form.
+ */
+interface BaseUIRenderStyles<State> {
+  /** The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element. A function may be provided to compute the class based on component state. */
+  className?: StyleRenderProps<State>['className']
+  /** The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the element. A function may be provided to compute the style based on component state. */
+  style?: StyleRenderProps<State>['style']
+}
 
 /**
  * An OTP field lets users enter a one-time passcode across multiple single-character inputs.
  */
-export interface OTPFieldProps extends Omit<
-  OTPFieldPrimitive.Root.Props,
-  'disabled' | 'readOnly' | 'required' | 'onValueChange'
-> {
+export interface OTPFieldProps
+  extends
+    Omit<
+      OTPFieldPrimitive.Root.Props,
+      | 'disabled'
+      | 'readOnly'
+      | 'required'
+      | 'onValueChange'
+      | 'className'
+      | 'style'
+      | 'render'
+    >,
+    BaseUIRenderStyles<OTPFieldPrimitive.Root.State> {
   /** Whether the field is disabled. */
   isDisabled?: boolean
   /** Whether the current value is invalid. */
@@ -23,6 +44,10 @@ export interface OTPFieldProps extends Omit<
 /**
  * A separator visually divides groups of inputs within the OTP field.
  */
-export interface OTPFieldSeparatorProps extends React.ComponentProps<
-  typeof OTPFieldPrimitive.Separator
-> {}
+export interface OTPFieldSeparatorProps
+  extends
+    Omit<
+      React.ComponentProps<typeof OTPFieldPrimitive.Separator>,
+      'className' | 'style' | 'render'
+    >,
+    BaseUIRenderStyles<OTPFieldPrimitive.Separator.State> {}

--- a/www/src/registry/ui/toast/types.ts
+++ b/www/src/registry/ui/toast/types.ts
@@ -33,4 +33,7 @@ export interface ToastData {
 /**
  * Options for a toast, passed to the toast manager when adding it to the queue. These include the toast's title, description, type, timeout, and custom data.
  */
-export interface ToastProps extends ToastManagerAddOptions<ToastData> {}
+export interface ToastProps extends Omit<
+  ToastManagerAddOptions<ToastData>,
+  'transitionStatus'
+> {}


### PR DESCRIPTION
## What

The API references for the three Base UI–based components — `drawer` (6 parts), `otp-field` (2 parts), and `toast` — leaked Base UI internals into their prop tables and read inconsistently with the React Aria components. This curates their docs-source `types.ts` and regenerates the references.

## Issues fixed

| Issue | Where | Fix |
| --- | --- | --- |
| `render` (Base UI's polymorphic escape hatch) leaked into the tables | otp-field, otp-field-separator, drawer-swipe-area, drawer-indent, drawer-indent-background | `Omit`'d — nothing else in dotUI documents `render` |
| `className`/`style` shown as Base UI's `(state: …State) => string \| undefined`, popovers pointing at Base UI internals | every styleable part | Re-typed via `StyleRenderProps<State>['className'\|'style']` → renders the React Aria form `string \| (values: State) => string`, popover resolves to the Base UI `State` |
| Empty table (`DrawerProvider.Props` is just `{ children }` with no JSDoc) | drawer-provider | Documented `children` |
| `transitionStatus` (internal toast state; Base UI's own `UpdateOptions` omits it) leaked | toast | `Omit`'d |
| `style` missing, `className` a generic fallback row | drawer | Both now present in the clean function form |

All legitimate props are preserved (OTP's `length`/`value`/`validationType`/…, toast's `actionProps`/`positionerProps`/…). A small non-exported `BaseUIRenderStyles<State>` helper keeps the className/style JSDoc DRY; the generator already expands React Aria's `ClassNameOrFunction`/`StyleOrFunction` aliases.

## Approach

Fixed at the `types.ts` layer — the documented-props source of truth per `CLAUDE.md` — rather than special-casing the generator. New Base UI components should follow the same pattern: `Omit` `render`/`className`/`style`, then extend `BaseUIRenderStyles<…State>`.

## Verification

- `pnpm build:references` regenerated and deterministic (re-ran, no further diff)
- `pnpm typecheck` ✅ · `pnpm check` ✅ (2 warnings are pre-existing, unrelated files)
- Diff is exactly 11 files (3 `types.ts` + 8 regenerated JSON) — no drift to other components
- Confirmed: no `render` props, no `node_modules`-path typeLink ids, every `…State` typeLink resolves to a real interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
