### PR TITLE
fix(docs): wrap demos in hydration islands to stop TOC flicker

### DIFF
--- a/www/src/modules/docs/demo-island.tsx
+++ b/www/src/modules/docs/demo-island.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+
+/**
+ * Hydration island for a live component demo.
+ *
+ * Docs pages are prerendered, so a demo that renders runtime-dependent state is
+ * baked into static HTML at build time. The clearest case is React Aria's date
+ * components: their cells are marked relative to the real `today()`, so the day
+ * after a deploy the client renders a different `today()` than the prerender did
+ * — a hydration mismatch.
+ *
+ * React recovers from a mismatch by client-rendering up to the nearest
+ * `<Suspense>` boundary. Without one around each demo, that recovery bubbles up
+ * to the route and momentarily blanks the prose and the table of contents.
+ * Giving every demo its own boundary scopes the recovery to the demo, so the
+ * surrounding shell never blanks.
+ */
+export function DemoIsland({ children }: { children: React.ReactNode }) {
+  return <Suspense fallback={null}>{children}</Suspense>
+}

--- a/www/src/modules/docs/demo.tsx
+++ b/www/src/modules/docs/demo.tsx
@@ -5,6 +5,7 @@ import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
 import { Button } from '@/registry/ui/button'
 
 import { CodeBlock, Pre } from './code-block'
+import { DemoIsland } from './demo-island'
 
 // ============================================================================
 // Slot Components
@@ -74,7 +75,9 @@ export function Demo({ component: Component, children, ...props }: DemoProps) {
     <div {...props}>
       {/* Preview frame */}
       <div className="flex min-h-56 items-center justify-center overflow-x-auto rounded-t-lg border bg-bg p-6 sm:p-10">
-        <Component />
+        <DemoIsland>
+          <Component />
+        </DemoIsland>
       </div>
 
       {/* Code block with toggle */}

--- a/www/src/modules/docs/example.tsx
+++ b/www/src/modules/docs/example.tsx
@@ -5,6 +5,8 @@ import { Button } from '@/registry/ui/button'
 import { Dialog, DialogBody, DialogContent } from '@/registry/ui/dialog'
 import { Modal } from '@/registry/ui/modal'
 
+import { DemoIsland } from './demo-island'
+
 export interface ExampleProps extends React.ComponentProps<'div'> {
   component: React.ComponentType
   title?: string
@@ -39,7 +41,9 @@ export function Example({
           tabIndex={-1}
           className="pointer-events-none scrollbar-none flex min-h-32 flex-1 flex-col items-center justify-center gap-6 overflow-x-auto p-6 sm:p-10"
         >
-          <Component />
+          <DemoIsland>
+            <Component />
+          </DemoIsland>
         </div>
         <Dialog>
           <Button
@@ -50,7 +54,9 @@ export function Example({
           <Modal>
             <DialogContent aria-label={title ? `${title} example` : 'Example'}>
               <DialogBody>
-                <Component />
+                <DemoIsland>
+                  <Component />
+                </DemoIsland>
               </DialogBody>
             </DialogContent>
           </Modal>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## Summary

- Fixes the ~0.1s flicker where the table of contents (and prose) blank on first load of `/docs/components/calendar` (and any component page with a date demo).
- **Root cause:** docs pages are prerendered, so demos rendering runtime state get baked into static HTML at build time. React Aria's date components mark cells relative to the real `today()`, so the day after a deploy the client renders a different `today()` than the prerender did — a React **hydration mismatch**. (Confirmed live: deployed HTML said "Today, June 24"; today was June 26.) React recovers from a mismatch by client-rendering up to the nearest `<Suspense>` boundary — and with none around the demos, that recovery bubbled up to the route and momentarily blanked the whole shell, TOC included.
- **Fix:** a small `DemoIsland` Suspense boundary wrapping each `Demo`/`Example` render, so the mismatch recovery is scoped to the offending demo and the surrounding prose + TOC never blank.

## Notes for reviewers

- This is the "islands" idea applied narrowly: the static shell stays put; only a demo re-hydrates if it mismatches. It also acts as a general safety net — any future demo mismatch is now contained to that demo.
- Verified in a real production build under a forced build-date-vs-client mismatch (shifted the client clock): **zero** shell removals with the fix, vs. a full route blank without it. With matching dates (deploy day) the boundary is inert — normal in-place hydration, no behavior change.
- **Known residual:** for an *attribute-only* mismatch (e.g. the same month, just a different highlighted day), React keeps the server HTML rather than re-rendering, so a calendar demo's circled "today" can lag to the last deploy date until you interact with it. This is inherent to prerendering a live-`today()` widget and self-corrects on any interaction. Eliminating it entirely would require client-only date demos (a demo-frame pop-in) or a forced remount (a tiny in-place highlight shift) — deliberately left out of this PR as a separate UX call.
- No registry/`types.ts` changes, so no `__generated__` regeneration. `pnpm check` and `pnpm typecheck` pass.