### PR TITLE
refactor(docs): strip card chrome from playground controls

### DIFF
--- a/www/src/modules/docs/interactive-demo/interactive-demo.tsx
+++ b/www/src/modules/docs/interactive-demo/interactive-demo.tsx
@@ -10,7 +10,6 @@ import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
 
 import { cn } from '@/registry/lib/utils'
 import { Button } from '@/registry/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/registry/ui/card'
 import { CodeBlock } from '@/modules/docs/code-block'
 import { renderCode } from '@/modules/docs/codegen/code-template'
 import type { CodeTemplate } from '@/modules/docs/codegen/code-template'
@@ -123,30 +122,24 @@ export function InteractiveDemo({
           {previewElement}
         </div>
 
-        {/* Controls — always grouped in a titled card; a fixed-width column to the right at md+
-				    when horizontal, otherwise a wrapping row beneath the preview (also on small screens). */}
+        {/* Controls — bare, no card chrome: a self-sizing column to the right at md+ when
+				    horizontal (clamped by min/max width), otherwise a wrapping row beneath the preview. */}
         <div
           className={cn(
             '**:data-field:gap-1 **:data-label:text-[0.8125rem] **:data-label:text-fg-muted',
-            'p-5',
-            horizontal && 'md:w-64 md:shrink-0',
+            'flex p-5',
+            controlListClass,
+            // Right column at md+: drop the left padding (the preview's flex space is the gap)
+            // and let it size to content between a min and max instead of a fixed width.
+            horizontal && 'md:max-w-72 md:min-w-52 md:shrink-0 md:pl-0',
           )}
         >
-          <Card size="sm" className="md:h-full">
-            <CardHeader>
-              <CardTitle className="text-xs font-medium text-fg-muted">
-                Props
-              </CardTitle>
-            </CardHeader>
-            <CardContent className={cn('flex', controlListClass)}>
-              <Controls
-                controls={controls}
-                values={values}
-                onChange={handleChange}
-                layout={layout}
-              />
-            </CardContent>
-          </Card>
+          <Controls
+            controls={controls}
+            values={values}
+            onChange={handleChange}
+            layout={layout}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Redesign the docs interactive playground (props controls) to a cleaner, card-less look.

- **Removed the card chrome** — the controls were wrapped in a titled `Card` (border, background, "Props" heading). They now render bare: no card, no title, no border, no background.
- **Min/max width instead of fixed** — the right column was a fixed `md:w-64` (256px); now `md:min-w-52 md:max-w-72` (208–288px) so it sizes to its content within bounds.
- **Dropped the column's left padding** on the desktop side-column layout (`md:pl-0`) since the preview's flex space already supplies the gap.

### Note on scope
The left-padding removal is scoped to `md:` (the horizontal desktop layout). On mobile the controls stack *below* the preview, where removing left padding made them hug the border (~3px off the edge), so mobile/vertical keeps symmetric padding.

### Verification
- Verified live on desktop (borderless controls column) and mobile (controls wrap below preview, padding intact).
- Controls remain fully interactive — preview and generated code update live (e.g. toggling `isDisabled`/`isPending` → `<Button isDisabled isPending>`).
- `pnpm check` (format/lint) and `pnpm typecheck` pass. Pre-existing lint warnings and the 4 skipped publisher components are unrelated.

Single file changed: `www/src/modules/docs/interactive-demo/interactive-demo.tsx`.
