### PR TITLE
fix: clean up dev console warnings

### DIFF
--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -65,11 +65,12 @@ export function Header({ className, items = [] }: HeaderProps) {
   const { pathname } = useLocation()
   // Longest-matching-prefix wins so "/docs/components" highlights Components (not
   // Docs) while "/docs/button" still highlights Docs.
-  const activeTo = [...navItems]
-    .sort((a, b) => b.to.length - a.to.length)
+  const activeMatch = [...navItems]
+    .sort((a, b) => b.match.length - a.match.length)
     .find(
-      (item) => pathname === item.to || pathname.startsWith(`${item.to}/`),
-    )?.to
+      (item) =>
+        pathname === item.match || pathname.startsWith(`${item.match}/`),
+    )?.match
 
   return (
     <header
@@ -116,11 +117,12 @@ export function Header({ className, items = [] }: HeaderProps) {
             // Link with `exact` matching so it marks only the literal current page
             // — otherwise Link's default fuzzy match lights aria-current on both
             // Docs and Components for any /docs/components/* page.
-            const isActive = item.to === activeTo
+            const isActive = item.match === activeMatch
             return (
               <RouterLink
                 key={item.name}
                 to={item.to}
+                params={item.params}
                 activeOptions={{ exact: true }}
                 className={cn(
                   'px-0.5 transition-colors hover:text-fg',

--- a/www/src/components/layout/mobile-nav.tsx
+++ b/www/src/components/layout/mobile-nav.tsx
@@ -56,6 +56,7 @@ export function MobileNav({ items }: { items: PageTree.Node[] }) {
                     <MobileLink
                       key={item.name}
                       to={item.to}
+                      params={item.params}
                       onOpenChange={close}
                     >
                       {item.name}
@@ -102,11 +103,13 @@ export function MobileNav({ items }: { items: PageTree.Node[] }) {
 
 function MobileLink({
   to,
+  params,
   onOpenChange,
   className,
   children,
 }: {
   to: string
+  params?: { _splat: string }
   onOpenChange?: (open: boolean) => void
   children: React.ReactNode
   className?: string
@@ -114,6 +117,7 @@ function MobileLink({
   return (
     <Link
       to={to}
+      params={params}
       onClick={() => onOpenChange?.(false)}
       className={cn('text-2xl font-medium', className)}
     >

--- a/www/src/components/search-command.tsx
+++ b/www/src/components/search-command.tsx
@@ -41,7 +41,12 @@ export function SearchCommand({
   return (
     <SearchCommandDialog keyboardShortcut={keyboardShortcut} trigger={children}>
       <Command className="h-72">
-        <SearchField autoFocus value={search} onChange={setSearch}>
+        <SearchField
+          aria-label="Search"
+          autoFocus
+          value={search}
+          onChange={setSearch}
+        >
           <InputGroup>
             <SearchIcon />
             <Input placeholder="Search" />

--- a/www/src/config/site.ts
+++ b/www/src/config/site.ts
@@ -36,8 +36,23 @@ export const siteConfig = {
   },
 } as const
 
-export const navItems: { name: string; to: string }[] = [
-  { name: 'Docs', to: '/docs' },
-  { name: 'Components', to: '/docs/components' },
-  { name: 'Create', to: '/create' },
+export const navItems: {
+  name: string
+  /** Pathname prefix used for active-state highlighting. */
+  match: string
+  /** Router link target. Docs entries target the splat route (`/docs/$`) rather
+   *  than the bare `/docs` layout route: linking the layout route generates a
+   *  path that re-matches to its splat child, tripping TanStack's
+   *  `params.stringify` dev warning on every render. */
+  to: string
+  params?: { _splat: string }
+}[] = [
+  { name: 'Docs', match: '/docs', to: '/docs/$', params: { _splat: '' } },
+  {
+    name: 'Components',
+    match: '/docs/components',
+    to: '/docs/$',
+    params: { _splat: 'components' },
+  },
+  { name: 'Create', match: '/create', to: '/create' },
 ]

--- a/www/src/modules/create/components/index.tsx
+++ b/www/src/modules/create/components/index.tsx
@@ -191,6 +191,7 @@ function ParamEditor({ paramName, def, selected, onChange }: ParamEditorProps) {
           {toTitleCase(paramName)}
         </span>
         <Select
+          aria-label={toTitleCase(paramName)}
           selectedKey={selected ?? def.default}
           onSelectionChange={(key) => onChange(key as string)}
         >
@@ -256,6 +257,7 @@ function ParamEditor({ paramName, def, selected, onChange }: ParamEditorProps) {
         {toTitleCase(paramName)}
       </span>
       <Select
+        aria-label={toTitleCase(paramName)}
         selectedKey={selected ?? def.default}
         onSelectionChange={(key) => onChange(key as string)}
       >

--- a/www/src/modules/create/cursor/index.tsx
+++ b/www/src/modules/create/cursor/index.tsx
@@ -39,6 +39,7 @@ export function CursorConfig({
       <div className="flex flex-col gap-2">
         <span className="text-xs font-medium text-fg-muted">Interactive</span>
         <CursorSelect
+          aria-label="Interactive cursor"
           value={interactive}
           onChange={(v) => onChange(CURSOR_INTERACTIVE_VAR, v)}
         />
@@ -46,6 +47,7 @@ export function CursorConfig({
       <div className="flex flex-col gap-2">
         <span className="text-xs font-medium text-fg-muted">Disabled</span>
         <CursorSelect
+          aria-label="Disabled cursor"
           value={disabled}
           onChange={(v) => onChange(CURSOR_DISABLED_VAR, v)}
         />
@@ -57,12 +59,15 @@ export function CursorConfig({
 function CursorSelect({
   value,
   onChange,
+  'aria-label': ariaLabel,
 }: {
   value: string
   onChange: (v: string) => void
+  'aria-label'?: string
 }) {
   return (
     <Select
+      aria-label={ariaLabel}
       selectedKey={value}
       onSelectionChange={(key) => onChange(key as string)}
     >

--- a/www/src/modules/create/preview/group-examples/progress.tsx
+++ b/www/src/modules/create/preview/group-examples/progress.tsx
@@ -12,7 +12,11 @@ export default function ProgressGroupExamples() {
   return (
     <Examples>
       <Example title="Progress Bar">
-        <ProgressBar value={60} className="w-full max-w-sm">
+        <ProgressBar
+          aria-label="Progress"
+          value={60}
+          className="w-full max-w-sm"
+        >
           <ProgressBarOutput />
           <ProgressBarControl />
         </ProgressBar>

--- a/www/src/modules/create/typography/index.tsx
+++ b/www/src/modules/create/typography/index.tsx
@@ -28,7 +28,11 @@ const FontPicker = ({ label }: { label: string }) => {
       <SelectTrigger className="w-full" />
       <Popover>
         <Command>
-          <SearchField autoFocus className="w-full p-2">
+          <SearchField
+            aria-label="Search fonts"
+            autoFocus
+            className="w-full p-2"
+          >
             <Input className="w-full" />
           </SearchField>
           <ListBox>

--- a/www/src/modules/docs/docs-sidebar.tsx
+++ b/www/src/modules/docs/docs-sidebar.tsx
@@ -74,7 +74,12 @@ function DocsSidebarLink({
   }, [isActive])
 
   return (
-    <Link ref={ref} to={item.url} className="text-[0.8rem]">
+    <Link
+      ref={ref}
+      to="/docs/$"
+      params={{ _splat: item.url.replace(/^\/docs\/?/, '') }}
+      className="text-[0.8rem]"
+    >
       <span
         className={cn(
           'flex items-center gap-2 rounded-md bg-transparent px-2 py-1 text-fg-muted transition-colors hover:text-fg',

--- a/www/src/routes/playground.tsx
+++ b/www/src/routes/playground.tsx
@@ -45,7 +45,7 @@ function RouteComponent() {
             <Modal className="w-full rounded-t-xl bg-muted/40 p-4">
               <Dialog className="flex flex-col gap-30">
                 <p>this is the dialog content</p>
-                <TextField>
+                <TextField aria-label="Playground input">
                   <Input />
                 </TextField>
               </Dialog>


### PR DESCRIPTION
## What

Clears the warnings React Aria and TanStack Router were logging to the dev console across the app. Two independent sources, both browser-traced at runtime (capturing the render stack), not guessed statically.

## 1. Accessible names for unlabeled fields (`useLabel` warnings)

Field components rendered without a `label`, `aria-label`, or `aria-labelledby` make React Aria's `useLabel` log a `console.warn`. The global command palette is mounted on every page, so its warning appeared everywhere. These are also real a11y gaps (screen readers announce an unnamed control).

- **`components/search-command.tsx`** — global ⌘K palette `SearchField` → `aria-label="Search"` (the warning shown on every page).
- **`modules/create/components/index.tsx`** — both per-param `Select` dropdowns → `aria-label={toTitleCase(paramName)}`.
- **`modules/create/cursor/index.tsx`** — `CursorSelect` forwards `aria-label` ("Interactive cursor" / "Disabled cursor").
- **`modules/create/typography/index.tsx`** — font-picker `SearchField` → `aria-label="Search fonts"`.
- **`modules/create/preview/group-examples/progress.tsx`** — `ProgressBar` → `aria-label="Progress"`.
- **`routes/playground.tsx`** — scratch-route dialog `TextField` → `aria-label`.

## 2. Docs nav links trip TanStack's `params.stringify` warning

Linking the bare `/docs` targets the docs **layout** route (`/_app/docs`), which has no index — only a splat child. The generated path `/docs` re-matches to that splat, so on every header render TanStack logged:

```
Generated path "/docs" for route "/_app/docs" did not match the same route after params.stringify.
```

Point the header, mobile nav, and docs sidebar links at the splat route (`/docs/$` with an empty / derived `_splat`) instead — the same form already used by the pager and component cards. Same hrefs, no warning. Active-state highlighting keeps a separate `match` prefix so nothing changes visually.

- `config/site.ts`, `components/layout/header.tsx`, `components/layout/mobile-nav.tsx`, `modules/docs/docs-sidebar.tsx`

## Verification

- **`/docs` warning** — gone on the home page (header), `/docs/button`, and `/docs/components` (header + sidebar). Docs/Components/sidebar links still render `/docs`, `/docs/components`, etc. (no trailing slash).
- **`/preview/*`** — swept 18 pages (all group examples + field-heavy component examples: slider, select, combobox, date-picker, list-box, menu, otp-field, radio-group, tag-group, …) — all clean.
- `pnpm typecheck` ✅ · `pnpm check` ✅ (2 pre-existing unrelated warnings) · no registry/reference drift (www-side files only).

---

> Note: a separate nested-`<a>` hydration error on `/docs/components` (component preview cards wrapping anchor-rendering demos) was found during this work but is **not** included here — that page is being refactored in another PR, which should fold in the fix.
