### PR TITLE
fix(home): restore hero "to" spacing, shrink Lovable wordmark

### DIFF
--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -24,7 +24,7 @@ const HEADLINE_STYLE = { fontFamily: 'var(--font-josefin)' }
 // Shared connector for the tool / codebase frames. The trailing space is a non-breaking
 // space on purpose: the rotator sizes the connector slot from this text, and a normal
 // trailing space gets trimmed in the flex slot (so "to" would butt against the logo).
-const TO = 'to '
+const TO = 'to\u00A0'
 
 // Swappable destinations in the hero headline — "Ship it ___". The shared "to" lives in
 // `connector`, not the lead, so it renders once in the lead's font and — because the
@@ -57,7 +57,7 @@ const EXPORT_TARGETS: RotatingTextItem[] = [
     id: 'lovable',
     text: 'to Lovable',
     connector: TO,
-    segments: [{ icon: <LovableIcon className="h-[0.72em] w-auto" /> }],
+    segments: [{ icon: <LovableIcon className="h-[0.66em] w-auto" /> }],
   },
   {
     id: 'codebase',


### PR DESCRIPTION
## Summary

- Fix the missing space after "to" in the home hero word animation ("to v0", "to bolt.new", "to Lovable"). The shared `to` connector ended in a **regular** space. The rotator renders the connector and the destination in two separate `inline-flex` slots, and a regular trailing space at a flex-slot edge is trimmed by the browser — so "to" butted against the logo (`tov0`, `tobolt.new`). It now uses an explicit `U+00A0` non-breaking space (written as a `\u00A0` escape, not a literal char — stable against formatters and oxlint's `no-irregular-whitespace`, which is how the gap silently regressed). This matches the intent already documented in the code comment above the constant.
- Shrink the Lovable wordmark from `h-[0.72em]` to `h-[0.66em]` so it reads slightly smaller next to the other destinations. The heart keeps its brand gradient.

## Notes for reviewers

- One file, two lines: `www/src/modules/marketing/home-page.tsx`.
- www-side marketing page — no registry/reference regeneration needed.
- `pnpm check` passes; the 2 oxlint warnings it reports are pre-existing and in unrelated files.
- The Lovable size is a taste call: `0.66em` is ~8% smaller than before. Trivial to nudge to `0.68em` (gentler) or `0.64em` (a touch more) if preferred.
