### PR TITLE
feat(www): ios-style progressive blur on site header

### DIFF
--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -13,6 +13,37 @@ import { MobileNav } from '@/components/layout/mobile-nav'
 import { SearchCommand } from '@/components/search-command'
 import { ThemeToggle } from '@/components/theme-toggle'
 
+// iOS-style progressive blur: each layer adds a larger backdrop blur over an
+// overlapping gradient window. Where the windows overlap the blurs compound,
+// ramping smoothly from sharp (bottom edge) to heavily blurred (top). The
+// `to top` direction puts the strongest blur under the nav content. The wrapper
+// must stay mask-free — a mask there establishes a backdrop root and kills the
+// cross-layer compounding that makes the ramp smooth.
+const BLUR_LAYERS = [
+  {
+    blur: 0.5,
+    mask: 'linear-gradient(to top, transparent 0%, #000 10%, #000 30%, transparent 40%)',
+  },
+  {
+    blur: 1,
+    mask: 'linear-gradient(to top, transparent 10%, #000 20%, #000 40%, transparent 50%)',
+  },
+  {
+    blur: 2,
+    mask: 'linear-gradient(to top, transparent 15%, #000 30%, #000 50%, transparent 60%)',
+  },
+  {
+    blur: 4,
+    mask: 'linear-gradient(to top, transparent 20%, #000 40%, #000 60%, transparent 70%)',
+  },
+  {
+    blur: 8,
+    mask: 'linear-gradient(to top, transparent 40%, #000 60%, #000 80%, transparent 90%)',
+  },
+  { blur: 16, mask: 'linear-gradient(to top, transparent 60%, #000 80%)' },
+  { blur: 24, mask: 'linear-gradient(to top, transparent 70%, #000 100%)' },
+]
+
 function useScrolled(threshold = 8) {
   const [scrolled, setScrolled] = useState(false)
   useEffect(() => {
@@ -42,18 +73,28 @@ export function Header({ className, items = [] }: HeaderProps) {
     >
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[180%] opacity-0 transition-opacity duration-300 ease-out group-data-scrolled/header:opacity-100"
-        style={{
-          backdropFilter: 'blur(12px)',
-          WebkitBackdropFilter: 'blur(12px)',
-          backgroundColor:
-            'color-mix(in oklab, var(--color-bg) 60%, transparent)',
-          maskImage:
-            'linear-gradient(to bottom, black 0%, black 55%, transparent 100%)',
-          WebkitMaskImage:
-            'linear-gradient(to bottom, black 0%, black 55%, transparent 100%)',
-        }}
-      />
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[180%] opacity-0 transition-opacity duration-300 ease-out group-data-[scrolled]/header:opacity-100"
+      >
+        {BLUR_LAYERS.map(({ blur, mask }) => (
+          <div
+            key={blur}
+            className="absolute inset-0"
+            style={{
+              backdropFilter: `blur(${blur}px)`,
+              WebkitBackdropFilter: `blur(${blur}px)`,
+              maskImage: mask,
+              WebkitMaskImage: mask,
+            }}
+          />
+        ))}
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              'linear-gradient(to top, transparent 0%, color-mix(in oklab, var(--color-bg) 55%, transparent) 55%, color-mix(in oklab, var(--color-bg) 72%, transparent) 100%)',
+          }}
+        />
+      </div>
       <div className="flex items-center gap-3 md:gap-6">
         <MobileNav items={items} />
         <Logo className="max-md:hidden" />


### PR DESCRIPTION
## Summary

- Replace the site header's single uniform `backdrop-filter: blur(12px)` (a constant-strength layer faded by an opacity mask) with a true iOS-style **progressive blur**: a 7-layer stack with blur radii `0.5 → 1 → 2 → 4 → 8 → 16 → 24px`, each clipped to an *overlapping* `to top` gradient mask so the blurs compound into a smooth ramp — sharp at the bottom edge, heavily blurred under the nav content. A gradient tint over `--color-bg` keeps the nav legible and stays theme-aware. The wrapper is deliberately mask-free (a mask there would establish a backdrop root and break the cross-layer compounding).
- Fix a dead scroll fade-in. The wrapper gated visibility on a bare Tailwind v4 variant `group-data-scrolled/header:opacity-100`, which compiles to nothing (there's no `@custom-variant scrolled`, and every other data-variant in the repo is the bracket form). It was therefore permanently `opacity-0` — the header blur **never showed**, before or after this change. Corrected to `group-data-[scrolled]/header:opacity-100`; verified the wrapper now resolves opacity `0 → 1` on scroll.

## Notes for reviewers

- This is site chrome (`www/src/components/layout/header.tsx`), not a registry component — no new product axis is involved.
- I couldn't attach a screenshot: headless Chromium renders `backdrop-filter` as a black block (no GPU compositor). Verified structurally instead — 7 layers with the expected radii/masks, tint present, header sticky at `top:0`, and the fade trigger resolving `0 → 1` via `getComputedStyle`. `oxfmt`, `oxlint`, and `tsc` are all clean.
- Two taste knobs, both plain constants: the blur **peak (24px)** in `BLUR_LAYERS`, and the **tint** percentages (`55%` / `80%` of `--color-bg`). Worth an eyeball on a real dev server since I couldn't tune them visually.
