### PR TITLE
fix(charts): data table columns and Show code install deps

### DIFF
--- a/www/src/modules/charts/chart-code-modal-content.tsx
+++ b/www/src/modules/charts/chart-code-modal-content.tsx
@@ -16,6 +16,7 @@ import {
   demoSource,
   getDemoComponent,
   installCommands,
+  installItems,
   PACKAGE_MANAGERS,
 } from './data'
 
@@ -39,7 +40,7 @@ export default function ChartCodeModalContent({
 }: ChartCodeModalContentProps) {
   const Component = getDemoComponent(demoKey)
   const source = use(demoSource(demoKey))
-  const commands = installCommands(demoKey)
+  const commands = installCommands(installItems(demoKey, source))
 
   return (
     <div className="flex h-full min-h-0 flex-col md:flex-row">

--- a/www/src/modules/charts/data.ts
+++ b/www/src/modules/charts/data.ts
@@ -20,11 +20,32 @@ export function familyOf(demoKey: string): string {
   return demoKey.slice(0, demoKey.indexOf('/'))
 }
 
-/** The shadcn install command per package manager for a demo's family. */
+/**
+ * The registry items to install for a variant: its family, plus any other
+ * registry UI components the variant's source imports (e.g. the interactive
+ * area chart pulls in `select`). The chart primitive and sibling chart families
+ * are skipped — installing the family item already brings the primitive along.
+ */
+export function installItems(demoKey: string, source: string | null): string[] {
+  const family = familyOf(demoKey)
+  if (!source) return [family]
+  const extras = new Set<string>()
+  for (const match of source.matchAll(/@\/components\/ui\/([a-z0-9-]+)/g)) {
+    const name = match[1]
+    // Skip the chart primitive and sibling chart families — installing the
+    // family item already pulls those in.
+    if (name && name !== 'chart' && !name.startsWith('chart-')) {
+      extras.add(name)
+    }
+  }
+  return [family, ...[...extras].sort()]
+}
+
+/** The shadcn install command per package manager for a set of registry items. */
 export function installCommands(
-  demoKey: string,
+  items: string[],
 ): Record<PackageManager, string> {
-  const arg = `shadcn@latest add @dotui/${familyOf(demoKey)}`
+  const arg = `shadcn@latest add ${items.map((i) => `@dotui/${i}`).join(' ')}`
   return {
     npm: `npx ${arg}`,
     pnpm: `pnpm dlx ${arg}`,

--- a/www/src/registry/ui/chart/base.tsx
+++ b/www/src/registry/ui/chart/base.tsx
@@ -417,20 +417,13 @@ function ChartDataTable({
   className,
   ...props
 }: ChartDataTableProps) {
-  // Long-format data (pie/radial) encodes each series as a ROW: `labelKey` values
-  // are themselves keys in `config`, and the numeric value sits in a column every
-  // row shares. Detect that and render category/value columns; otherwise render
-  // one column per `config` entry (wide-format).
+  // Columns are the `config` entries that are actual data columns — keys present
+  // in the rows. Config also carries metadata-only entries: a long-format pie
+  // (`labelKey` values are themselves `config` keys) lists per-slice color
+  // configs that are row *values*, not columns. Including those would render
+  // empty columns that misrepresent the data to screen readers.
   const row0 = data[0] ?? {}
-  const configKeys = Object.keys(config)
-  const valueColumns = configKeys.filter((key) => key in row0)
-  const categoryKeys = configKeys.filter((key) => !(key in row0))
-  const isLong =
-    labelKey != null &&
-    valueColumns.length > 0 &&
-    categoryKeys.length > 0 &&
-    data.some((datum) => categoryKeys.includes(String(datum[labelKey])))
-  const columns = isLong ? valueColumns : configKeys
+  const columns = Object.keys(config).filter((key) => key in row0)
 
   const headerLabel = labelName ?? (labelKey ? capitalize(labelKey) : undefined)
   const rowHeader = (value: unknown): string =>


### PR DESCRIPTION
Follow-up to #279 addressing the Cursor Bugbot review.

## Summary

- **Data table columns** — `ChartDataTable` rendered one column per `config` entry in wide format, including metadata-only entries (e.g. a long-format pie's per-slice color configs), which showed up as **empty columns** in the visually-hidden screen-reader table. It now renders only config keys that are actual data columns (present in the rows). Verified for both wide (`Date | Desktop | Mobile`) and long (`Browser | Visitors`) tables — no regression.
- **Show code install deps** — the modal's install command only added the variant's family, so the **interactive** area chart (which imports `select`) produced copy-paste code that wouldn't build. The command is now variant-aware: it derives extra `@dotui/*` items from the shown source's registry imports. interactive → `add @dotui/chart-area @dotui/select`; every other variant is unchanged (`add @dotui/chart-area`).

## Reviewed, not changed
- **Polar accessibility layer** — pie/radar/radial don't pass Recharts' `accessibilityLayer`, but that's a cartesian keyboard-nav feature; polar charts get their a11y from the visually-hidden `ChartDataTable` (verified present). No functional gap — at most a docs-wording clarification.
- **Duplicate gradient ids** — opening the modal mounts a second instance of a gradient demo whose `linearGradient` ids are fixed. Both gradient defs are identical, so it's visually harmless (technically invalid); left as-is to keep the copy-paste demo source clean.

Lint, typecheck, and registry build pass; both fixes verified in the browser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chart a11y and docs install-string logic; no auth, data, or core runtime paths.
> 
> **Overview**
> **`ChartDataTable`** no longer treats every `config` key as a column. It only includes keys that appear on the data rows, so long-format pies no longer expose **empty screen-reader columns** from per-slice color/metadata entries.
> 
> The charts **Show code** modal builds install commands from the variant’s displayed source: **`installItems`** adds the chart family plus any extra `@/components/ui/*` registry imports (e.g. `select`), skipping `chart` and other `chart-*` families. **`installCommands`** now accepts that item list and emits a single `shadcn add` with multiple `@dotui/*` packages instead of only the family id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 923c7d6db6b3ae84239b33740ccefe0914930cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->