### PR TITLE
feat(docs): animate component gallery cards on hover

### DIFF
--- a/www/src/modules/create/preset/storage.ts
+++ b/www/src/modules/create/preset/storage.ts
@@ -1,0 +1,83 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+
+import { decodePreset, encodePreset } from './codec'
+import { DEFAULTS } from './defaults'
+import type { DesignSystem } from './types'
+
+/**
+ * The user's selected design-system preset, persisted in localStorage so it
+ * survives reloads and is shared across the whole site: the /create page writes
+ * it as the user customizes, and every docs component demo reads it to render in
+ * that exact preset.
+ *
+ * The stored value is the same compact, URL-safe string the /create page uses in
+ * its `?preset=` param (see codec.ts), so a preset round-trips between the two.
+ */
+const STORAGE_KEY = 'dotui:preset'
+
+// Same-tab listeners don't get the native `storage` event (it only fires in
+// *other* tabs), so saving also dispatches this for live in-tab updates.
+const CHANGE_EVENT = 'dotui:preset-change'
+
+export function loadStoredPreset(): DesignSystem {
+  if (typeof window === 'undefined') return DEFAULTS
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    return raw ? decodePreset(raw) : DEFAULTS
+  } catch {
+    return DEFAULTS
+  }
+}
+
+export function saveStoredPreset(ds: DesignSystem): void {
+  if (typeof window === 'undefined') return
+  try {
+    const encoded = encodePreset(ds)
+    // `encodePreset` returns undefined when everything matches the defaults —
+    // clear the key so we fall back to DEFAULTS rather than storing an empty diff.
+    if (encoded) window.localStorage.setItem(STORAGE_KEY, encoded)
+    else window.localStorage.removeItem(STORAGE_KEY)
+    window.dispatchEvent(new Event(CHANGE_EVENT))
+  } catch {
+    // Private mode / quota / disabled storage — non-fatal, the preset just won't persist.
+  }
+}
+
+/* ----------------------------- reactive hook ----------------------------- */
+
+function subscribe(onChange: () => void): () => void {
+  window.addEventListener('storage', onChange)
+  window.addEventListener(CHANGE_EVENT, onChange)
+  return () => {
+    window.removeEventListener('storage', onChange)
+    window.removeEventListener(CHANGE_EVENT, onChange)
+  }
+}
+
+// Cache the decoded preset keyed by its raw string so getSnapshot returns a
+// stable reference between unchanged reads (useSyncExternalStore requires it).
+let snapshot: { raw: string | null; ds: DesignSystem } = {
+  raw: null,
+  ds: DEFAULTS,
+}
+
+function getSnapshot(): DesignSystem {
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (raw !== snapshot.raw) {
+    snapshot = { raw, ds: raw ? decodePreset(raw) : DEFAULTS }
+  }
+  return snapshot.ds
+}
+
+// Server (and the first client render, for hydration parity) always sees DEFAULTS;
+// the stored preset is applied on mount, after which scoped theming swaps it in.
+function getServerSnapshot(): DesignSystem {
+  return DEFAULTS
+}
+
+/** Subscribe to the user's stored preset (SSR-safe; updates across tabs and in-tab). */
+export function useStoredPreset(): DesignSystem {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}

--- a/www/src/modules/docs/components-list/autoplay/card-hover.tsx
+++ b/www/src/modules/docs/components-list/autoplay/card-hover.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+
+/**
+ * Whether the surrounding component card is "active" — hovered or keyboard
+ * focused. The card (component-card.tsx) is the only pointer/focus target: the
+ * demo it previews is `inert`, so it can never receive hover/focus itself. The
+ * card tracks its own hover/focus and broadcasts it down here, and the demo's
+ * autoplay hooks read it to drive their looping interaction animations.
+ *
+ * Nothing here ever touches real focus — the animations are purely visual state
+ * (controlled props, faux focus rings, motion transforms), so simulating a
+ * "focused" field or an "open" popover never steals the page's focus.
+ */
+const CardHoverContext = createContext(false)
+
+export const CardHoverProvider = CardHoverContext.Provider
+
+export function useCardHover(): boolean {
+  return useContext(CardHoverContext)
+}

--- a/www/src/modules/docs/components-list/autoplay/cursor.tsx
+++ b/www/src/modules/docs/components-list/autoplay/cursor.tsx
@@ -5,10 +5,13 @@ import { cn } from '@/registry/lib/utils'
 import type { ScenePhase } from './use-autoplay'
 
 /**
- * A decorative pointer that fades in over a trigger, then dips on "press" to
- * sell the click. Purely cosmetic (aria-hidden); it never moves the real cursor.
- * CSS-transition driven so it animates inside the `inert` preview. Positioned by
- * the caller — defaults to the bottom-right corner of a centered trigger.
+ * A decorative pointer for the overlay scenes. It glides in toward the trigger
+ * (a smooth, decelerating travel), gives a quick press dip, and emits a click
+ * ripple — then drifts away as the overlay opens. Purely cosmetic (aria-hidden);
+ * it never moves the real cursor.
+ *
+ * All CSS-driven so it animates inside the `inert` preview. The ripple mounts
+ * only during the press phase, so it replays from the start on every loop.
  */
 export function FakeCursor({
   phase,
@@ -17,37 +20,59 @@ export function FakeCursor({
   phase: ScenePhase
   className?: string
 }) {
-  const visible = phase === 'hover' || phase === 'press'
+  const arrived = phase === 'hover' || phase === 'press'
   const pressed = phase === 'press'
+  const leaving = phase === 'open'
+
+  // Resting just inside the trigger; far down-right before arrival; a small drift
+  // out as the overlay takes over.
+  const transform = arrived
+    ? 'translate(-5px, -5px) scale(1)'
+    : leaving
+      ? 'translate(4px, 4px) scale(0.85)'
+      : 'translate(42px, 36px) scale(0.55)'
 
   return (
-    <svg
+    <div
       aria-hidden="true"
-      viewBox="0 0 24 24"
-      width={20}
-      height={20}
-      className={cn(
-        'pointer-events-none absolute z-30 drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)]',
-        className,
-      )}
+      className={cn('pointer-events-none absolute z-30', className)}
       style={{
-        opacity: visible ? 1 : 0,
-        transform: `translate(${visible ? '0px,0px' : '8px,8px'}) scale(${
-          pressed ? 0.82 : visible ? 1 : 0.6
-        })`,
+        opacity: arrived ? 1 : 0,
+        transform,
         transformOrigin: 'top left',
-        transition:
-          'opacity 280ms ease, transform 280ms cubic-bezier(0.32,0.72,0,1)',
+        // Glide in slowly with a natural deceleration; leave a touch quicker.
+        transition: arrived
+          ? 'opacity 180ms ease-out, transform 520ms cubic-bezier(0.16, 1, 0.3, 1)'
+          : 'opacity 260ms ease-in, transform 320ms cubic-bezier(0.4, 0, 1, 1)',
       }}
     >
-      {/* Classic arrow pointer: white fill, dark outline so it reads on any bg. */}
-      <path
-        d="M5 3.5 L5 19 L9 15 L11.5 20.5 L14 19.3 L11.6 14 L17 14 Z"
-        fill="white"
-        stroke="black"
-        strokeWidth={1.4}
-        strokeLinejoin="round"
-      />
-    </svg>
+      {/* Click ripple — keyed to the press phase so it remounts and replays. */}
+      {pressed && (
+        <span
+          className="absolute size-6 [animation:cursor-click_320ms_ease-out_forwards] rounded-full bg-white/35 ring-1 ring-black/30"
+          style={{ left: 4, top: 3 }}
+        />
+      )}
+      {/* The arrow itself dips on press for the tactile click. */}
+      <svg
+        viewBox="0 0 24 24"
+        width={20}
+        height={20}
+        className="relative drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)]"
+        style={{
+          transform: pressed ? 'scale(0.82)' : 'scale(1)',
+          transformOrigin: '5px 4px',
+          transition: 'transform 130ms cubic-bezier(0.32, 0.72, 0, 1)',
+        }}
+      >
+        <path
+          d="M5 3.5 L5 19 L9 15 L11.5 20.5 L14 19.3 L11.6 14 L17 14 Z"
+          fill="white"
+          stroke="black"
+          strokeWidth={1.4}
+          strokeLinejoin="round"
+        />
+      </svg>
+    </div>
   )
 }

--- a/www/src/modules/docs/components-list/autoplay/cursor.tsx
+++ b/www/src/modules/docs/components-list/autoplay/cursor.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { cn } from '@/registry/lib/utils'
+
+import type { ScenePhase } from './use-autoplay'
+
+/**
+ * A decorative pointer that fades in over a trigger, then dips on "press" to
+ * sell the click. Purely cosmetic (aria-hidden); it never moves the real cursor.
+ * CSS-transition driven so it animates inside the `inert` preview. Positioned by
+ * the caller — defaults to the bottom-right corner of a centered trigger.
+ */
+export function FakeCursor({
+  phase,
+  className,
+}: {
+  phase: ScenePhase
+  className?: string
+}) {
+  const visible = phase === 'hover' || phase === 'press'
+  const pressed = phase === 'press'
+
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width={20}
+      height={20}
+      className={cn(
+        'pointer-events-none absolute z-30 drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)]',
+        className,
+      )}
+      style={{
+        opacity: visible ? 1 : 0,
+        transform: `translate(${visible ? '0px,0px' : '8px,8px'}) scale(${
+          pressed ? 0.82 : visible ? 1 : 0.6
+        })`,
+        transformOrigin: 'top left',
+        transition:
+          'opacity 280ms ease, transform 280ms cubic-bezier(0.32,0.72,0,1)',
+      }}
+    >
+      {/* Classic arrow pointer: white fill, dark outline so it reads on any bg. */}
+      <path
+        d="M5 3.5 L5 19 L9 15 L11.5 20.5 L14 19.3 L11.6 14 L17 14 Z"
+        fill="white"
+        stroke="black"
+        strokeWidth={1.4}
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/www/src/modules/docs/components-list/autoplay/index.ts
+++ b/www/src/modules/docs/components-list/autoplay/index.ts
@@ -4,6 +4,7 @@ export {
   useTypewriter,
   useToggleAutoplay,
   useStepAutoplay,
+  useCycle,
   useOpenAutoplay,
   useValueAutoplay,
 } from './use-autoplay'
@@ -18,10 +19,12 @@ export type {
 } from './use-autoplay'
 export { FakeCursor } from './cursor'
 export {
+  DemoState,
   DemoPress,
+  DemoFocus,
   DemoCaret,
-  DEMO_FOCUS_RING,
-  demoFocusProps,
+  applyDemoState,
 } from './interaction'
+export type { DemoStateFlags } from './interaction'
 export { OverlayScene } from './overlay-scene'
 export type { SurfaceVariant } from './overlay-scene'

--- a/www/src/modules/docs/components-list/autoplay/index.ts
+++ b/www/src/modules/docs/components-list/autoplay/index.ts
@@ -1,0 +1,27 @@
+export { CardHoverProvider, useCardHover } from './card-hover'
+export {
+  useAutoplay,
+  useTypewriter,
+  useToggleAutoplay,
+  useStepAutoplay,
+  useOpenAutoplay,
+  useValueAutoplay,
+} from './use-autoplay'
+export type {
+  AutoplayPhase,
+  AutoplayState,
+  TypewriterState,
+  ToggleAutoplayState,
+  StepAutoplayState,
+  ValueAutoplayState,
+  ScenePhase,
+} from './use-autoplay'
+export { FakeCursor } from './cursor'
+export {
+  DemoPress,
+  DemoCaret,
+  DEMO_FOCUS_RING,
+  demoFocusProps,
+} from './interaction'
+export { OverlayScene } from './overlay-scene'
+export type { SurfaceVariant } from './overlay-scene'

--- a/www/src/modules/docs/components-list/autoplay/interaction.tsx
+++ b/www/src/modules/docs/components-list/autoplay/interaction.tsx
@@ -1,89 +1,145 @@
 'use client'
 
-import type * as React from 'react'
+import { type ReactNode, useEffect, useLayoutEffect, useRef } from 'react'
 
 import { cn } from '@/registry/lib/utils'
 
 /**
- * Generic, component-agnostic "this is being interacted with" wrapper. It maps a
- * phase to a small scale + brightness shift on whatever it wraps, so a button,
- * link, swatch or menu item reads as hovered → pressed without us needing to
- * know its colours.
+ * Exact-fidelity state simulation for the preview cards.
  *
- * Animations are plain CSS transitions on inline styles (not a JS animation
- * library): the previews live inside an `inert` subtree, where script-driven
- * transform animations don't run, but CSS transitions do — and they cost nothing
- * when idle. It styles nothing permanently and never fires real events.
+ * Instead of faking interaction with our own transforms, we mirror the desired
+ * state onto the REAL React Aria state attributes (`data-hovered`, `data-pressed`,
+ * `data-focused`, …) of the real component. The component then renders its OWN
+ * state styles — the exact look it will have under any design-system preset —
+ * with no interaction and without ever touching the page's real focus.
+ *
+ * The attributes are (re)applied in a layout effect after every render because
+ * React Aria rewrites them from its internal state (always idle here) on each
+ * render; re-applying post-commit, pre-paint, keeps them set with no flicker.
  */
-const PRESS_TRANSFORM: Record<string, string> = {
-  idle: 'scale(1)',
-  hover: 'scale(1.045)',
-  press: 'scale(0.95)',
-}
-const PRESS_FILTER: Record<string, string> = {
-  idle: 'brightness(1)',
-  hover: 'brightness(1.07)',
-  press: 'brightness(0.92)',
+
+// useLayoutEffect on the client, no-op useEffect on the server (avoids the SSR warning).
+const useIsoLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect
+
+export interface DemoStateFlags {
+  hovered?: boolean
+  pressed?: boolean
+  /** Adds `data-focused` — drives `focus:` (input rings, etc.). */
+  focused?: boolean
+  /** Adds `data-focused` + `data-focus-visible` — drives `focus-visible:` rings. */
+  focusVisible?: boolean
+  selected?: boolean
+  open?: boolean
+  current?: boolean
 }
 
-export function DemoPress({
-  phase,
-  pressing,
-  hovering,
-  className,
+const FLAG_ATTRS: [keyof DemoStateFlags, string][] = [
+  ['hovered', 'data-hovered'],
+  ['pressed', 'data-pressed'],
+  ['selected', 'data-selected'],
+  ['open', 'data-open'],
+  ['current', 'data-current'],
+]
+
+export function applyDemoState(el: HTMLElement, flags: DemoStateFlags): void {
+  for (const [key, attr] of FLAG_ATTRS) {
+    if (flags[key]) el.setAttribute(attr, '')
+    else el.removeAttribute(attr)
+  }
+  const focused = flags.focused || flags.focusVisible
+  if (focused) el.setAttribute('data-focused', '')
+  else el.removeAttribute('data-focused')
+  if (flags.focusVisible) el.setAttribute('data-focus-visible', '')
+  else el.removeAttribute('data-focus-visible')
+}
+
+/**
+ * Wraps a single child in a `display:contents` span (so it adds no box) and
+ * mirrors `flags` onto the child element's real state attributes. `target`
+ * selects which descendant to drive when the styled element isn't the wrapper's
+ * first child.
+ */
+export function DemoState({
+  flags,
+  target = 'first',
   children,
 }: {
-  /** Explicit phase. Takes precedence over the boolean shorthands. */
-  phase?: 'idle' | 'hover' | 'press' | (string & {})
-  /** Shorthand: show the press state. */
-  pressing?: boolean
-  /** Shorthand: show the hover state. */
-  hovering?: boolean
-  className?: string
-  children: React.ReactNode
+  flags: DemoStateFlags
+  target?: 'first' | 'last' | 'all'
+  children: ReactNode
 }) {
-  const resolved =
-    phase && phase in PRESS_TRANSFORM
-      ? phase
-      : pressing
-        ? 'press'
-        : hovering
-          ? 'hover'
-          : 'idle'
+  const ref = useRef<HTMLSpanElement>(null)
+
+  useIsoLayoutEffect(() => {
+    const host = ref.current
+    if (!host) return
+    const targets =
+      target === 'all'
+        ? Array.from(host.children)
+        : target === 'last'
+          ? [host.lastElementChild]
+          : [host.firstElementChild]
+    for (const el of targets) {
+      if (el instanceof HTMLElement) applyDemoState(el, flags)
+    }
+  })
 
   return (
-    <div
-      className={cn('inline-flex', className)}
-      style={{
-        transform: PRESS_TRANSFORM[resolved] ?? PRESS_TRANSFORM.idle,
-        filter: PRESS_FILTER[resolved] ?? PRESS_FILTER.idle,
-        transformOrigin: 'center',
-        transition:
-          'transform 220ms cubic-bezier(0.32,0.72,0,1), filter 220ms ease',
-      }}
-    >
+    <span ref={ref} style={{ display: 'contents' }}>
       {children}
-    </div>
+    </span>
   )
 }
 
 /**
- * Faux focus-ring classes. Applied to the real field element via a custom
- * `data-demo-focus` attribute so we replicate the exact focus look (the same
- * `border-border-focus` + `ring-border-focus-muted` tokens RAC uses) without
- * the field actually being `:focus`. The attribute selector out-specifies the
- * resting `border-border-field`, so toggling `data-demo-focus` flips the ring.
- *
- * Usage: spread `demoFocusProps(active)` onto the bordered field element.
+ * Drives the real hover / pressed states of a pressable (Button, Link,
+ * ToggleButton, menu item…). Accepts either an explicit `phase`
+ * (`idle | hover | press | …`) or the `hovering` / `pressing` booleans.
  */
-export const DEMO_FOCUS_RING =
-  'transition-[box-shadow,border-color] duration-200 data-demo-focus:border-border-focus data-demo-focus:ring-2 data-demo-focus:ring-border-focus-muted'
+export function DemoPress({
+  phase,
+  pressing,
+  hovering,
+  target,
+  children,
+}: {
+  phase?: string
+  pressing?: boolean
+  hovering?: boolean
+  target?: 'first' | 'last' | 'all'
+  children: ReactNode
+}) {
+  const isPressed = pressing || phase === 'press'
+  const isHovered = isPressed || hovering || phase === 'hover'
+  return (
+    <DemoState
+      flags={{ hovered: isHovered, pressed: isPressed }}
+      target={target}
+    >
+      {children}
+    </DemoState>
+  )
+}
 
-export function demoFocusProps(active: boolean) {
-  return {
-    'data-demo-focus': active ? '' : undefined,
-    className: DEMO_FOCUS_RING,
-  }
+/**
+ * Drives the real focus state of a field so it shows its actual focus ring/border
+ * — without taking real focus (the preview is `inert`; we only set the attribute).
+ */
+export function DemoFocus({
+  active,
+  target,
+  children,
+}: {
+  active: boolean
+  target?: 'first' | 'last' | 'all'
+  children: ReactNode
+}) {
+  return (
+    <DemoState flags={{ focused: active }} target={target}>
+      {children}
+    </DemoState>
+  )
 }
 
 /**

--- a/www/src/modules/docs/components-list/autoplay/interaction.tsx
+++ b/www/src/modules/docs/components-list/autoplay/interaction.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import type * as React from 'react'
+
+import { cn } from '@/registry/lib/utils'
+
+/**
+ * Generic, component-agnostic "this is being interacted with" wrapper. It maps a
+ * phase to a small scale + brightness shift on whatever it wraps, so a button,
+ * link, swatch or menu item reads as hovered → pressed without us needing to
+ * know its colours.
+ *
+ * Animations are plain CSS transitions on inline styles (not a JS animation
+ * library): the previews live inside an `inert` subtree, where script-driven
+ * transform animations don't run, but CSS transitions do — and they cost nothing
+ * when idle. It styles nothing permanently and never fires real events.
+ */
+const PRESS_TRANSFORM: Record<string, string> = {
+  idle: 'scale(1)',
+  hover: 'scale(1.045)',
+  press: 'scale(0.95)',
+}
+const PRESS_FILTER: Record<string, string> = {
+  idle: 'brightness(1)',
+  hover: 'brightness(1.07)',
+  press: 'brightness(0.92)',
+}
+
+export function DemoPress({
+  phase,
+  pressing,
+  hovering,
+  className,
+  children,
+}: {
+  /** Explicit phase. Takes precedence over the boolean shorthands. */
+  phase?: 'idle' | 'hover' | 'press' | (string & {})
+  /** Shorthand: show the press state. */
+  pressing?: boolean
+  /** Shorthand: show the hover state. */
+  hovering?: boolean
+  className?: string
+  children: React.ReactNode
+}) {
+  const resolved =
+    phase && phase in PRESS_TRANSFORM
+      ? phase
+      : pressing
+        ? 'press'
+        : hovering
+          ? 'hover'
+          : 'idle'
+
+  return (
+    <div
+      className={cn('inline-flex', className)}
+      style={{
+        transform: PRESS_TRANSFORM[resolved] ?? PRESS_TRANSFORM.idle,
+        filter: PRESS_FILTER[resolved] ?? PRESS_FILTER.idle,
+        transformOrigin: 'center',
+        transition:
+          'transform 220ms cubic-bezier(0.32,0.72,0,1), filter 220ms ease',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Faux focus-ring classes. Applied to the real field element via a custom
+ * `data-demo-focus` attribute so we replicate the exact focus look (the same
+ * `border-border-focus` + `ring-border-focus-muted` tokens RAC uses) without
+ * the field actually being `:focus`. The attribute selector out-specifies the
+ * resting `border-border-field`, so toggling `data-demo-focus` flips the ring.
+ *
+ * Usage: spread `demoFocusProps(active)` onto the bordered field element.
+ */
+export const DEMO_FOCUS_RING =
+  'transition-[box-shadow,border-color] duration-200 data-demo-focus:border-border-focus data-demo-focus:ring-2 data-demo-focus:ring-border-focus-muted'
+
+export function demoFocusProps(active: boolean) {
+  return {
+    'data-demo-focus': active ? '' : undefined,
+    className: DEMO_FOCUS_RING,
+  }
+}
+
+/**
+ * A blinking text caret, for fields where the typed text sits in normal flow
+ * (search, command palette) rather than inside a real `<input>`.
+ */
+export function DemoCaret({
+  visible = true,
+  className,
+}: {
+  visible?: boolean
+  className?: string
+}) {
+  if (!visible) return null
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'inline-block h-[1.1em] w-px translate-y-[0.15em] animate-caret-blink bg-fg',
+        className,
+      )}
+    />
+  )
+}

--- a/www/src/modules/docs/components-list/autoplay/overlay-scene.tsx
+++ b/www/src/modules/docs/components-list/autoplay/overlay-scene.tsx
@@ -1,0 +1,249 @@
+'use client'
+
+import type * as React from 'react'
+
+import { cn } from '@/registry/lib/utils'
+
+import { FakeCursor } from './cursor'
+import { DemoPress } from './interaction'
+import type { ScenePhase } from './use-autoplay'
+
+/**
+ * The cinematic for overlay triggers. A trigger sits centered; a cursor moves in,
+ * hovers and clicks; then the overlay opens and the whole scene "zooms out" — the
+ * trigger rides up and shrinks as the surface unfolds, so the entire interaction
+ * stays framed inside the small preview.
+ *
+ * Everything is presentational: the trigger is a real component, the surface uses
+ * the real token classes, but the open state is faked so nothing portals out of
+ * the card or touches real focus. Animations are CSS transitions (the previews
+ * are `inert`, where script-driven animation libraries don't run): surfaces stay
+ * mounted and toggle their visual state, so they animate in and out, and the
+ * anchored layout uses the grid-rows `0fr → 1fr` trick to reflow the column
+ * height — which is what carries the trigger up.
+ */
+
+export type SurfaceVariant = 'popover' | 'menu' | 'modal' | 'drawer' | 'tooltip'
+
+interface OverlaySceneProps {
+  phase: ScenePhase
+  variant: SurfaceVariant
+  /** Which side of the trigger the surface unfolds (anchored variants only). */
+  side?: 'top' | 'bottom'
+  /** The real trigger (a Button, icon button, input group…). */
+  trigger: React.ReactNode
+  /** The surface contents — real sub-components (DialogHeader, ListBox…). */
+  children: React.ReactNode
+  /** Scale of the trigger+surface stack when open (anchored variants). */
+  openScale?: number
+  /** Extra classes for the surface frame. */
+  surfaceClassName?: string
+  /** Position the cursor over the trigger (defaults to the bottom-right corner). */
+  cursorClassName?: string
+}
+
+const SURFACE_FRAME: Record<SurfaceVariant, string> = {
+  popover:
+    'rounded-(--popover-radius) border bg-popover p-2.5 text-xs/relaxed shadow-md',
+  menu: 'rounded-(--popover-radius) border bg-popover p-1 shadow-md',
+  modal:
+    'rounded-(--modal-radius,var(--radius-lg)) border bg-bg p-4 text-sm shadow-lg',
+  drawer: 'rounded-t-(--radius-xl) border-t bg-bg p-4 text-sm shadow-lg',
+  tooltip:
+    'rounded-(--tooltip-radius) bg-tooltip px-3 py-1.5 text-center text-xs text-fg-on-tooltip shadow-md',
+}
+
+// The ancestor data attribute the real Dialog* sub-components key their
+// in-context padding on (`in-data-popover:` / `in-data-modal:`).
+const SURFACE_DATA: Partial<Record<SurfaceVariant, Record<string, string>>> = {
+  popover: { 'data-popover': '' },
+  menu: { 'data-popover': '' },
+  modal: { 'data-modal': '' },
+}
+
+const SCENE_ROOT =
+  'relative flex h-full w-full items-center justify-center overflow-hidden'
+const EASE = 'cubic-bezier(0.32,0.72,0,1)'
+
+function Trigger({
+  phase,
+  dim,
+  scale,
+  cursorClassName,
+  children,
+}: {
+  phase: ScenePhase
+  dim?: boolean
+  scale?: number
+  cursorClassName?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className="relative"
+      style={{
+        opacity: dim ? 0.55 : 1,
+        transform: `scale(${scale ?? 1})`,
+        transition: `opacity 300ms ease, transform 300ms ${EASE}`,
+      }}
+    >
+      <DemoPress phase={phase}>{children}</DemoPress>
+      <FakeCursor
+        phase={phase}
+        className={cn(
+          'right-0 bottom-0 translate-x-1 translate-y-1',
+          cursorClassName,
+        )}
+      />
+    </div>
+  )
+}
+
+/** A surface that grows in/out of the column flow (driving the trigger's ride). */
+function AnchoredSurface({
+  open,
+  side,
+  children,
+}: {
+  open: boolean
+  side: 'top' | 'bottom'
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className="grid overflow-hidden"
+      style={{
+        gridTemplateRows: open ? '1fr' : '0fr',
+        transition: `grid-template-rows 360ms ${EASE}`,
+      }}
+    >
+      <div className="min-h-0">
+        <div
+          className={side === 'bottom' ? 'pt-2' : 'pb-2'}
+          style={{
+            opacity: open ? 1 : 0,
+            transform: open
+              ? 'none'
+              : `translateY(${side === 'bottom' ? '-4px' : '4px'}) scale(0.96)`,
+            transition: `opacity 240ms ease, transform 300ms ${EASE}`,
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function OverlayScene({
+  phase,
+  variant,
+  side = 'bottom',
+  trigger,
+  children,
+  openScale,
+  surfaceClassName,
+  cursorClassName,
+}: OverlaySceneProps) {
+  const open = phase === 'open'
+  const surface = (
+    <div
+      {...SURFACE_DATA[variant]}
+      className={cn(SURFACE_FRAME[variant], surfaceClassName)}
+    >
+      {children}
+    </div>
+  )
+
+  // Modal: centered panel over a dimming backdrop; the trigger dims behind it.
+  if (variant === 'modal') {
+    return (
+      <div className={SCENE_ROOT}>
+        <Trigger
+          phase={phase}
+          dim={open}
+          scale={open ? 0.96 : 1}
+          cursorClassName={cursorClassName}
+        >
+          {trigger}
+        </Trigger>
+        <div
+          aria-hidden
+          className="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
+          style={{ opacity: open ? 1 : 0, transition: 'opacity 250ms ease' }}
+        />
+        <div
+          className="absolute w-[78%] max-w-[15rem]"
+          style={{
+            opacity: open ? 1 : 0,
+            transform: open ? 'none' : 'translateY(6px) scale(0.95)',
+            transition: `opacity 250ms ease, transform 300ms ${EASE}`,
+          }}
+        >
+          {surface}
+        </div>
+      </div>
+    )
+  }
+
+  // Drawer: bottom sheet slides up over a dimming backdrop.
+  if (variant === 'drawer') {
+    return (
+      <div className={SCENE_ROOT}>
+        <Trigger
+          phase={phase}
+          dim={open}
+          scale={open ? 0.96 : 1}
+          cursorClassName={cursorClassName}
+        >
+          {trigger}
+        </Trigger>
+        <div
+          aria-hidden
+          className="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
+          style={{ opacity: open ? 1 : 0, transition: 'opacity 250ms ease' }}
+        />
+        <div
+          className="absolute inset-x-2 bottom-0"
+          style={{
+            transform: open ? 'translateY(0)' : 'translateY(100%)',
+            transition: `transform 360ms ${EASE}`,
+          }}
+        >
+          {surface}
+        </div>
+      </div>
+    )
+  }
+
+  // Anchored (popover / menu / tooltip): the trigger + surface share a column
+  // that scales down when open so both fit — the "zoom out" the trigger rides.
+  const resolvedScale = openScale ?? (variant === 'tooltip' ? 0.95 : 0.82)
+
+  return (
+    <div className={SCENE_ROOT}>
+      <div
+        className="flex flex-col items-center"
+        style={{
+          transform: `scale(${open ? resolvedScale : 1})`,
+          transformOrigin: 'center',
+          transition: `transform 400ms ${EASE}`,
+        }}
+      >
+        {side === 'top' && (
+          <AnchoredSurface open={open} side="top">
+            {surface}
+          </AnchoredSurface>
+        )}
+        <Trigger phase={phase} cursorClassName={cursorClassName}>
+          {trigger}
+        </Trigger>
+        {side === 'bottom' && (
+          <AnchoredSurface open={open} side="bottom">
+            {surface}
+          </AnchoredSurface>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/docs/components-list/autoplay/overlay-scene.tsx
+++ b/www/src/modules/docs/components-list/autoplay/overlay-scene.tsx
@@ -65,16 +65,18 @@ const SCENE_ROOT =
   'relative flex h-full w-full items-center justify-center overflow-hidden'
 const EASE = 'cubic-bezier(0.32,0.72,0,1)'
 
+// The trigger is a real component; it only ever shows real hover/pressed styles
+// (via DemoPress → real RAC state attributes), never a synthetic scale. When an
+// overlay opens it can dim back (a depth cue), but it does not resize — the only
+// scaling is the scene "camera" on the anchored column below.
 function Trigger({
   phase,
   dim,
-  scale,
   cursorClassName,
   children,
 }: {
   phase: ScenePhase
   dim?: boolean
-  scale?: number
   cursorClassName?: string
   children: React.ReactNode
 }) {
@@ -83,8 +85,7 @@ function Trigger({
       className="relative"
       style={{
         opacity: dim ? 0.55 : 1,
-        transform: `scale(${scale ?? 1})`,
-        transition: `opacity 300ms ease, transform 300ms ${EASE}`,
+        transition: 'opacity 300ms ease',
       }}
     >
       <DemoPress phase={phase}>{children}</DemoPress>
@@ -159,12 +160,7 @@ export function OverlayScene({
   if (variant === 'modal') {
     return (
       <div className={SCENE_ROOT}>
-        <Trigger
-          phase={phase}
-          dim={open}
-          scale={open ? 0.96 : 1}
-          cursorClassName={cursorClassName}
-        >
+        <Trigger phase={phase} dim={open} cursorClassName={cursorClassName}>
           {trigger}
         </Trigger>
         <div
@@ -190,12 +186,7 @@ export function OverlayScene({
   if (variant === 'drawer') {
     return (
       <div className={SCENE_ROOT}>
-        <Trigger
-          phase={phase}
-          dim={open}
-          scale={open ? 0.96 : 1}
-          cursorClassName={cursorClassName}
-        >
+        <Trigger phase={phase} dim={open} cursorClassName={cursorClassName}>
           {trigger}
         </Trigger>
         <div

--- a/www/src/modules/docs/components-list/autoplay/overlay-scene.tsx
+++ b/www/src/modules/docs/components-list/autoplay/overlay-scene.tsx
@@ -176,15 +176,20 @@ export function OverlayScene({
           className="absolute inset-0 bg-black/40 backdrop-blur-[1px]"
           style={{ opacity: open ? 1 : 0, transition: 'opacity 250ms ease' }}
         />
-        <div
-          className="absolute w-[78%] max-w-[15rem]"
-          style={{
-            opacity: open ? 1 : 0,
-            transform: open ? 'none' : 'translateY(6px) scale(0.95)',
-            transition: `opacity 250ms ease, transform 300ms ${EASE}`,
-          }}
-        >
-          {surface}
+        <div className="absolute inset-0 flex items-center justify-center p-3">
+          <div
+            className="w-full max-w-[13rem]"
+            style={{
+              opacity: open ? 1 : 0,
+              transform: open
+                ? `scale(${openScale ?? 0.92})`
+                : 'translateY(6px) scale(0.9)',
+              transformOrigin: 'center',
+              transition: `opacity 250ms ease, transform 300ms ${EASE}`,
+            }}
+          >
+            {surface}
+          </div>
         </div>
       </div>
     )
@@ -217,7 +222,7 @@ export function OverlayScene({
 
   // Anchored (popover / menu / tooltip): the trigger + surface share a column
   // that scales down when open so both fit — the "zoom out" the trigger rides.
-  const resolvedScale = openScale ?? (variant === 'tooltip' ? 0.95 : 0.82)
+  const resolvedScale = openScale ?? (variant === 'tooltip' ? 0.92 : 0.7)
 
   return (
     <div className={SCENE_ROOT}>

--- a/www/src/modules/docs/components-list/autoplay/overlay-scene.tsx
+++ b/www/src/modules/docs/components-list/autoplay/overlay-scene.tsx
@@ -36,6 +36,9 @@ interface OverlaySceneProps {
   children: React.ReactNode
   /** Scale of the trigger+surface stack when open (anchored variants). */
   openScale?: number
+  /** Field-style trigger: fill the width so it matches the stretched field demos
+   *  (combobox, select, date-picker) instead of sizing to content. */
+  fluid?: boolean
   /** Extra classes for the surface frame. */
   surfaceClassName?: string
   /** Position the cursor over the trigger (defaults to the bottom-right corner). */
@@ -72,17 +75,21 @@ const EASE = 'cubic-bezier(0.32,0.72,0,1)'
 function Trigger({
   phase,
   dim,
+  fluid,
   cursorClassName,
   children,
 }: {
   phase: ScenePhase
   dim?: boolean
+  fluid?: boolean
   cursorClassName?: string
   children: React.ReactNode
 }) {
   return (
     <div
-      className="relative"
+      // `fluid` field triggers fill the column so their width matches the
+      // stretched field demos; the cursor still anchors to the field's corner.
+      className={cn('relative', fluid && 'w-full')}
       style={{
         opacity: dim ? 0.55 : 1,
         transition: 'opacity 300ms ease',
@@ -143,6 +150,7 @@ export function OverlayScene({
   trigger,
   children,
   openScale,
+  fluid = false,
   surfaceClassName,
   cursorClassName,
 }: OverlaySceneProps) {
@@ -214,7 +222,10 @@ export function OverlayScene({
   return (
     <div className={SCENE_ROOT}>
       <div
-        className="flex flex-col items-center"
+        // `fluid` makes field-style triggers (combobox, select, date-picker) fill
+        // the width + horizontal inset so they match the stretched field demos;
+        // icon-button triggers stay content-sized and centered.
+        className={cn('flex flex-col items-center', fluid && 'w-full px-4')}
         style={{
           transform: `scale(${open ? resolvedScale : 1})`,
           transformOrigin: 'center',
@@ -226,7 +237,7 @@ export function OverlayScene({
             {surface}
           </AnchoredSurface>
         )}
-        <Trigger phase={phase} cursorClassName={cursorClassName}>
+        <Trigger phase={phase} fluid={fluid} cursorClassName={cursorClassName}>
           {trigger}
         </Trigger>
         {side === 'bottom' && (

--- a/www/src/modules/docs/components-list/autoplay/use-autoplay.ts
+++ b/www/src/modules/docs/components-list/autoplay/use-autoplay.ts
@@ -1,0 +1,328 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useReducedMotion } from 'motion/react'
+
+import { useCardHover } from './card-hover'
+
+/**
+ * Looping timeline primitives that drive the component-card preview animations.
+ *
+ * Every hook here is gated on two things: the card being hovered/focused
+ * (`useCardHover`) and `prefers-reduced-motion` being off. When either is false
+ * the hook returns its resting value (phase 0 / empty text / default selection)
+ * so the card looks exactly like the static preview did before — the animation
+ * is strictly additive and only ever plays on hover.
+ */
+
+export interface AutoplayPhase {
+  /** Phase name the demo switches on. */
+  name: string
+  /** How long to stay in this phase before advancing, in ms. */
+  duration: number
+}
+
+export interface AutoplayState {
+  /** Current phase name (resting phase when not playing). */
+  phase: string
+  /** Index of the current phase in the timeline. */
+  index: number
+  /** How many full loops have completed. */
+  cycle: number
+  /** True while the timeline is actively advancing. */
+  playing: boolean
+}
+
+interface AutoplayOptions {
+  /** Override the active signal (defaults to the card's hover/focus state). */
+  active?: boolean
+  /** Loop back to the first phase after the last (default true). */
+  loop?: boolean
+  /** Delay before the first advance, in ms. */
+  startDelay?: number
+}
+
+function usePrefersReducedMotion(): boolean {
+  return useReducedMotion() ?? false
+}
+
+/**
+ * Steps through `phases` while active, then loops. Returns the resting phase
+ * (index 0) whenever inactive or under reduced motion. Timers are torn down on
+ * deactivation/unmount, so an un-hovered card runs nothing.
+ */
+export function useAutoplay(
+  phases: AutoplayPhase[],
+  options: AutoplayOptions = {},
+): AutoplayState {
+  const hovered = useCardHover()
+  const reduce = usePrefersReducedMotion()
+  const { active = hovered, loop = true, startDelay = 0 } = options
+
+  const [index, setIndex] = useState(0)
+  const [cycle, setCycle] = useState(0)
+
+  const phasesRef = useRef(phases)
+  phasesRef.current = phases
+
+  // Restart the timeline whenever its shape changes, not just its array identity.
+  const shape = phases.map((p) => `${p.name}:${p.duration}`).join('|')
+  const enabled = active && !reduce && phases.length > 1
+
+  useEffect(() => {
+    if (!enabled) {
+      setIndex(0)
+      setCycle(0)
+      return
+    }
+
+    let i = 0
+    let c = 0
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    setIndex(0)
+    setCycle(0)
+
+    const advance = (delay: number) => {
+      timer = setTimeout(() => {
+        if (cancelled) return
+        const list = phasesRef.current
+        i += 1
+        if (i >= list.length) {
+          if (!loop) return
+          i = 0
+          c += 1
+        }
+        setIndex(i)
+        setCycle(c)
+        advance(list[i]?.duration ?? 600)
+      }, delay)
+    }
+
+    advance(startDelay + (phasesRef.current[0]?.duration ?? 600))
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [enabled, loop, startDelay, shape])
+
+  const resolvedIndex = enabled ? index : 0
+  const phase = phases[resolvedIndex]?.name ?? phases[0]?.name ?? 'idle'
+
+  return { phase, index: resolvedIndex, cycle, playing: enabled }
+}
+
+export interface TypewriterState {
+  /** Currently visible substring. */
+  value: string
+  /** True while characters are still being added. */
+  typing: boolean
+  /** True once the full string is shown. */
+  done: boolean
+  /** True while active — use to show a faux focus ring / caret. */
+  active: boolean
+}
+
+interface TypewriterOptions extends Pick<AutoplayOptions, 'active' | 'loop'> {
+  /** Delay before the first character, in ms. */
+  startDelay?: number
+  /** Time between characters, in ms. */
+  charInterval?: number
+  /** Hold the full string this long before clearing to loop, in ms. */
+  holdAfter?: number
+}
+
+/**
+ * Reveals `text` one character at a time while active, then (looping) clears and
+ * retypes. Returns an empty string when inactive so the field shows its
+ * placeholder. Pair `value` with a controlled, read-only field and `active` with
+ * a faux focus ring.
+ */
+export function useTypewriter(
+  text: string,
+  options: TypewriterOptions = {},
+): TypewriterState {
+  const hovered = useCardHover()
+  const reduce = usePrefersReducedMotion()
+  const {
+    active = hovered,
+    loop = true,
+    startDelay = 450,
+    charInterval = 65,
+    holdAfter = 1400,
+  } = options
+
+  const [count, setCount] = useState(0)
+  const enabled = active && !reduce && text.length > 0
+
+  useEffect(() => {
+    if (!enabled) {
+      setCount(0)
+      return
+    }
+
+    let n = 0
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    setCount(0)
+
+    const tick = () => {
+      if (cancelled) return
+      if (n < text.length) {
+        n += 1
+        setCount(n)
+        timer = setTimeout(tick, charInterval)
+        return
+      }
+      if (!loop) return
+      timer = setTimeout(() => {
+        if (cancelled) return
+        n = 0
+        setCount(0)
+        timer = setTimeout(tick, charInterval)
+      }, holdAfter)
+    }
+
+    timer = setTimeout(tick, startDelay)
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [enabled, text, charInterval, holdAfter, startDelay, loop])
+
+  const value = enabled ? text.slice(0, count) : ''
+  return {
+    value,
+    typing: enabled && count < text.length,
+    done: enabled && count >= text.length,
+    active: enabled,
+  }
+}
+
+export interface ToggleAutoplayState {
+  /** The simulated on/off (or selected) value. */
+  selected: boolean
+  /** True for a brief beat around each flip — drive a press dip with it. */
+  pressing: boolean
+}
+
+/**
+ * Flips a boolean on/off on a loop while active, with a short "pressing" beat
+ * around each flip so the control can show a click. Used by checkbox, switch,
+ * single-checkbox-style toggles, etc.
+ */
+export function useToggleAutoplay(
+  options: AutoplayOptions & { initial?: boolean } = {},
+): ToggleAutoplayState {
+  const { initial = false, ...rest } = options
+  const { phase } = useAutoplay(
+    [
+      { name: 'rest-a', duration: 1100 },
+      { name: 'press-a', duration: 170 },
+      { name: 'rest-b', duration: 1100 },
+      { name: 'press-b', duration: 170 },
+    ],
+    rest,
+  )
+  const pressing = phase === 'press-a' || phase === 'press-b'
+  // After press-a we're "on", after press-b we're "off" again.
+  const flipped = phase === 'press-a' || phase === 'rest-b'
+  return { selected: initial ? !flipped : flipped, pressing }
+}
+
+export interface StepAutoplayState {
+  /** Currently selected step index. */
+  index: number
+  /** True for a brief beat around each step change. */
+  pressing: boolean
+}
+
+/**
+ * Cycles a selected index through `0..count-1` on a loop while active, with a
+ * short press beat at each change. Used for tabs, segmented/toggle-button
+ * groups, radio groups, single-select lists, pagination, etc.
+ */
+export function useStepAutoplay(
+  count: number,
+  options: AutoplayOptions & {
+    /** Where the cycle rests when not playing. */
+    initial?: number
+    /** How long each step is shown, in ms. */
+    dwell?: number
+  } = {},
+): StepAutoplayState {
+  const { initial = 0, dwell = 1150, ...rest } = options
+  const safeCount = Math.max(1, count)
+
+  const phases: AutoplayPhase[] = []
+  for (let i = 0; i < safeCount; i += 1) {
+    phases.push({ name: `press-${i}`, duration: 180 })
+    phases.push({ name: `dwell-${i}`, duration: dwell })
+  }
+
+  const { index: phaseIndex, playing } = useAutoplay(phases, rest)
+  if (!playing) return { index: initial, pressing: false }
+
+  const step = Math.floor(phaseIndex / 2) % safeCount
+  const pressing = phaseIndex % 2 === 0
+  return { index: step, pressing }
+}
+
+export type ScenePhase = 'idle' | 'hover' | 'press' | 'open'
+
+/**
+ * The shared timeline for overlay triggers: trigger sits idle, a cursor moves in
+ * and hovers, presses, then the overlay opens and holds before looping. Feed the
+ * returned `phase` straight into `<OverlayScene>`.
+ */
+export function useOpenAutoplay(
+  options: AutoplayOptions & {
+    /** How long the opened overlay holds before looping, in ms. */
+    holdOpen?: number
+  } = {},
+): { phase: ScenePhase; cycle: number } {
+  const { holdOpen = 2000, ...rest } = options
+  const { phase, cycle } = useAutoplay(
+    [
+      { name: 'idle', duration: 750 },
+      { name: 'hover', duration: 480 },
+      { name: 'press', duration: 240 },
+      { name: 'open', duration: holdOpen },
+    ],
+    rest,
+  )
+  return { phase: phase as ScenePhase, cycle }
+}
+
+export interface ValueAutoplayState {
+  /** The current animated value. */
+  value: number
+  /** True while the thumb/fill is moving toward a new target. */
+  moving: boolean
+}
+
+/**
+ * Oscillates a numeric value between waypoints while active (sliders), or sweeps
+ * once to a target and holds (progress). Returns `from` when inactive.
+ */
+export function useValueAutoplay(
+  waypoints: number[],
+  options: AutoplayOptions & { dwell?: number } = {},
+): ValueAutoplayState {
+  const { dwell = 950, ...rest } = options
+  const stops = waypoints.length > 0 ? waypoints : [0]
+
+  const phases: AutoplayPhase[] = stops.map((_, i) => ({
+    name: `stop-${i}`,
+    duration: dwell,
+  }))
+
+  const { index, playing } = useAutoplay(phases, rest)
+  return {
+    value: playing ? (stops[index] ?? stops[0]) : stops[0],
+    moving: playing,
+  }
+}

--- a/www/src/modules/docs/components-list/autoplay/use-autoplay.ts
+++ b/www/src/modules/docs/components-list/autoplay/use-autoplay.ts
@@ -302,9 +302,11 @@ export function useOpenAutoplay(
   const { holdOpen = 2000, ...rest } = options
   const { phase, cycle } = useAutoplay(
     [
-      { name: 'idle', duration: 750 },
-      { name: 'hover', duration: 480 },
-      { name: 'press', duration: 240 },
+      { name: 'idle', duration: 700 },
+      // Long enough for the cursor's ~520ms glide-in to settle before the click.
+      { name: 'hover', duration: 640 },
+      // Covers the click ripple (~320ms) plus a brief hold.
+      { name: 'press', duration: 360 },
       { name: 'open', duration: holdOpen },
     ],
     rest,

--- a/www/src/modules/docs/components-list/autoplay/use-autoplay.ts
+++ b/www/src/modules/docs/components-list/autoplay/use-autoplay.ts
@@ -271,6 +271,21 @@ export function useStepAutoplay(
   return { index: step, pressing }
 }
 
+/**
+ * Cycles through `items` and returns the current ITEM (typed, never undefined)
+ * — a typed convenience over `useStepAutoplay` for selection demos that map an
+ * index back to a key/value (lists, tag groups, segmented controls).
+ */
+export function useCycle<T>(
+  items: readonly T[],
+  options: AutoplayOptions & { initial?: number; dwell?: number } = {},
+): { item: T; index: number; pressing: boolean } {
+  const { index, pressing } = useStepAutoplay(items.length, options)
+  const len = items.length
+  const safe = len > 0 ? ((index % len) + len) % len : 0
+  return { item: items[safe] as T, index: safe, pressing }
+}
+
 export type ScenePhase = 'idle' | 'hover' | 'press' | 'open'
 
 /**
@@ -321,8 +336,9 @@ export function useValueAutoplay(
   }))
 
   const { index, playing } = useAutoplay(phases, rest)
+  const first = stops[0] ?? 0
   return {
-    value: playing ? (stops[index] ?? stops[0]) : stops[0],
+    value: playing ? (stops[index] ?? first) : first,
     moving: playing,
   }
 }

--- a/www/src/modules/docs/components-list/component-card.tsx
+++ b/www/src/modules/docs/components-list/component-card.tsx
@@ -36,6 +36,9 @@ interface ComponentCardProps {
   /** Full-bleed demos (overlay scenes) fill the preview instead of being centered
    *  and scaled — they manage their own framing and the "zoom out" choreography. */
   fill?: boolean
+  /** Field-like demos render full-width (not scaled), so the field is responsive
+   *  to the card and consistent across the set; the demo caps itself via max-width. */
+  stretch?: boolean
 }
 
 export function ComponentCard({
@@ -45,6 +48,7 @@ export function ComponentCard({
   scale = 0.8,
   previewClassName,
   fill = false,
+  stretch = false,
 }: ComponentCardProps) {
   const Demo = componentDemos[slug]
   // Hover/keyboard-focus on the card drives the demo's autoplay animation. The
@@ -84,6 +88,10 @@ export function ComponentCard({
         <CardHoverProvider value={active}>
           {fill ? (
             <div inert className="absolute inset-0">
+              {content}
+            </div>
+          ) : stretch ? (
+            <div inert className="flex w-full items-center justify-center">
               {content}
             </div>
           ) : (

--- a/www/src/modules/docs/components-list/component-card.tsx
+++ b/www/src/modules/docs/components-list/component-card.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { useState } from 'react'
 import { Link } from '@tanstack/react-router'
 
 import { cn } from '@/registry/lib/utils'
 
+import { CardHoverProvider } from './autoplay'
 import { componentDemos } from './demos'
 
 function ComponentPreview({
@@ -31,6 +33,9 @@ interface ComponentCardProps {
   href: string
   scale?: number
   previewClassName?: string
+  /** Full-bleed demos (overlay scenes) fill the preview instead of being centered
+   *  and scaled — they manage their own framing and the "zoom out" choreography. */
+  fill?: boolean
 }
 
 export function ComponentCard({
@@ -39,8 +44,19 @@ export function ComponentCard({
   href,
   scale = 0.8,
   previewClassName,
+  fill = false,
 }: ComponentCardProps) {
   const Demo = componentDemos[slug]
+  // Hover/keyboard-focus on the card drives the demo's autoplay animation. The
+  // demo itself is `inert`, so the card is the only thing that can be pointed at
+  // or focused — it broadcasts that state down through CardHoverProvider.
+  const [active, setActive] = useState(false)
+
+  const content = Demo ? (
+    <Demo />
+  ) : (
+    <span className="text-sm text-fg-muted">{name}</span>
+  )
 
   return (
     <Link
@@ -49,6 +65,10 @@ export function ComponentCard({
       aria-label={name}
       data-component={slug}
       className="group flex flex-col items-center gap-3 rounded-lg focus-reset focus-visible:focus-ring"
+      onPointerEnter={() => setActive(true)}
+      onPointerLeave={() => setActive(false)}
+      onFocus={() => setActive(true)}
+      onBlur={() => setActive(false)}
     >
       <ComponentPreview
         className={cn(
@@ -59,18 +79,23 @@ export function ComponentCard({
         {/* The demo is a non-interactive preview: `inert` keeps its controls out of
             the tab order and lets clicks fall through to the card link, so the whole
             card navigates instead of an embedded demo (Modal/Menu/Popover…) hijacking
-            the click. */}
-        <div
-          inert
-          className="flex items-center justify-center"
-          style={{ transform: `scale(${scale})` }}
-        >
-          {Demo ? (
-            <Demo />
+            the click. `inert` also blocks focus, so the autoplay animations (which
+            simulate focus/press/open states) can never steal the page's real focus. */}
+        <CardHoverProvider value={active}>
+          {fill ? (
+            <div inert className="absolute inset-0">
+              {content}
+            </div>
           ) : (
-            <span className="text-sm text-fg-muted">{name}</span>
+            <div
+              inert
+              className="flex items-center justify-center"
+              style={{ transform: `scale(${scale})` }}
+            >
+              {content}
+            </div>
           )}
-        </div>
+        </CardHoverProvider>
       </ComponentPreview>
       <span className="text-sm font-medium text-fg group-hover:underline">
         {name}

--- a/www/src/modules/docs/components-list/components-data.ts
+++ b/www/src/modules/docs/components-list/components-data.ts
@@ -5,6 +5,9 @@ export interface ComponentInfo {
   slug: string
   href: string
   scale?: number
+  /** Render the demo full-bleed (overlay "zoom out" scenes manage their own
+   *  framing) instead of the default centered + scaled preview. */
+  fill?: boolean
   status: ComponentStatus
 }
 
@@ -162,6 +165,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'menu',
         href: '/docs/components/menu',
         scale: 1,
+        fill: true,
         status: 'in review',
       },
       {
@@ -169,6 +173,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'combobox',
         href: '/docs/components/combobox',
         scale: 0.9,
+        fill: true,
         status: 'done',
       },
       {
@@ -176,6 +181,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'select',
         href: '/docs/components/select',
         scale: 0.95,
+        fill: true,
         status: 'done',
       },
     ],
@@ -203,6 +209,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'date-picker',
         href: '/docs/components/date-picker',
         scale: 0.8,
+        fill: true,
         status: 'done',
       },
       {
@@ -415,6 +422,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'color-picker',
         href: '/docs/components/color-picker',
         scale: 0.65,
+        fill: true,
         status: 'pending',
       },
       {
@@ -442,6 +450,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'modal',
         href: '/docs/components/modal',
         scale: 1,
+        fill: true,
         status: 'done',
       },
       {
@@ -449,6 +458,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'popover',
         href: '/docs/components/popover',
         scale: 1,
+        fill: true,
         status: 'done',
       },
       {
@@ -456,6 +466,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'drawer',
         href: '/docs/components/drawer',
         scale: 1,
+        fill: true,
         status: 'in review',
       },
       {
@@ -463,6 +474,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'tooltip',
         href: '/docs/components/tooltip',
         scale: 1,
+        fill: true,
         status: 'pending',
       },
     ],

--- a/www/src/modules/docs/components-list/components-data.ts
+++ b/www/src/modules/docs/components-list/components-data.ts
@@ -8,6 +8,9 @@ export interface ComponentInfo {
   /** Render the demo full-bleed (overlay "zoom out" scenes manage their own
    *  framing) instead of the default centered + scaled preview. */
   fill?: boolean
+  /** Render the demo full-width (responsive, not scaled) — for field-like demos
+   *  that should share one consistent, responsive width. */
+  stretch?: boolean
   status: ComponentStatus
 }
 
@@ -67,35 +70,35 @@ export const componentsData: ComponentCategory[] = [
         name: 'Input',
         slug: 'input',
         href: '/docs/components/input',
-        scale: 0.9,
+        stretch: true,
         status: 'done',
       },
       {
         name: 'TextArea',
         slug: 'text-area',
         href: '/docs/components/text-area',
-        scale: 0.9,
+        stretch: true,
         status: 'done',
       },
       {
         name: 'InputGroup',
         slug: 'input-group',
         href: '/docs/components/input-group',
-        scale: 0.9,
+        stretch: true,
         status: 'done',
       },
       {
         name: 'TextField',
         slug: 'text-field',
         href: '/docs/components/text-field',
-        scale: 0.9,
+        stretch: true,
         status: 'in review',
       },
       {
         name: 'SearchField',
         slug: 'search-field',
         href: '/docs/components/search-field',
-        scale: 0.9,
+        stretch: true,
         status: 'in review',
       },
       {
@@ -151,7 +154,7 @@ export const componentsData: ComponentCategory[] = [
         name: 'Field',
         slug: 'field',
         href: '/docs/components/field',
-        scale: 0.9,
+        stretch: true,
         status: 'pending',
       },
     ],
@@ -201,7 +204,7 @@ export const componentsData: ComponentCategory[] = [
         name: 'DateField',
         slug: 'date-field',
         href: '/docs/components/date-field',
-        scale: 0.9,
+        stretch: true,
         status: 'done',
       },
       {
@@ -216,7 +219,7 @@ export const componentsData: ComponentCategory[] = [
         name: 'TimeField',
         slug: 'time-field',
         href: '/docs/components/time-field',
-        scale: 0.9,
+        stretch: true,
         status: 'in review',
       },
     ],
@@ -414,7 +417,7 @@ export const componentsData: ComponentCategory[] = [
         name: 'ColorField',
         slug: 'color-field',
         href: '/docs/components/color-field',
-        scale: 0.9,
+        stretch: true,
         status: 'pending',
       },
       {

--- a/www/src/modules/docs/components-list/components-data.ts
+++ b/www/src/modules/docs/components-list/components-data.ts
@@ -57,7 +57,7 @@ export const componentsData: ComponentCategory[] = [
         name: 'Group',
         slug: 'group',
         href: '/docs/components/group',
-        scale: 0.9,
+        scale: 1,
         status: 'done',
       },
     ],
@@ -147,7 +147,7 @@ export const componentsData: ComponentCategory[] = [
         name: 'Slider',
         slug: 'slider',
         href: '/docs/components/slider',
-        scale: 0.9,
+        stretch: true,
         status: 'pending',
       },
       {
@@ -239,7 +239,7 @@ export const componentsData: ComponentCategory[] = [
         name: 'ProgressBar',
         slug: 'progress-bar',
         href: '/docs/components/progress-bar',
-        scale: 1,
+        stretch: true,
         status: 'pending',
       },
       {
@@ -376,7 +376,7 @@ export const componentsData: ComponentCategory[] = [
         name: 'Card',
         slug: 'card',
         href: '/docs/components/card',
-        scale: 0.45,
+        stretch: true,
         status: 'done',
       },
       {

--- a/www/src/modules/docs/components-list/components-grid.tsx
+++ b/www/src/modules/docs/components-list/components-grid.tsx
@@ -40,6 +40,7 @@ export function ComponentsGrid({ category }: { category: string }) {
           slug={component.slug}
           href={component.href}
           scale={component.scale}
+          fill={component.fill}
           previewClassName={CATEGORY_PREVIEW_HEIGHT[category]}
         />
       ))}

--- a/www/src/modules/docs/components-list/components-grid.tsx
+++ b/www/src/modules/docs/components-list/components-grid.tsx
@@ -13,6 +13,9 @@ const CATEGORY_PREVIEW_HEIGHT: Record<string, string> = {
   'data-display': 'h-52',
   colors: 'h-52',
   charts: 'h-72',
+  // Overlay scenes (and the pickers' dropdowns) need room for the opened surface.
+  overlays: 'h-52',
+  pickers: 'h-52',
 }
 
 /**

--- a/www/src/modules/docs/components-list/components-grid.tsx
+++ b/www/src/modules/docs/components-list/components-grid.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { DemoPreset } from '../demo-preset'
 import { ComponentCard } from './component-card'
 import { componentsData } from './components-data'
 
@@ -32,19 +33,21 @@ export function ComponentsGrid({ category }: { category: string }) {
   }
 
   return (
-    <div className="mt-6 grid grid-cols-2 gap-x-6 gap-y-8 sm:grid-cols-3">
-      {data.components.map((component) => (
-        <ComponentCard
-          key={component.slug}
-          name={component.name}
-          slug={component.slug}
-          href={component.href}
-          scale={component.scale}
-          fill={component.fill}
-          stretch={component.stretch}
-          previewClassName={CATEGORY_PREVIEW_HEIGHT[category]}
-        />
-      ))}
-    </div>
+    <DemoPreset>
+      <div className="mt-6 grid grid-cols-2 gap-x-6 gap-y-8 sm:grid-cols-3">
+        {data.components.map((component) => (
+          <ComponentCard
+            key={component.slug}
+            name={component.name}
+            slug={component.slug}
+            href={component.href}
+            scale={component.scale}
+            fill={component.fill}
+            stretch={component.stretch}
+            previewClassName={CATEGORY_PREVIEW_HEIGHT[category]}
+          />
+        ))}
+      </div>
+    </DemoPreset>
   )
 }

--- a/www/src/modules/docs/components-list/components-grid.tsx
+++ b/www/src/modules/docs/components-list/components-grid.tsx
@@ -41,6 +41,7 @@ export function ComponentsGrid({ category }: { category: string }) {
           href={component.href}
           scale={component.scale}
           fill={component.fill}
+          stretch={component.stretch}
           previewClassName={CATEGORY_PREVIEW_HEIGHT[category]}
         />
       ))}

--- a/www/src/modules/docs/components-list/demos/accordion.tsx
+++ b/www/src/modules/docs/components-list/demos/accordion.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Accordion } from '@/registry/ui/accordion'
 import {
   Disclosure,
@@ -5,9 +7,17 @@ import {
   DisclosureTrigger,
 } from '@/registry/ui/disclosure'
 
+import { useStepAutoplay } from '../autoplay'
+
 export function AccordionDemo() {
+  const { index } = useStepAutoplay(2, { dwell: 1600 })
+  const expandedKeys = index === 0 ? ['react'] : ['nextjs']
   return (
-    <Accordion className="w-72" defaultExpandedKeys={['react']}>
+    <Accordion
+      className="w-72"
+      expandedKeys={expandedKeys}
+      onExpandedChange={() => {}}
+    >
       <Disclosure id="react">
         <DisclosureTrigger>What is React?</DisclosureTrigger>
         <DisclosurePanel>

--- a/www/src/modules/docs/components-list/demos/breadcrumbs.tsx
+++ b/www/src/modules/docs/components-list/demos/breadcrumbs.tsx
@@ -5,15 +5,18 @@ import {
   Breadcrumbs,
 } from '@/registry/ui/breadcrumbs'
 
+// The card itself is an <a>; an href here would render nested anchors. Omitting
+// it makes RAC render spans (same breadcrumb-link styles), which is correct for
+// an inert preview.
 export function BreadcrumbsDemo() {
   return (
     <Breadcrumbs className="flex-nowrap">
       <BreadcrumbItem>
-        <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        <BreadcrumbLink>Home</BreadcrumbLink>
         <BreadcrumbSeparator />
       </BreadcrumbItem>
       <BreadcrumbItem>
-        <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+        <BreadcrumbLink>Docs</BreadcrumbLink>
         <BreadcrumbSeparator />
       </BreadcrumbItem>
       <BreadcrumbItem>

--- a/www/src/modules/docs/components-list/demos/button.tsx
+++ b/www/src/modules/docs/components-list/demos/button.tsx
@@ -1,5 +1,18 @@
+'use client'
+
 import { Button } from '@/registry/ui/button'
 
+import { DemoPress, useAutoplay } from '../autoplay'
+
 export function ButtonDemo() {
-  return <Button>Button</Button>
+  const { phase } = useAutoplay([
+    { name: 'idle', duration: 850 },
+    { name: 'hover', duration: 520 },
+    { name: 'press', duration: 260 },
+  ])
+  return (
+    <DemoPress phase={phase}>
+      <Button>Button</Button>
+    </DemoPress>
+  )
 }

--- a/www/src/modules/docs/components-list/demos/calendar.tsx
+++ b/www/src/modules/docs/components-list/demos/calendar.tsx
@@ -1,5 +1,25 @@
+'use client'
+
+import { getLocalTimeZone, today } from '@internationalized/date'
+
 import { Calendar } from '@/registry/ui/calendar'
 
+import { useStepAutoplay } from '../autoplay'
+
+// Mid-month days that exist in every month, so `.set({ day })` always lands on a
+// real cell in the currently shown month without spilling into the next one.
+const DAYS = [8, 15, 22, 18]
+const BASE = today(getLocalTimeZone())
+
+// On hover, the selected day hops across a few dates — driving the calendar's
+// controlled `value` (a CalendarDate). Rests on the first day when idle.
 export function CalendarDemo() {
-  return <Calendar aria-label="Select date" />
+  const { index } = useStepAutoplay(DAYS.length, { dwell: 1100 })
+  return (
+    <Calendar
+      aria-label="Select date"
+      value={BASE.set({ day: DAYS[index] })}
+      onChange={() => {}}
+    />
+  )
 }

--- a/www/src/modules/docs/components-list/demos/card.tsx
+++ b/www/src/modules/docs/components-list/demos/card.tsx
@@ -18,7 +18,7 @@ export function CardDemo() {
   // inline "register" link doesn't nest anchors.
   const linkStyles = useLinkStyles()
   return (
-    <Card className="w-full max-w-xs">
+    <Card className="w-full max-w-sm">
       <CardHeader>
         <CardTitle className="text-xl">Login to your account</CardTitle>
         <CardDescription>

--- a/www/src/modules/docs/components-list/demos/card.tsx
+++ b/www/src/modules/docs/components-list/demos/card.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Button } from '@/registry/ui/button'
 import {
   Card,
@@ -8,10 +10,13 @@ import {
 } from '@/registry/ui/card'
 import { Label } from '@/registry/ui/field'
 import { Input } from '@/registry/ui/input'
-import { Link } from '@/registry/ui/link'
+import { useStyles as useLinkStyles } from '@/registry/ui/link/styles'
 import { TextField } from '@/registry/ui/text-field'
 
 export function CardDemo() {
+  // The card is itself an <a>; render the real link STYLES on a span so the
+  // inline "register" link doesn't nest anchors.
+  const linkStyles = useLinkStyles()
   return (
     <Card className="w-full max-w-xs">
       <CardHeader>
@@ -70,9 +75,9 @@ export function CardDemo() {
         </Button>
         <p className="mt-4 text-sm text-fg-muted">
           Don&apos;t have an account?{' '}
-          <Link href="#" variant="quiet">
+          <span data-rac="" className={linkStyles({ variant: 'quiet' })}>
             register
-          </Link>
+          </span>
         </p>
       </CardContent>
       {/* <CardFooter>

--- a/www/src/modules/docs/components-list/demos/checkbox-group.tsx
+++ b/www/src/modules/docs/components-list/demos/checkbox-group.tsx
@@ -4,14 +4,14 @@ import { Checkbox, CheckboxControl } from '@/registry/ui/checkbox'
 import { CheckboxGroup } from '@/registry/ui/checkbox-group'
 import { FieldGroup, Label } from '@/registry/ui/field'
 
-import { useStepAutoplay } from '../autoplay'
+import { useCycle } from '../autoplay'
 
 const KEYS = ['nextjs', 'remix', 'astro']
 
 export function CheckboxGroupDemo() {
-  const { index } = useStepAutoplay(KEYS.length, { dwell: 1300 })
+  const { item } = useCycle(KEYS, { dwell: 1300 })
   return (
-    <CheckboxGroup value={[KEYS[index]]} onChange={() => {}}>
+    <CheckboxGroup value={[item]} onChange={() => {}}>
       <Label>React frameworks</Label>
       <FieldGroup>
         <Checkbox value="nextjs">

--- a/www/src/modules/docs/components-list/demos/checkbox-group.tsx
+++ b/www/src/modules/docs/components-list/demos/checkbox-group.tsx
@@ -1,10 +1,17 @@
+'use client'
+
 import { Checkbox, CheckboxControl } from '@/registry/ui/checkbox'
 import { CheckboxGroup } from '@/registry/ui/checkbox-group'
 import { FieldGroup, Label } from '@/registry/ui/field'
 
+import { useStepAutoplay } from '../autoplay'
+
+const KEYS = ['nextjs', 'remix', 'astro']
+
 export function CheckboxGroupDemo() {
+  const { index } = useStepAutoplay(KEYS.length, { dwell: 1300 })
   return (
-    <CheckboxGroup defaultValue={['nextjs']}>
+    <CheckboxGroup value={[KEYS[index]]} onChange={() => {}}>
       <Label>React frameworks</Label>
       <FieldGroup>
         <Checkbox value="nextjs">

--- a/www/src/modules/docs/components-list/demos/checkbox.tsx
+++ b/www/src/modules/docs/components-list/demos/checkbox.tsx
@@ -1,10 +1,17 @@
+'use client'
+
 import { Checkbox, CheckboxControl } from '@/registry/ui/checkbox'
 import { Label } from '@/registry/ui/field'
 
+import { DemoPress, useToggleAutoplay } from '../autoplay'
+
 export function CheckboxDemo() {
+  const { selected, pressing } = useToggleAutoplay({ initial: true })
   return (
-    <Checkbox defaultSelected>
-      <CheckboxControl />
+    <Checkbox isSelected={selected} onChange={() => {}}>
+      <DemoPress pressing={pressing}>
+        <CheckboxControl />
+      </DemoPress>
       <Label>Accept terms</Label>
     </Checkbox>
   )

--- a/www/src/modules/docs/components-list/demos/color-area.tsx
+++ b/www/src/modules/docs/components-list/demos/color-area.tsx
@@ -1,5 +1,28 @@
+'use client'
+
+import * as ColorAreaPrimitives from 'react-aria-components/ColorArea'
+
 import { ColorArea } from '@/registry/ui/color-area'
 
+import { useStepAutoplay } from '../autoplay'
+
+// Cycle a handful of colors spread across the 2D area; the thumb (ColorThumb,
+// positioned via `left`/`top`) CSS-transitions between the spots so it glides
+// diagonally instead of jumping.
+const COLORS = [
+  ColorAreaPrimitives.parseColor('hsl(0, 90%, 30%)'),
+  ColorAreaPrimitives.parseColor('hsl(0, 25%, 75%)'),
+  ColorAreaPrimitives.parseColor('hsl(0, 95%, 60%)'),
+  ColorAreaPrimitives.parseColor('hsl(0, 40%, 20%)'),
+]
+
 export function ColorAreaDemo() {
-  return <ColorArea defaultValue="hsl(0, 100%, 50%)" />
+  const { index } = useStepAutoplay(COLORS.length, { dwell: 1000 })
+  return (
+    <ColorArea
+      value={COLORS[index]}
+      onChange={() => {}}
+      className="[&_[data-slot=color-thumb]]:transition-[left,top] [&_[data-slot=color-thumb]]:duration-700 [&_[data-slot=color-thumb]]:ease-out"
+    />
+  )
 }

--- a/www/src/modules/docs/components-list/demos/color-field.tsx
+++ b/www/src/modules/docs/components-list/demos/color-field.tsx
@@ -9,7 +9,7 @@ import { DemoFocus, useTypewriter } from '../autoplay'
 export function ColorFieldDemo() {
   const { value, active } = useTypewriter('#7f00ff')
   return (
-    <ColorField defaultValue="#7f007f" className="w-full max-w-[14rem]">
+    <ColorField defaultValue="#7f007f" className="w-full max-w-[11.5rem]">
       <Label>Color</Label>
       <DemoFocus active={active}>
         <Input value={value} readOnly className="w-full" />

--- a/www/src/modules/docs/components-list/demos/color-field.tsx
+++ b/www/src/modules/docs/components-list/demos/color-field.tsx
@@ -1,24 +1,19 @@
 'use client'
 
-import { cn } from '@/registry/lib/utils'
 import { ColorField } from '@/registry/ui/color-field'
 import { Label } from '@/registry/ui/field'
 import { Input } from '@/registry/ui/input'
 
-import { demoFocusProps, useTypewriter } from '../autoplay'
+import { DemoFocus, useTypewriter } from '../autoplay'
 
 export function ColorFieldDemo() {
   const { value, active } = useTypewriter('#7f00ff')
-  const focus = demoFocusProps(active)
   return (
     <ColorField defaultValue="#7f007f">
       <Label>Color</Label>
-      <Input
-        value={value}
-        readOnly
-        data-demo-focus={focus['data-demo-focus']}
-        className={cn('w-36', focus.className)}
-      />
+      <DemoFocus active={active}>
+        <Input value={value} readOnly className="w-36" />
+      </DemoFocus>
     </ColorField>
   )
 }

--- a/www/src/modules/docs/components-list/demos/color-field.tsx
+++ b/www/src/modules/docs/components-list/demos/color-field.tsx
@@ -9,10 +9,10 @@ import { DemoFocus, useTypewriter } from '../autoplay'
 export function ColorFieldDemo() {
   const { value, active } = useTypewriter('#7f00ff')
   return (
-    <ColorField defaultValue="#7f007f">
+    <ColorField defaultValue="#7f007f" className="w-full max-w-[14rem]">
       <Label>Color</Label>
       <DemoFocus active={active}>
-        <Input value={value} readOnly className="w-36" />
+        <Input value={value} readOnly className="w-full" />
       </DemoFocus>
     </ColorField>
   )

--- a/www/src/modules/docs/components-list/demos/color-field.tsx
+++ b/www/src/modules/docs/components-list/demos/color-field.tsx
@@ -1,12 +1,24 @@
+'use client'
+
+import { cn } from '@/registry/lib/utils'
 import { ColorField } from '@/registry/ui/color-field'
 import { Label } from '@/registry/ui/field'
 import { Input } from '@/registry/ui/input'
 
+import { demoFocusProps, useTypewriter } from '../autoplay'
+
 export function ColorFieldDemo() {
+  const { value, active } = useTypewriter('#7f00ff')
+  const focus = demoFocusProps(active)
   return (
     <ColorField defaultValue="#7f007f">
       <Label>Color</Label>
-      <Input className="w-36" />
+      <Input
+        value={value}
+        readOnly
+        data-demo-focus={focus['data-demo-focus']}
+        className={cn('w-36', focus.className)}
+      />
     </ColorField>
   )
 }

--- a/www/src/modules/docs/components-list/demos/color-picker.tsx
+++ b/www/src/modules/docs/components-list/demos/color-picker.tsx
@@ -19,6 +19,7 @@ export function ColorPickerDemo() {
       phase={phase}
       variant="popover"
       side="bottom"
+      openScale={0.66}
       surfaceClassName="w-56 p-2"
       trigger={
         <Button className="w-40 justify-start font-normal">

--- a/www/src/modules/docs/components-list/demos/color-picker.tsx
+++ b/www/src/modules/docs/components-list/demos/color-picker.tsx
@@ -1,5 +1,40 @@
+'use client'
+
+import { ChevronDownIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
 import { ColorEditor } from '@/registry/ui/color-editor'
 
+import { OverlayScene, useOpenAutoplay } from '../autoplay'
+
+const COLOR = '#7f007f'
+
+// Trigger → hover → click → the color editor popover unfolds and the scene zooms
+// out. The trigger is a real Button showing the current swatch + hex; the surface
+// is the real ColorEditor (area + hue slider + hex field).
 export function ColorPickerDemo() {
-  return <ColorEditor defaultValue="#7f007f" />
+  const { phase } = useOpenAutoplay()
+  return (
+    <OverlayScene
+      phase={phase}
+      variant="popover"
+      side="bottom"
+      surfaceClassName="w-56 p-2"
+      trigger={
+        <Button className="w-40 justify-start font-normal">
+          <span
+            aria-hidden
+            className="size-4 rounded-sm border border-black/10"
+            style={{ backgroundColor: COLOR }}
+          />
+          <span className="font-mono text-xs tracking-wide uppercase">
+            {COLOR}
+          </span>
+          <ChevronDownIcon className="ml-auto text-fg-muted" />
+        </Button>
+      }
+    >
+      <ColorEditor defaultValue={COLOR} showFormatSelector={false} />
+    </OverlayScene>
+  )
 }

--- a/www/src/modules/docs/components-list/demos/color-slider.tsx
+++ b/www/src/modules/docs/components-list/demos/color-slider.tsx
@@ -1,3 +1,7 @@
+'use client'
+
+import * as ColorAreaPrimitives from 'react-aria-components/ColorArea'
+
 import {
   ColorSlider,
   ColorSliderControl,
@@ -5,9 +9,23 @@ import {
 } from '@/registry/ui/color-slider'
 import { Description, Label } from '@/registry/ui/field'
 
+import { useValueAutoplay } from '../autoplay'
+
+// Step the hue through a few stops; the thumb (ColorThumb, positioned via
+// `left`) CSS-transitions between them. We rebuild the Color from the numeric
+// hue each render — cheaper than animating a Color object per frame, and the
+// gradient track + Output update for free.
+const HUES = [200, 310, 20, 130]
+
 export function ColorSliderDemo() {
+  const { value: hue } = useValueAutoplay(HUES, { dwell: 850 })
   return (
-    <ColorSlider channel="hue" defaultValue="hsl(200, 100%, 50%)">
+    <ColorSlider
+      channel="hue"
+      value={ColorAreaPrimitives.parseColor(`hsl(${hue}, 100%, 50%)`)}
+      onChange={() => {}}
+      className="[&_[data-slot=color-thumb]]:transition-[left,inset-inline-start] [&_[data-slot=color-thumb]]:duration-700 [&_[data-slot=color-thumb]]:ease-out"
+    >
       <div className="flex items-center justify-between">
         <Label>Hue</Label>
         <ColorSliderOutput />

--- a/www/src/modules/docs/components-list/demos/color-swatch-picker.tsx
+++ b/www/src/modules/docs/components-list/demos/color-swatch-picker.tsx
@@ -7,7 +7,7 @@ import {
   ColorSwatchPickerItem,
 } from '@/registry/ui/color-swatch-picker'
 
-import { useStepAutoplay } from '../autoplay'
+import { useCycle } from '../autoplay'
 
 // Selection is controlled by a Color matched against each item's `color`, so we
 // cycle `value` through the swatches — the selected one lights up its ring.
@@ -21,10 +21,10 @@ const SWATCHES = [
 ]
 
 export function ColorSwatchPickerDemo() {
-  const { index } = useStepAutoplay(SWATCHES.length, { dwell: 750 })
+  const { item } = useCycle(SWATCHES, { dwell: 750 })
   return (
     <ColorSwatchPicker
-      value={ColorAreaPrimitives.parseColor(SWATCHES[index])}
+      value={ColorAreaPrimitives.parseColor(item)}
       onChange={() => {}}
     >
       {SWATCHES.map((color) => (

--- a/www/src/modules/docs/components-list/demos/color-swatch-picker.tsx
+++ b/www/src/modules/docs/components-list/demos/color-swatch-picker.tsx
@@ -1,17 +1,35 @@
+'use client'
+
+import * as ColorAreaPrimitives from 'react-aria-components/ColorArea'
+
 import {
   ColorSwatchPicker,
   ColorSwatchPickerItem,
 } from '@/registry/ui/color-swatch-picker'
 
+import { useStepAutoplay } from '../autoplay'
+
+// Selection is controlled by a Color matched against each item's `color`, so we
+// cycle `value` through the swatches — the selected one lights up its ring.
+const SWATCHES = [
+  '#FF6B6B',
+  '#FFA07A',
+  '#FFD93D',
+  '#6BCB77',
+  '#4D96FF',
+  '#A29BFE',
+]
+
 export function ColorSwatchPickerDemo() {
+  const { index } = useStepAutoplay(SWATCHES.length, { dwell: 750 })
   return (
-    <ColorSwatchPicker defaultValue="#FF6B6B">
-      <ColorSwatchPickerItem color="#FF6B6B" />
-      <ColorSwatchPickerItem color="#FFA07A" />
-      <ColorSwatchPickerItem color="#FFD93D" />
-      <ColorSwatchPickerItem color="#6BCB77" />
-      <ColorSwatchPickerItem color="#4D96FF" />
-      <ColorSwatchPickerItem color="#A29BFE" />
+    <ColorSwatchPicker
+      value={ColorAreaPrimitives.parseColor(SWATCHES[index])}
+      onChange={() => {}}
+    >
+      {SWATCHES.map((color) => (
+        <ColorSwatchPickerItem key={color} color={color} />
+      ))}
     </ColorSwatchPicker>
   )
 }

--- a/www/src/modules/docs/components-list/demos/combobox.tsx
+++ b/www/src/modules/docs/components-list/demos/combobox.tsx
@@ -16,9 +16,9 @@ export function ComboboxDemo() {
       variant="menu"
       side="bottom"
       fluid
-      surfaceClassName="w-full max-w-[14rem] p-0"
+      surfaceClassName="w-full max-w-[11.5rem] p-0"
       trigger={
-        <InputGroup className="w-full max-w-[14rem]">
+        <InputGroup className="w-full max-w-[11.5rem]">
           <Input placeholder="Select country..." value="France" readOnly />
           <InputGroupAddon>
             <Button variant="quiet" isIconOnly>
@@ -37,7 +37,6 @@ export function ComboboxDemo() {
         <ListBoxItem id="canada">Canada</ListBoxItem>
         <ListBoxItem id="france">France</ListBoxItem>
         <ListBoxItem id="germany">Germany</ListBoxItem>
-        <ListBoxItem id="japan">Japan</ListBoxItem>
       </ListBox>
     </OverlayScene>
   )

--- a/www/src/modules/docs/components-list/demos/combobox.tsx
+++ b/www/src/modules/docs/components-list/demos/combobox.tsx
@@ -1,32 +1,43 @@
+'use client'
+
 import { ChevronDownIcon } from 'lucide-react'
 
 import { Button } from '@/registry/ui/button'
-import { Combobox } from '@/registry/ui/combobox'
 import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
-import { Popover } from '@/registry/ui/popover'
+
+import { OverlayScene, useOpenAutoplay } from '../autoplay'
 
 export function ComboboxDemo() {
+  const { phase } = useOpenAutoplay()
   return (
-    <Combobox aria-label="Country" menuTrigger="focus">
-      <InputGroup>
-        <Input placeholder="Select country..." />
-        <InputGroupAddon>
-          <Button variant="quiet" isIconOnly>
-            <ChevronDownIcon />
-          </Button>
-        </InputGroupAddon>
-      </InputGroup>
-      <Popover>
-        <ListBox>
-          <ListBoxItem>Canada</ListBoxItem>
-          <ListBoxItem>France</ListBoxItem>
-          <ListBoxItem>Germany</ListBoxItem>
-          <ListBoxItem>Japan</ListBoxItem>
-          <ListBoxItem>United Kingdom</ListBoxItem>
-          <ListBoxItem>United States</ListBoxItem>
-        </ListBox>
-      </Popover>
-    </Combobox>
+    <OverlayScene
+      phase={phase}
+      variant="menu"
+      side="bottom"
+      surfaceClassName="w-56 p-0"
+      trigger={
+        <InputGroup className="w-56">
+          <Input placeholder="Select country..." value="France" readOnly />
+          <InputGroupAddon>
+            <Button variant="quiet" isIconOnly>
+              <ChevronDownIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+      }
+    >
+      <ListBox
+        aria-label="Country"
+        selectionMode="single"
+        selectedKeys={['france']}
+        className="border-0 bg-transparent shadow-none"
+      >
+        <ListBoxItem id="canada">Canada</ListBoxItem>
+        <ListBoxItem id="france">France</ListBoxItem>
+        <ListBoxItem id="germany">Germany</ListBoxItem>
+        <ListBoxItem id="japan">Japan</ListBoxItem>
+      </ListBox>
+    </OverlayScene>
   )
 }

--- a/www/src/modules/docs/components-list/demos/combobox.tsx
+++ b/www/src/modules/docs/components-list/demos/combobox.tsx
@@ -15,9 +15,10 @@ export function ComboboxDemo() {
       phase={phase}
       variant="menu"
       side="bottom"
-      surfaceClassName="w-56 p-0"
+      fluid
+      surfaceClassName="w-full max-w-[14rem] p-0"
       trigger={
-        <InputGroup className="w-56">
+        <InputGroup className="w-full max-w-[14rem]">
           <Input placeholder="Select country..." value="France" readOnly />
           <InputGroupAddon>
             <Button variant="quiet" isIconOnly>

--- a/www/src/modules/docs/components-list/demos/command.tsx
+++ b/www/src/modules/docs/components-list/demos/command.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   Command,
   CommandContent,
@@ -5,22 +7,33 @@ import {
   CommandItem,
 } from '@/registry/ui/command'
 
+import { useTypewriter } from '../autoplay'
+
+// Command's own autocomplete filter can't be driven through props (its
+// `inputValue` doesn't reach the wrapped Autocomplete), so we type into the
+// controlled input — a `value` prop wins over the autocomplete's internal
+// state — and filter the visible items ourselves to mirror the live filtering.
+const ITEMS = ['Create new file...', 'Create new folder...', 'Open settings']
+
 export function CommandDemo() {
+  const { value } = useTypewriter('settings')
+  const query = value.trim().toLowerCase()
+  const visible = ITEMS.filter((item) => item.toLowerCase().includes(query))
   return (
     <Command className="w-60">
       <CommandInput
         aria-label="Search commands"
         placeholder="Type a command..."
         className="w-full"
+        value={value}
+        onChange={() => {}}
       />
       <CommandContent className="h-30">
-        <CommandItem textValue="Create new file">
-          Create new file...
-        </CommandItem>
-        <CommandItem textValue="Create new folder">
-          Create new folder...
-        </CommandItem>
-        <CommandItem textValue="Open settings">Open settings</CommandItem>
+        {visible.map((item) => (
+          <CommandItem key={item} textValue={item}>
+            {item}
+          </CommandItem>
+        ))}
       </CommandContent>
     </Command>
   )

--- a/www/src/modules/docs/components-list/demos/date-field.tsx
+++ b/www/src/modules/docs/components-list/demos/date-field.tsx
@@ -14,10 +14,13 @@ import { DemoFocus, useCardHover } from '../autoplay'
 export function DateFieldDemo() {
   const active = useCardHover()
   return (
-    <DateField defaultValue={parseDate('2024-06-12')}>
+    <DateField
+      defaultValue={parseDate('2024-06-12')}
+      className="w-full max-w-[14rem]"
+    >
       <Label>Meeting date</Label>
       <DemoFocus active={active}>
-        <DateInput className="w-40" />
+        <DateInput className="w-full" />
       </DemoFocus>
     </DateField>
   )

--- a/www/src/modules/docs/components-list/demos/date-field.tsx
+++ b/www/src/modules/docs/components-list/demos/date-field.tsx
@@ -1,12 +1,21 @@
+'use client'
+
+import { parseDate } from '@internationalized/date'
+
 import { DateField } from '@/registry/ui/date-field'
 import { Label } from '@/registry/ui/field'
 import { DateInput } from '@/registry/ui/input'
 
+import { demoFocusProps, useCardHover } from '../autoplay'
+
+// The field shows a real date and lights up its focus ring whenever the card is
+// hovered — a faux ring (no real `:focus`), so it never steals page focus.
 export function DateFieldDemo() {
+  const active = useCardHover()
   return (
-    <DateField>
+    <DateField defaultValue={parseDate('2024-06-12')}>
       <Label>Meeting date</Label>
-      <DateInput className="w-40" />
+      <DateInput className="w-40" {...demoFocusProps(active)} />
     </DateField>
   )
 }

--- a/www/src/modules/docs/components-list/demos/date-field.tsx
+++ b/www/src/modules/docs/components-list/demos/date-field.tsx
@@ -16,7 +16,7 @@ export function DateFieldDemo() {
   return (
     <DateField
       defaultValue={parseDate('2024-06-12')}
-      className="w-full max-w-[14rem]"
+      className="w-full max-w-[11.5rem]"
     >
       <Label>Meeting date</Label>
       <DemoFocus active={active}>

--- a/www/src/modules/docs/components-list/demos/date-field.tsx
+++ b/www/src/modules/docs/components-list/demos/date-field.tsx
@@ -6,16 +6,19 @@ import { DateField } from '@/registry/ui/date-field'
 import { Label } from '@/registry/ui/field'
 import { DateInput } from '@/registry/ui/input'
 
-import { demoFocusProps, useCardHover } from '../autoplay'
+import { DemoFocus, useCardHover } from '../autoplay'
 
-// The field shows a real date and lights up its focus ring whenever the card is
-// hovered — a faux ring (no real `:focus`), so it never steals page focus.
+// Shows a real date and lights up its real focus ring while the card is hovered.
+// We only set `data-focused` on the field (no real `:focus`), so it never steals
+// the page's focus.
 export function DateFieldDemo() {
   const active = useCardHover()
   return (
     <DateField defaultValue={parseDate('2024-06-12')}>
       <Label>Meeting date</Label>
-      <DateInput className="w-40" {...demoFocusProps(active)} />
+      <DemoFocus active={active}>
+        <DateInput className="w-40" />
+      </DemoFocus>
     </DateField>
   )
 }

--- a/www/src/modules/docs/components-list/demos/date-picker.tsx
+++ b/www/src/modules/docs/components-list/demos/date-picker.tsx
@@ -23,10 +23,11 @@ export function DatePickerDemo() {
       variant="popover"
       side="bottom"
       fluid
+      openScale={0.6}
       surfaceClassName="p-2"
       trigger={
         <DateField
-          className="w-full max-w-[14rem]"
+          className="w-full max-w-[11.5rem]"
           aria-label="Date"
           value={VALUE}
           onChange={() => {}}

--- a/www/src/modules/docs/components-list/demos/date-picker.tsx
+++ b/www/src/modules/docs/components-list/demos/date-picker.tsx
@@ -22,15 +22,16 @@ export function DatePickerDemo() {
       phase={phase}
       variant="popover"
       side="bottom"
+      fluid
       surfaceClassName="p-2"
       trigger={
         <DateField
-          className="w-56"
+          className="w-full max-w-[14rem]"
           aria-label="Date"
           value={VALUE}
           onChange={() => {}}
         >
-          <InputGroup>
+          <InputGroup className="w-full">
             <DateInput />
             <InputGroupAddon>
               <Button variant="default" size="sm" isIconOnly>

--- a/www/src/modules/docs/components-list/demos/date-picker.tsx
+++ b/www/src/modules/docs/components-list/demos/date-picker.tsx
@@ -1,27 +1,52 @@
+'use client'
+
+import { parseDate } from '@internationalized/date'
+
 import { CalendarIcon } from '@/registry/__generated__/icons'
 import { Button } from '@/registry/ui/button'
 import { Calendar } from '@/registry/ui/calendar'
-import { DatePicker } from '@/registry/ui/date-picker'
-import { DialogContent } from '@/registry/ui/dialog'
+import { DateField } from '@/registry/ui/date-field'
 import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
-import { Popover } from '@/registry/ui/popover'
 
+import { OverlayScene, useOpenAutoplay } from '../autoplay'
+
+const VALUE = parseDate('2024-06-12')
+
+// Trigger → hover → click → the calendar popover unfolds and the scene zooms out.
+// The trigger is the real closed input group; the surface is the real Calendar,
+// its selection matching the date shown in the field.
 export function DatePickerDemo() {
+  const { phase } = useOpenAutoplay()
   return (
-    <DatePicker className="w-56" aria-label="Date">
-      <InputGroup>
-        <DateInput />
-        <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
-            <CalendarIcon />
-          </Button>
-        </InputGroupAddon>
-      </InputGroup>
-      <Popover>
-        <DialogContent className="in-popover:p-0">
-          <Calendar className="mx-auto" />
-        </DialogContent>
-      </Popover>
-    </DatePicker>
+    <OverlayScene
+      phase={phase}
+      variant="popover"
+      side="bottom"
+      surfaceClassName="p-2"
+      trigger={
+        <DateField
+          className="w-56"
+          aria-label="Date"
+          value={VALUE}
+          onChange={() => {}}
+        >
+          <InputGroup>
+            <DateInput />
+            <InputGroupAddon>
+              <Button variant="default" size="sm" isIconOnly>
+                <CalendarIcon />
+              </Button>
+            </InputGroupAddon>
+          </InputGroup>
+        </DateField>
+      }
+    >
+      <Calendar
+        aria-label="Date"
+        className="mx-auto"
+        value={VALUE}
+        onChange={() => {}}
+      />
+    </OverlayScene>
   )
 }

--- a/www/src/modules/docs/components-list/demos/drawer.tsx
+++ b/www/src/modules/docs/components-list/demos/drawer.tsx
@@ -1,16 +1,24 @@
 'use client'
 
 import { Button } from '@/registry/ui/button'
-import { Dialog, DialogContent } from '@/registry/ui/dialog'
-import { Drawer } from '@/registry/ui/drawer'
+import { DialogHeader, DialogTitle } from '@/registry/ui/dialog'
+
+import { OverlayScene, useOpenAutoplay } from '../autoplay'
 
 export function DrawerDemo() {
+  const { phase } = useOpenAutoplay()
   return (
-    <Dialog>
-      <Button>Open Drawer</Button>
-      <Drawer placement="bottom">
-        <DialogContent>drawer content</DialogContent>
-      </Drawer>
-    </Dialog>
+    <OverlayScene
+      phase={phase}
+      variant="drawer"
+      trigger={<Button>Open Drawer</Button>}
+    >
+      <DialogHeader>
+        <DialogTitle>Settings</DialogTitle>
+      </DialogHeader>
+      <p className="mt-1 text-fg-muted">
+        Manage your workspace preferences and notifications.
+      </p>
+    </OverlayScene>
   )
 }

--- a/www/src/modules/docs/components-list/demos/field.tsx
+++ b/www/src/modules/docs/components-list/demos/field.tsx
@@ -8,7 +8,7 @@ import { DemoFocus, useTypewriter } from '../autoplay'
 export function FieldDemo() {
   const { value, active } = useTypewriter('john_doe')
   return (
-    <Field>
+    <Field className="w-full max-w-[14rem]">
       <Label>Username</Label>
       <DemoFocus active={active}>
         <Input value={value} readOnly placeholder="Enter username" />

--- a/www/src/modules/docs/components-list/demos/field.tsx
+++ b/www/src/modules/docs/components-list/demos/field.tsx
@@ -1,11 +1,21 @@
+'use client'
+
 import { Description, Field, Label } from '@/registry/ui/field'
 import { Input } from '@/registry/ui/input'
 
+import { demoFocusProps, useTypewriter } from '../autoplay'
+
 export function FieldDemo() {
+  const { value, active } = useTypewriter('john_doe')
   return (
     <Field>
       <Label>Username</Label>
-      <Input placeholder="Enter username" />
+      <Input
+        value={value}
+        readOnly
+        placeholder="Enter username"
+        {...demoFocusProps(active)}
+      />
       <Description>Choose a unique username</Description>
     </Field>
   )

--- a/www/src/modules/docs/components-list/demos/field.tsx
+++ b/www/src/modules/docs/components-list/demos/field.tsx
@@ -8,7 +8,7 @@ import { DemoFocus, useTypewriter } from '../autoplay'
 export function FieldDemo() {
   const { value, active } = useTypewriter('john_doe')
   return (
-    <Field className="w-full max-w-[14rem]">
+    <Field className="w-full max-w-[11.5rem]">
       <Label>Username</Label>
       <DemoFocus active={active}>
         <Input value={value} readOnly placeholder="Enter username" />

--- a/www/src/modules/docs/components-list/demos/field.tsx
+++ b/www/src/modules/docs/components-list/demos/field.tsx
@@ -3,19 +3,16 @@
 import { Description, Field, Label } from '@/registry/ui/field'
 import { Input } from '@/registry/ui/input'
 
-import { demoFocusProps, useTypewriter } from '../autoplay'
+import { DemoFocus, useTypewriter } from '../autoplay'
 
 export function FieldDemo() {
   const { value, active } = useTypewriter('john_doe')
   return (
     <Field>
       <Label>Username</Label>
-      <Input
-        value={value}
-        readOnly
-        placeholder="Enter username"
-        {...demoFocusProps(active)}
-      />
+      <DemoFocus active={active}>
+        <Input value={value} readOnly placeholder="Enter username" />
+      </DemoFocus>
       <Description>Choose a unique username</Description>
     </Field>
   )

--- a/www/src/modules/docs/components-list/demos/file-trigger.tsx
+++ b/www/src/modules/docs/components-list/demos/file-trigger.tsx
@@ -4,13 +4,22 @@ import { UploadIcon } from '@/registry/__generated__/icons'
 import { Button } from '@/registry/ui/button'
 import { FileTrigger } from '@/registry/ui/file-trigger'
 
+import { DemoPress, useAutoplay } from '../autoplay'
+
 export function FileTriggerDemo() {
+  const { phase } = useAutoplay([
+    { name: 'idle', duration: 850 },
+    { name: 'hover', duration: 520 },
+    { name: 'press', duration: 260 },
+  ])
   return (
     <FileTrigger onSelect={(e) => console.log(e)}>
-      <Button>
-        <UploadIcon />
-        Upload
-      </Button>
+      <DemoPress phase={phase}>
+        <Button>
+          <UploadIcon />
+          Upload
+        </Button>
+      </DemoPress>
     </FileTrigger>
   )
 }

--- a/www/src/modules/docs/components-list/demos/group.tsx
+++ b/www/src/modules/docs/components-list/demos/group.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { EllipsisIcon } from 'lucide-react'
 
 import { SearchIcon } from '@/registry/__generated__/icons'
@@ -5,14 +7,27 @@ import { Button } from '@/registry/ui/button'
 import { Group } from '@/registry/ui/group'
 import { Input } from '@/registry/ui/input'
 
+import { DemoPress, useAutoplay } from '../autoplay'
+
 export function GroupDemo() {
+  const { phase } = useAutoplay([
+    { name: 'idle', duration: 900 },
+    { name: 'hover', duration: 540 },
+    { name: 'press', duration: 260 },
+  ])
   return (
     <div className="flex flex-col items-center gap-4">
       <Group orientation="horizontal">
         <Button>Button</Button>
-        <Button isIconOnly>
-          <EllipsisIcon />
-        </Button>
+        {/* Wrapping the trailing cell in DemoPress makes the wrapper the
+            Group's last child, so the Group's positional `rounded-l-none`
+            lands on the wrapper instead of the button — re-flatten the
+            button's left edge here to keep the segmented seam. */}
+        <DemoPress phase={phase}>
+          <Button isIconOnly className="rounded-l-none">
+            <EllipsisIcon />
+          </Button>
+        </DemoPress>
       </Group>
       <Group orientation="horizontal">
         <Input className="w-32" />

--- a/www/src/modules/docs/components-list/demos/index.ts
+++ b/www/src/modules/docs/components-list/demos/index.ts
@@ -41,6 +41,7 @@ import { MenuDemo } from './menu'
 import { ModalDemo } from './modal'
 import { NumberFieldDemo } from './number-field'
 import { OTPFieldDemo } from './otp-field'
+import { PaginationDemo } from './pagination'
 import { PopoverDemo } from './popover'
 import { ProgressBarDemo } from './progress-bar'
 import { RadioGroupDemo } from './radio-group'
@@ -105,6 +106,7 @@ export const componentDemos: Record<string, ComponentType> = {
   modal: ModalDemo,
   'number-field': NumberFieldDemo,
   'otp-field': OTPFieldDemo,
+  pagination: PaginationDemo,
   popover: PopoverDemo,
   'progress-bar': ProgressBarDemo,
   'radio-group': RadioGroupDemo,

--- a/www/src/modules/docs/components-list/demos/input-group.tsx
+++ b/www/src/modules/docs/components-list/demos/input-group.tsx
@@ -1,10 +1,15 @@
+'use client'
+
 import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 
+import { demoFocusProps, useTypewriter } from '../autoplay'
+
 export function InputGroupDemo() {
+  const { value, active } = useTypewriter('john_doe')
   return (
-    <InputGroup className="w-full">
+    <InputGroup className="w-full" {...demoFocusProps(active)}>
       <InputGroupAddon>@</InputGroupAddon>
-      <Input placeholder="username" />
+      <Input value={value} readOnly placeholder="username" />
     </InputGroup>
   )
 }

--- a/www/src/modules/docs/components-list/demos/input-group.tsx
+++ b/www/src/modules/docs/components-list/demos/input-group.tsx
@@ -2,14 +2,18 @@
 
 import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 
-import { demoFocusProps, useTypewriter } from '../autoplay'
+import { DemoFocus, useTypewriter } from '../autoplay'
 
 export function InputGroupDemo() {
   const { value, active } = useTypewriter('john_doe')
   return (
-    <InputGroup className="w-full" {...demoFocusProps(active)}>
+    <InputGroup className="w-full">
       <InputGroupAddon>@</InputGroupAddon>
-      <Input value={value} readOnly placeholder="username" />
+      {/* Drive the inner control's real focus: the group lights its own ring via
+          `has-[[data-input-control][data-focused]]`. */}
+      <DemoFocus active={active}>
+        <Input value={value} readOnly placeholder="username" />
+      </DemoFocus>
     </InputGroup>
   )
 }

--- a/www/src/modules/docs/components-list/demos/input-group.tsx
+++ b/www/src/modules/docs/components-list/demos/input-group.tsx
@@ -7,7 +7,7 @@ import { DemoFocus, useTypewriter } from '../autoplay'
 export function InputGroupDemo() {
   const { value, active } = useTypewriter('john_doe')
   return (
-    <InputGroup className="w-full max-w-[14rem]">
+    <InputGroup className="w-full max-w-[11.5rem]">
       <InputGroupAddon>@</InputGroupAddon>
       {/* Drive the inner control's real focus: the group lights its own ring via
           `has-[[data-input-control][data-focused]]`. */}

--- a/www/src/modules/docs/components-list/demos/input-group.tsx
+++ b/www/src/modules/docs/components-list/demos/input-group.tsx
@@ -7,7 +7,7 @@ import { DemoFocus, useTypewriter } from '../autoplay'
 export function InputGroupDemo() {
   const { value, active } = useTypewriter('john_doe')
   return (
-    <InputGroup className="w-full">
+    <InputGroup className="w-full max-w-[14rem]">
       <InputGroupAddon>@</InputGroupAddon>
       {/* Drive the inner control's real focus: the group lights its own ring via
           `has-[[data-input-control][data-focused]]`. */}

--- a/www/src/modules/docs/components-list/demos/input.tsx
+++ b/www/src/modules/docs/components-list/demos/input.tsx
@@ -12,7 +12,7 @@ export function InputDemo() {
         value={value}
         readOnly
         placeholder="Enter text..."
-        className="w-full max-w-[14rem]"
+        className="w-full max-w-[11.5rem]"
       />
     </DemoFocus>
   )

--- a/www/src/modules/docs/components-list/demos/input.tsx
+++ b/www/src/modules/docs/components-list/demos/input.tsx
@@ -1,20 +1,19 @@
 'use client'
 
-import { cn } from '@/registry/lib/utils'
 import { Input } from '@/registry/ui/input'
 
-import { demoFocusProps, useTypewriter } from '../autoplay'
+import { DemoFocus, useTypewriter } from '../autoplay'
 
 export function InputDemo() {
   const { value, active } = useTypewriter('Hello world')
-  const focus = demoFocusProps(active)
   return (
-    <Input
-      value={value}
-      readOnly
-      placeholder="Enter text..."
-      data-demo-focus={focus['data-demo-focus']}
-      className={cn('w-full', focus.className)}
-    />
+    <DemoFocus active={active}>
+      <Input
+        value={value}
+        readOnly
+        placeholder="Enter text..."
+        className="w-full"
+      />
+    </DemoFocus>
   )
 }

--- a/www/src/modules/docs/components-list/demos/input.tsx
+++ b/www/src/modules/docs/components-list/demos/input.tsx
@@ -1,5 +1,20 @@
+'use client'
+
+import { cn } from '@/registry/lib/utils'
 import { Input } from '@/registry/ui/input'
 
+import { demoFocusProps, useTypewriter } from '../autoplay'
+
 export function InputDemo() {
-  return <Input placeholder="Enter text..." className="w-full" />
+  const { value, active } = useTypewriter('Hello world')
+  const focus = demoFocusProps(active)
+  return (
+    <Input
+      value={value}
+      readOnly
+      placeholder="Enter text..."
+      data-demo-focus={focus['data-demo-focus']}
+      className={cn('w-full', focus.className)}
+    />
+  )
 }

--- a/www/src/modules/docs/components-list/demos/input.tsx
+++ b/www/src/modules/docs/components-list/demos/input.tsx
@@ -12,7 +12,7 @@ export function InputDemo() {
         value={value}
         readOnly
         placeholder="Enter text..."
-        className="w-full"
+        className="w-full max-w-[14rem]"
       />
     </DemoFocus>
   )

--- a/www/src/modules/docs/components-list/demos/link.tsx
+++ b/www/src/modules/docs/components-list/demos/link.tsx
@@ -1,20 +1,23 @@
 'use client'
 
-import { Link } from '@/registry/ui/link'
+import { useStyles as useLinkStyles } from '@/registry/ui/link/styles'
 
-import { DemoPress, useAutoplay } from '../autoplay'
+import { DemoState, useAutoplay } from '../autoplay'
 
+// The card itself is an <a>, so a real <Link> (also an <a>) would nest anchors.
+// We render the real link STYLES on a span instead — exact, preset-accurate look
+// with valid markup — and drive its real focus-visible ring so it still animates.
 export function LinkDemo() {
+  const linkStyles = useLinkStyles()
   const { phase } = useAutoplay([
-    { name: 'idle', duration: 950 },
-    { name: 'hover', duration: 620 },
-    { name: 'press', duration: 200 },
+    { name: 'idle', duration: 1000 },
+    { name: 'focus', duration: 900 },
   ])
   return (
-    <DemoPress phase={phase}>
-      <Link href="https://x.com/mehdibha" target="_blank">
+    <DemoState flags={{ focusVisible: phase === 'focus' }}>
+      <span data-rac="" className={linkStyles()}>
         @mehdibha
-      </Link>
-    </DemoPress>
+      </span>
+    </DemoState>
   )
 }

--- a/www/src/modules/docs/components-list/demos/link.tsx
+++ b/www/src/modules/docs/components-list/demos/link.tsx
@@ -1,9 +1,20 @@
+'use client'
+
 import { Link } from '@/registry/ui/link'
 
+import { DemoPress, useAutoplay } from '../autoplay'
+
 export function LinkDemo() {
+  const { phase } = useAutoplay([
+    { name: 'idle', duration: 950 },
+    { name: 'hover', duration: 620 },
+    { name: 'press', duration: 200 },
+  ])
   return (
-    <Link href="https://x.com/mehdibha" target="_blank">
-      @mehdibha
-    </Link>
+    <DemoPress phase={phase}>
+      <Link href="https://x.com/mehdibha" target="_blank">
+        @mehdibha
+      </Link>
+    </DemoPress>
   )
 }

--- a/www/src/modules/docs/components-list/demos/list-box.tsx
+++ b/www/src/modules/docs/components-list/demos/list-box.tsx
@@ -2,17 +2,17 @@
 
 import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
 
-import { useStepAutoplay } from '../autoplay'
+import { useCycle } from '../autoplay'
 
 const KEYS = ['nextjs', 'remix', 'astro', 'gatsby']
 
 export function ListBoxDemo() {
-  const { index } = useStepAutoplay(KEYS.length, { dwell: 1150 })
+  const { item } = useCycle(KEYS, { dwell: 1150 })
   return (
     <ListBox
       aria-label="Framework"
       selectionMode="single"
-      selectedKeys={[KEYS[index]]}
+      selectedKeys={[item]}
       onSelectionChange={() => {}}
     >
       <ListBoxItem id="nextjs">Next.js</ListBoxItem>

--- a/www/src/modules/docs/components-list/demos/list-box.tsx
+++ b/www/src/modules/docs/components-list/demos/list-box.tsx
@@ -1,12 +1,24 @@
+'use client'
+
 import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
 
+import { useStepAutoplay } from '../autoplay'
+
+const KEYS = ['nextjs', 'remix', 'astro', 'gatsby']
+
 export function ListBoxDemo() {
+  const { index } = useStepAutoplay(KEYS.length, { dwell: 1150 })
   return (
-    <ListBox aria-label="Framework">
-      <ListBoxItem>Next.js</ListBoxItem>
-      <ListBoxItem>Remix</ListBoxItem>
-      <ListBoxItem>Astro</ListBoxItem>
-      <ListBoxItem>Gatsby</ListBoxItem>
+    <ListBox
+      aria-label="Framework"
+      selectionMode="single"
+      selectedKeys={[KEYS[index]]}
+      onSelectionChange={() => {}}
+    >
+      <ListBoxItem id="nextjs">Next.js</ListBoxItem>
+      <ListBoxItem id="remix">Remix</ListBoxItem>
+      <ListBoxItem id="astro">Astro</ListBoxItem>
+      <ListBoxItem id="gatsby">Gatsby</ListBoxItem>
     </ListBox>
   )
 }

--- a/www/src/modules/docs/components-list/demos/menu.tsx
+++ b/www/src/modules/docs/components-list/demos/menu.tsx
@@ -27,7 +27,6 @@ export function MenuDemo() {
       >
         <ListBoxItem id="account">Account settings</ListBoxItem>
         <ListBoxItem id="team">Create team</ListBoxItem>
-        <ListBoxItem id="command">Command menu</ListBoxItem>
         <ListBoxItem id="logout">Log out</ListBoxItem>
       </ListBox>
     </OverlayScene>

--- a/www/src/modules/docs/components-list/demos/menu.tsx
+++ b/www/src/modules/docs/components-list/demos/menu.tsx
@@ -1,23 +1,35 @@
+'use client'
+
 import { MenuIcon } from 'lucide-react'
 
 import { Button } from '@/registry/ui/button'
-import { Menu, MenuContent, MenuItem } from '@/registry/ui/menu'
-import { Popover } from '@/registry/ui/popover'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+
+import { OverlayScene, useOpenAutoplay } from '../autoplay'
 
 export function MenuDemo() {
+  const { phase } = useOpenAutoplay()
   return (
-    <Menu>
-      <Button isIconOnly>
-        <MenuIcon />
-      </Button>
-      <Popover placement="bottom end">
-        <MenuContent>
-          <MenuItem>Account settings</MenuItem>
-          <MenuItem>Create team</MenuItem>
-          <MenuItem>Command menu</MenuItem>
-          <MenuItem>Log out</MenuItem>
-        </MenuContent>
-      </Popover>
-    </Menu>
+    <OverlayScene
+      phase={phase}
+      variant="menu"
+      side="bottom"
+      surfaceClassName="w-44 p-0"
+      trigger={
+        <Button aria-label="Menu" isIconOnly>
+          <MenuIcon />
+        </Button>
+      }
+    >
+      <ListBox
+        aria-label="Menu"
+        className="border-0 bg-transparent shadow-none"
+      >
+        <ListBoxItem id="account">Account settings</ListBoxItem>
+        <ListBoxItem id="team">Create team</ListBoxItem>
+        <ListBoxItem id="command">Command menu</ListBoxItem>
+        <ListBoxItem id="logout">Log out</ListBoxItem>
+      </ListBox>
+    </OverlayScene>
   )
 }

--- a/www/src/modules/docs/components-list/demos/modal.tsx
+++ b/www/src/modules/docs/components-list/demos/modal.tsx
@@ -1,40 +1,40 @@
+'use client'
+
 import { Button } from '@/registry/ui/button'
 import {
-  Dialog,
   DialogBody,
-  DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/registry/ui/dialog'
 import { Label } from '@/registry/ui/field'
 import { Input } from '@/registry/ui/input'
-import { Modal } from '@/registry/ui/modal'
 import { TextField } from '@/registry/ui/text-field'
 
+import { OverlayScene, useOpenAutoplay } from '../autoplay'
+
 export function ModalDemo() {
+  const { phase } = useOpenAutoplay()
   return (
-    <Dialog>
-      <Button>Open Modal</Button>
-      <Modal>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit username</DialogTitle>
-          </DialogHeader>
-          <DialogBody>
-            <TextField defaultValue="@mehdibha" className="w-full">
-              <Label>Username</Label>
-              <Input />
-            </TextField>
-          </DialogBody>
-          <DialogFooter className="flex-row! justify-end">
-            <Button slot="close">Cancel</Button>
-            <Button slot="close" variant="primary">
-              Apply
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Modal>
-    </Dialog>
+    <OverlayScene
+      phase={phase}
+      variant="modal"
+      surfaceClassName="space-y-3"
+      trigger={<Button>Open Modal</Button>}
+    >
+      <DialogHeader>
+        <DialogTitle>Edit username</DialogTitle>
+      </DialogHeader>
+      <DialogBody>
+        <TextField defaultValue="@mehdibha" className="w-full">
+          <Label>Username</Label>
+          <Input />
+        </TextField>
+      </DialogBody>
+      <DialogFooter className="flex-row! justify-end">
+        <Button variant="quiet">Cancel</Button>
+        <Button variant="primary">Apply</Button>
+      </DialogFooter>
+    </OverlayScene>
   )
 }

--- a/www/src/modules/docs/components-list/demos/number-field.tsx
+++ b/www/src/modules/docs/components-list/demos/number-field.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Label } from '@/registry/ui/field'
 import { Group } from '@/registry/ui/group'
 import { Input } from '@/registry/ui/input'
@@ -7,14 +9,19 @@ import {
   NumberFieldIncrement,
 } from '@/registry/ui/number-field'
 
+import { DemoPress, useStepAutoplay } from '../autoplay'
+
 export function NumberFieldDemo() {
+  const { index, pressing } = useStepAutoplay(5, { initial: 0, dwell: 950 })
   return (
-    <NumberField defaultValue={10}>
+    <NumberField value={10 + index} onChange={() => {}}>
       <Label>Quantity</Label>
       <Group>
         <NumberFieldDecrement />
         <Input className="w-16" />
-        <NumberFieldIncrement />
+        <DemoPress pressing={pressing}>
+          <NumberFieldIncrement />
+        </DemoPress>
       </Group>
     </NumberField>
   )

--- a/www/src/modules/docs/components-list/demos/otp-field.tsx
+++ b/www/src/modules/docs/components-list/demos/otp-field.tsx
@@ -1,23 +1,32 @@
+'use client'
+
 import { Label } from '@/registry/ui/field'
 import { Group } from '@/registry/ui/group'
 import { Input } from '@/registry/ui/input'
 import { OTPField, OTPFieldSeparator } from '@/registry/ui/otp-field'
 
+import { demoFocusProps, useTypewriter } from '../autoplay'
+
 export function OTPFieldDemo() {
+  const { value, active } = useTypewriter('284917', {
+    charInterval: 220,
+    holdAfter: 1600,
+  })
+  const focus = demoFocusProps(active)
   return (
-    <OTPField length={6}>
+    <OTPField length={6} value={value} onChange={() => {}}>
       <Label>Code</Label>
       <div className="flex items-center">
         <Group>
-          <Input />
-          <Input aria-label="Digit 2" />
-          <Input aria-label="Digit 3" />
+          <Input {...focus} />
+          <Input aria-label="Digit 2" {...focus} />
+          <Input aria-label="Digit 3" {...focus} />
         </Group>
         <OTPFieldSeparator className="px-2 text-fg-muted">-</OTPFieldSeparator>
         <Group>
-          <Input aria-label="Digit 4" />
-          <Input aria-label="Digit 5" />
-          <Input aria-label="Digit 6" />
+          <Input aria-label="Digit 4" {...focus} />
+          <Input aria-label="Digit 5" {...focus} />
+          <Input aria-label="Digit 6" {...focus} />
         </Group>
       </div>
     </OTPField>

--- a/www/src/modules/docs/components-list/demos/otp-field.tsx
+++ b/www/src/modules/docs/components-list/demos/otp-field.tsx
@@ -5,28 +5,34 @@ import { Group } from '@/registry/ui/group'
 import { Input } from '@/registry/ui/input'
 import { OTPField, OTPFieldSeparator } from '@/registry/ui/otp-field'
 
-import { demoFocusProps, useTypewriter } from '../autoplay'
+import { DemoFocus, useTypewriter } from '../autoplay'
 
 export function OTPFieldDemo() {
   const { value, active } = useTypewriter('284917', {
     charInterval: 220,
     holdAfter: 1600,
   })
-  const focus = demoFocusProps(active)
+  // Focus follows the digit being entered (the next empty slot), like a real OTP.
+  const current = Math.min(value.length, 5)
+  const digit = (i: number, label?: string) => (
+    <DemoFocus active={active && i === current}>
+      <Input aria-label={label} />
+    </DemoFocus>
+  )
   return (
     <OTPField length={6} value={value} onChange={() => {}}>
       <Label>Code</Label>
       <div className="flex items-center">
         <Group>
-          <Input {...focus} />
-          <Input aria-label="Digit 2" {...focus} />
-          <Input aria-label="Digit 3" {...focus} />
+          {digit(0)}
+          {digit(1, 'Digit 2')}
+          {digit(2, 'Digit 3')}
         </Group>
         <OTPFieldSeparator className="px-2 text-fg-muted">-</OTPFieldSeparator>
         <Group>
-          <Input aria-label="Digit 4" {...focus} />
-          <Input aria-label="Digit 5" {...focus} />
-          <Input aria-label="Digit 6" {...focus} />
+          {digit(3, 'Digit 4')}
+          {digit(4, 'Digit 5')}
+          {digit(5, 'Digit 6')}
         </Group>
       </div>
     </OTPField>

--- a/www/src/modules/docs/components-list/demos/pagination.tsx
+++ b/www/src/modules/docs/components-list/demos/pagination.tsx
@@ -11,7 +11,8 @@ import {
 
 import { useStepAutoplay } from '../autoplay'
 
-const PAGES = [1, 2, 3, 4, 5]
+// Kept short so the row fits the preview card without overflowing.
+const PAGES = [1, 2, 3]
 
 export function PaginationDemo() {
   const { index } = useStepAutoplay(PAGES.length, { dwell: 1100 })

--- a/www/src/modules/docs/components-list/demos/pagination.tsx
+++ b/www/src/modules/docs/components-list/demos/pagination.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import {
+  Pagination,
+  PaginationItem,
+  PaginationLink,
+  PaginationList,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/registry/ui/pagination'
+
+import { useStepAutoplay } from '../autoplay'
+
+const PAGES = [1, 2, 3, 4, 5]
+
+export function PaginationDemo() {
+  const { index } = useStepAutoplay(PAGES.length, { dwell: 1100 })
+  const page = PAGES[index] ?? PAGES[0]
+
+  return (
+    <Pagination>
+      <PaginationList>
+        <PaginationItem>
+          <PaginationPrevious isDisabled={page === 1} onPress={() => {}} />
+        </PaginationItem>
+        {PAGES.map((p) => (
+          <PaginationItem key={p}>
+            <PaginationLink
+              isActive={p === page}
+              aria-label={`Page ${p}`}
+              onPress={() => {}}
+            >
+              {p}
+            </PaginationLink>
+          </PaginationItem>
+        ))}
+        <PaginationItem>
+          <PaginationNext
+            isDisabled={page === PAGES.length}
+            onPress={() => {}}
+          />
+        </PaginationItem>
+      </PaginationList>
+    </Pagination>
+  )
+}

--- a/www/src/modules/docs/components-list/demos/popover.tsx
+++ b/www/src/modules/docs/components-list/demos/popover.tsx
@@ -1,30 +1,32 @@
+'use client'
+
 import { InfoIcon } from 'lucide-react'
 
 import { Button } from '@/registry/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/registry/ui/dialog'
-import { Popover } from '@/registry/ui/popover'
+import { DialogHeader, DialogTitle } from '@/registry/ui/dialog'
+
+import { OverlayScene, useOpenAutoplay } from '../autoplay'
 
 export function PopoverDemo() {
+  const { phase } = useOpenAutoplay()
   return (
-    <Dialog>
-      <Button aria-label="Help" isIconOnly>
-        <InfoIcon />
-      </Button>
-      <Popover>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Need help?</DialogTitle>
-          </DialogHeader>
-          <p>
-            If you&apos;re having issues, contact our customer support team.
-          </p>
-        </DialogContent>
-      </Popover>
-    </Dialog>
+    <OverlayScene
+      phase={phase}
+      variant="popover"
+      side="bottom"
+      surfaceClassName="w-52 text-left"
+      trigger={
+        <Button aria-label="Help" isIconOnly>
+          <InfoIcon />
+        </Button>
+      }
+    >
+      <DialogHeader>
+        <DialogTitle>Need help?</DialogTitle>
+      </DialogHeader>
+      <p className="mt-1 text-fg-muted">
+        If you&apos;re having issues, contact our customer support team.
+      </p>
+    </OverlayScene>
   )
 }

--- a/www/src/modules/docs/components-list/demos/progress-bar.tsx
+++ b/www/src/modules/docs/components-list/demos/progress-bar.tsx
@@ -19,10 +19,12 @@ export function ProgressBarDemo() {
     <ProgressBar
       value={value}
       valueLabel={`${value}%`}
-      className="w-44 [&_[data-rac]]:transition-transform [&_[data-rac]]:duration-700 [&_[data-rac]]:ease-out"
+      className="w-full max-w-[11.5rem] [&_[data-rac]]:transition-transform [&_[data-rac]]:duration-700 [&_[data-rac]]:ease-out"
     >
-      <Label>Uploading…</Label>
-      <ProgressBarOutput />
+      <div className="flex items-center justify-between gap-2">
+        <Label>Uploading…</Label>
+        <ProgressBarOutput />
+      </div>
       <ProgressBarControl />
     </ProgressBar>
   )

--- a/www/src/modules/docs/components-list/demos/progress-bar.tsx
+++ b/www/src/modules/docs/components-list/demos/progress-bar.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Label } from '@/registry/ui/field'
 import {
   ProgressBar,
@@ -5,9 +7,20 @@ import {
   ProgressBarOutput,
 } from '@/registry/ui/progress-bar'
 
+import { useValueAutoplay } from '../autoplay'
+
+// The fill already ships `transition-all` + `origin-left`, so its `scaleX`
+// transform glides on its own — we just step `value` through waypoints and the
+// CSS transition (slowed/eased via the root className) animates the sweep. The
+// Output reads `value` automatically, so the % label stays in sync.
 export function ProgressBarDemo() {
+  const { value } = useValueAutoplay([0, 35, 66, 92], { dwell: 900 })
   return (
-    <ProgressBar value={66} valueLabel="66%" className="w-44">
+    <ProgressBar
+      value={value}
+      valueLabel={`${value}%`}
+      className="w-44 [&_[data-rac]]:transition-transform [&_[data-rac]]:duration-700 [&_[data-rac]]:ease-out"
+    >
       <Label>Uploading…</Label>
       <ProgressBarOutput />
       <ProgressBarControl />

--- a/www/src/modules/docs/components-list/demos/radio-group.tsx
+++ b/www/src/modules/docs/components-list/demos/radio-group.tsx
@@ -1,9 +1,16 @@
+'use client'
+
 import { FieldGroup, Label } from '@/registry/ui/field'
 import { Radio, RadioControl, RadioGroup } from '@/registry/ui/radio-group'
 
+import { useStepAutoplay } from '../autoplay'
+
+const KEYS = ['nextjs', 'remix', 'gatsby']
+
 export function RadioGroupDemo() {
+  const { index } = useStepAutoplay(KEYS.length, { dwell: 1300 })
   return (
-    <RadioGroup defaultValue="nextjs">
+    <RadioGroup value={KEYS[index]} onChange={() => {}}>
       <Label>React frameworks</Label>
       <FieldGroup>
         <Radio value="nextjs">

--- a/www/src/modules/docs/components-list/demos/search-field.tsx
+++ b/www/src/modules/docs/components-list/demos/search-field.tsx
@@ -1,12 +1,22 @@
+'use client'
+
 import { SearchIcon, XIcon } from '@/registry/__generated__/icons'
 import { Button } from '@/registry/ui/button'
 import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 import { SearchField } from '@/registry/ui/search-field'
 
+import { demoFocusProps, useTypewriter } from '../autoplay'
+
 export function SearchFieldDemo() {
+  const { value, active } = useTypewriter('invoices')
   return (
-    <SearchField aria-label="Search" className="w-full">
-      <InputGroup className="w-full">
+    <SearchField
+      aria-label="Search"
+      className="w-full"
+      value={value}
+      onChange={() => {}}
+    >
+      <InputGroup className="w-full" {...demoFocusProps(active)}>
         <InputGroupAddon>
           <SearchIcon />
         </InputGroupAddon>

--- a/www/src/modules/docs/components-list/demos/search-field.tsx
+++ b/www/src/modules/docs/components-list/demos/search-field.tsx
@@ -12,7 +12,7 @@ export function SearchFieldDemo() {
   return (
     <SearchField
       aria-label="Search"
-      className="w-full max-w-[14rem]"
+      className="w-full max-w-[11.5rem]"
       value={value}
       onChange={() => {}}
     >

--- a/www/src/modules/docs/components-list/demos/search-field.tsx
+++ b/www/src/modules/docs/components-list/demos/search-field.tsx
@@ -12,7 +12,7 @@ export function SearchFieldDemo() {
   return (
     <SearchField
       aria-label="Search"
-      className="w-full"
+      className="w-full max-w-[14rem]"
       value={value}
       onChange={() => {}}
     >

--- a/www/src/modules/docs/components-list/demos/search-field.tsx
+++ b/www/src/modules/docs/components-list/demos/search-field.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/registry/ui/button'
 import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 import { SearchField } from '@/registry/ui/search-field'
 
-import { demoFocusProps, useTypewriter } from '../autoplay'
+import { DemoFocus, useTypewriter } from '../autoplay'
 
 export function SearchFieldDemo() {
   const { value, active } = useTypewriter('invoices')
@@ -16,11 +16,13 @@ export function SearchFieldDemo() {
       value={value}
       onChange={() => {}}
     >
-      <InputGroup className="w-full" {...demoFocusProps(active)}>
+      <InputGroup className="w-full">
         <InputGroupAddon>
           <SearchIcon />
         </InputGroupAddon>
-        <Input placeholder="Search..." />
+        <DemoFocus active={active}>
+          <Input placeholder="Search..." />
+        </DemoFocus>
         <InputGroupAddon>
           <Button variant="quiet" isIconOnly className="rounded-full">
             <XIcon />

--- a/www/src/modules/docs/components-list/demos/select.tsx
+++ b/www/src/modules/docs/components-list/demos/select.tsx
@@ -15,9 +15,9 @@ export function SelectDemo() {
       variant="menu"
       side="bottom"
       fluid
-      surfaceClassName="w-full max-w-[14rem] p-0"
+      surfaceClassName="w-full max-w-[11.5rem] p-0"
       trigger={
-        <Button className="w-full max-w-[14rem] justify-between font-normal">
+        <Button className="w-full max-w-[11.5rem] justify-between font-normal">
           Perplexity
           <ChevronDownIcon className="ml-auto text-fg-muted" />
         </Button>
@@ -32,7 +32,6 @@ export function SelectDemo() {
         <ListBoxItem id="perplexity">Perplexity</ListBoxItem>
         <ListBoxItem id="replicate">Replicate</ListBoxItem>
         <ListBoxItem id="together">Together AI</ListBoxItem>
-        <ListBoxItem id="eleven">ElevenLabs</ListBoxItem>
       </ListBox>
     </OverlayScene>
   )

--- a/www/src/modules/docs/components-list/demos/select.tsx
+++ b/www/src/modules/docs/components-list/demos/select.tsx
@@ -1,20 +1,38 @@
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from '@/registry/ui/select'
+'use client'
+
+import { ChevronDownIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+
+import { OverlayScene, useOpenAutoplay } from '../autoplay'
 
 export function SelectDemo() {
+  const { phase } = useOpenAutoplay()
   return (
-    <Select aria-label="Provider" className="w-48">
-      <SelectTrigger />
-      <SelectContent>
-        <SelectItem>Perplexity</SelectItem>
-        <SelectItem>Replicate</SelectItem>
-        <SelectItem>Together AI</SelectItem>
-        <SelectItem>ElevenLabs</SelectItem>
-      </SelectContent>
-    </Select>
+    <OverlayScene
+      phase={phase}
+      variant="menu"
+      side="bottom"
+      surfaceClassName="w-44 p-0"
+      trigger={
+        <Button className="w-44 justify-between font-normal">
+          Perplexity
+          <ChevronDownIcon className="ml-auto text-fg-muted" />
+        </Button>
+      }
+    >
+      <ListBox
+        aria-label="Provider"
+        selectionMode="single"
+        selectedKeys={['perplexity']}
+        className="border-0 bg-transparent shadow-none"
+      >
+        <ListBoxItem id="perplexity">Perplexity</ListBoxItem>
+        <ListBoxItem id="replicate">Replicate</ListBoxItem>
+        <ListBoxItem id="together">Together AI</ListBoxItem>
+        <ListBoxItem id="eleven">ElevenLabs</ListBoxItem>
+      </ListBox>
+    </OverlayScene>
   )
 }

--- a/www/src/modules/docs/components-list/demos/select.tsx
+++ b/www/src/modules/docs/components-list/demos/select.tsx
@@ -14,9 +14,10 @@ export function SelectDemo() {
       phase={phase}
       variant="menu"
       side="bottom"
-      surfaceClassName="w-44 p-0"
+      fluid
+      surfaceClassName="w-full max-w-[14rem] p-0"
       trigger={
-        <Button className="w-44 justify-between font-normal">
+        <Button className="w-full max-w-[14rem] justify-between font-normal">
           Perplexity
           <ChevronDownIcon className="ml-auto text-fg-muted" />
         </Button>

--- a/www/src/modules/docs/components-list/demos/slider.tsx
+++ b/www/src/modules/docs/components-list/demos/slider.tsx
@@ -1,8 +1,21 @@
+'use client'
+
 import { Slider, SliderControl } from '@/registry/ui/slider'
 
+import { useValueAutoplay } from '../autoplay'
+
+// Discrete waypoints; the CSS transitions on the thumb/fill (added via the
+// className below) glide between them — cheaper and more reliable than a
+// per-frame value tween.
 export function SliderDemo() {
+  const { value } = useValueAutoplay([50, 80, 92, 64], { dwell: 850 })
   return (
-    <Slider aria-label="Opacity" defaultValue={50} className="w-64">
+    <Slider
+      aria-label="Opacity"
+      value={value}
+      onChange={() => {}}
+      className="w-64 [&_[data-slider-fill]]:transition-[width,inset-inline-start] [&_[data-slider-fill]]:duration-700 [&_[data-slider-fill]]:ease-out [&_[data-slider-thumb]]:transition-[left,inset-inline-start] [&_[data-slider-thumb]]:duration-700 [&_[data-slider-thumb]]:ease-out"
+    >
       <SliderControl />
     </Slider>
   )

--- a/www/src/modules/docs/components-list/demos/slider.tsx
+++ b/www/src/modules/docs/components-list/demos/slider.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Slider, SliderControl } from '@/registry/ui/slider'
+import { Label } from '@/registry/ui/field'
+import { Slider, SliderControl, SliderOutput } from '@/registry/ui/slider'
 
 import { useValueAutoplay } from '../autoplay'
 
@@ -11,11 +12,14 @@ export function SliderDemo() {
   const { value } = useValueAutoplay([50, 80, 92, 64], { dwell: 850 })
   return (
     <Slider
-      aria-label="Opacity"
       value={value}
       onChange={() => {}}
-      className="w-64 [&_[data-slider-fill]]:transition-[width,inset-inline-start] [&_[data-slider-fill]]:duration-700 [&_[data-slider-fill]]:ease-out [&_[data-slider-thumb]]:transition-[left,inset-inline-start] [&_[data-slider-thumb]]:duration-700 [&_[data-slider-thumb]]:ease-out"
+      className="w-full max-w-[11.5rem] [&_[data-slider-fill]]:transition-[width,inset-inline-start] [&_[data-slider-fill]]:duration-700 [&_[data-slider-fill]]:ease-out [&_[data-slider-thumb]]:transition-[left,inset-inline-start] [&_[data-slider-thumb]]:duration-700 [&_[data-slider-thumb]]:ease-out"
     >
+      <div className="flex items-center justify-between">
+        <Label>Opacity</Label>
+        <SliderOutput />
+      </div>
       <SliderControl />
     </Slider>
   )

--- a/www/src/modules/docs/components-list/demos/switch.tsx
+++ b/www/src/modules/docs/components-list/demos/switch.tsx
@@ -1,10 +1,17 @@
+'use client'
+
 import { Label } from '@/registry/ui/field'
 import { Switch, SwitchControl } from '@/registry/ui/switch'
 
+import { DemoPress, useToggleAutoplay } from '../autoplay'
+
 export function SwitchDemo() {
+  const { selected, pressing } = useToggleAutoplay()
   return (
-    <Switch>
-      <SwitchControl />
+    <Switch isSelected={selected} onChange={() => {}}>
+      <DemoPress pressing={pressing}>
+        <SwitchControl />
+      </DemoPress>
       <Label>Focus mode</Label>
     </Switch>
   )

--- a/www/src/modules/docs/components-list/demos/tabs.tsx
+++ b/www/src/modules/docs/components-list/demos/tabs.tsx
@@ -1,8 +1,15 @@
+'use client'
+
 import { Tab, TabList, TabPanel, Tabs } from '@/registry/ui/tabs'
 
+import { useStepAutoplay } from '../autoplay'
+
+const KEYS = ['overview', 'usage', 'settings']
+
 export function TabsDemo() {
+  const { index } = useStepAutoplay(KEYS.length, { dwell: 1300 })
   return (
-    <Tabs>
+    <Tabs selectedKey={KEYS[index]} onSelectionChange={() => {}}>
       <TabList>
         <Tab id="overview">Overview</Tab>
         <Tab id="usage">Usage</Tab>

--- a/www/src/modules/docs/components-list/demos/tag-group.tsx
+++ b/www/src/modules/docs/components-list/demos/tag-group.tsx
@@ -1,14 +1,25 @@
+'use client'
+
 import { Label } from '@/registry/ui/field'
 import { Tag, TagGroup, TagList } from '@/registry/ui/tag-group'
 
+import { useStepAutoplay } from '../autoplay'
+
+const KEYS = ['react', 'typescript', 'nextjs']
+
 export function TagGroupDemo() {
+  const { index } = useStepAutoplay(KEYS.length, { dwell: 1300 })
   return (
-    <TagGroup>
+    <TagGroup
+      selectionMode="single"
+      selectedKeys={[KEYS[index]]}
+      onSelectionChange={() => {}}
+    >
       <Label>Tags</Label>
       <TagList>
-        <Tag>React</Tag>
-        <Tag>TypeScript</Tag>
-        <Tag>Next.js</Tag>
+        <Tag id="react">React</Tag>
+        <Tag id="typescript">TypeScript</Tag>
+        <Tag id="nextjs">Next.js</Tag>
       </TagList>
     </TagGroup>
   )

--- a/www/src/modules/docs/components-list/demos/tag-group.tsx
+++ b/www/src/modules/docs/components-list/demos/tag-group.tsx
@@ -3,16 +3,16 @@
 import { Label } from '@/registry/ui/field'
 import { Tag, TagGroup, TagList } from '@/registry/ui/tag-group'
 
-import { useStepAutoplay } from '../autoplay'
+import { useCycle } from '../autoplay'
 
 const KEYS = ['react', 'typescript', 'nextjs']
 
 export function TagGroupDemo() {
-  const { index } = useStepAutoplay(KEYS.length, { dwell: 1300 })
+  const { item } = useCycle(KEYS, { dwell: 1300 })
   return (
     <TagGroup
       selectionMode="single"
-      selectedKeys={[KEYS[index]]}
+      selectedKeys={[item]}
       onSelectionChange={() => {}}
     >
       <Label>Tags</Label>

--- a/www/src/modules/docs/components-list/demos/text-area.tsx
+++ b/www/src/modules/docs/components-list/demos/text-area.tsx
@@ -12,7 +12,7 @@ export function TextAreaDemo() {
         value={value}
         onChange={() => {}}
         placeholder="Enter description..."
-        className="w-full max-w-[14rem]"
+        className="w-full max-w-[11.5rem]"
       />
     </DemoFocus>
   )

--- a/www/src/modules/docs/components-list/demos/text-area.tsx
+++ b/www/src/modules/docs/components-list/demos/text-area.tsx
@@ -1,20 +1,19 @@
 'use client'
 
-import { cn } from '@/registry/lib/utils'
 import { TextArea } from '@/registry/ui/input'
 
-import { demoFocusProps, useTypewriter } from '../autoplay'
+import { DemoFocus, useTypewriter } from '../autoplay'
 
 export function TextAreaDemo() {
   const { value, active } = useTypewriter('Tell us a bit about yourself.')
-  const focus = demoFocusProps(active)
   return (
-    <TextArea
-      value={value}
-      onChange={() => {}}
-      placeholder="Enter description..."
-      data-demo-focus={focus['data-demo-focus']}
-      className={cn('w-full', focus.className)}
-    />
+    <DemoFocus active={active}>
+      <TextArea
+        value={value}
+        onChange={() => {}}
+        placeholder="Enter description..."
+        className="w-full"
+      />
+    </DemoFocus>
   )
 }

--- a/www/src/modules/docs/components-list/demos/text-area.tsx
+++ b/www/src/modules/docs/components-list/demos/text-area.tsx
@@ -12,7 +12,7 @@ export function TextAreaDemo() {
         value={value}
         onChange={() => {}}
         placeholder="Enter description..."
-        className="w-full"
+        className="w-full max-w-[14rem]"
       />
     </DemoFocus>
   )

--- a/www/src/modules/docs/components-list/demos/text-area.tsx
+++ b/www/src/modules/docs/components-list/demos/text-area.tsx
@@ -1,5 +1,20 @@
+'use client'
+
+import { cn } from '@/registry/lib/utils'
 import { TextArea } from '@/registry/ui/input'
 
+import { demoFocusProps, useTypewriter } from '../autoplay'
+
 export function TextAreaDemo() {
-  return <TextArea placeholder="Enter description..." className="w-full" />
+  const { value, active } = useTypewriter('Tell us a bit about yourself.')
+  const focus = demoFocusProps(active)
+  return (
+    <TextArea
+      value={value}
+      onChange={() => {}}
+      placeholder="Enter description..."
+      data-demo-focus={focus['data-demo-focus']}
+      className={cn('w-full', focus.className)}
+    />
+  )
 }

--- a/www/src/modules/docs/components-list/demos/text-field.tsx
+++ b/www/src/modules/docs/components-list/demos/text-field.tsx
@@ -9,7 +9,11 @@ import { DemoFocus, useTypewriter } from '../autoplay'
 export function TextFieldDemo() {
   const { value, active } = useTypewriter('hello@example.com')
   return (
-    <TextField className="w-56" value={value} onChange={() => {}}>
+    <TextField
+      className="w-full max-w-[14rem]"
+      value={value}
+      onChange={() => {}}
+    >
       <Label>Email</Label>
       <DemoFocus active={active}>
         <Input placeholder="hello@example.com" />

--- a/www/src/modules/docs/components-list/demos/text-field.tsx
+++ b/www/src/modules/docs/components-list/demos/text-field.tsx
@@ -10,7 +10,7 @@ export function TextFieldDemo() {
   const { value, active } = useTypewriter('hello@example.com')
   return (
     <TextField
-      className="w-full max-w-[14rem]"
+      className="w-full max-w-[11.5rem]"
       value={value}
       onChange={() => {}}
     >

--- a/www/src/modules/docs/components-list/demos/text-field.tsx
+++ b/www/src/modules/docs/components-list/demos/text-field.tsx
@@ -1,12 +1,17 @@
+'use client'
+
 import { Description, Label } from '@/registry/ui/field'
 import { Input } from '@/registry/ui/input'
 import { TextField } from '@/registry/ui/text-field'
 
+import { demoFocusProps, useTypewriter } from '../autoplay'
+
 export function TextFieldDemo() {
+  const { value, active } = useTypewriter('hello@example.com')
   return (
-    <TextField className="w-56">
+    <TextField className="w-56" value={value} onChange={() => {}}>
       <Label>Email</Label>
-      <Input placeholder="hello@example.com" />
+      <Input placeholder="hello@example.com" {...demoFocusProps(active)} />
       <Description>Enter your email.</Description>
     </TextField>
   )

--- a/www/src/modules/docs/components-list/demos/text-field.tsx
+++ b/www/src/modules/docs/components-list/demos/text-field.tsx
@@ -4,14 +4,16 @@ import { Description, Label } from '@/registry/ui/field'
 import { Input } from '@/registry/ui/input'
 import { TextField } from '@/registry/ui/text-field'
 
-import { demoFocusProps, useTypewriter } from '../autoplay'
+import { DemoFocus, useTypewriter } from '../autoplay'
 
 export function TextFieldDemo() {
   const { value, active } = useTypewriter('hello@example.com')
   return (
     <TextField className="w-56" value={value} onChange={() => {}}>
       <Label>Email</Label>
-      <Input placeholder="hello@example.com" {...demoFocusProps(active)} />
+      <DemoFocus active={active}>
+        <Input placeholder="hello@example.com" />
+      </DemoFocus>
       <Description>Enter your email.</Description>
     </TextField>
   )

--- a/www/src/modules/docs/components-list/demos/time-field.tsx
+++ b/www/src/modules/docs/components-list/demos/time-field.tsx
@@ -14,7 +14,10 @@ import { DemoFocus, useCardHover } from '../autoplay'
 export function TimeFieldDemo() {
   const active = useCardHover()
   return (
-    <TimeField defaultValue={new Time(11, 45)} className="w-full max-w-[14rem]">
+    <TimeField
+      defaultValue={new Time(11, 45)}
+      className="w-full max-w-[11.5rem]"
+    >
       <Label>Event time</Label>
       <DemoFocus active={active}>
         <DateInput className="w-full" />

--- a/www/src/modules/docs/components-list/demos/time-field.tsx
+++ b/www/src/modules/docs/components-list/demos/time-field.tsx
@@ -14,10 +14,10 @@ import { DemoFocus, useCardHover } from '../autoplay'
 export function TimeFieldDemo() {
   const active = useCardHover()
   return (
-    <TimeField defaultValue={new Time(11, 45)}>
+    <TimeField defaultValue={new Time(11, 45)} className="w-full max-w-[14rem]">
       <Label>Event time</Label>
       <DemoFocus active={active}>
-        <DateInput className="w-40" />
+        <DateInput className="w-full" />
       </DemoFocus>
     </TimeField>
   )

--- a/www/src/modules/docs/components-list/demos/time-field.tsx
+++ b/www/src/modules/docs/components-list/demos/time-field.tsx
@@ -1,12 +1,21 @@
+'use client'
+
+import { Time } from '@internationalized/date'
+
 import { Label } from '@/registry/ui/field'
 import { DateInput } from '@/registry/ui/input'
 import { TimeField } from '@/registry/ui/time-field'
 
+import { demoFocusProps, useCardHover } from '../autoplay'
+
+// The field shows a real time and lights up its focus ring whenever the card is
+// hovered — a faux ring (no real `:focus`), so it never steals page focus.
 export function TimeFieldDemo() {
+  const active = useCardHover()
   return (
-    <TimeField>
+    <TimeField defaultValue={new Time(11, 45)}>
       <Label>Event time</Label>
-      <DateInput className="w-40" />
+      <DateInput className="w-40" {...demoFocusProps(active)} />
     </TimeField>
   )
 }

--- a/www/src/modules/docs/components-list/demos/time-field.tsx
+++ b/www/src/modules/docs/components-list/demos/time-field.tsx
@@ -6,16 +6,19 @@ import { Label } from '@/registry/ui/field'
 import { DateInput } from '@/registry/ui/input'
 import { TimeField } from '@/registry/ui/time-field'
 
-import { demoFocusProps, useCardHover } from '../autoplay'
+import { DemoFocus, useCardHover } from '../autoplay'
 
-// The field shows a real time and lights up its focus ring whenever the card is
-// hovered — a faux ring (no real `:focus`), so it never steals page focus.
+// Shows a real time and lights up its real focus ring while the card is hovered.
+// We only set `data-focused` on the field (no real `:focus`), so it never steals
+// the page's focus.
 export function TimeFieldDemo() {
   const active = useCardHover()
   return (
     <TimeField defaultValue={new Time(11, 45)}>
       <Label>Event time</Label>
-      <DateInput className="w-40" {...demoFocusProps(active)} />
+      <DemoFocus active={active}>
+        <DateInput className="w-40" />
+      </DemoFocus>
     </TimeField>
   )
 }

--- a/www/src/modules/docs/components-list/demos/toast.tsx
+++ b/www/src/modules/docs/components-list/demos/toast.tsx
@@ -1,10 +1,27 @@
+'use client'
+
 import { CircleCheckIcon } from 'lucide-react'
+
+import { useAutoplay } from '../autoplay'
 
 // A static, presentational stand-in for a toast — the real component is
 // triggered + portaled at runtime, which doesn't preview well in a static grid.
+// On hover it loops a slide-up + fade re-entry; at rest it just sits visible.
 export function ToastDemo() {
+  const { phase, playing } = useAutoplay([
+    { name: 'out', duration: 400 },
+    { name: 'in', duration: 1900 },
+  ])
+  const hidden = playing && phase === 'out'
   return (
-    <div className="flex w-64 items-center gap-3 rounded-lg border bg-bg p-3 shadow-lg">
+    <div
+      className="flex w-64 items-center gap-3 rounded-lg border bg-bg p-3 shadow-lg"
+      style={{
+        opacity: hidden ? 0 : 1,
+        transform: hidden ? 'translateY(8px)' : 'none',
+        transition: 'opacity .3s, transform .3s cubic-bezier(0.32,0.72,0,1)',
+      }}
+    >
       <CircleCheckIcon className="size-5 shrink-0 text-fg-success" />
       <div className="flex min-w-0 flex-col">
         <span className="text-sm font-medium text-fg">

--- a/www/src/modules/docs/components-list/demos/toast.tsx
+++ b/www/src/modules/docs/components-list/demos/toast.tsx
@@ -6,20 +6,22 @@ import { useAutoplay } from '../autoplay'
 
 // A static, presentational stand-in for a toast — the real component is
 // triggered + portaled at runtime, which doesn't preview well in a static grid.
-// On hover it loops a slide-up + fade re-entry; at rest it just sits visible.
+// The surface + entrance mirror the real toast (bg-card, slide up from below the
+// frame, like its `data-[starting-style]` enter); at rest it just sits visible.
 export function ToastDemo() {
   const { phase, playing } = useAutoplay([
-    { name: 'out', duration: 400 },
+    { name: 'out', duration: 450 },
     { name: 'in', duration: 1900 },
   ])
   const hidden = playing && phase === 'out'
   return (
     <div
-      className="flex w-64 items-center gap-3 rounded-lg border bg-bg p-3 shadow-lg"
+      className="flex w-64 items-center gap-3 rounded-lg border bg-card p-3 text-fg shadow-lg"
       style={{
         opacity: hidden ? 0 : 1,
-        transform: hidden ? 'translateY(8px)' : 'none',
-        transition: 'opacity .3s, transform .3s cubic-bezier(0.32,0.72,0,1)',
+        transform: hidden ? 'translateY(calc(100% + 1rem))' : 'translateY(0)',
+        transition:
+          'opacity .3s ease, transform .45s cubic-bezier(0.22,1,0.36,1)',
       }}
     >
       <CircleCheckIcon className="size-5 shrink-0 text-fg-success" />

--- a/www/src/modules/docs/components-list/demos/toggle-button-group.tsx
+++ b/www/src/modules/docs/components-list/demos/toggle-button-group.tsx
@@ -5,17 +5,17 @@ import { AlignCenterIcon, AlignLeftIcon, AlignRightIcon } from 'lucide-react'
 import { ToggleButton } from '@/registry/ui/toggle-button'
 import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
 
-import { useStepAutoplay } from '../autoplay'
+import { useCycle } from '../autoplay'
 
 const KEYS = ['left', 'center', 'right']
 
 export function ToggleButtonGroupDemo() {
-  const { index } = useStepAutoplay(KEYS.length, { dwell: 1100 })
+  const { item } = useCycle(KEYS, { dwell: 1100 })
   return (
     <ToggleButtonGroup
       orientation="horizontal"
       selectionMode="single"
-      selectedKeys={[KEYS[index]]}
+      selectedKeys={[item]}
       onSelectionChange={() => {}}
     >
       <ToggleButton id="left" isIconOnly aria-label="Align left">

--- a/www/src/modules/docs/components-list/demos/toggle-button-group.tsx
+++ b/www/src/modules/docs/components-list/demos/toggle-button-group.tsx
@@ -1,14 +1,22 @@
+'use client'
+
 import { AlignCenterIcon, AlignLeftIcon, AlignRightIcon } from 'lucide-react'
 
 import { ToggleButton } from '@/registry/ui/toggle-button'
 import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
 
+import { useStepAutoplay } from '../autoplay'
+
+const KEYS = ['left', 'center', 'right']
+
 export function ToggleButtonGroupDemo() {
+  const { index } = useStepAutoplay(KEYS.length, { dwell: 1100 })
   return (
     <ToggleButtonGroup
       orientation="horizontal"
       selectionMode="single"
-      defaultSelectedKeys={['left']}
+      selectedKeys={[KEYS[index]]}
+      onSelectionChange={() => {}}
     >
       <ToggleButton id="left" isIconOnly aria-label="Align left">
         <AlignLeftIcon />

--- a/www/src/modules/docs/components-list/demos/toggle-button.tsx
+++ b/www/src/modules/docs/components-list/demos/toggle-button.tsx
@@ -1,11 +1,23 @@
+'use client'
+
 import { PinIcon } from 'lucide-react'
 
 import { ToggleButton } from '@/registry/ui/toggle-button'
 
+import { DemoPress, useToggleAutoplay } from '../autoplay'
+
 export function ToggleButtonDemo() {
+  const { selected, pressing } = useToggleAutoplay({ initial: true })
   return (
-    <ToggleButton isIconOnly aria-label="Toggle pin" defaultSelected>
-      <PinIcon className="rotate-45" />
-    </ToggleButton>
+    <DemoPress pressing={pressing}>
+      <ToggleButton
+        isIconOnly
+        aria-label="Toggle pin"
+        isSelected={selected}
+        onChange={() => {}}
+      >
+        <PinIcon className="rotate-45" />
+      </ToggleButton>
+    </DemoPress>
   )
 }

--- a/www/src/modules/docs/components-list/demos/tooltip.tsx
+++ b/www/src/modules/docs/components-list/demos/tooltip.tsx
@@ -4,17 +4,24 @@ import { SquarePenIcon } from 'lucide-react'
 
 import { Button } from '@/registry/ui/button'
 import { Kbd } from '@/registry/ui/kbd'
-import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { OverlayScene, useOpenAutoplay } from '../autoplay'
 
 export function TooltipDemo() {
+  const { phase } = useOpenAutoplay()
   return (
-    <Tooltip>
-      <Button isIconOnly>
-        <SquarePenIcon />
-      </Button>
-      <TooltipContent>
-        Create new issue <Kbd>C</Kbd>
-      </TooltipContent>
-    </Tooltip>
+    <OverlayScene
+      phase={phase}
+      variant="tooltip"
+      side="top"
+      surfaceClassName="inline-flex items-center gap-1.5 whitespace-nowrap"
+      trigger={
+        <Button aria-label="Create new issue" isIconOnly>
+          <SquarePenIcon />
+        </Button>
+      }
+    >
+      Create new issue <Kbd>C</Kbd>
+    </OverlayScene>
   )
 }

--- a/www/src/modules/docs/demo-preset.tsx
+++ b/www/src/modules/docs/demo-preset.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+import { DesignSystemProvider } from '@/lib/styles'
+import { useStoredPreset } from '@/modules/create/preset/storage'
+
+/**
+ * Renders a docs demo subtree in the user's selected design-system preset (the
+ * one they build at /create, persisted in localStorage). Scoped, so only the
+ * demo re-themes — the surrounding docs chrome stays in the site theme — and any
+ * overlays the demo portals are themed too. When the user hasn't customized
+ * anything it resolves to the defaults and injects nothing.
+ */
+export function DemoPreset({ children }: { children: ReactNode }) {
+  const ds = useStoredPreset()
+  return (
+    <DesignSystemProvider
+      params={ds.componentParams}
+      tokens={ds.tokens}
+      density={ds.density}
+      color={ds.color}
+      scoped
+    >
+      {children}
+    </DesignSystemProvider>
+  )
+}

--- a/www/src/modules/docs/demo.tsx
+++ b/www/src/modules/docs/demo.tsx
@@ -5,6 +5,7 @@ import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
 import { Button } from '@/registry/ui/button'
 
 import { CodeBlock, Pre } from './code-block'
+import { DemoPreset } from './demo-preset'
 
 // ============================================================================
 // Slot Components
@@ -74,7 +75,9 @@ export function Demo({ component: Component, children, ...props }: DemoProps) {
     <div {...props}>
       {/* Preview frame */}
       <div className="flex min-h-56 items-center justify-center overflow-x-auto rounded-t-lg border bg-bg p-6 sm:p-10">
-        <Component />
+        <DemoPreset>
+          <Component />
+        </DemoPreset>
       </div>
 
       {/* Code block with toggle */}

--- a/www/src/modules/docs/example.tsx
+++ b/www/src/modules/docs/example.tsx
@@ -5,6 +5,8 @@ import { Button } from '@/registry/ui/button'
 import { Dialog, DialogBody, DialogContent } from '@/registry/ui/dialog'
 import { Modal } from '@/registry/ui/modal'
 
+import { DemoPreset } from './demo-preset'
+
 export interface ExampleProps extends React.ComponentProps<'div'> {
   component: React.ComponentType
   title?: string
@@ -33,29 +35,33 @@ export function Example({
       {...props}
     >
       {children ?? (title ? <h3>{title}</h3> : null)}
-      <div className="relative flex flex-1 flex-col">
-        <div
-          data-example-preview=""
-          tabIndex={-1}
-          className="pointer-events-none scrollbar-none flex min-h-32 flex-1 flex-col items-center justify-center gap-6 overflow-x-auto p-6 sm:p-10"
-        >
-          <Component />
+      <DemoPreset>
+        <div className="relative flex flex-1 flex-col">
+          <div
+            data-example-preview=""
+            tabIndex={-1}
+            className="pointer-events-none scrollbar-none flex min-h-32 flex-1 flex-col items-center justify-center gap-6 overflow-x-auto p-6 sm:p-10"
+          >
+            <Component />
+          </div>
+          <Dialog>
+            <Button
+              variant="quiet"
+              aria-label={title ? `Expand ${title} example` : 'Expand example'}
+              className="absolute inset-0 z-2 size-auto h-auto! border hover:border-border-hover"
+            />
+            <Modal>
+              <DialogContent
+                aria-label={title ? `${title} example` : 'Example'}
+              >
+                <DialogBody>
+                  <Component />
+                </DialogBody>
+              </DialogContent>
+            </Modal>
+          </Dialog>
         </div>
-        <Dialog>
-          <Button
-            variant="quiet"
-            aria-label={title ? `Expand ${title} example` : 'Expand example'}
-            className="absolute inset-0 z-2 size-auto h-auto! border hover:border-border-hover"
-          />
-          <Modal>
-            <DialogContent aria-label={title ? `${title} example` : 'Example'}>
-              <DialogBody>
-                <Component />
-              </DialogBody>
-            </DialogContent>
-          </Modal>
-        </Dialog>
-      </div>
+      </DemoPreset>
     </div>
   )
 }

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
 import { z } from 'zod'
 
@@ -7,6 +7,11 @@ import { ToggleButton } from '@/registry/ui/toggle-button'
 import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
 import { CustomizerPanel } from '@/modules/create/customizer-panel'
 import { LabExperience } from '@/modules/create/panel'
+import { DEFAULTS, useDesignSystem } from '@/modules/create/preset'
+import {
+  loadStoredPreset,
+  saveStoredPreset,
+} from '@/modules/create/preset/storage'
 import { PreviewPanel } from '@/modules/create/preview/preview-panel'
 
 type MobilePane = 'customize' | 'preview'
@@ -33,12 +38,36 @@ export const Route = createFileRoute('/_app/create')({
 })
 
 function CreatePage() {
-  const { lab } = Route.useSearch()
+  const { lab, preset } = Route.useSearch()
+  const { designSystem, setDesignSystem } = useDesignSystem()
   // Below `lg` the customizer and the live preview can't sit side by side (the iframe
   // would be a ~15px sliver), so they collapse into a single switchable pane toggled
   // by the segmented control. Both stay mounted — only CSS-hidden, never unmounted —
   // so switching never reloads the preview. Above `lg` this state is inert; both show.
   const [mobilePane, setMobilePane] = useState<MobilePane>('customize')
+
+  // The user's selected preset is persisted in localStorage so every docs
+  // component demo renders in it. Seed the editor from it on open (unless a
+  // shared ?preset= link is being viewed), then persist back as it's edited.
+  const seededFromStorage = useRef(false)
+  useEffect(() => {
+    if (seededFromStorage.current) return
+    seededFromStorage.current = true
+    if (preset) return // a shared / deep-linked preset wins over the saved one
+    const stored = loadStoredPreset()
+    if (stored !== DEFAULTS) setDesignSystem(stored)
+  }, [preset, setDesignSystem])
+
+  const skipFirstPersist = useRef(true)
+  useEffect(() => {
+    // Skip the initial value so merely opening a shared link doesn't overwrite
+    // the saved preset; persist once the user actually changes something.
+    if (skipFirstPersist.current) {
+      skipFirstPersist.current = false
+      return
+    }
+    saveStoredPreset(designSystem)
+  }, [designSystem])
 
   // Opt-in exploration of the redesigned control panel + floating panel lab.
   if (lab) return <LabExperience />

--- a/www/src/styles.css
+++ b/www/src/styles.css
@@ -76,3 +76,17 @@
     display: none;
   }
 }
+
+/* Click ripple for the docs component-gallery cursor (components-list/autoplay).
+   Expands and fades from the pointer hotspot; mounts only during the press beat
+   so it replays on each loop. */
+@keyframes cursor-click {
+  0% {
+    transform: translate(-50%, -50%) scale(0.25);
+    opacity: 0.6;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1.8);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary

- Every `/docs/components` preview card now plays a looping animation of its component **being used**, on hover or keyboard-focus. It idles to the previous static look when not hovered, and under `prefers-reduced-motion`.
- Purely visual: the demos stay `inert`, so the animations **never touch the page's real focus** — focus is faked with `data-demo-focus` rings, state is driven through controlled props, and nothing calls `.focus()`.

### What each kind of component does
- **Buttons / links / toggles** — hover highlight → press dip (Button, ToggleButton, FileTrigger, Link, Group).
- **Text inputs** — a faux focus ring lights up and text types in char-by-char (Input, TextField, TextArea, SearchField, InputGroup, ColorField, Field; OTP fills digit-by-digit; NumberField steps).
- **Selection** — the checked/selected item flips or cycles (Checkbox, CheckboxGroup, RadioGroup, Switch, ToggleButtonGroup, TagGroup, ListBox, Tabs, Pagination, ColorSwatchPicker, Calendar).
- **Sliders / progress** — the thumb/fill glides through values.
- **Overlays (the cinematic)** — the real trigger sits centered, a fake cursor moves in, hovers, **clicks**, then the overlay opens *and the scene zooms out* (the trigger rides up + shrinks) so the surface fits the card. Applies to Popover, Modal, Drawer, Tooltip, Menu, Select, Combobox, DatePicker, ColorPicker.

### How it's built
A self-contained toolkit in `www/src/modules/docs/components-list/autoplay/`:
- `card-hover.tsx` — the card is the only hover/focus target (the demo is `inert`) and broadcasts its state down via context.
- `use-autoplay.ts` — `setTimeout`-based timeline hooks (`useAutoplay`, `useTypewriter`, `useToggleAutoplay`, `useStepAutoplay`, `useOpenAutoplay`, `useValueAutoplay`), all gated on hover + reduced-motion.
- `interaction.tsx` (`DemoPress`, `demoFocusProps`, `DemoCaret`), `cursor.tsx` (`FakeCursor`), `overlay-scene.tsx` (`OverlayScene`).
- Overlay demos get `fill: true` in `components-data.ts` to render full-bleed.

Also adds a previously-missing **Pagination** demo.

### Reviewer notes
- **Why CSS transitions, not Framer Motion:** Motion's transform/`animate` props silently don't run inside an `inert` subtree (they render `transform: none`). The demos must stay `inert` to keep the real RAC controls out of the tab order, so the toolkit animates via CSS transitions; the overlay "zoom out" reflow uses the grid `0fr → 1fr` trick + a `scale()` on the centered column.
- **Left intentionally static** (no clear "action"): Avatar, Badge, Kbd, Separator, Table, Alert, Loader, Skeleton, ScrollFade, Sidebar, Card, Empty, Breadcrumbs. Easy to extend on request.
- **Pre-existing, not from this PR:** the card root is an `<a>` and the `link` demo renders an anchor inside it → a nested-`<a>` hydration warning. Tracked separately; best fixed at the card level.
- No registry source changed, so no `build:registry`/drift implications. `pnpm typecheck` and `pnpm check` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only UI and client-side localStorage for presets; no auth, API, or registry changes. Main risk is animation/timer churn on hover across many cards.
> 
> **Overview**
> Adds **hover/focus-driven preview animations** on `/docs/components` gallery cards: demos stay `inert` and loop scripted interactions only while the card is active, respecting `prefers-reduced-motion`.
> 
> Introduces an **`autoplay/` toolkit** (`CardHoverProvider`, timeline hooks like `useTypewriter` / `useOpenAutoplay`, `DemoPress`/`DemoFocus` mirroring React Aria `data-*` states, `OverlayScene` + `FakeCursor` for overlay “cinematics” with CSS transitions). **`ComponentCard`** gains `fill` / `stretch` layouts; **`components-data.ts`** tags overlays and fields accordingly.
> 
> **Wires most gallery demos** to controlled props + autoplay (typing, selection cycles, sliders, overlay open sequences). Overlay pickers (**Menu, Modal, Popover**, etc.) swap real portaled dialogs for in-card **`OverlayScene`** previews. Adds a **Pagination** demo and fixes **nested `<a>`** issues in Link/Breadcrumbs/Card previews.
> 
> **Design-system preset sync:** new **`localStorage`** persistence (`preset/storage.ts`, `useStoredPreset`), **`DemoPreset`** scopes user presets across gallery, inline demos, and examples; **`/create`** seeds from storage and saves edits (unless `?preset=` wins).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8b1c11f28c3d3de6e5a5ea5bc0112d94d4c8d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->