### PR TITLE
fix(www): per-item connector in hero headline

### DIFF
--- a/www/src/components/marketing/rotating-text.tsx
+++ b/www/src/components/marketing/rotating-text.tsx
@@ -114,22 +114,20 @@ function Segments({ item }: { item: RotatingTextItem }) {
  * `swapKey` is unchanged between renders the content stays mounted and does NOT animate
  * — that's what keeps a shared connector static while only the destination swaps.
  * `wordStyle` is applied to the content (Josefin for destinations; omitted for the
- * connector so it inherits the lead's font). `enterDelay` holds the incoming content back
- * for one swap, so the connector fades in *as* the new destination arrives rather than
- * over the still-exiting old one (no "to anywhere" ghost at the no-connector boundary).
+ * connector so it inherits the lead's font). Both slots use mode="wait", so the incoming
+ * content waits one swap for the outgoing one to clear — that keeps the connector and the
+ * destination entering together at a boundary (and means no extra enter delay is needed).
  */
 function SwapSlot({
   swapKey,
   children,
   wordStyle,
   reduce,
-  enterDelay = 0,
 }: {
   swapKey: string
   children: ReactNode
   wordStyle?: CSSProperties
   reduce: boolean
-  enterDelay?: number
 }) {
   // Measure the active content's natural width from the invisible sizer, then animate the
   // slot to it — animating the real `width` (not a transform) keeps the surrounding text
@@ -179,18 +177,9 @@ function SwapSlot({
           <motion.span
             key={swapKey}
             initial={swapVariants.initial}
-            animate={{
-              ...swapVariants.animate,
-              transition: {
-                duration: SWAP_DURATION,
-                ease: SWAP_EASE,
-                delay: enterDelay,
-              },
-            }}
-            exit={{
-              ...swapVariants.exit,
-              transition: { duration: SWAP_DURATION, ease: SWAP_EASE },
-            }}
+            animate={swapVariants.animate}
+            exit={swapVariants.exit}
+            transition={{ duration: SWAP_DURATION, ease: SWAP_EASE }}
             style={wordStyle}
             className="inline-flex items-baseline whitespace-nowrap"
           >
@@ -242,13 +231,7 @@ function RotatingWord({
       {/* Connector slot — keyed by the connector text, so the "to" shared across the tool /
 			    codebase frames keeps the same key and never re-animates between them. No wordStyle:
 			    it inherits the lead's font, matching "Ship it". Empty for the no-connector frame. */}
-      {/* enterDelay holds "to" back for one swap so, at the "anywhere" boundary, it fades in
-				    with the new destination instead of ghosting over the outgoing word. */}
-      <SwapSlot
-        swapKey={connector}
-        reduce={reduce}
-        enterDelay={reduce ? 0 : SWAP_DURATION}
-      >
+      <SwapSlot swapKey={connector} reduce={reduce}>
         <BaselineAnchor />
         {connector || null}
       </SwapSlot>

--- a/www/src/components/marketing/rotating-text.tsx
+++ b/www/src/components/marketing/rotating-text.tsx
@@ -8,6 +8,11 @@
  * animate the same way. The swap motion matches theirs — `{y, opacity, blur(4px)}`,
  * 0.25s, easeOutExpo. The slot springs to the incoming word's measured width so
  * the surrounding text never snaps.
+ *
+ * A destination and its optional connector ("to") render in two independent slots,
+ * each keyed by its own content. So a connector shared by consecutive destinations
+ * (every "to …") keeps the same key and stays put — only the destination swaps —
+ * instead of the "to" pointlessly blurring out and back in on every change.
  */
 
 import {
@@ -41,7 +46,13 @@ export interface RotatingTextItem {
   /** Plain-text reading of the word — the rotation is decorative (the slot renders
 	    aria-hidden by the caller), so keep the caller's accessible label in sync with these. */
   text: string
-  /** Visual content (text and/or a logo). */
+  /** Optional connector rendered before the destination, in the lead's font (e.g. "to ").
+	    It lives in its own slot keyed by this string, so a connector shared by consecutive
+	    items stays mounted and does not re-animate between them — only the destination swaps.
+	    End it with a non-breaking space for the word gap: the slot is sized from this text and
+	    a normal trailing space is trimmed. Omit it for items that read without one ("anywhere"). */
+  connector?: string
+  /** Visual content of the destination (text and/or a logo). */
   segments: RotatingTextSegment[]
 }
 
@@ -87,6 +98,100 @@ function Segments({ item }: { item: RotatingTextItem }) {
   )
 }
 
+/**
+ * One measured-width slot with the x.ai blur-slide swap. The slot springs its width to
+ * the active content; content crossfades via AnimatePresence keyed by `swapKey`. When
+ * `swapKey` is unchanged between renders the content stays mounted and does NOT animate
+ * — that's what keeps a shared connector static while only the destination swaps.
+ * `wordStyle` is applied to the content (Josefin for destinations; omitted for the
+ * connector so it inherits the lead's font). `enterDelay` holds the incoming content back
+ * for one swap, so the connector fades in *as* the new destination arrives rather than
+ * over the still-exiting old one (no "to anywhere" ghost at the no-connector boundary).
+ */
+function SwapSlot({
+  swapKey,
+  children,
+  wordStyle,
+  reduce,
+  enterDelay = 0,
+}: {
+  swapKey: string
+  children: ReactNode
+  wordStyle?: CSSProperties
+  reduce: boolean
+  enterDelay?: number
+}) {
+  // Measure the active content's natural width from the invisible sizer, then animate the
+  // slot to it — animating the real `width` (not a transform) keeps the surrounding text
+  // from snapping. The ResizeObserver re-measures when the natural width changes without a
+  // key change: the webfont swapping in over the fallback, or the responsive headline
+  // font-size crossing a breakpoint mid-interval.
+  const sizerRef = useRef<HTMLSpanElement | null>(null)
+  const [width, setWidth] = useState<number | undefined>(undefined)
+  useEffect(() => {
+    const el = sizerRef.current
+    if (!el) return
+    const measure = () => {
+      const next = Math.round(el.scrollWidth)
+      setWidth((prev) => (prev === next ? prev : next))
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [swapKey, wordStyle])
+
+  const swapVariants = reduce ? REDUCED_SWAP_VARIANTS : SWAP_VARIANTS
+
+  return (
+    <motion.span
+      // Cap the slot to one line so a taller logo spills out visually (overflow-visible)
+      // rather than growing the headline's line height on an icon word.
+      className="inline-grid h-[1em] items-baseline overflow-visible"
+      animate={width != null ? { width } : undefined}
+      // Snap (don't spring) the slot under prefers-reduced-motion: the width change is
+      // the one piece of layout motion the variants above don't cover.
+      transition={{ width: reduce ? { duration: 0 } : WIDTH_SPRING }}
+    >
+      {/* Sizer: invisibly holds the current content so the slot keeps a baseline + a
+			    measurable width through the swap, and never collapses between words. */}
+      <span
+        ref={sizerRef}
+        style={wordStyle}
+        className="invisible col-start-1 row-start-1 inline-flex items-baseline justify-self-start whitespace-nowrap"
+      >
+        {children}
+      </span>
+      {/* Visible content: swapped sequentially over the sizer (mode="wait"). `initial={false}`
+			    so the first word shows statically on load — only later swaps animate. */}
+      <span className="col-start-1 row-start-1 inline-flex items-baseline justify-self-start whitespace-nowrap">
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.span
+            key={swapKey}
+            initial={swapVariants.initial}
+            animate={{
+              ...swapVariants.animate,
+              transition: {
+                duration: SWAP_DURATION,
+                ease: SWAP_EASE,
+                delay: enterDelay,
+              },
+            }}
+            exit={{
+              ...swapVariants.exit,
+              transition: { duration: SWAP_DURATION, ease: SWAP_EASE },
+            }}
+            style={wordStyle}
+            className="inline-flex items-baseline whitespace-nowrap"
+          >
+            {children}
+          </motion.span>
+        </AnimatePresence>
+      </span>
+    </motion.span>
+  )
+}
+
 interface RotatingWordProps {
   items: RotatingTextItem[]
   /** Time each word stays fully on screen, ms. */
@@ -96,9 +201,9 @@ interface RotatingWordProps {
 }
 
 /**
- * The cycling trailing word — measured-width slot + whole-word blur-slide swap.
- * Purely decorative: the caller owns the accessible reading (e.g. an `aria-label`
- * on the heading with the subtree `aria-hidden`).
+ * The cycling trailing word — a connector slot + a destination slot, each a measured-width
+ * blur-slide swap. Purely decorative: the caller owns the accessible reading (e.g. an
+ * `aria-label` on the heading with the subtree `aria-hidden`).
  */
 function RotatingWord({
   items,
@@ -117,69 +222,29 @@ function RotatingWord({
     return () => window.clearInterval(id)
   }, [items.length, interval])
 
-  // Measure the incoming word's natural width from the invisible sizer, then animate
-  // the slot to it — animating the real `width` (not a transform) keeps the surrounding
-  // text from snapping. The ResizeObserver re-measures when the word's natural width
-  // changes without an index change: the webfont swapping in over the fallback, or the
-  // responsive headline font-size crossing a breakpoint mid-interval.
-  const sizerRef = useRef<HTMLSpanElement | null>(null)
-  const [width, setWidth] = useState<number | undefined>(undefined)
-  useEffect(() => {
-    const el = sizerRef.current
-    if (!el) return
-    const measure = () => {
-      const next = Math.round(el.scrollWidth)
-      setWidth((prev) => (prev === next ? prev : next))
-    }
-    measure()
-    const observer = new ResizeObserver(measure)
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [index, wordStyle])
-
   const active = items[index] ?? items[0]
   if (!active) return null
 
-  const swapVariants = reduce ? REDUCED_SWAP_VARIANTS : SWAP_VARIANTS
+  const connector = active.connector ?? ''
 
   return (
     <span className="relative inline-flex items-baseline align-baseline text-fg">
-      <motion.span
-        // Cap the slot to one line so a taller logo spills out visually (overflow-visible)
-        // rather than growing the headline's line height on an icon word.
-        className="inline-grid h-[1em] items-baseline overflow-visible"
-        animate={width != null ? { width } : undefined}
-        // Snap (don't spring) the slot under prefers-reduced-motion: the width change is
-        // the one piece of layout motion the variants above don't cover.
-        transition={{ width: reduce ? { duration: 0 } : WIDTH_SPRING }}
+      {/* Connector slot — keyed by the connector text, so the "to" shared across the tool /
+			    codebase frames keeps the same key and never re-animates between them. No wordStyle:
+			    it inherits the lead's font, matching "Ship it". Empty for the no-connector frame. */}
+      {/* enterDelay holds "to" back for one swap so, at the "anywhere" boundary, it fades in
+				    with the new destination instead of ghosting over the outgoing word. */}
+      <SwapSlot
+        swapKey={connector}
+        reduce={reduce}
+        enterDelay={reduce ? 0 : SWAP_DURATION}
       >
-        {/* Sizer: invisibly holds the current word so the slot keeps a baseline + a
-				    measurable width through the swap, and never collapses between words. */}
-        <span
-          ref={sizerRef}
-          style={wordStyle}
-          className="invisible col-start-1 row-start-1 inline-flex items-baseline justify-self-start whitespace-nowrap"
-        >
-          <Segments item={active} />
-        </span>
-        {/* Visible word: swapped sequentially over the sizer (mode="wait"). `initial={false}`
-				    so the first word shows statically on load — only later swaps animate. */}
-        <span className="col-start-1 row-start-1 inline-flex items-baseline justify-self-start whitespace-nowrap">
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.span
-              key={active.id}
-              initial={swapVariants.initial}
-              animate={swapVariants.animate}
-              exit={swapVariants.exit}
-              transition={{ duration: SWAP_DURATION, ease: SWAP_EASE }}
-              style={{ ...wordStyle }}
-              className="inline-flex items-baseline whitespace-nowrap"
-            >
-              <Segments item={active} />
-            </motion.span>
-          </AnimatePresence>
-        </span>
-      </motion.span>
+        {connector || null}
+      </SwapSlot>
+      {/* Destination slot — the cycling logo / keyword in the rotating Josefin style. */}
+      <SwapSlot swapKey={active.id} wordStyle={wordStyle} reduce={reduce}>
+        <Segments item={active} />
+      </SwapSlot>
     </span>
   )
 }

--- a/www/src/components/marketing/rotating-text.tsx
+++ b/www/src/components/marketing/rotating-text.tsx
@@ -75,14 +75,24 @@ const REDUCED_SWAP_VARIANTS = {
   exit: { opacity: 0 },
 }
 
+/**
+ * Zero-width text-baseline anchor. Gives a slot a real text baseline even when its content
+ * has none — an icon-only logo, or the connector slot on the no-connector ("anywhere")
+ * frame. Without it an empty first slot has no baseline, which drags the rotor's inline-flex
+ * baseline down and inflates the headline row (a tall phantom gap below it).
+ */
+function BaselineAnchor() {
+  return (
+    <span aria-hidden="true" className="inline-block w-0">
+      {'​'}
+    </span>
+  )
+}
+
 function Segments({ item }: { item: RotatingTextItem }) {
   return (
     <>
-      {/* Zero-width baseline anchor: gives icon-only words (a logo with no text) a real
-			    text baseline, so the slot sits at the same height as text words — no line jump. */}
-      <span aria-hidden="true" className="inline-block w-0">
-        {'​'}
-      </span>
+      <BaselineAnchor />
       {item.segments.map((seg, i) =>
         seg.icon ? (
           <span key={i} className="inline-flex items-center">
@@ -239,6 +249,7 @@ function RotatingWord({
         reduce={reduce}
         enterDelay={reduce ? 0 : SWAP_DURATION}
       >
+        <BaselineAnchor />
         {connector || null}
       </SwapSlot>
       {/* Destination slot — the cycling logo / keyword in the rotating Josefin style. */}

--- a/www/src/routes/_app/index.tsx
+++ b/www/src/routes/_app/index.tsx
@@ -31,7 +31,7 @@ const TO = 'to '
 // Swappable destinations in the hero headline — "Ship it ___". The shared "to" lives in
 // `connector`, not the lead, so it renders once in the lead's font and — because the
 // rotator keys the connector slot by this string — stays put across the v0 / bolt.new /
-// Lovable / your-codebase frames instead of re-animating; only the destination swaps.
+// Lovable / your-code frames instead of re-animating; only the destination swaps.
 // "anywhere" reads without a connector. v0 / bolt.new / Lovable are their official brand
 // wordmarks (logo-only); the rest are text. Everything inherits the headline color
 // (white); the Lovable heart keeps its brand gradient.
@@ -63,9 +63,9 @@ const EXPORT_TARGETS: RotatingTextItem[] = [
   },
   {
     id: 'codebase',
-    text: 'to your codebase',
+    text: 'to your code',
     connector: TO,
-    segments: [{ text: 'your codebase', className: 'font-bold italic' }],
+    segments: [{ text: 'your code', className: 'font-bold italic' }],
   },
 ]
 
@@ -86,7 +86,7 @@ function HomePage() {
           <div className="flex flex-col items-center gap-3 text-center md:gap-4">
             <Announcement />
             <h1
-              aria-label="Build your design system. Ship it to v0, bolt.new, Lovable, your codebase, or anywhere."
+              aria-label="Build your design system. Ship it to v0, bolt.new, Lovable, your code, or anywhere."
               className="text-3xl leading-tight tracking-tighter text-balance max-lg:font-medium md:text-4xl lg:text-5xl"
             >
               <span aria-hidden="true">

--- a/www/src/routes/_app/index.tsx
+++ b/www/src/routes/_app/index.tsx
@@ -23,16 +23,18 @@ import Cards from '@/components/marketing/showcase/cards'
 // letter-spacing and size come from the original headline classes on the <h1>.
 const HEADLINE_STYLE = { fontFamily: 'var(--font-josefin)' }
 
-// Swappable destinations in the hero headline — "Ship it ___". Each item carries its
-// own connector ("to" / "into your") as a leading segment, so "Ship it anywhere",
-// "Ship it to v0" and "Ship it into your codebase" all read naturally — no single
-// static preposition that breaks on "anywhere". The connector renders in the lead's
-// sans font (CONNECTOR_CLASS) to match the static "Build your design system. Ship it",
-// while the destination keyword inherits the rotating Josefin style (bold italic).
-// v0 / bolt.new / Lovable are their official brand wordmarks (logo-only); the rest are
-// text. Everything inherits the headline color (white); the Lovable heart keeps its
-// brand gradient.
-const CONNECTOR_CLASS = 'font-sans font-normal not-italic'
+// Shared connector for the tool / codebase frames. The trailing space is a non-breaking
+// space on purpose: the rotator sizes the connector slot from this text, and a normal
+// trailing space gets trimmed in the flex slot (so "to" would butt against the logo).
+const TO = 'to '
+
+// Swappable destinations in the hero headline — "Ship it ___". The shared "to" lives in
+// `connector`, not the lead, so it renders once in the lead's font and — because the
+// rotator keys the connector slot by this string — stays put across the v0 / bolt.new /
+// Lovable / your-codebase frames instead of re-animating; only the destination swaps.
+// "anywhere" reads without a connector. v0 / bolt.new / Lovable are their official brand
+// wordmarks (logo-only); the rest are text. Everything inherits the headline color
+// (white); the Lovable heart keeps its brand gradient.
 const EXPORT_TARGETS: RotatingTextItem[] = [
   {
     id: 'anywhere',
@@ -42,34 +44,28 @@ const EXPORT_TARGETS: RotatingTextItem[] = [
   {
     id: 'v0',
     text: 'to v0',
-    segments: [
-      { text: 'to ', className: CONNECTOR_CLASS },
-      { icon: <V0Icon className="h-[0.58em] w-auto" /> },
-    ],
+    connector: TO,
+    segments: [{ icon: <V0Icon className="h-[0.58em] w-auto" /> }],
   },
   {
     id: 'bolt',
     text: 'to bolt.new',
+    connector: TO,
     segments: [
-      { text: 'to ', className: CONNECTOR_CLASS },
       { icon: <BoltIcon className="h-[0.72em] w-auto translate-y-[0.09em]" /> },
     ],
   },
   {
     id: 'lovable',
     text: 'to Lovable',
-    segments: [
-      { text: 'to ', className: CONNECTOR_CLASS },
-      { icon: <LovableIcon className="h-[0.72em] w-auto" /> },
-    ],
+    connector: TO,
+    segments: [{ icon: <LovableIcon className="h-[0.72em] w-auto" /> }],
   },
   {
     id: 'codebase',
-    text: 'into your codebase',
-    segments: [
-      { text: 'into your ', className: CONNECTOR_CLASS },
-      { text: 'codebase', className: 'font-bold italic' },
-    ],
+    text: 'to your codebase',
+    connector: TO,
+    segments: [{ text: 'your codebase', className: 'font-bold italic' }],
   },
 ]
 
@@ -90,7 +86,7 @@ function HomePage() {
           <div className="flex flex-col items-center gap-3 text-center md:gap-4">
             <Announcement />
             <h1
-              aria-label="Build your design system. Ship it to v0, bolt.new, Lovable, into your codebase, or anywhere."
+              aria-label="Build your design system. Ship it to v0, bolt.new, Lovable, your codebase, or anywhere."
               className="text-3xl leading-tight tracking-tighter text-balance max-lg:font-medium md:text-4xl lg:text-5xl"
             >
               <span aria-hidden="true">

--- a/www/src/routes/_app/index.tsx
+++ b/www/src/routes/_app/index.tsx
@@ -23,10 +23,16 @@ import Cards from '@/components/marketing/showcase/cards'
 // letter-spacing and size come from the original headline classes on the <h1>.
 const HEADLINE_STYLE = { fontFamily: 'var(--font-josefin)' }
 
-// Swappable destinations in the hero headline — "ship it to ___". "to" is a static
-// prefix, so only the destination swaps. v0 / bolt.new / Lovable are their official
-// brand wordmarks (logo-only); the rest are plain text. Everything inherits the
-// headline color (white); the Lovable heart keeps its brand gradient.
+// Swappable destinations in the hero headline — "Ship it ___". Each item carries its
+// own connector ("to" / "into your") as a leading segment, so "Ship it anywhere",
+// "Ship it to v0" and "Ship it into your codebase" all read naturally — no single
+// static preposition that breaks on "anywhere". The connector renders in the lead's
+// sans font (CONNECTOR_CLASS) to match the static "Build your design system. Ship it",
+// while the destination keyword inherits the rotating Josefin style (bold italic).
+// v0 / bolt.new / Lovable are their official brand wordmarks (logo-only); the rest are
+// text. Everything inherits the headline color (white); the Lovable heart keeps its
+// brand gradient.
+const CONNECTOR_CLASS = 'font-sans font-normal not-italic'
 const EXPORT_TARGETS: RotatingTextItem[] = [
   {
     id: 'anywhere',
@@ -35,25 +41,35 @@ const EXPORT_TARGETS: RotatingTextItem[] = [
   },
   {
     id: 'v0',
-    text: 'v0',
-    segments: [{ icon: <V0Icon className="h-[0.58em] w-auto" /> }],
+    text: 'to v0',
+    segments: [
+      { text: 'to ', className: CONNECTOR_CLASS },
+      { icon: <V0Icon className="h-[0.58em] w-auto" /> },
+    ],
   },
   {
     id: 'bolt',
-    text: 'bolt.new',
+    text: 'to bolt.new',
     segments: [
+      { text: 'to ', className: CONNECTOR_CLASS },
       { icon: <BoltIcon className="h-[0.72em] w-auto translate-y-[0.09em]" /> },
     ],
   },
   {
     id: 'lovable',
-    text: 'Lovable',
-    segments: [{ icon: <LovableIcon className="h-[0.72em] w-auto" /> }],
+    text: 'to Lovable',
+    segments: [
+      { text: 'to ', className: CONNECTOR_CLASS },
+      { icon: <LovableIcon className="h-[0.72em] w-auto" /> },
+    ],
   },
   {
     id: 'codebase',
-    text: 'your codebase',
-    segments: [{ text: 'your codebase', className: 'font-bold italic' }],
+    text: 'into your codebase',
+    segments: [
+      { text: 'into your ', className: CONNECTOR_CLASS },
+      { text: 'codebase', className: 'font-bold italic' },
+    ],
   },
 ]
 
@@ -74,12 +90,12 @@ function HomePage() {
           <div className="flex flex-col items-center gap-3 text-center md:gap-4">
             <Announcement />
             <h1
-              aria-label="Build your design system. Ship it to v0, bolt.new, Lovable, your own codebase, or anywhere."
+              aria-label="Build your design system. Ship it to v0, bolt.new, Lovable, into your codebase, or anywhere."
               className="text-3xl leading-tight tracking-tighter text-balance max-lg:font-medium md:text-4xl lg:text-5xl"
             >
               <span aria-hidden="true">
                 <AnimatedHeadline
-                  lead="Build your design system. Ship it to"
+                  lead="Build your design system. Ship it"
                   items={EXPORT_TARGETS}
                   trailing="."
                   wordStyle={HEADLINE_STYLE}


### PR DESCRIPTION
## What

Reworks the rotating hero headline on the homepage so its connecting preposition is carried per-destination instead of being a single static word.

Before: `Build your design system. Ship it to ___` where `___` cycles through `v0 · bolt.new · Lovable · your codebase · anywhere`.

After: `Build your design system. Ship it ___` where each frame supplies its own connector:

| Frame | Reads as |
|-------|----------|
| anywhere | Ship it *anywhere* |
| v0 | Ship it to **▿0** |
| bolt | Ship it to **bolt.new** |
| lovable | Ship it to **Lovable** |
| codebase | Ship it into your *codebase* |

## Why

A single static `to` had to serve a heterogeneous list and broke on the last item — "Ship it to **anywhere**" is ungrammatical, and "anywhere" is the punchline frame that lands last. Pulling the connector into each item fixes the grammar and lets "your codebase" take the more natural "into".

## How

All in `www/src/routes/_app/index.tsx`:

- `lead` is now `"Build your design system. Ship it"` — the `to` moved into the items.
- Each destination's `segments` start with a connector segment (`"to "` / `"into your "`) tagged `CONNECTOR_CLASS = 'font-sans font-normal not-italic'`. A `font-sans` class on the segment overrides the slot's inherited Josefin (a class on the child beats an inherited inline `font-family`), so the connector matches the static lead while the destination keyword keeps the rotating Josefin bold-italic.
- `aria-label` and the explanatory comment updated to match.

The codebase frame splits as "into your" (normal) + "codebase" (emphasized), so only the keyword carries the fancy style.

## Verification

Checked in the running dev server:

- Connector computes to `"Geist Variable"`, weight `400`, `font-style: normal` — identical to "Build your design system. Ship it".
- The connector's trailing space measures ~12px (a real word-space before the logo/keyword).
- `pnpm check` and `pnpm typecheck` pass. The 2 lint warnings are pre-existing and in unrelated files.

No registry or generated files affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
