### PR TITLE
fix(www): mobile builder + docs layouts, a11y, wire shuffle/undo

### DIFF
--- a/www/src/components/layout/footer.tsx
+++ b/www/src/components/layout/footer.tsx
@@ -1,6 +1,6 @@
 export function Footer() {
   return (
-    <div className="container flex items-center justify-center py-10">
+    <footer className="container flex items-center justify-center py-10">
       <p className="text-sm text-fg-muted">
         Built with passion by{' '}
         <a
@@ -13,6 +13,6 @@ export function Footer() {
         </a>
         .
       </p>
-    </div>
+    </footer>
   )
 }

--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -97,8 +97,11 @@ export function Header({ className, items = [] }: HeaderProps) {
       </div>
       <div className="flex items-center gap-3 md:gap-6">
         <MobileNav items={items} />
-        <Logo className="max-md:hidden" />
-        <nav className="flex items-center gap-3 text-sm max-md:hidden">
+        <Logo />
+        <nav
+          aria-label="Main"
+          className="flex items-center gap-3 text-sm max-md:hidden"
+        >
           {navItems.map((item) => (
             <RouterLink
               key={item.name}

--- a/www/src/components/layout/mobile-nav.tsx
+++ b/www/src/components/layout/mobile-nav.tsx
@@ -40,9 +40,12 @@ export function MobileNav({ items }: { items: PageTree.Node[] }) {
         containerPadding={0}
         className="size-full max-w-none rounded-none border-0 bg-bg/95 backdrop-blur-md"
       >
-        <DialogContent className="overflow-y-auto pt-4">
+        <DialogContent
+          aria-label="Mobile navigation"
+          className="overflow-y-auto pt-4"
+        >
           {({ close }) => (
-            <div className="flex flex-col gap-12">
+            <nav aria-label="Mobile" className="flex flex-col gap-12">
               <div className="space-y-2">
                 <div className="text-lg font-medium text-fg-muted">Menu</div>
                 <div className="flex flex-col gap-3">
@@ -89,7 +92,7 @@ export function MobileNav({ items }: { items: PageTree.Node[] }) {
                 }
                 return null
               })}
-            </div>
+            </nav>
           )}
         </DialogContent>
       </Popover>

--- a/www/src/modules/create/components-config.tsx
+++ b/www/src/modules/create/components-config.tsx
@@ -196,7 +196,7 @@ function ParamEditor({ paramName, def, selected, onChange }: ParamEditorProps) {
         >
           <Button size="sm" className="w-full">
             <SelectValue />
-            <ChevronDownIcon />
+            <ChevronDownIcon data-icon-end="" />
           </Button>
           <Popover>
             <ListBox>
@@ -261,7 +261,7 @@ function ParamEditor({ paramName, def, selected, onChange }: ParamEditorProps) {
       >
         <Button size="sm" className="w-full">
           <SelectValue />
-          <ChevronDownIcon />
+          <ChevronDownIcon data-icon-end="" />
         </Button>
         <Popover>
           <ListBox>

--- a/www/src/modules/create/customizer-panel.tsx
+++ b/www/src/modules/create/customizer-panel.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo } from 'react'
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { getRouteApi } from '@tanstack/react-router'
 import {
   ChevronDownIcon,
@@ -13,6 +13,8 @@ import { AnimatePresence, motion, type Transition } from 'motion/react'
 import * as ButtonPrimitives from 'react-aria-components/Button'
 
 import * as icons from '@/registry/__generated__/icons'
+import { cn } from '@/registry/lib/utils'
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
 import { Button } from '@/registry/ui/button'
 import { Command } from '@/registry/ui/command'
 import { Input } from '@/registry/ui/input'
@@ -149,6 +151,28 @@ const menu: MenuItem[] = [
 
 export const MENU_IDS = new Set(menu.map((m) => m.id))
 
+/* ------------------------------- Shuffle ------------------------------- */
+
+// "Surprise me" pools for the shuffle button — the punchy, always-legible axes
+// (accent / radius / density), each curated so any random pick still looks good.
+const SHUFFLE_ACCENTS = [
+  '#3b82f6',
+  '#6366f1',
+  '#8b5cf6',
+  '#ec4899',
+  '#f43f5e',
+  '#f59e0b',
+  '#22c55e',
+  '#14b8a6',
+  '#06b6d4',
+]
+const SHUFFLE_RADII = ['0', '0.5', '1', '1.5', '2']
+const SHUFFLE_DENSITIES = ['compact', 'default', 'comfortable'] as const
+
+function pickRandom<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)] as T
+}
+
 /* -------------------------------- Panel -------------------------------- */
 
 const routeApi = getRouteApi('/_app/create')
@@ -156,16 +180,72 @@ const routeApi = getRouteApi('/_app/create')
 export function CustomizerPanel({
   previewMode = 'light',
   onTogglePreviewMode,
+  className,
 }: {
   previewMode?: PreviewMode
   onTogglePreviewMode?: () => void
+  className?: string
 }) {
-  const { panel, preview } = routeApi.useSearch()
+  const { panel, preview, preset } = routeApi.useSearch()
   const navigate = routeApi.useNavigate()
-  const { designSystem, setComponentParam, setToken, setDensity } =
-    useDesignSystem()
+  const {
+    designSystem,
+    setDesignSystem,
+    setComponentParam,
+    setToken,
+    setDensity,
+  } = useDesignSystem()
 
   const navStack = useMemo(() => (panel ? panel.split('.') : []), [panel])
+
+  // Undo history. Every design change is encoded into the `?preset=` search param
+  // with `replace: true`, so the browser back button can't step through edits — we
+  // keep our own stack of past preset values and walk back through it. Watching
+  // `preset` (not wiring into each setter) captures changes from every config panel,
+  // each of which owns a separate `useDesignSystem()` instance but shares this URL.
+  const historyRef = useRef<(string | undefined)[]>([])
+  const prevPresetRef = useRef<string | undefined>(preset)
+  const isUndoingRef = useRef(false)
+  const [canUndo, setCanUndo] = useState(false)
+
+  useEffect(() => {
+    if (prevPresetRef.current === preset) return
+    if (isUndoingRef.current) {
+      isUndoingRef.current = false
+    } else {
+      historyRef.current.push(prevPresetRef.current)
+      setCanUndo(true)
+    }
+    prevPresetRef.current = preset
+  }, [preset])
+
+  function undo() {
+    if (historyRef.current.length === 0) return
+    const previous = historyRef.current.pop()
+    isUndoingRef.current = true
+    navigate({
+      search: (prev) => ({ ...prev, preset: previous }),
+      replace: true,
+    })
+    setCanUndo(historyRef.current.length > 0)
+  }
+
+  // Shuffle the always-legible axes (accent / radius / density) in one update so
+  // they land as a single history entry that Undo can revert in one step.
+  function shuffle() {
+    const accent = pickRandom(SHUFFLE_ACCENTS)
+    const radius = pickRandom(SHUFFLE_RADII)
+    const density = pickRandom(SHUFFLE_DENSITIES)
+    setDesignSystem((prev) => {
+      const base = prev.color ?? DEFAULT_COLOR_CONFIG
+      return {
+        ...prev,
+        density,
+        tokens: { ...prev.tokens, [RADIUS_FACTOR_VAR]: radius },
+        color: { ...base, seeds: { ...base.seeds, accent } },
+      }
+    })
+  }
 
   function push(id: string) {
     navigate({
@@ -351,7 +431,12 @@ export function CustomizerPanel({
   }
 
   return (
-    <div className="relative flex w-72 shrink-0 flex-col rounded-xl border bg-card">
+    <div
+      className={cn(
+        'relative flex w-full flex-1 flex-col rounded-xl border bg-card lg:w-72 lg:flex-none lg:shrink-0',
+        className,
+      )}
+    >
       {/* Header */}
       <div className="relative overflow-hidden border-b p-2">
         <div className="flex w-full items-center gap-2">
@@ -401,7 +486,7 @@ export function CustomizerPanel({
               </Command>
             </Popover>
           </Select>
-          <Button size="sm" isIconOnly>
+          <Button size="sm" isIconOnly aria-label="Shuffle" onPress={shuffle}>
             <ShuffleIcon />
           </Button>
           <Button
@@ -412,7 +497,13 @@ export function CustomizerPanel({
           >
             {previewMode === 'dark' ? <SunIcon /> : <MoonIcon />}
           </Button>
-          <Button size="sm" isIconOnly>
+          <Button
+            size="sm"
+            isIconOnly
+            onPress={undo}
+            isDisabled={!canUndo}
+            aria-label="Undo"
+          >
             <Undo2Icon />
           </Button>
         </div>

--- a/www/src/modules/create/install-command.tsx
+++ b/www/src/modules/create/install-command.tsx
@@ -10,19 +10,23 @@ import { useEffect, useMemo, useState } from 'react'
 import { CheckIcon, CopyIcon } from 'lucide-react'
 import * as ButtonPrimitives from 'react-aria-components/Button'
 
+import { siteConfig } from '@/config/site'
+
 import { useDesignSystem } from './preset'
 import { encodePreset } from './preset/codec'
 
-const DEFAULT_REGISTRY_HOST = 'https://dotui.com'
+const DEFAULT_REGISTRY_HOST: string = siteConfig.url
 
 function getRegistryHost(): string {
   if (typeof window === 'undefined') return DEFAULT_REGISTRY_HOST
-  // Honour the deployed origin so local dev (http://localhost:4444) shows the
-  // command pointing back at itself.
-  const { origin } = window.location
+  // On a deployed origin the command points back at it; on localhost / file we
+  // fall back to the public host, since v0 and the shadcn CLI can't fetch a local
+  // URL. Match on `hostname` (not the full origin) so any dev port still counts.
+  const { origin, hostname } = window.location
   if (
     origin === 'null' ||
-    origin === 'http://localhost' ||
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
     origin.startsWith('file:')
   ) {
     return DEFAULT_REGISTRY_HOST

--- a/www/src/modules/create/open-in-v0.tsx
+++ b/www/src/modules/create/open-in-v0.tsx
@@ -14,19 +14,23 @@
 
 import { useEffect, useMemo, useState } from 'react'
 
+import { siteConfig } from '@/config/site'
 import { V0Icon } from '@/components/icons/v0'
 
 import { useDesignSystem } from './preset'
 import { encodePreset } from './preset/codec'
 
-const DEFAULT_REGISTRY_HOST = 'https://dotui.com'
+const DEFAULT_REGISTRY_HOST: string = siteConfig.url
 
 function getRegistryHost(): string {
   if (typeof window === 'undefined') return DEFAULT_REGISTRY_HOST
-  const { origin } = window.location
+  // localhost / file fall back to the public host (v0 can't fetch a local URL);
+  // match on `hostname` so any dev port counts. A deployed origin points to itself.
+  const { origin, hostname } = window.location
   if (
     origin === 'null' ||
-    origin === 'http://localhost' ||
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
     origin.startsWith('file:')
   ) {
     return DEFAULT_REGISTRY_HOST

--- a/www/src/modules/create/typography-config.tsx
+++ b/www/src/modules/create/typography-config.tsx
@@ -23,7 +23,7 @@ export function TypographyConfig() {
 
 const FontPicker = ({ label }: { label: string }) => {
   return (
-    <Select className="w-full" defaultValue="geist">
+    <Select className="w-full" defaultValue="Geist">
       <Label>{label}</Label>
       <SelectTrigger className="w-full" />
       <Popover>

--- a/www/src/modules/docs/code-block.tsx
+++ b/www/src/modules/docs/code-block.tsx
@@ -65,7 +65,7 @@ export function CodeBlock({
           {!title && (
             <div
               className={cn(
-                'absolute top-1.75 right-1.75 gap-0.5 **:data-button:text-fg-muted **:data-button:*:[svg]:size-3.5',
+                'absolute top-1.75 right-1.75 flex items-center gap-0.5 **:data-button:text-fg-muted **:data-button:*:[svg]:size-3.5',
                 'backdrop-blur-[1px] **:data-button:bg-card/60 **:data-button:hover:bg-[color-mix(in_oklab,var(--color-card)_85%,var(--color-inverse))] **:data-button:pressed:bg-[color-mix(in_oklab,var(--color-card)_80%,var(--color-inverse))]',
               )}
             >

--- a/www/src/modules/docs/demo.tsx
+++ b/www/src/modules/docs/demo.tsx
@@ -73,7 +73,7 @@ export function Demo({ component: Component, children, ...props }: DemoProps) {
   return (
     <div {...props}>
       {/* Preview frame */}
-      <div className="flex min-h-56 items-center justify-center rounded-t-lg border bg-bg p-10">
+      <div className="flex min-h-56 items-center justify-center overflow-x-auto rounded-t-lg border bg-bg p-6 sm:p-10">
         <Component />
       </div>
 

--- a/www/src/modules/docs/docs-copy-page.tsx
+++ b/www/src/modules/docs/docs-copy-page.tsx
@@ -96,7 +96,7 @@ export function DocsCopyPage({
         {isCopied ? <CheckIcon /> : <CopyIcon />} Copy page
       </Button>
       <Menu>
-        <Button size="sm" isIconOnly>
+        <Button size="sm" isIconOnly aria-label="More formats">
           <ChevronDownIcon />
         </Button>
         <Popover placement="bottom end">

--- a/www/src/modules/docs/docs-sidebar.tsx
+++ b/www/src/modules/docs/docs-sidebar.tsx
@@ -8,7 +8,10 @@ export function DocsSidebar({ items }: { items: PageTree.Node[] }) {
   const { pathname } = useLocation()
 
   return (
-    <nav className="flex h-full flex-col gap-6 overflow-y-auto scroll-smooth rounded-2xl [mask-image:linear-gradient(to_bottom,transparent_0,black_24px,black_calc(100%-24px),transparent_100%)] py-6 pr-3 pl-4 [webkit-mask-image:linear-gradient(to_bottom,transparent_0,black_24px,black_calc(100%-24px),transparent_100%)]">
+    <nav
+      aria-label="Docs"
+      className="flex h-full flex-col gap-6 overflow-y-auto scroll-smooth rounded-2xl [mask-image:linear-gradient(to_bottom,transparent_0,black_24px,black_calc(100%-24px),transparent_100%)] py-6 pr-3 pl-4 [-webkit-mask-image:linear-gradient(to_bottom,transparent_0,black_24px,black_calc(100%-24px),transparent_100%)]"
+    >
       {items.map((item) => {
         if (item.type === 'folder') {
           return (

--- a/www/src/modules/docs/example.tsx
+++ b/www/src/modules/docs/example.tsx
@@ -5,8 +5,6 @@ import { Button } from '@/registry/ui/button'
 import { Dialog, DialogBody, DialogContent } from '@/registry/ui/dialog'
 import { Modal } from '@/registry/ui/modal'
 
-// import { DemoCode, DemoCodePreview, getSlotContent } from "./demo";
-
 export interface ExampleProps extends React.ComponentProps<'div'> {
   component: React.ComponentType
   title?: string
@@ -25,9 +23,6 @@ export function Example({
   // render nothing instead.
   if (!Component) return null
 
-  // const codeContent = getSlotContent(children, DemoCode);
-  // const previewContent = getSlotContent(children, DemoCodePreview);
-
   return (
     <div
       className={cn(
@@ -42,20 +37,18 @@ export function Example({
         <div
           data-example-preview=""
           tabIndex={-1}
-          className="pointer-events-none flex min-h-32 flex-1 flex-col items-center justify-center gap-6 p-10"
+          className="pointer-events-none scrollbar-none flex min-h-32 flex-1 flex-col items-center justify-center gap-6 overflow-x-auto p-6 sm:p-10"
         >
           <Component />
         </div>
         <Dialog>
           <Button
             variant="quiet"
+            aria-label={title ? `Expand ${title} example` : 'Expand example'}
             className="absolute inset-0 z-2 size-auto h-auto! border hover:border-border-hover"
           />
           <Modal>
-            <DialogContent>
-              {/* <DialogHeader>
-								<DialogTitle>{title}</DialogTitle>
-							</DialogHeader> */}
+            <DialogContent aria-label={title ? `${title} example` : 'Example'}>
               <DialogBody>
                 <Component />
               </DialogBody>

--- a/www/src/modules/docs/mdx-components.tsx
+++ b/www/src/modules/docs/mdx-components.tsx
@@ -82,7 +82,7 @@ export const mdxComponents: MDXComponents = {
     />
   ),
   a: ({ className, children, href, ...props }): React.ComponentProps<'a'> => {
-    const isInternal = href.startsWith('/')
+    const isInternal = href?.startsWith('/') ?? false
     return (
       <Link
         href={href}

--- a/www/src/modules/docs/page-layout.tsx
+++ b/www/src/modules/docs/page-layout.tsx
@@ -7,22 +7,6 @@ export function PageLayout({
   return <div className={cn('', className)} {...props} />
 }
 
-export function PageHeader({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<'section'>) {
-  return (
-    <section
-      data-page-header
-      className={cn('container py-6 md:py-8 lg:py-14', className)}
-      {...props}
-    >
-      {children}
-    </section>
-  )
-}
-
 export function PageHeaderHeading({
   className,
   ...props
@@ -46,21 +30,6 @@ export function PageHeaderDescription({
     <p
       className={cn(
         'sm:text-md mt-1 max-w-3xl text-base text-balance text-fg-muted',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-export function PageActions({
-  className,
-  ...props
-}: React.ComponentProps<'div'>) {
-  return (
-    <div
-      className={cn(
-        'mt-4 flex w-full flex-col gap-2 sm:flex-row sm:items-center',
         className,
       )}
       {...props}

--- a/www/src/modules/docs/toc.tsx
+++ b/www/src/modules/docs/toc.tsx
@@ -171,6 +171,7 @@ export function TOCItems({
       />
       <nav
         ref={mergeRefs(ref, containerRef)}
+        aria-label="On this page"
         className={cn('flex flex-col', className)}
         {...props}
       >

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -162,16 +162,11 @@ function RootComponent() {
   return (
     <ThemeProvider forcedTheme={forcedTheme}>
       <FaviconSwitcher />
-      {/* <DrawerProvider> */}
       <RootDocument>
-        {/* <DrawerIndentBackground /> */}
-        {/* <DrawerIndent> */}
         <ToastProvider>
           <Outlet />
         </ToastProvider>
-        {/* </DrawerIndent> */}
       </RootDocument>
-      {/* </DrawerProvider> */}
     </ThemeProvider>
   )
 }

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -3,6 +3,9 @@ import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
 import { useTheme } from 'starter-themes'
 import { z } from 'zod'
 
+import { cn } from '@/registry/lib/utils'
+import { ToggleButton } from '@/registry/ui/toggle-button'
+import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
 import { CustomizerPanel } from '@/modules/create/customizer-panel'
 import {
   sendPreviewMode,
@@ -10,6 +13,8 @@ import {
   useDesignSystem,
 } from '@/modules/create/preset'
 import type { PreviewMode } from '@/modules/create/preset'
+
+type MobilePane = 'customize' | 'preview'
 
 export const createSearchSchema = z.object({
   panel: z.string().optional().catch(undefined),
@@ -33,6 +38,9 @@ function CreatePage() {
   const { resolvedTheme } = useTheme()
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [previewMode, setPreviewMode] = useState<PreviewMode>('light')
+  // Below `lg` the customizer and the live preview can't sit side by side, so they
+  // collapse into a single switchable pane. Above `lg` this state is inert — both show.
+  const [mobilePane, setMobilePane] = useState<MobilePane>('customize')
 
   // Open the preview in the same light / dark mode the site is currently in. Seeded on
   // mount rather than via the useState initializer: this page is server-rendered and the
@@ -95,20 +103,39 @@ function CreatePage() {
   }, [previewMode])
 
   return (
-    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-row gap-6 p-6 pt-2">
+    <main className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2">
+      <ToggleButtonGroup
+        aria-label="Editor view"
+        selectionMode="single"
+        disallowEmptySelection
+        size="sm"
+        selectedKeys={[mobilePane]}
+        onSelectionChange={(keys) => {
+          const next = keys.values().next().value
+          if (next === 'customize' || next === 'preview') setMobilePane(next)
+        }}
+        className="w-full shrink-0 *:flex-1 lg:hidden"
+      >
+        <ToggleButton id="customize">Customize</ToggleButton>
+        <ToggleButton id="preview">Preview</ToggleButton>
+      </ToggleButtonGroup>
       <CustomizerPanel
         previewMode={previewMode}
         onTogglePreviewMode={() =>
           setPreviewMode((m) => (m === 'dark' ? 'light' : 'dark'))
         }
+        className={cn(mobilePane === 'preview' && 'max-lg:hidden')}
       />
       <iframe
         ref={iframeRef}
         key={effectivePreview}
         src={iframeSrc}
         title="preview"
-        className="min-w-0 flex-1 rounded-xl border"
+        className={cn(
+          'min-w-0 flex-1 rounded-xl border',
+          mobilePane === 'customize' && 'max-lg:hidden',
+        )}
       />
-    </div>
+    </main>
   )
 }

--- a/www/src/routes/_app/docs/$.tsx
+++ b/www/src/routes/_app/docs/$.tsx
@@ -133,10 +133,10 @@ const clientLoader = browserCollections.docs.createClientLoader({
     return (
       <TOCProvider toc={toc}>
         <PageLayout className="mt-4 flex scroll-mt-24 items-stretch pb-8 text-[1.05rem] sm:text-[15px] xl:w-full">
-          <div className="mx-auto flex w-full max-w-3xl min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-0 lg:py-8 dark:text-neutral-300">
+          <main className="mx-auto flex w-full max-w-3xl min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-0 lg:py-8 dark:text-neutral-300">
             <div data-page-header="" className="relative mb-2 space-y-3 pb-4">
-              <div className="flex items-start justify-between">
-                <div className="flex flex-col gap-2">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex min-w-0 flex-col gap-2">
                   <PageHeaderHeading className="xl:leading-none">
                     {frontmatter.title}
                   </PageHeaderHeading>
@@ -144,7 +144,7 @@ const clientLoader = browserCollections.docs.createClientLoader({
                     {frontmatter.description}
                   </PageHeaderDescription>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex shrink-0 items-center gap-2">
                   <DocsPager neighbours={neighbours} />
                   <DocsCopyPage content={rawContent} url={url} />
                 </div>
@@ -159,7 +159,7 @@ const clientLoader = browserCollections.docs.createClientLoader({
                 <PageLastUpdate date={lastModified} className="mt-12" />
               )}
             </div>
-          </div>
+          </main>
           <div className="sticky top-[calc(var(--header-height)+14px)] z-30 hidden h-[90svh] w-(--sidebar-width) flex-col gap-4 overflow-hidden overscroll-none pb-8 xl:flex">
             {hasToc && <TOC className="pr-12" />}
           </div>

--- a/www/src/styles.css
+++ b/www/src/styles.css
@@ -65,3 +65,14 @@
     content: counter(step);
   }
 }
+
+/* Hide the scrollbar while keeping the element scrollable. Used on scroll
+   containers where a visible bar would be noise (the create panel's stacked
+   views, docs example preview frames). */
+@utility scrollbar-none {
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}


### PR DESCRIPTION
Deep UI pass across the site (home, `/create`, docs) — fixing concrete defects found at every viewport/theme, then wiring two previously-inert builder controls.

## Mobile / responsive
- **`/create` was unusable on phones** — hardcoded `flex-row` collapsed the live preview to a ~15px sliver. Below `lg` the customizer and preview now stack into one pane with a full-width **Customize / Preview** segmented toggle. Desktop is pixel-identical.
- **Docs overflowed horizontally on mobile** — wide demo rows pushed the page ~38px wide. The `Example`/`Demo` preview frames now contain overflow + use lighter mobile padding. The page-header also stacks below `sm` so long titles (e.g. "Color Swatch Picker") get full width instead of wrapping to 3 lines.
- Added the **`scrollbar-none`** utility — it was referenced in two places but never defined (dead class).

## Accessibility
- Added the missing **`<main>`** landmark to `/create` and `/docs` (only home had one) and a real **`<footer>`** landmark.
- Labeled the **nav landmarks** distinctly (header "Main", docs sidebar "Docs", TOC "On this page"); named the **mobile-nav dialog** and wrapped its links in `<nav>`.
- Gave **icon-only buttons** accessible names: shuffle, undo, the docs "more formats" menu, and the example zoom-overlay button + its dialog.

## Create builder
- **Wired Shuffle and Undo** (they were non-functional). Shuffle randomizes accent / radius / density from curated pools; Undo walks back through real history (the design system lives in the `?preset=` URL written with `replace:true`, so it keeps its own stack — which captures edits from every config panel). Verified the full multi-step cycle, including the disabled-when-empty state.
- **Registry host → `dotui.org`** — now derived from `siteConfig.url` (kills the `.com`/`.org` drift), and the localhost dev-guard now matches any port (it missed `:4444`, so dev showed an unreachable URL).

## Cleanup
Removed dead `PageHeader`/`PageActions` exports, dead `example.tsx` code, and commented `Drawer*` scaffolding; guarded `href.startsWith`; fixed an invalid `webkit-mask-image` prefix; fixed the font-picker default casing.

## Verification
`pnpm typecheck`, `oxlint`, and `oxfmt` all pass; no `__generated__` drift. Verified live across mobile/desktop and light/dark — including the Shuffle/Undo multi-step cycle and the `dotui.org` install command / v0 deeplink.

> Intentionally left alone: the home scroll fade (heavily tuned), the `text-[11px]` density-toggle fine-tune, and `/playground` (dev scratchpad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)