### PR TITLE
feat(create): rebuild /create as a design-system studio

### DIFF
--- a/docs/research/2026-06-27-create-studio-redesign.md
+++ b/docs/research/2026-06-27-create-studio-redesign.md
@@ -43,6 +43,19 @@ Two speeds, one product — quick clean output **and** tweak-everything:
 - Browser (dev server): onboarding overlay, full studio, axis switching, Color inspector (engine + ramps + foundation), Components list → Alert detail with real params + canvas switch, Type specimen, light/dark split, mobile layout, and a live shuffle visibly recoloring the preview end-to-end (inspector → URL preset → iframe).
 - Two bugs found and fixed during verification: Framer Motion `AnimatePresence mode="wait"` stranded the inspector body, and an SSR'd `motion.div` with `initial={{opacity:0}}` stuck at opacity 0 — both replaced with a CSS `.studio-rise` keyframe (can't strand content). Mobile top-bar overflow fixed.
 
+## Round 2 — going deeper
+
+Four more "advanced builder" capabilities, all verified live:
+
+- **Command palette (⌘K)** — a global Modal+Command: jump to any axis, jump to + open any component (switches the canvas too), or run actions (Generate, Surprise me, Reset). Also opened from a top-bar Search affordance. Shared shuffle/reset live in `actions.ts` (used by the top bar too).
+- **Canvas view modes — Preview / Tokens / Code** — the stage is now multi-modal (the iframe stays mounted/hidden, so switching never reloads it):
+  - **Tokens** — a live, searchable browser of the resolved tokens: all six palettes as 50–950 swatch ramps (light/dark), plus the foundation tokens; click to copy.
+  - **Code** — the *real* generated `theme.css` via `emitPrimitivesCss(resolveColorConfig(...))` (with `--on-*` foregrounds), tabbed with the shadcn install command; updates live as the system changes. "The code you own," shown honestly.
+- **Vision simulation** — an eye control over the live preview: Protanopia / Deuteranopia / Tritanopia (SVG `feColorMatrix`) + Grayscale (CSS filter). A real accessibility lens on the whole system.
+- **Presets gallery** — a top-bar "Presets" dialog of eight curated complete systems (cool product, monochrome, fintech, developer-green, Material, warm editorial, glass, bold). Each has a live mini-specimen; clicking forks it (seeds + algorithm + radius + density + depth) through the real engine.
+
+New files: `actions.ts`, `command-palette.tsx`, `presets.tsx`, `tokens-view.tsx`, `code-view.tsx`; `store.tsx`/`top-bar.tsx`/`canvas.tsx`/`index.tsx` updated.
+
 ## Known limitations / next steps
 
 - Designed axes need engine consumers to become live (the var names are already aligned).

--- a/docs/research/2026-06-27-create-studio-redesign.md
+++ b/docs/research/2026-06-27-create-studio-redesign.md
@@ -1,0 +1,52 @@
+# /create studio redesign — report
+
+> Status: experiment (UI-only), branch `claude/elastic-clarke-fba9d3`, UNMERGED. 2026-06-27.
+> Scope: gut the old left control panel and redesign the whole `/create` experience as the most advanced design-system builder we can — brand in, complete on-brand library out, openable anywhere. Logic was explicitly out of scope; the brief was the experience and the surface area.
+
+## What was removed
+
+The old `/create` was a 288px left `CustomizerPanel` (a stacked push/pop menu) beside the iframe preview. The route no longer renders it. `routes/_app/create.tsx` now renders `<Studio/>`; `?lab=true` still renders the legacy `LabExperience` so nothing that depended on it broke. The old files (`customizer-panel.tsx`, `panel/*`) remain on disk but are unwired — safe to delete in a follow-up.
+
+## The new experience: a design-system **studio**
+
+A pro three-zone layout, canvas-first, so "preview every change live on real components" is literally the center of the screen.
+
+- **Top bar** — brand mark, editable system name, Draft chip; Surprise-me / Undo / Reset; Share (copies the deep-link URL); **Export** (popover: shadcn CLI command + Open in v0, both live; Bolt / Lovable / Claude / Figma shown as "Soon").
+- **Left rail** — the *axes* of the system as a slim icon nav: Brand · Color · Type · Shape · Space · Depth · Motion · Icons · Cursor · Components. Animated active indicator, tooltips. This is navigation, not a control stack — the opposite of the old fat left panel.
+- **Canvas** — the live iframe, elevated: scene switcher (Cards block + every component, searchable), device sizes, zoom, **light/dark split view** (two synced iframes), open-in-tab, fullscreen. Reuses the existing postMessage sync, so every token edit streams in without a reload.
+- **Inspector** — a context-sensitive panel per axis. This is where *all* tweaking lives. Each control carries an honest binding dot: filled = drives the preview now, hollow = designed, wires up as the engine grows.
+- **Onboarding overlay** — "Generate your design system": seed by one color (swatches + picker) or logo/URL (stubs), pick a vibe (Minimal / Modern / Playful / Soft glass), Generate → applies color + radius + density + depth and dissolves into the studio. Greets first-time visitors once per session; reopenable from the Brand axis.
+
+## How it meets the brief
+
+Two speeds, one product — quick clean output **and** tweak-everything:
+
+- **Seed one color → a complete system.** Color → Seed strategy → *One color*: a single brand seed; neutrals + every status family derive automatically (real OKLCH engine). The onboarding flow is the same promise in one screen.
+- **Decide how the color system is structured.** Seed strategy toggles One color / Custom seeds / Import; Foundation toggles **Palettes** (exposed 50–950 ramps) vs **Semantic only** (roles: bg/fg/border/primary/…); plus algorithm (OKLCH / Tailwind / Material / Contrast-locked), per-algorithm knobs, a context-aware-tokens switch, light/dark ramps, and a live WCAG readout.
+- **Palettes or not as foundations.** The Foundation toggle is exactly that choice.
+- **Tweak a specific component.** Components axis → searchable, grouped list → real per-component param editors (the registry's own `params`), with a **synced-group** note (e.g. Button ⇄ ToggleButton) so the user knows changes apply group-wide. Selecting a component also switches the canvas to it.
+- **Control anything.** Every visual axis has an inspector: type (font pairing, scale, base size, tracking, live specimen), shape (radius factor + borders), space (density + scale), depth (flat/soft/3D/glass + shadow + blur), motion (duration + easing + a live travelling-dot specimen), icons (library + stroke), cursor (interactive/disabled).
+
+## Live vs designed (honest)
+
+- **Live now** (reuses existing pure engine/state — no new "logic" written): color (seeds, algorithm, knobs, ramps, contrast), radius factor, density, cursor, per-component params, shuffle / undo / reset, export URLs.
+- **Designed** (writes real `--ds-*` CSS vars through the same channel, same names as the old `panel/schema.tsx`, so they go live the moment a consumer reads them): typography, depth, motion, icon stroke, spacing scale, border width. Each is marked with a hollow binding dot.
+
+## Files
+
+- New module `www/src/modules/create/studio/`: `index`, `top-bar`, `navigator`, `canvas`, `inspector`, `export-menu`, `onboarding`, `store`, `axes`, `primitives`, `tokens`, and `inspectors/{brand,color,typography,shape,spacing,elevation,motion,icons,cursor,components}`.
+- Edited `routes/_app/create.tsx` (render `<Studio/>`), `styles.css` (added a `studio-rise` enter keyframe).
+
+## Verification
+
+- `pnpm typecheck` — passes. `pnpm check` (oxlint + oxfmt) — 0 errors, 0 new warnings (2 pre-existing remain).
+- Browser (dev server): onboarding overlay, full studio, axis switching, Color inspector (engine + ramps + foundation), Components list → Alert detail with real params + canvas switch, Type specimen, light/dark split, mobile layout, and a live shuffle visibly recoloring the preview end-to-end (inspector → URL preset → iframe).
+- Two bugs found and fixed during verification: Framer Motion `AnimatePresence mode="wait"` stranded the inspector body, and an SSR'd `motion.div` with `initial={{opacity:0}}` stuck at opacity 0 — both replaced with a CSS `.studio-rise` keyframe (can't strand content). Mobile top-bar overflow fixed.
+
+## Known limitations / next steps
+
+- Designed axes need engine consumers to become live (the var names are already aligned).
+- Import-from-logo/URL and the "More targets" exports are visual stubs.
+- Fonts apply by `font-family` name only (no webfont loading yet), so the type specimen falls back if the font isn't installed.
+- System name and the onboarding vibe selection are local UI state (not yet persisted into the preset).
+- Headless preview screenshots intermittently show the iframe blank/zoomed — a compositing artifact, not a regression (content confirmed via DOM + curl). See `project-worktree-dev-publishables-500` memory.

--- a/www/src/modules/create/studio/actions.ts
+++ b/www/src/modules/create/studio/actions.ts
@@ -1,0 +1,58 @@
+'use client'
+
+import { getRouteApi } from '@tanstack/react-router'
+
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+
+import { RADIUS_FACTOR_VAR } from '../layout'
+import { useDesignSystem } from '../preset'
+
+/* Shared studio commands, reused by the top bar and the ⌘K palette. */
+
+const SHUFFLE_ACCENTS = [
+  '#3b82f6',
+  '#6366f1',
+  '#8b5cf6',
+  '#ec4899',
+  '#f43f5e',
+  '#f59e0b',
+  '#22c55e',
+  '#14b8a6',
+  '#06b6d4',
+]
+const SHUFFLE_RADII = ['0', '0.5', '1', '1.5', '2']
+const SHUFFLE_DENSITIES = ['compact', 'default', 'comfortable'] as const
+
+function pick<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)] as T
+}
+
+const routeApi = getRouteApi('/_app/create')
+
+export function useStudioActions() {
+  const navigate = routeApi.useNavigate()
+  const { setDesignSystem } = useDesignSystem()
+
+  /** Roll the always-legible axes (accent / radius / density) in one history entry. */
+  function shuffle() {
+    const accent = pick(SHUFFLE_ACCENTS)
+    const radius = pick(SHUFFLE_RADII)
+    const density = pick(SHUFFLE_DENSITIES)
+    setDesignSystem((p) => {
+      const base = p.color ?? DEFAULT_COLOR_CONFIG
+      return {
+        ...p,
+        density,
+        tokens: { ...p.tokens, [RADIUS_FACTOR_VAR]: radius },
+        color: { ...base, seeds: { ...base.seeds, accent } },
+      }
+    })
+  }
+
+  /** Clear the preset back to defaults. */
+  function reset() {
+    navigate({ search: (p) => ({ ...p, preset: undefined }), replace: true })
+  }
+
+  return { shuffle, reset }
+}

--- a/www/src/modules/create/studio/axes.ts
+++ b/www/src/modules/create/studio/axes.ts
@@ -1,0 +1,120 @@
+import {
+  BoxIcon,
+  type LucideIcon,
+  LayersIcon,
+  MousePointer2Icon,
+  PaletteIcon,
+  RulerIcon,
+  ShapesIcon,
+  SmileIcon,
+  SparklesIcon,
+  TypeIcon,
+  ZapIcon,
+} from 'lucide-react'
+
+/* ----------------------------------------------------------------------------
+ * The axes of the design system — the spine of the studio. The left rail lists
+ * them; selecting one swaps the inspector. "Every visual decision is a user-
+ * configurable axis" (CLAUDE.md), so this list is the contract the rest of the
+ * studio renders against — add an axis here and it appears everywhere at once.
+ * -------------------------------------------------------------------------- */
+
+export type AxisId =
+  | 'brand'
+  | 'color'
+  | 'typography'
+  | 'shape'
+  | 'spacing'
+  | 'elevation'
+  | 'motion'
+  | 'icons'
+  | 'cursor'
+  | 'components'
+
+export type AxisGroup = 'start' | 'foundations' | 'surface'
+
+export interface Axis {
+  id: AxisId
+  label: string
+  /** One-line promise shown in the inspector header. */
+  tagline: string
+  icon: LucideIcon
+  group: AxisGroup
+}
+
+export const AXES: Axis[] = [
+  {
+    id: 'brand',
+    label: 'Brand',
+    tagline: 'Seed the whole system from your brand.',
+    icon: SparklesIcon,
+    group: 'start',
+  },
+  {
+    id: 'color',
+    label: 'Color',
+    tagline: 'One seed to a full, accessible color system.',
+    icon: PaletteIcon,
+    group: 'foundations',
+  },
+  {
+    id: 'typography',
+    label: 'Type',
+    tagline: 'Font pairing, scale and rhythm.',
+    icon: TypeIcon,
+    group: 'foundations',
+  },
+  {
+    id: 'shape',
+    label: 'Shape',
+    tagline: 'Corner radius and border weight.',
+    icon: ShapesIcon,
+    group: 'foundations',
+  },
+  {
+    id: 'spacing',
+    label: 'Space',
+    tagline: 'Density and the spacing scale.',
+    icon: RulerIcon,
+    group: 'foundations',
+  },
+  {
+    id: 'elevation',
+    label: 'Depth',
+    tagline: 'Shadows, surfaces and the glass switch.',
+    icon: LayersIcon,
+    group: 'foundations',
+  },
+  {
+    id: 'motion',
+    label: 'Motion',
+    tagline: 'How the whole system moves.',
+    icon: ZapIcon,
+    group: 'foundations',
+  },
+  {
+    id: 'icons',
+    label: 'Icons',
+    tagline: 'Icon library and stroke.',
+    icon: SmileIcon,
+    group: 'foundations',
+  },
+  {
+    id: 'cursor',
+    label: 'Cursor',
+    tagline: 'Pointer feedback across states.',
+    icon: MousePointer2Icon,
+    group: 'foundations',
+  },
+  {
+    id: 'components',
+    label: 'Components',
+    tagline: 'Per-component styles, in synced groups.',
+    icon: BoxIcon,
+    group: 'surface',
+  },
+]
+
+export const AXIS_MAP: Record<AxisId, Axis> = Object.fromEntries(
+  AXES.map((a) => [a.id, a]),
+) as Record<AxisId, Axis>

--- a/www/src/modules/create/studio/canvas.tsx
+++ b/www/src/modules/create/studio/canvas.tsx
@@ -6,6 +6,7 @@ import {
   ChevronDownIcon,
   ColumnsIcon,
   ExternalLinkIcon,
+  EyeIcon,
   MaximizeIcon,
   MinimizeIcon,
   MonitorIcon,
@@ -38,9 +39,13 @@ import { componentsData } from '@/modules/docs/components-list/components-data'
 
 import { sendPreviewMode, sendToIframe, useDesignSystem } from '../preset'
 import type { DesignSystem, PreviewMode } from '../preset'
+import { CodeView } from './code-view'
+import { Segmented } from './primitives'
+import { TokensView } from './tokens-view'
 
 type DeviceSize = 'mobile' | 'tablet' | 'desktop'
-type ViewMode = 'single' | 'split'
+type SplitMode = 'single' | 'split'
+type Stage = 'preview' | 'tokens' | 'code'
 
 const DEVICE_WIDTHS: Record<Exclude<DeviceSize, 'desktop'>, number> = {
   mobile: 390,
@@ -59,13 +64,23 @@ const SIZE_OPTIONS: {
 
 const ZOOM_LEVELS = [0.5, 0.75, 1, 1.25, 1.5, 2]
 
+// Vision-deficiency simulation applied as a CSS filter over the live preview.
+const VISIONS: { id: string; label: string }[] = [
+  { id: 'normal', label: 'Normal vision' },
+  { id: 'protanopia', label: 'Protanopia (red-blind)' },
+  { id: 'deuteranopia', label: 'Deuteranopia (green-blind)' },
+  { id: 'tritanopia', label: 'Tritanopia (blue-blind)' },
+  { id: 'grayscale', label: 'Grayscale' },
+]
+
+function visionFilter(vision: string): string | undefined {
+  if (vision === 'normal') return undefined
+  if (vision === 'grayscale') return 'grayscale(1)'
+  return `url(#cvd-${vision})`
+}
+
 const routeApi = getRouteApi('/_app/create')
 
-/* ----------------------------------------------------------------------------
- * A single preview iframe that keeps itself in sync with the design system and
- * a forced light/dark mode over postMessage. Reloads only when the previewed
- * scene changes — every token edit streams in without a reload.
- * -------------------------------------------------------------------------- */
 function PreviewFrame({
   preview,
   preset,
@@ -139,13 +154,16 @@ export function Canvas({ className }: { className?: string }) {
   const { resolvedTheme } = useTheme()
 
   const stageRef = useRef<HTMLDivElement>(null)
+  const [stage, setStage] = useState<Stage>('preview')
   const [mode, setMode] = useState<PreviewMode>('light')
-  const [view, setView] = useState<ViewMode>('single')
+  const [split, setSplit] = useState<SplitMode>('single')
   const [size, setSize] = useState<DeviceSize>('desktop')
   const [zoom, setZoom] = useState(1)
+  const [vision, setVision] = useState('normal')
   const [isFullscreen, setIsFullscreen] = useState(false)
 
   const constrained = size !== 'desktop'
+  const filter = visionFilter(vision)
 
   useEffect(() => {
     setMode(resolvedTheme === 'dark' ? 'dark' : 'light')
@@ -176,224 +194,310 @@ export function Canvas({ className }: { className?: string }) {
         className,
       )}
     >
+      {/* Hidden color-vision-deficiency filter matrices. */}
+      <svg aria-hidden className="pointer-events-none absolute size-0">
+        <defs>
+          <filter id="cvd-protanopia">
+            <feColorMatrix
+              type="matrix"
+              values="0.567 0.433 0 0 0  0.558 0.442 0 0 0  0 0.242 0.758 0 0  0 0 0 1 0"
+            />
+          </filter>
+          <filter id="cvd-deuteranopia">
+            <feColorMatrix
+              type="matrix"
+              values="0.625 0.375 0 0 0  0.7 0.3 0 0 0  0 0.3 0.7 0 0  0 0 0 1 0"
+            />
+          </filter>
+          <filter id="cvd-tritanopia">
+            <feColorMatrix
+              type="matrix"
+              values="0.95 0.05 0 0 0  0 0.433 0.567 0 0  0 0.475 0.525 0 0  0 0 0 1 0"
+            />
+          </filter>
+        </defs>
+      </svg>
+
       {/* Toolbar */}
       <div className="flex h-12 shrink-0 items-center gap-2 border-b px-3">
-        {/* Scene selector */}
-        <Select
-          value={preview}
-          onChange={(v) =>
-            navigate({ search: (prev) => ({ ...prev, preview: v as string }) })
-          }
-          className="w-48 max-w-[45%]"
-          aria-label="Preview scene"
-        >
-          <Button size="sm" className="w-full">
-            <SelectValue className="truncate" />
-            <ChevronDownIcon data-icon-end="" />
-          </Button>
-          <Popover>
-            <Command>
-              <SearchField autoFocus aria-label="Search scenes">
-                <Input />
-              </SearchField>
-              <ListBox>
-                <ListBoxSection>
-                  <ListBoxSectionHeader>Blocks</ListBoxSectionHeader>
-                  <ListBoxItem id="cards" textValue="Cards">
-                    <span className="truncate">Cards</span>
-                  </ListBoxItem>
-                </ListBoxSection>
-                <ListBoxSection>
-                  <ListBoxSectionHeader>Components</ListBoxSectionHeader>
-                  {componentsData
-                    .flatMap((c) => c.components)
-                    .sort((a, b) => a.name.localeCompare(b.name))
-                    .map((comp) => (
-                      <ListBoxItem
-                        key={comp.slug}
-                        id={comp.slug}
-                        textValue={comp.name}
-                      >
-                        <span className="truncate">{comp.name}</span>
-                      </ListBoxItem>
-                    ))}
-                </ListBoxSection>
-              </ListBox>
-            </Command>
-          </Popover>
-        </Select>
+        <div className="w-56 max-w-[55%]">
+          <Segmented<Stage>
+            ariaLabel="Canvas view"
+            value={stage}
+            onChange={setStage}
+            options={[
+              { value: 'preview', label: 'Preview' },
+              { value: 'tokens', label: 'Tokens' },
+              { value: 'code', label: 'Code' },
+            ]}
+          />
+        </div>
 
-        <div className="ml-auto flex items-center gap-1">
-          {/* Device size */}
-          <ToggleButtonGroup
-            aria-label="Device size"
-            selectionMode="single"
-            disallowEmptySelection
-            size="sm"
-            isIconOnly
-            selectedKeys={[size]}
-            onSelectionChange={(keys) => {
-              const next = keys.values().next().value
-              if (next) setSize(next as DeviceSize)
-            }}
-            className="max-lg:hidden"
+        {stage === 'preview' && (
+          <Select
+            value={preview}
+            onChange={(v) =>
+              navigate({
+                search: (prev) => ({ ...prev, preview: v as string }),
+              })
+            }
+            className="w-44 max-lg:hidden"
+            aria-label="Preview scene"
           >
-            {SIZE_OPTIONS.map(({ id, label, Icon }) => (
-              <ToggleButton key={id} id={id} aria-label={label}>
-                <Icon />
-              </ToggleButton>
-            ))}
-          </ToggleButtonGroup>
-
-          {/* Zoom */}
-          <Menu>
-            <Button
-              size="sm"
-              variant="quiet"
-              className="gap-1 tabular-nums max-lg:hidden"
-            >
-              {Math.round(zoom * 100)}%
+            <Button size="sm" className="w-full">
+              <SelectValue className="truncate" />
               <ChevronDownIcon data-icon-end="" />
             </Button>
-            <Popover placement="bottom end" className="min-w-28">
-              <MenuContent
-                selectionMode="single"
-                selectedKeys={[String(zoom)]}
-                onSelectionChange={(keys) => {
-                  if (keys === 'all') return
-                  const v = keys.values().next().value
-                  if (v != null) setZoom(Number(v))
-                }}
-              >
-                {ZOOM_LEVELS.map((z) => (
-                  <MenuItem key={z} id={String(z)} textValue={`${z * 100}%`}>
-                    {Math.round(z * 100)}%
-                  </MenuItem>
-                ))}
-              </MenuContent>
+            <Popover>
+              <Command>
+                <SearchField autoFocus aria-label="Search scenes">
+                  <Input />
+                </SearchField>
+                <ListBox>
+                  <ListBoxSection>
+                    <ListBoxSectionHeader>Blocks</ListBoxSectionHeader>
+                    <ListBoxItem id="cards" textValue="Cards">
+                      <span className="truncate">Cards</span>
+                    </ListBoxItem>
+                  </ListBoxSection>
+                  <ListBoxSection>
+                    <ListBoxSectionHeader>Components</ListBoxSectionHeader>
+                    {componentsData
+                      .flatMap((c) => c.components)
+                      .sort((a, b) => a.name.localeCompare(b.name))
+                      .map((comp) => (
+                        <ListBoxItem
+                          key={comp.slug}
+                          id={comp.slug}
+                          textValue={comp.name}
+                        >
+                          <span className="truncate">{comp.name}</span>
+                        </ListBoxItem>
+                      ))}
+                  </ListBoxSection>
+                </ListBox>
+              </Command>
             </Popover>
-          </Menu>
+          </Select>
+        )}
 
-          <div className="mx-0.5 h-5 w-px bg-border max-lg:hidden" />
+        {stage === 'preview' && (
+          <div className="ml-auto flex items-center gap-1">
+            <ToggleButtonGroup
+              aria-label="Device size"
+              selectionMode="single"
+              disallowEmptySelection
+              size="sm"
+              isIconOnly
+              selectedKeys={[size]}
+              onSelectionChange={(keys) => {
+                const next = keys.values().next().value
+                if (next) setSize(next as DeviceSize)
+              }}
+              className="max-lg:hidden"
+            >
+              {SIZE_OPTIONS.map(({ id, label, Icon }) => (
+                <ToggleButton key={id} id={id} aria-label={label}>
+                  <Icon />
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
 
-          {/* Single / split light-dark */}
-          <ToggleButtonGroup
-            aria-label="View mode"
-            selectionMode="single"
-            disallowEmptySelection
-            size="sm"
-            isIconOnly
-            selectedKeys={[view]}
-            onSelectionChange={(keys) => {
-              const next = keys.values().next().value
-              if (next) setView(next as ViewMode)
-            }}
-            className="max-lg:hidden"
-          >
-            <ToggleButton id="single" aria-label="Single view">
-              <SquareIcon />
-            </ToggleButton>
-            <ToggleButton id="split" aria-label="Light + dark split">
-              <ColumnsIcon />
-            </ToggleButton>
-          </ToggleButtonGroup>
+            <Menu>
+              <Button
+                size="sm"
+                variant="quiet"
+                className="gap-1 tabular-nums max-lg:hidden"
+              >
+                {Math.round(zoom * 100)}%
+                <ChevronDownIcon data-icon-end="" />
+              </Button>
+              <Popover placement="bottom end" className="min-w-28">
+                <MenuContent
+                  selectionMode="single"
+                  selectedKeys={[String(zoom)]}
+                  onSelectionChange={(keys) => {
+                    if (keys === 'all') return
+                    const v = keys.values().next().value
+                    if (v != null) setZoom(Number(v))
+                  }}
+                >
+                  {ZOOM_LEVELS.map((z) => (
+                    <MenuItem key={z} id={String(z)} textValue={`${z * 100}%`}>
+                      {Math.round(z * 100)}%
+                    </MenuItem>
+                  ))}
+                </MenuContent>
+              </Popover>
+            </Menu>
 
-          {/* Light / dark (single view only) */}
-          {view === 'single' && (
+            {/* Vision simulation */}
+            <Menu>
+              <Tooltip>
+                <Button
+                  size="sm"
+                  variant={vision === 'normal' ? 'quiet' : 'primary'}
+                  isIconOnly
+                  aria-label="Vision simulation"
+                >
+                  <EyeIcon />
+                </Button>
+                <TooltipContent>Simulate color vision</TooltipContent>
+              </Tooltip>
+              <Popover placement="bottom end" className="min-w-56">
+                <MenuContent
+                  selectionMode="single"
+                  selectedKeys={[vision]}
+                  onSelectionChange={(keys) => {
+                    if (keys === 'all') return
+                    const v = keys.values().next().value
+                    if (v != null) setVision(String(v))
+                  }}
+                >
+                  {VISIONS.map((v) => (
+                    <MenuItem key={v.id} id={v.id} textValue={v.label}>
+                      {v.label}
+                    </MenuItem>
+                  ))}
+                </MenuContent>
+              </Popover>
+            </Menu>
+
+            <div className="mx-0.5 h-5 w-px bg-border max-lg:hidden" />
+
+            <ToggleButtonGroup
+              aria-label="Split mode"
+              selectionMode="single"
+              disallowEmptySelection
+              size="sm"
+              isIconOnly
+              selectedKeys={[split]}
+              onSelectionChange={(keys) => {
+                const next = keys.values().next().value
+                if (next) setSplit(next as SplitMode)
+              }}
+              className="max-lg:hidden"
+            >
+              <ToggleButton id="single" aria-label="Single view">
+                <SquareIcon />
+              </ToggleButton>
+              <ToggleButton id="split" aria-label="Light + dark split">
+                <ColumnsIcon />
+              </ToggleButton>
+            </ToggleButtonGroup>
+
+            {split === 'single' && (
+              <Tooltip>
+                <Button
+                  size="sm"
+                  variant="quiet"
+                  isIconOnly
+                  onPress={() =>
+                    setMode((m) => (m === 'dark' ? 'light' : 'dark'))
+                  }
+                  aria-label="Toggle preview mode"
+                >
+                  {mode === 'dark' ? <SunIcon /> : <MoonIcon />}
+                </Button>
+                <TooltipContent>
+                  {mode === 'dark' ? 'Light mode' : 'Dark mode'}
+                </TooltipContent>
+              </Tooltip>
+            )}
+
             <Tooltip>
               <Button
                 size="sm"
                 variant="quiet"
                 isIconOnly
                 onPress={() =>
-                  setMode((m) => (m === 'dark' ? 'light' : 'dark'))
+                  window.open(sharedSrc, '_blank', 'noopener,noreferrer')
                 }
-                aria-label="Toggle preview mode"
+                aria-label="Open preview in new tab"
               >
-                {mode === 'dark' ? <SunIcon /> : <MoonIcon />}
+                <ExternalLinkIcon />
+              </Button>
+              <TooltipContent>Open in new tab</TooltipContent>
+            </Tooltip>
+
+            <Tooltip>
+              <Button
+                size="sm"
+                variant="quiet"
+                isIconOnly
+                onPress={toggleFullscreen}
+                aria-label="Toggle fullscreen"
+              >
+                {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}
               </Button>
               <TooltipContent>
-                {mode === 'dark' ? 'Light mode' : 'Dark mode'}
+                {isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
               </TooltipContent>
             </Tooltip>
-          )}
-
-          <Tooltip>
-            <Button
-              size="sm"
-              variant="quiet"
-              isIconOnly
-              onPress={() =>
-                window.open(sharedSrc, '_blank', 'noopener,noreferrer')
-              }
-              aria-label="Open preview in new tab"
-            >
-              <ExternalLinkIcon />
-            </Button>
-            <TooltipContent>Open in new tab</TooltipContent>
-          </Tooltip>
-
-          <Tooltip>
-            <Button
-              size="sm"
-              variant="quiet"
-              isIconOnly
-              onPress={toggleFullscreen}
-              aria-label="Toggle fullscreen"
-            >
-              {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}
-            </Button>
-            <TooltipContent>
-              {isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-            </TooltipContent>
-          </Tooltip>
-        </div>
+          </div>
+        )}
       </div>
 
-      {/* Stage */}
-      <div
-        className={cn(
-          'relative flex-1 overflow-auto',
-          (constrained || view === 'split') && 'bg-neutral',
-        )}
-      >
-        {view === 'split' ? (
-          <div className="flex h-full w-full">
-            {(['light', 'dark'] as const).map((m) => (
-              <div
-                key={m}
-                className={cn(
-                  'relative flex h-full min-w-0 flex-1 flex-col',
-                  m === 'light' && 'border-r',
-                )}
-              >
-                <span className="absolute top-2 left-2 z-10 rounded bg-bg/70 px-1.5 py-0.5 text-[10px] font-medium text-fg-muted uppercase backdrop-blur">
-                  {m}
-                </span>
-                <PreviewFrame
-                  preview={preview}
-                  preset={preset}
-                  designSystem={designSystem}
-                  mode={m}
-                  className="w-full flex-1"
-                  style={{ zoom }}
-                />
-              </div>
-            ))}
+      {/* Stage — the preview iframe stays mounted (just hidden) when Tokens/Code
+          are shown, so switching back never reloads it. */}
+      <div className="relative min-h-0 flex-1">
+        <div
+          className={cn(
+            'absolute inset-0 overflow-auto',
+            (constrained || split === 'split') && 'bg-neutral',
+            stage !== 'preview' && 'hidden',
+          )}
+        >
+          {split === 'split' ? (
+            <div className="flex h-full w-full">
+              {(['light', 'dark'] as const).map((m) => (
+                <div
+                  key={m}
+                  className={cn(
+                    'relative flex h-full min-w-0 flex-1 flex-col',
+                    m === 'light' && 'border-r',
+                  )}
+                >
+                  <span className="absolute top-2 left-2 z-10 rounded bg-bg/70 px-1.5 py-0.5 text-[10px] font-medium text-fg-muted uppercase backdrop-blur">
+                    {m}
+                  </span>
+                  <PreviewFrame
+                    preview={preview}
+                    preset={preset}
+                    designSystem={designSystem}
+                    mode={m}
+                    className="w-full flex-1"
+                    style={{ zoom, filter }}
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex h-full w-full justify-center">
+              <PreviewFrame
+                preview={preview}
+                preset={preset}
+                designSystem={designSystem}
+                mode={mode}
+                className={cn(constrained && 'border-x shadow-sm')}
+                style={{
+                  width: constrained ? DEVICE_WIDTHS[size] : '100%',
+                  zoom,
+                  filter,
+                }}
+              />
+            </div>
+          )}
+        </div>
+
+        {stage === 'tokens' && (
+          <div className="absolute inset-0">
+            <TokensView />
           </div>
-        ) : (
-          <div className="flex h-full w-full justify-center">
-            <PreviewFrame
-              preview={preview}
-              preset={preset}
-              designSystem={designSystem}
-              mode={mode}
-              className={cn(constrained && 'border-x shadow-sm')}
-              style={{
-                width: constrained ? DEVICE_WIDTHS[size] : '100%',
-                zoom,
-              }}
-            />
+        )}
+        {stage === 'code' && (
+          <div className="absolute inset-0">
+            <CodeView />
           </div>
         )}
       </div>

--- a/www/src/modules/create/studio/canvas.tsx
+++ b/www/src/modules/create/studio/canvas.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+import {
+  ChevronDownIcon,
+  ColumnsIcon,
+  ExternalLinkIcon,
+  MaximizeIcon,
+  MinimizeIcon,
+  MonitorIcon,
+  MoonIcon,
+  SmartphoneIcon,
+  SquareIcon,
+  SunIcon,
+  TabletIcon,
+} from 'lucide-react'
+import { useTheme } from 'starter-themes'
+
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+import { Command } from '@/registry/ui/command'
+import { Input } from '@/registry/ui/input'
+import {
+  ListBox,
+  ListBoxItem,
+  ListBoxSection,
+  ListBoxSectionHeader,
+} from '@/registry/ui/list-box'
+import { Menu, MenuContent, MenuItem } from '@/registry/ui/menu'
+import { Popover } from '@/registry/ui/popover'
+import { SearchField } from '@/registry/ui/search-field'
+import { Select, SelectValue } from '@/registry/ui/select'
+import { ToggleButton } from '@/registry/ui/toggle-button'
+import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+import { componentsData } from '@/modules/docs/components-list/components-data'
+
+import { sendPreviewMode, sendToIframe, useDesignSystem } from '../preset'
+import type { DesignSystem, PreviewMode } from '../preset'
+
+type DeviceSize = 'mobile' | 'tablet' | 'desktop'
+type ViewMode = 'single' | 'split'
+
+const DEVICE_WIDTHS: Record<Exclude<DeviceSize, 'desktop'>, number> = {
+  mobile: 390,
+  tablet: 768,
+}
+
+const SIZE_OPTIONS: {
+  id: DeviceSize
+  label: string
+  Icon: typeof MonitorIcon
+}[] = [
+  { id: 'mobile', label: 'Mobile', Icon: SmartphoneIcon },
+  { id: 'tablet', label: 'Tablet', Icon: TabletIcon },
+  { id: 'desktop', label: 'Desktop', Icon: MonitorIcon },
+]
+
+const ZOOM_LEVELS = [0.5, 0.75, 1, 1.25, 1.5, 2]
+
+const routeApi = getRouteApi('/_app/create')
+
+/* ----------------------------------------------------------------------------
+ * A single preview iframe that keeps itself in sync with the design system and
+ * a forced light/dark mode over postMessage. Reloads only when the previewed
+ * scene changes — every token edit streams in without a reload.
+ * -------------------------------------------------------------------------- */
+function PreviewFrame({
+  preview,
+  preset,
+  designSystem,
+  mode,
+  className,
+  style,
+}: {
+  preview: string
+  preset: string | undefined
+  designSystem: DesignSystem
+  mode: PreviewMode
+  className?: string
+  style?: CSSProperties
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+
+  const iframeSrc = useMemo(() => {
+    const base = `/preview/${preview}`
+    return preset ? `${base}?preset=${encodeURIComponent(preset)}` : base
+    // oxlint-disable-next-line react/exhaustive-deps -- live preset changes ride the postMessage channel to avoid reloads
+  }, [preview])
+
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!iframe) return
+    const send = () => sendToIframe(iframe, designSystem)
+    if (iframe.contentWindow) send()
+    iframe.addEventListener('load', send)
+    const onReady = (e: MessageEvent) => {
+      if (e.data?.type === 'preview-ready') send()
+    }
+    window.addEventListener('message', onReady)
+    return () => {
+      iframe.removeEventListener('load', send)
+      window.removeEventListener('message', onReady)
+    }
+  }, [designSystem])
+
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!iframe) return
+    const send = () => sendPreviewMode(iframe, mode)
+    if (iframe.contentWindow) send()
+    iframe.addEventListener('load', send)
+    const onReady = (e: MessageEvent) => {
+      if (e.data?.type === 'preview-ready') send()
+    }
+    window.addEventListener('message', onReady)
+    return () => {
+      iframe.removeEventListener('load', send)
+      window.removeEventListener('message', onReady)
+    }
+  }, [mode])
+
+  return (
+    <iframe
+      ref={iframeRef}
+      src={iframeSrc}
+      title={`preview-${mode}`}
+      className={cn('h-full border-0 bg-bg', className)}
+      style={style}
+    />
+  )
+}
+
+export function Canvas({ className }: { className?: string }) {
+  const { preview, preset } = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+  const { designSystem } = useDesignSystem()
+  const { resolvedTheme } = useTheme()
+
+  const stageRef = useRef<HTMLDivElement>(null)
+  const [mode, setMode] = useState<PreviewMode>('light')
+  const [view, setView] = useState<ViewMode>('single')
+  const [size, setSize] = useState<DeviceSize>('desktop')
+  const [zoom, setZoom] = useState(1)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  const constrained = size !== 'desktop'
+
+  useEffect(() => {
+    setMode(resolvedTheme === 'dark' ? 'dark' : 'light')
+    // oxlint-disable-next-line react/exhaustive-deps -- seed once from the site theme; canvas mode is independent thereafter
+  }, [])
+
+  useEffect(() => {
+    const onChange = () =>
+      setIsFullscreen(document.fullscreenElement === stageRef.current)
+    document.addEventListener('fullscreenchange', onChange)
+    return () => document.removeEventListener('fullscreenchange', onChange)
+  }, [])
+
+  function toggleFullscreen() {
+    if (document.fullscreenElement) document.exitFullscreen()
+    else stageRef.current?.requestFullscreen()
+  }
+
+  const sharedSrc = preset
+    ? `/preview/${preview}?preset=${encodeURIComponent(preset)}`
+    : `/preview/${preview}`
+
+  return (
+    <div
+      ref={stageRef}
+      className={cn(
+        'relative flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border bg-bg',
+        className,
+      )}
+    >
+      {/* Toolbar */}
+      <div className="flex h-12 shrink-0 items-center gap-2 border-b px-3">
+        {/* Scene selector */}
+        <Select
+          value={preview}
+          onChange={(v) =>
+            navigate({ search: (prev) => ({ ...prev, preview: v as string }) })
+          }
+          className="w-48 max-w-[45%]"
+          aria-label="Preview scene"
+        >
+          <Button size="sm" className="w-full">
+            <SelectValue className="truncate" />
+            <ChevronDownIcon data-icon-end="" />
+          </Button>
+          <Popover>
+            <Command>
+              <SearchField autoFocus aria-label="Search scenes">
+                <Input />
+              </SearchField>
+              <ListBox>
+                <ListBoxSection>
+                  <ListBoxSectionHeader>Blocks</ListBoxSectionHeader>
+                  <ListBoxItem id="cards" textValue="Cards">
+                    <span className="truncate">Cards</span>
+                  </ListBoxItem>
+                </ListBoxSection>
+                <ListBoxSection>
+                  <ListBoxSectionHeader>Components</ListBoxSectionHeader>
+                  {componentsData
+                    .flatMap((c) => c.components)
+                    .sort((a, b) => a.name.localeCompare(b.name))
+                    .map((comp) => (
+                      <ListBoxItem
+                        key={comp.slug}
+                        id={comp.slug}
+                        textValue={comp.name}
+                      >
+                        <span className="truncate">{comp.name}</span>
+                      </ListBoxItem>
+                    ))}
+                </ListBoxSection>
+              </ListBox>
+            </Command>
+          </Popover>
+        </Select>
+
+        <div className="ml-auto flex items-center gap-1">
+          {/* Device size */}
+          <ToggleButtonGroup
+            aria-label="Device size"
+            selectionMode="single"
+            disallowEmptySelection
+            size="sm"
+            isIconOnly
+            selectedKeys={[size]}
+            onSelectionChange={(keys) => {
+              const next = keys.values().next().value
+              if (next) setSize(next as DeviceSize)
+            }}
+            className="max-lg:hidden"
+          >
+            {SIZE_OPTIONS.map(({ id, label, Icon }) => (
+              <ToggleButton key={id} id={id} aria-label={label}>
+                <Icon />
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+
+          {/* Zoom */}
+          <Menu>
+            <Button
+              size="sm"
+              variant="quiet"
+              className="gap-1 tabular-nums max-lg:hidden"
+            >
+              {Math.round(zoom * 100)}%
+              <ChevronDownIcon data-icon-end="" />
+            </Button>
+            <Popover placement="bottom end" className="min-w-28">
+              <MenuContent
+                selectionMode="single"
+                selectedKeys={[String(zoom)]}
+                onSelectionChange={(keys) => {
+                  if (keys === 'all') return
+                  const v = keys.values().next().value
+                  if (v != null) setZoom(Number(v))
+                }}
+              >
+                {ZOOM_LEVELS.map((z) => (
+                  <MenuItem key={z} id={String(z)} textValue={`${z * 100}%`}>
+                    {Math.round(z * 100)}%
+                  </MenuItem>
+                ))}
+              </MenuContent>
+            </Popover>
+          </Menu>
+
+          <div className="mx-0.5 h-5 w-px bg-border max-lg:hidden" />
+
+          {/* Single / split light-dark */}
+          <ToggleButtonGroup
+            aria-label="View mode"
+            selectionMode="single"
+            disallowEmptySelection
+            size="sm"
+            isIconOnly
+            selectedKeys={[view]}
+            onSelectionChange={(keys) => {
+              const next = keys.values().next().value
+              if (next) setView(next as ViewMode)
+            }}
+            className="max-lg:hidden"
+          >
+            <ToggleButton id="single" aria-label="Single view">
+              <SquareIcon />
+            </ToggleButton>
+            <ToggleButton id="split" aria-label="Light + dark split">
+              <ColumnsIcon />
+            </ToggleButton>
+          </ToggleButtonGroup>
+
+          {/* Light / dark (single view only) */}
+          {view === 'single' && (
+            <Tooltip>
+              <Button
+                size="sm"
+                variant="quiet"
+                isIconOnly
+                onPress={() =>
+                  setMode((m) => (m === 'dark' ? 'light' : 'dark'))
+                }
+                aria-label="Toggle preview mode"
+              >
+                {mode === 'dark' ? <SunIcon /> : <MoonIcon />}
+              </Button>
+              <TooltipContent>
+                {mode === 'dark' ? 'Light mode' : 'Dark mode'}
+              </TooltipContent>
+            </Tooltip>
+          )}
+
+          <Tooltip>
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              onPress={() =>
+                window.open(sharedSrc, '_blank', 'noopener,noreferrer')
+              }
+              aria-label="Open preview in new tab"
+            >
+              <ExternalLinkIcon />
+            </Button>
+            <TooltipContent>Open in new tab</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              onPress={toggleFullscreen}
+              aria-label="Toggle fullscreen"
+            >
+              {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}
+            </Button>
+            <TooltipContent>
+              {isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {/* Stage */}
+      <div
+        className={cn(
+          'relative flex-1 overflow-auto',
+          (constrained || view === 'split') && 'bg-neutral',
+        )}
+      >
+        {view === 'split' ? (
+          <div className="flex h-full w-full">
+            {(['light', 'dark'] as const).map((m) => (
+              <div
+                key={m}
+                className={cn(
+                  'relative flex h-full min-w-0 flex-1 flex-col',
+                  m === 'light' && 'border-r',
+                )}
+              >
+                <span className="absolute top-2 left-2 z-10 rounded bg-bg/70 px-1.5 py-0.5 text-[10px] font-medium text-fg-muted uppercase backdrop-blur">
+                  {m}
+                </span>
+                <PreviewFrame
+                  preview={preview}
+                  preset={preset}
+                  designSystem={designSystem}
+                  mode={m}
+                  className="w-full flex-1"
+                  style={{ zoom }}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex h-full w-full justify-center">
+            <PreviewFrame
+              preview={preview}
+              preset={preset}
+              designSystem={designSystem}
+              mode={mode}
+              className={cn(constrained && 'border-x shadow-sm')}
+              style={{
+                width: constrained ? DEVICE_WIDTHS[size] : '100%',
+                zoom,
+              }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/code-view.tsx
+++ b/www/src/modules/create/studio/code-view.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { CheckIcon, CopyIcon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import {
+  DEFAULT_COLOR_CONFIG,
+  emitPrimitivesCss,
+  resolveColorConfig,
+} from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+
+import { useExportUrl } from '../export/use-export-url'
+import { useDesignSystem } from '../preset'
+
+type Tab = 'css' | 'install'
+
+/** The "code you own" — the real generated primitive CSS + the install command. */
+export function CodeView() {
+  const { designSystem } = useDesignSystem()
+  const presetUrl = useExportUrl()
+  const [tab, setTab] = useState<Tab>('css')
+  const [copied, setCopied] = useState(false)
+
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const css = useMemo(
+    () => emitPrimitivesCss(resolveColorConfig(config), { onColors: true }),
+    [config],
+  )
+  const install = `npx shadcn init ${presetUrl('/r/init')}`
+  const content = tab === 'css' ? css : install
+
+  function copy() {
+    navigator.clipboard?.writeText(content).then(
+      () => {
+        setCopied(true)
+        window.setTimeout(() => setCopied(false), 1400)
+      },
+      () => {},
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b px-4 py-2.5">
+        <div className="flex gap-1 rounded-md bg-neutral p-0.5">
+          {(
+            [
+              { id: 'css', label: 'theme.css' },
+              { id: 'install', label: 'Install' },
+            ] as const
+          ).map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              className={cn(
+                'rounded px-2.5 py-1 font-mono text-[12px] transition-colors',
+                tab === t.id
+                  ? 'bg-card text-fg shadow-sm'
+                  : 'text-fg-muted hover:text-fg',
+              )}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <Button
+          size="sm"
+          variant="quiet"
+          onPress={copy}
+          className={cn('ml-auto gap-1.5', copied && 'text-success')}
+        >
+          {copied ? <CheckIcon /> : <CopyIcon />}
+          {copied ? 'Copied' : 'Copy'}
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto bg-bg p-4">
+        <pre className="font-mono text-[12px] leading-relaxed text-fg-muted">
+          <code>{content}</code>
+        </pre>
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/command-palette.tsx
+++ b/www/src/modules/create/studio/command-palette.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { useEffect } from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+import {
+  BoxIcon,
+  RotateCcwIcon,
+  SearchIcon,
+  ShuffleIcon,
+  WandSparklesIcon,
+} from 'lucide-react'
+
+import { Command } from '@/registry/ui/command'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Kbd } from '@/registry/ui/kbd'
+import {
+  ListBox,
+  ListBoxItem,
+  ListBoxSection,
+  ListBoxSectionHeader,
+} from '@/registry/ui/list-box'
+import { Modal } from '@/registry/ui/modal'
+import { registryUi } from '@/registry/ui/registry'
+import { SearchField } from '@/registry/ui/search-field'
+
+import { ExamplesIndex } from '../__generated__/examples'
+import { useStudioActions } from './actions'
+import { type AxisId, AXES } from './axes'
+import { useStudio } from './store'
+
+const routeApi = getRouteApi('/_app/create')
+
+const TWEAKABLE = registryUi
+  .filter((i) => i.params && Object.keys(i.params).length > 0)
+  .sort((a, b) => a.name.localeCompare(b.name))
+
+function titleCase(slug: string) {
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+export function CommandPalette() {
+  const navigate = routeApi.useNavigate()
+  const {
+    setAxis,
+    setSelectedComponent,
+    setOnboardingOpen,
+    commandOpen: open,
+    setCommandOpen: setOpen,
+  } = useStudio()
+  const { shuffle, reset } = useStudioActions()
+
+  // ⌘K / Ctrl-K toggles the palette from anywhere in the studio.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setOpen(!open)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, setOpen])
+
+  function run(key: string) {
+    if (key.startsWith('axis:')) {
+      setAxis(key.slice(5) as AxisId)
+    } else if (key.startsWith('comp:')) {
+      const name = key.slice(5)
+      setAxis('components')
+      setSelectedComponent(name)
+      if (name in ExamplesIndex) {
+        navigate({ search: (p) => ({ ...p, preview: name }) })
+      }
+    } else if (key === 'act:shuffle') {
+      shuffle()
+    } else if (key === 'act:reset') {
+      reset()
+    } else if (key === 'act:generate') {
+      setOnboardingOpen(true)
+    }
+    setOpen(false)
+  }
+
+  return (
+    <Modal isOpen={open} onOpenChange={setOpen} isDismissable>
+      <DialogContent className="w-full max-w-xl p-0">
+        <Command aria-label="Command palette">
+          <SearchField aria-label="Search the studio" autoFocus>
+            <InputGroup size="lg">
+              <InputGroupAddon>
+                <SearchIcon />
+              </InputGroupAddon>
+              <Input placeholder="Jump to an axis, component or action…" />
+              <InputGroupAddon>
+                <Kbd className="bg-transparent">Esc</Kbd>
+              </InputGroupAddon>
+            </InputGroup>
+          </SearchField>
+          <ListBox
+            aria-label="Commands"
+            onAction={(key) => run(String(key))}
+            className="max-h-80"
+          >
+            <ListBoxSection>
+              <ListBoxSectionHeader>Go to</ListBoxSectionHeader>
+              {AXES.map((axis) => (
+                <ListBoxItem
+                  key={axis.id}
+                  id={`axis:${axis.id}`}
+                  textValue={axis.label}
+                >
+                  <axis.icon />
+                  <span>{axis.label}</span>
+                  <span className="ml-auto text-[11px] text-fg-muted">
+                    {axis.tagline}
+                  </span>
+                </ListBoxItem>
+              ))}
+            </ListBoxSection>
+
+            <ListBoxSection>
+              <ListBoxSectionHeader>Actions</ListBoxSectionHeader>
+              <ListBoxItem id="act:generate" textValue="Generate from brand">
+                <WandSparklesIcon />
+                <span>Generate from brand</span>
+              </ListBoxItem>
+              <ListBoxItem id="act:shuffle" textValue="Surprise me shuffle">
+                <ShuffleIcon />
+                <span>Surprise me</span>
+              </ListBoxItem>
+              <ListBoxItem id="act:reset" textValue="Reset to defaults">
+                <RotateCcwIcon />
+                <span>Reset to defaults</span>
+              </ListBoxItem>
+            </ListBoxSection>
+
+            <ListBoxSection>
+              <ListBoxSectionHeader>Components</ListBoxSectionHeader>
+              {TWEAKABLE.map((item) => (
+                <ListBoxItem
+                  key={item.name}
+                  id={`comp:${item.name}`}
+                  textValue={titleCase(item.name)}
+                >
+                  <BoxIcon />
+                  <span>{titleCase(item.name)}</span>
+                </ListBoxItem>
+              ))}
+            </ListBoxSection>
+          </ListBox>
+        </Command>
+      </DialogContent>
+    </Modal>
+  )
+}

--- a/www/src/modules/create/studio/export-menu.tsx
+++ b/www/src/modules/create/studio/export-menu.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { ChevronDownIcon, DownloadIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { Dialog, DialogContent } from '@/registry/ui/dialog'
+import { Popover } from '@/registry/ui/popover'
+
+import { CommandCard, DeeplinkButton } from '../export/renderers'
+import { EXPORT_TARGETS } from '../export/targets'
+import { useExportUrl } from '../export/use-export-url'
+
+const SOON = ['Bolt', 'Lovable', 'Claude', 'Figma']
+
+export function ExportMenu() {
+  const presetUrl = useExportUrl()
+
+  return (
+    <Dialog>
+      <Button variant="primary" size="sm" className="gap-1.5">
+        <DownloadIcon />
+        Export
+        <ChevronDownIcon data-icon-end="" />
+      </Button>
+      <Popover placement="bottom end" className="w-80">
+        <DialogContent className="flex flex-col gap-4 p-4">
+          <div className="flex flex-col gap-1">
+            <h3 className="text-sm font-semibold">Export your system</h3>
+            <p className="text-[11px] text-fg-muted">
+              Code you own — into your codebase or any builder.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            {EXPORT_TARGETS.map((target) =>
+              target.kind === 'command' ? (
+                <div key={target.id} className="flex flex-col gap-1.5">
+                  <span className="text-[11px] font-medium text-fg-muted">
+                    shadcn CLI
+                  </span>
+                  <CommandCard
+                    label={target.label}
+                    command={target.command(presetUrl)}
+                  />
+                </div>
+              ) : (
+                <DeeplinkButton
+                  key={target.id}
+                  label={target.label}
+                  ariaLabel={target.ariaLabel}
+                  icon={target.icon}
+                  href={target.href(presetUrl)}
+                />
+              ),
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2 border-t pt-3">
+            <span className="text-[11px] font-medium text-fg-muted">
+              More targets
+            </span>
+            <div className="grid grid-cols-2 gap-2">
+              {SOON.map((name) => (
+                <div
+                  key={name}
+                  className="flex items-center justify-between rounded-md border border-dashed px-2.5 py-2 text-[13px] text-fg-muted"
+                >
+                  {name}
+                  <span className="rounded-full bg-neutral px-1.5 py-0.5 text-[9px] font-medium tracking-wide uppercase">
+                    Soon
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </DialogContent>
+      </Popover>
+    </Dialog>
+  )
+}

--- a/www/src/modules/create/studio/index.tsx
+++ b/www/src/modules/create/studio/index.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useEffect } from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+import { AnimatePresence } from 'motion/react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { ToggleButton } from '@/registry/ui/toggle-button'
+import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
+
+import { AXES } from './axes'
+import { Canvas } from './canvas'
+import { Inspector } from './inspector'
+import { Navigator } from './navigator'
+import { Onboarding } from './onboarding'
+import { StudioProvider, useStudio } from './store'
+import { TopBar } from './top-bar'
+
+const routeApi = getRouteApi('/_app/create')
+
+/** The redesigned /create: a brand-to-system studio. */
+export function Studio() {
+  return (
+    <StudioProvider initialOnboarding={false}>
+      <StudioShell />
+    </StudioProvider>
+  )
+}
+
+function StudioShell() {
+  const { preset } = routeApi.useSearch()
+  const { onboardingOpen, setOnboardingOpen, mobilePane, setMobilePane } =
+    useStudio()
+
+  // Greet first-time visitors (no preset yet) with the generator, once per
+  // session. Run after mount to avoid an SSR/hydration mismatch.
+  useEffect(() => {
+    if (preset) return
+    if (sessionStorage.getItem('dotui-onboarded')) return
+    sessionStorage.setItem('dotui-onboarded', '1')
+    setOnboardingOpen(true)
+    // oxlint-disable-next-line react/exhaustive-deps -- mount-only greeting
+  }, [])
+
+  return (
+    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col">
+      <TopBar />
+
+      {/* Mobile pane switcher */}
+      <div className="px-4 pb-2 lg:hidden">
+        <ToggleButtonGroup
+          aria-label="Studio view"
+          selectionMode="single"
+          disallowEmptySelection
+          size="sm"
+          selectedKeys={[mobilePane]}
+          onSelectionChange={(keys) => {
+            const next = keys.values().next().value
+            if (next === 'design' || next === 'preview') setMobilePane(next)
+          }}
+          className="w-full *:flex-1"
+        >
+          <ToggleButton id="design">Design</ToggleButton>
+          <ToggleButton id="preview">Preview</ToggleButton>
+        </ToggleButtonGroup>
+      </div>
+
+      <div className="relative flex min-h-0 flex-1 gap-3 p-4 pt-0 lg:gap-3">
+        <Navigator className="max-lg:hidden" />
+
+        <Canvas className={cn(mobilePane === 'design' && 'max-lg:hidden')} />
+
+        <div
+          className={cn(
+            'flex min-h-0 min-w-0 flex-col gap-3 max-lg:flex-1',
+            mobilePane === 'preview' && 'max-lg:hidden',
+          )}
+        >
+          <MobileAxisBar />
+          <Inspector className="min-h-0 flex-1" />
+        </div>
+
+        <AnimatePresence>{onboardingOpen && <Onboarding />}</AnimatePresence>
+      </div>
+    </div>
+  )
+}
+
+/** A horizontal axis switcher shown only on mobile (the rail is desktop-only). */
+function MobileAxisBar() {
+  const { axis, setAxis } = useStudio()
+  return (
+    <div className="flex gap-1 overflow-x-auto rounded-lg border bg-card p-1 lg:hidden">
+      {AXES.map((item) => {
+        const active = axis === item.id
+        return (
+          <ButtonPrimitives.Button
+            key={item.id}
+            onPress={() => setAxis(item.id)}
+            className={cn(
+              'flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-medium focus-reset transition-colors focus-visible:focus-ring',
+              active
+                ? 'bg-primary/10 text-primary'
+                : 'text-fg-muted hover:bg-neutral hover:text-fg',
+            )}
+          >
+            <item.icon className="size-3.5" />
+            {item.label}
+          </ButtonPrimitives.Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/index.tsx
+++ b/www/src/modules/create/studio/index.tsx
@@ -11,6 +11,7 @@ import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
 
 import { AXES } from './axes'
 import { Canvas } from './canvas'
+import { CommandPalette } from './command-palette'
 import { Inspector } from './inspector'
 import { Navigator } from './navigator'
 import { Onboarding } from './onboarding'
@@ -83,6 +84,8 @@ function StudioShell() {
 
         <AnimatePresence>{onboardingOpen && <Onboarding />}</AnimatePresence>
       </div>
+
+      <CommandPalette />
     </div>
   )
 }

--- a/www/src/modules/create/studio/index.tsx
+++ b/www/src/modules/create/studio/index.tsx
@@ -44,8 +44,12 @@ function StudioShell() {
     // oxlint-disable-next-line react/exhaustive-deps -- mount-only greeting
   }, [])
 
+  // The studio owns the full viewport now that the site Header is suppressed on
+  // /create (see _app/route.tsx); the TopBar below is the single `--header-height`
+  // bar, so the shell spans the whole screen rather than subtracting a header
+  // that no longer sits above it.
   return (
-    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col">
+    <div className="flex h-svh min-h-0 flex-1 flex-col">
       <TopBar />
 
       {/* Mobile pane switcher */}

--- a/www/src/modules/create/studio/inspector.tsx
+++ b/www/src/modules/create/studio/inspector.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { cn } from '@/registry/lib/utils'
+
+import { AXIS_MAP } from './axes'
+import { BrandInspector } from './inspectors/brand'
+import { ColorInspector } from './inspectors/color'
+import { ComponentsInspector } from './inspectors/components'
+import { CursorInspector } from './inspectors/cursor'
+import { ElevationInspector } from './inspectors/elevation'
+import { IconsInspector } from './inspectors/icons'
+import { MotionInspector } from './inspectors/motion'
+import { ShapeInspector } from './inspectors/shape'
+import { SpacingInspector } from './inspectors/spacing'
+import { TypographyInspector } from './inspectors/typography'
+import { useStudio } from './store'
+
+const BODIES = {
+  brand: BrandInspector,
+  color: ColorInspector,
+  typography: TypographyInspector,
+  shape: ShapeInspector,
+  spacing: SpacingInspector,
+  elevation: ElevationInspector,
+  motion: MotionInspector,
+  icons: IconsInspector,
+  cursor: CursorInspector,
+  components: ComponentsInspector,
+} as const
+
+export function Inspector({ className }: { className?: string }) {
+  const { axis } = useStudio()
+  const meta = AXIS_MAP[axis]
+  const Body = BODIES[axis]
+
+  return (
+    <div
+      className={cn(
+        'flex w-full flex-col rounded-xl border bg-card lg:w-[340px] lg:shrink-0',
+        className,
+      )}
+    >
+      {/* Header */}
+      <div className="flex shrink-0 items-start gap-3 border-b p-4">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border bg-neutral text-fg">
+          <meta.icon className="size-4.5" />
+        </div>
+        <div className="flex min-w-0 flex-col">
+          <h2 className="text-sm font-semibold">{meta.label}</h2>
+          <p className="text-[11px] leading-snug text-fg-muted">
+            {meta.tagline}
+          </p>
+        </div>
+      </div>
+
+      {/* Body — keyed per axis so the CSS rise replays on each switch. */}
+      <div className="relative min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        <div key={axis} className="studio-rise p-4">
+          <Body />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspectors/brand.tsx
+++ b/www/src/modules/create/studio/inspectors/brand.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import {
+  BriefcaseIcon,
+  GlassWaterIcon,
+  MinusIcon,
+  NewspaperIcon,
+  SmileIcon,
+  WandSparklesIcon,
+  ZapIcon,
+} from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import type { Density } from '@/registry/types'
+
+import { DEFAULT_RADIUS_FACTOR, RADIUS_FACTOR_VAR } from '../../layout'
+import { useDesignSystem } from '../../preset'
+import { Field, Section, SwatchButton } from '../primitives'
+import { useStudio } from '../store'
+import { ELEVATION_STYLE_VAR } from '../tokens'
+
+interface Vibe {
+  id: string
+  label: string
+  description: string
+  icon: typeof MinusIcon
+  accent: string
+  radius: number
+  density: Density
+  elevation: string
+}
+
+const VIBES: Vibe[] = [
+  {
+    id: 'minimal',
+    label: 'Minimal',
+    description: 'Tight, flat, restrained',
+    icon: MinusIcon,
+    accent: '#2563eb',
+    radius: 0.5,
+    density: 'compact',
+    elevation: 'flat',
+  },
+  {
+    id: 'bold',
+    label: 'Bold',
+    description: 'High-contrast & punchy',
+    icon: ZapIcon,
+    accent: '#f43f5e',
+    radius: 1,
+    density: 'default',
+    elevation: 'depth',
+  },
+  {
+    id: 'playful',
+    label: 'Playful',
+    description: 'Round, airy, friendly',
+    icon: SmileIcon,
+    accent: '#8b5cf6',
+    radius: 2,
+    density: 'comfortable',
+    elevation: 'soft',
+  },
+  {
+    id: 'corporate',
+    label: 'Corporate',
+    description: 'Trustworthy & calm',
+    icon: BriefcaseIcon,
+    accent: '#0ea5e9',
+    radius: 0.5,
+    density: 'default',
+    elevation: 'soft',
+  },
+  {
+    id: 'editorial',
+    label: 'Editorial',
+    description: 'Warm, spacious, serif',
+    icon: NewspaperIcon,
+    accent: '#b45309',
+    radius: 0.25,
+    density: 'comfortable',
+    elevation: 'flat',
+  },
+  {
+    id: 'glass',
+    label: 'Soft glass',
+    description: 'Frosted & translucent',
+    icon: GlassWaterIcon,
+    accent: '#06b6d4',
+    radius: 1.5,
+    density: 'default',
+    elevation: 'glass',
+  },
+]
+
+export function BrandInspector() {
+  const { setOnboardingOpen } = useStudio()
+  const { designSystem, setDesignSystem, setColorSeed } = useDesignSystem()
+  const accent =
+    designSystem.color?.seeds.accent ?? DEFAULT_COLOR_CONFIG.seeds.accent
+  const activeRadius =
+    designSystem.tokens[RADIUS_FACTOR_VAR] ?? DEFAULT_RADIUS_FACTOR
+  const activeElevation = designSystem.tokens[ELEVATION_STYLE_VAR]
+
+  function applyVibe(vibe: Vibe) {
+    setDesignSystem((prev) => {
+      const base = prev.color ?? DEFAULT_COLOR_CONFIG
+      return {
+        ...prev,
+        density: vibe.density,
+        tokens: {
+          ...prev.tokens,
+          [RADIUS_FACTOR_VAR]: String(vibe.radius),
+          [ELEVATION_STYLE_VAR]: vibe.elevation,
+        },
+        color: { ...base, seeds: { ...base.seeds, accent: vibe.accent } },
+      }
+    })
+  }
+
+  function isActive(vibe: Vibe) {
+    return (
+      accent.toLowerCase() === vibe.accent.toLowerCase() &&
+      Number.parseFloat(activeRadius) === vibe.radius &&
+      designSystem.density === vibe.density &&
+      activeElevation === vibe.elevation
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-7">
+      {/* The generator front door. */}
+      <button
+        type="button"
+        onClick={() => setOnboardingOpen(true)}
+        className="group/gen relative flex w-full items-center gap-3 overflow-hidden rounded-xl border border-primary/30 bg-gradient-to-br from-primary/12 to-primary/5 p-4 text-left transition-colors hover:from-primary/18"
+      >
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary text-fg-on-primary shadow-sm">
+          <WandSparklesIcon className="size-5" />
+        </div>
+        <div className="flex flex-col">
+          <span className="text-sm font-semibold">Generate from brand</span>
+          <span className="text-[11px] text-fg-muted">
+            One color, a logo or a URL → a full system
+          </span>
+        </div>
+      </button>
+
+      <Section title="Brand color">
+        <Field label="Primary seed" live hint="Drives the accent ramps live.">
+          <SwatchButton
+            ariaLabel="Brand color"
+            value={accent}
+            onChange={(hex) => setColorSeed('accent', hex)}
+          />
+        </Field>
+      </Section>
+
+      <Section title="Personality">
+        <p className="-mt-1 text-xs text-fg-muted">
+          Each vibe sets color, radius, density and depth together.
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          {VIBES.map((vibe) => {
+            const active = isActive(vibe)
+            return (
+              <ButtonPrimitives.Button
+                key={vibe.id}
+                onPress={() => applyVibe(vibe)}
+                className={cn(
+                  'flex flex-col items-start gap-2 rounded-lg border p-3 text-left focus-reset transition-colors focus-visible:focus-ring',
+                  active
+                    ? 'border-primary bg-primary/8 ring-1 ring-primary/30'
+                    : 'hover:border-fg-muted/30 hover:bg-neutral',
+                )}
+              >
+                <div className="flex w-full items-center justify-between">
+                  <vibe.icon
+                    className={cn(
+                      'size-4',
+                      active ? 'text-primary' : 'text-fg-muted',
+                    )}
+                  />
+                  <span
+                    className="size-4 rounded-full border"
+                    style={{ backgroundColor: vibe.accent }}
+                  />
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-[13px] font-medium">{vibe.label}</span>
+                  <span className="text-[11px] leading-snug text-fg-muted">
+                    {vibe.description}
+                  </span>
+                </div>
+              </ButtonPrimitives.Button>
+            )
+          })}
+        </div>
+      </Section>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspectors/color.tsx
+++ b/www/src/modules/create/studio/inspectors/color.tsx
@@ -1,0 +1,376 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import {
+  ChevronDownIcon,
+  GlobeIcon,
+  ImageIcon,
+  PaintBucketIcon,
+  PipetteIcon,
+} from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import {
+  DEFAULT_COLOR_CONFIG,
+  PALETTE_ORDER,
+  resolveColorConfig,
+} from '@/registry/theme'
+import type { AlgorithmId, PaletteSeeds } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+import { Popover } from '@/registry/ui/popover'
+import { Select, SelectValue } from '@/registry/ui/select'
+import { Switch } from '@/registry/ui/switch'
+
+import { ContrastReadout } from '../../colors/contrast'
+import { ColorKnobsControls } from '../../colors/knobs'
+import { useDesignSystem } from '../../preset'
+import {
+  Field,
+  InlineRow,
+  OptionGrid,
+  Section,
+  Segmented,
+  SwatchButton,
+} from '../primitives'
+
+const ALGORITHMS: ReadonlyArray<{ id: AlgorithmId; label: string }> = [
+  { id: 'oklch', label: 'OKLCH — perceptual' },
+  { id: 'tailwind', label: 'Tailwind-style' },
+  { id: 'material', label: 'Material' },
+  { id: 'contrast', label: 'Contrast-locked' },
+]
+
+const STATUS_SEEDS: ReadonlyArray<{ seed: keyof PaletteSeeds; label: string }> =
+  [
+    { seed: 'success', label: 'Success' },
+    { seed: 'warning', label: 'Warning' },
+    { seed: 'danger', label: 'Danger' },
+    { seed: 'info', label: 'Info' },
+  ]
+
+type SeedStrategy = 'one' | 'seeds' | 'import'
+type Foundation = 'palettes' | 'semantic'
+type RampMode = 'light' | 'dark'
+
+function rampAt(
+  ramp: Record<string, string> | undefined,
+  step: string,
+): string | undefined {
+  return ramp?.[step]
+}
+
+export function ColorInspector() {
+  const { designSystem, setColorSeed, setColorAlgorithm, setColorKnob } =
+    useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const seeds = config.seeds
+  const resolved = useMemo(() => resolveColorConfig(config), [config])
+
+  const [strategy, setStrategy] = useState<SeedStrategy>('one')
+  const [foundation, setFoundation] = useState<Foundation>('palettes')
+  const [rampMode, setRampMode] = useState<RampMode>('light')
+  const [contextAware, setContextAware] = useState(false)
+  const [tintNeutrals, setTintNeutrals] = useState(
+    (seeds.neutral ?? '#808080').toLowerCase() !== '#808080',
+  )
+
+  const ramps = rampMode === 'light' ? resolved.light : resolved.dark
+
+  function setTint(on: boolean) {
+    setTintNeutrals(on)
+    setColorSeed(
+      'neutral',
+      on ? (seeds.accent ?? DEFAULT_COLOR_CONFIG.seeds.accent) : '#808080',
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-7">
+      {/* How seeds are provided — the "1 color → full system" promise. */}
+      <Section
+        title="Seed strategy"
+        aside={
+          <span className="text-[11px] text-fg-muted">
+            how the system starts
+          </span>
+        }
+      >
+        <Segmented<SeedStrategy>
+          ariaLabel="Seed strategy"
+          value={strategy}
+          onChange={setStrategy}
+          options={[
+            { value: 'one', label: 'One color' },
+            { value: 'seeds', label: 'Custom seeds' },
+            { value: 'import', label: 'Import' },
+          ]}
+        />
+
+        {strategy === 'one' && (
+          <div className="flex flex-col gap-4">
+            <div className="flex items-stretch gap-3 rounded-lg border bg-card p-3">
+              <div
+                className="size-14 shrink-0 rounded-md border"
+                style={{ backgroundColor: seeds.accent }}
+              />
+              <div className="flex min-w-0 flex-1 flex-col gap-2">
+                <span className="text-[13px] font-medium">Brand color</span>
+                <SwatchButton
+                  ariaLabel="Brand color"
+                  value={seeds.accent ?? DEFAULT_COLOR_CONFIG.seeds.accent}
+                  onChange={(hex) => setColorSeed('accent', hex)}
+                />
+              </div>
+            </div>
+            <p className="text-xs leading-snug text-fg-muted">
+              Neutrals and every status family are derived automatically from
+              this single seed. Switch to{' '}
+              <span className="font-medium text-fg">Custom seeds</span> to drive
+              each one by hand.
+            </p>
+            <InlineRow
+              label="Tint neutrals with brand"
+              hint="Warm the grays toward the accent"
+              live
+            >
+              <Switch
+                isSelected={tintNeutrals}
+                onChange={setTint}
+                aria-label="Tint neutrals with brand"
+              />
+            </InlineRow>
+          </div>
+        )}
+
+        {strategy === 'seeds' && (
+          <div className="flex flex-col gap-4">
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Accent" live>
+                <SwatchButton
+                  ariaLabel="Accent"
+                  value={seeds.accent ?? DEFAULT_COLOR_CONFIG.seeds.accent}
+                  onChange={(hex) => setColorSeed('accent', hex)}
+                />
+              </Field>
+              <Field label="Neutral" live>
+                <SwatchButton
+                  ariaLabel="Neutral"
+                  value={seeds.neutral ?? DEFAULT_COLOR_CONFIG.seeds.neutral}
+                  onChange={(hex) => setColorSeed('neutral', hex)}
+                />
+              </Field>
+            </div>
+            <Section title="Status families">
+              <div className="grid grid-cols-2 gap-3">
+                {STATUS_SEEDS.map(({ seed, label }) => (
+                  <Field key={seed} label={label} live>
+                    <SwatchButton
+                      ariaLabel={label}
+                      value={
+                        seeds[seed] ??
+                        DEFAULT_COLOR_CONFIG.seeds[seed] ??
+                        '#808080'
+                      }
+                      onChange={(hex) => setColorSeed(seed, hex)}
+                    />
+                  </Field>
+                ))}
+              </div>
+            </Section>
+          </div>
+        )}
+
+        {strategy === 'import' && (
+          <div className="grid gap-2">
+            {[
+              {
+                icon: ImageIcon,
+                label: 'Upload a logo',
+                hint: 'Extract the palette from your mark',
+              },
+              {
+                icon: GlobeIcon,
+                label: 'Paste a website URL',
+                hint: 'Pull brand colors from any site',
+              },
+              {
+                icon: PipetteIcon,
+                label: 'Paste hex / OKLCH values',
+                hint: 'Bring an existing palette',
+              },
+            ].map((opt) => (
+              <button
+                key={opt.label}
+                type="button"
+                className="flex items-center gap-3 rounded-lg border border-dashed p-3 text-left transition-colors hover:border-fg-muted/40 hover:bg-neutral"
+              >
+                <opt.icon className="size-4 text-fg-muted" />
+                <div className="flex flex-col">
+                  <span className="text-[13px] font-medium">{opt.label}</span>
+                  <span className="text-[11px] text-fg-muted">{opt.hint}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      {/* The generation engine — fully live. */}
+      <Section title="Generation engine">
+        <Field
+          label="Algorithm"
+          live
+          hint="How a seed expands into a tonal ramp."
+        >
+          <Select
+            className="w-full"
+            selectedKey={config.algorithm}
+            onSelectionChange={(key) => setColorAlgorithm(key as AlgorithmId)}
+            aria-label="Color algorithm"
+          >
+            <Button size="sm" className="w-full justify-between">
+              <SelectValue className="truncate" />
+              <ChevronDownIcon data-icon-end="" />
+            </Button>
+            <Popover>
+              <ListBox>
+                {ALGORITHMS.map((a) => (
+                  <ListBoxItem key={a.id} id={a.id}>
+                    {a.label}
+                  </ListBoxItem>
+                ))}
+              </ListBox>
+            </Popover>
+          </Select>
+        </Field>
+        <ColorKnobsControls
+          algorithm={config.algorithm}
+          knobs={config.knobs ?? {}}
+          steps={resolved.steps}
+          onChange={setColorKnob}
+        />
+      </Section>
+
+      {/* Foundation: palettes vs semantic tokens — "palettes or not". */}
+      <Section
+        title="Foundation"
+        aside={
+          <Segmented<RampMode>
+            ariaLabel="Ramp mode"
+            value={rampMode}
+            onChange={setRampMode}
+            options={[
+              { value: 'light', label: 'Light' },
+              { value: 'dark', label: 'Dark' },
+            ]}
+          />
+        }
+      >
+        <OptionGrid<Foundation>
+          value={foundation}
+          onChange={setFoundation}
+          options={[
+            {
+              value: 'palettes',
+              label: 'Palettes',
+              description: 'Expose full 50–950 ramps',
+              icon: PaintBucketIcon,
+            },
+            {
+              value: 'semantic',
+              label: 'Semantic only',
+              description: 'Just roles: bg, fg, primary…',
+              icon: PipetteIcon,
+            },
+          ]}
+        />
+
+        {foundation === 'palettes' ? (
+          <div className="flex flex-col gap-2">
+            {PALETTE_ORDER.map((palette) => {
+              const ramp = ramps[palette]
+              if (!ramp) return null
+              return (
+                <div key={palette} className="flex flex-col gap-1">
+                  <span className="text-[10px] tracking-wide text-fg-muted capitalize">
+                    {palette}
+                  </span>
+                  <div className="flex overflow-hidden rounded-md">
+                    {Object.entries(ramp).map(([step, value]) => (
+                      <div
+                        key={step}
+                        className="h-6 flex-1"
+                        style={{ backgroundColor: value }}
+                        title={`--${palette}-${step}: ${value}`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <SemanticTokens ramps={ramps} />
+        )}
+
+        <InlineRow
+          label="Context-aware tokens"
+          hint="Re-map roles inside cards & overlays"
+        >
+          <Switch
+            isSelected={contextAware}
+            onChange={setContextAware}
+            aria-label="Context-aware tokens"
+          />
+        </InlineRow>
+      </Section>
+
+      {/* Accessibility — live WCAG readout from the resolved ramps. */}
+      <Section title="Accessibility">
+        <ContrastReadout resolved={resolved} />
+      </Section>
+    </div>
+  )
+}
+
+/** Semantic roles derived from the resolved ramps for an at-a-glance token map. */
+function SemanticTokens({
+  ramps,
+}: {
+  ramps: Record<string, Record<string, string>>
+}) {
+  const roles: Array<{ name: string; value: string | undefined }> = [
+    { name: 'background', value: rampAt(ramps.neutral, '50') },
+    { name: 'foreground', value: rampAt(ramps.neutral, '950') },
+    { name: 'muted', value: rampAt(ramps.neutral, '100') },
+    { name: 'border', value: rampAt(ramps.neutral, '200') },
+    { name: 'primary', value: rampAt(ramps.accent, '600') },
+    { name: 'success', value: rampAt(ramps.success, '600') },
+    { name: 'warning', value: rampAt(ramps.warning, '500') },
+    { name: 'danger', value: rampAt(ramps.danger, '600') },
+  ]
+  return (
+    <div className="grid grid-cols-2 gap-1.5">
+      {roles.map((role) => (
+        <div
+          key={role.name}
+          className="flex items-center gap-2 rounded-md border bg-card p-1.5"
+        >
+          <div
+            className={cn('size-6 shrink-0 rounded border')}
+            style={{ backgroundColor: role.value }}
+          />
+          <div className="flex min-w-0 flex-col">
+            <span className="truncate text-[11px] font-medium">
+              {role.name}
+            </span>
+            <span className="truncate font-mono text-[10px] text-fg-muted">
+              {role.value}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspectors/components.tsx
+++ b/www/src/modules/create/studio/inspectors/components.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  LinkIcon,
+  SearchIcon,
+  SlidersHorizontalIcon,
+} from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import type { RegistryItem } from '@/registry/types'
+import { Button } from '@/registry/ui/button'
+import { registryUi } from '@/registry/ui/registry'
+
+import { ExamplesIndex } from '../../__generated__/examples'
+import { ComponentDetailView, getComponentDisplayName } from '../../components'
+import { useDesignSystem } from '../../preset'
+import { Section } from '../primitives'
+import { useStudio } from '../store'
+
+const routeApi = getRouteApi('/_app/create')
+
+function titleCase(slug: string) {
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+const TWEAKABLE = registryUi
+  .filter((i) => i.params && Object.keys(i.params).length > 0)
+  .sort((a, b) => a.name.localeCompare(b.name))
+
+const BY_GROUP = (() => {
+  const map = new Map<string, RegistryItem[]>()
+  for (const item of TWEAKABLE) {
+    const key = item.group ?? 'other'
+    const list = map.get(key) ?? []
+    list.push(item)
+    map.set(key, list)
+  }
+  return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b))
+})()
+
+export function ComponentsInspector() {
+  const { selectedComponent, setSelectedComponent } = useStudio()
+  if (selectedComponent) {
+    return (
+      <ComponentDetail
+        name={selectedComponent}
+        onBack={() => setSelectedComponent(null)}
+      />
+    )
+  }
+  return <ComponentList onSelect={setSelectedComponent} />
+}
+
+function ComponentList({ onSelect }: { onSelect: (name: string) => void }) {
+  const navigate = routeApi.useNavigate()
+  const [query, setQuery] = useState('')
+
+  const groups = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return BY_GROUP
+    return BY_GROUP.map(
+      ([group, items]) =>
+        [group, items.filter((i) => i.name.toLowerCase().includes(q))] as const,
+    ).filter(([, items]) => items.length > 0)
+  }, [query])
+
+  function select(name: string) {
+    onSelect(name)
+    // Switch the canvas to the component being tuned, like the old panel did.
+    if (name in ExamplesIndex) {
+      navigate({ search: (prev) => ({ ...prev, preview: name }) })
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-center gap-2 rounded-md border bg-bg px-2.5 focus-within:focus-ring">
+        <SearchIcon className="size-4 shrink-0 text-fg-muted" />
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search components…"
+          className="h-8 w-full bg-transparent text-[13px] outline-none placeholder:text-fg-muted"
+        />
+      </div>
+
+      {groups.length === 0 && (
+        <p className="px-1 text-xs text-fg-muted">No components match.</p>
+      )}
+
+      {groups.map(([group, items]) => (
+        <Section key={group} title={titleCase(group)}>
+          <div className="flex flex-col gap-1">
+            {items.map((item) => {
+              const count = item.params ? Object.keys(item.params).length : 0
+              return (
+                <ButtonPrimitives.Button
+                  key={item.name}
+                  onPress={() => select(item.name)}
+                  className="group/row flex items-center justify-between gap-2 rounded-md border bg-card px-3 py-2 text-left focus-reset transition-colors hover:border-fg-muted/30 hover:bg-neutral focus-visible:focus-ring"
+                >
+                  <span className="text-[13px] font-medium">
+                    {titleCase(item.name)}
+                  </span>
+                  <span className="flex items-center gap-2 text-[11px] text-fg-muted">
+                    <span className="flex items-center gap-1">
+                      <SlidersHorizontalIcon className="size-3" />
+                      {count}
+                    </span>
+                    <ChevronRightIcon className="size-4 text-fg-muted/60 transition-transform group-hover/row:translate-x-0.5" />
+                  </span>
+                </ButtonPrimitives.Button>
+              )
+            })}
+          </div>
+        </Section>
+      ))}
+    </div>
+  )
+}
+
+function ComponentDetail({
+  name,
+  onBack,
+}: {
+  name: string
+  onBack: () => void
+}) {
+  const { designSystem, setComponentParam } = useDesignSystem()
+  const meta = registryUi.find((i) => i.name === name)
+  const siblings = meta?.group
+    ? TWEAKABLE.filter((i) => i.group === meta.group && i.name !== name)
+    : []
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-center gap-2">
+        <Button
+          variant="quiet"
+          size="sm"
+          isIconOnly
+          onPress={onBack}
+          aria-label="Back to components"
+          className="-ml-1 size-7"
+        >
+          <ChevronLeftIcon />
+        </Button>
+        <h3 className="text-sm font-semibold">
+          {getComponentDisplayName(name)}
+        </h3>
+      </div>
+
+      {siblings.length > 0 && (
+        <div className="flex items-start gap-2 rounded-md border border-primary/30 bg-primary/8 p-2.5 text-[11px] leading-snug text-fg-muted">
+          <LinkIcon className="mt-0.5 size-3.5 shrink-0 text-primary" />
+          <span>
+            Style is <span className="font-medium text-fg">synced</span> with{' '}
+            {siblings.map((s, i) => (
+              <span key={s.name}>
+                {i > 0 && ', '}
+                <button
+                  type="button"
+                  onClick={onBack}
+                  className="font-medium text-fg underline-offset-2 hover:underline"
+                >
+                  {titleCase(s.name)}
+                </button>
+              </span>
+            ))}
+            . Changes apply to the whole group.
+          </span>
+        </div>
+      )}
+
+      <div
+        className={cn('**:data-label:text-fg-muted', '[&_[data-label]]:pl-0')}
+      >
+        <ComponentDetailView
+          componentName={name}
+          selectedParams={designSystem.componentParams[name] ?? {}}
+          onParamChange={(param, value) =>
+            setComponentParam(name, param, value)
+          }
+        />
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspectors/cursor.tsx
+++ b/www/src/modules/create/studio/inspectors/cursor.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { ChevronDownIcon, MousePointer2Icon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+import { Popover } from '@/registry/ui/popover'
+import { Select, SelectValue } from '@/registry/ui/select'
+
+import {
+  CURSOR_DISABLED_VAR,
+  CURSOR_INTERACTIVE_VAR,
+  DEFAULT_CURSOR_DISABLED,
+  DEFAULT_CURSOR_INTERACTIVE,
+} from '../../cursor'
+import { Field, Section } from '../primitives'
+import { useToken } from '../tokens'
+
+const CURSORS = [
+  'default',
+  'pointer',
+  'not-allowed',
+  'wait',
+  'progress',
+  'text',
+  'grab',
+  'crosshair',
+]
+
+function CursorSelect({
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  value: string
+  onChange: (v: string) => void
+  ariaLabel: string
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Select
+        className="flex-1"
+        selectedKey={value}
+        onSelectionChange={(k) => onChange(k as string)}
+        aria-label={ariaLabel}
+      >
+        <Button size="sm" className="w-full justify-between">
+          <SelectValue className="truncate capitalize" />
+          <ChevronDownIcon data-icon-end="" />
+        </Button>
+        <Popover>
+          <ListBox>
+            {CURSORS.map((c) => (
+              <ListBoxItem key={c} id={c} className="capitalize">
+                {c}
+              </ListBoxItem>
+            ))}
+          </ListBox>
+        </Popover>
+      </Select>
+      <div
+        className="flex size-8 shrink-0 items-center justify-center rounded-md border text-fg-muted"
+        style={{ cursor: value }}
+      >
+        <MousePointer2Icon className="size-4" />
+      </div>
+    </div>
+  )
+}
+
+export function CursorInspector() {
+  const [interactive, setInteractive] = useToken(
+    CURSOR_INTERACTIVE_VAR,
+    DEFAULT_CURSOR_INTERACTIVE,
+  )
+  const [disabled, setDisabled] = useToken(
+    CURSOR_DISABLED_VAR,
+    DEFAULT_CURSOR_DISABLED,
+  )
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Section title="Pointer feedback">
+        <Field
+          label="Interactive"
+          live
+          hint="Cursor over buttons, links and other actionable elements."
+        >
+          <CursorSelect
+            ariaLabel="Interactive cursor"
+            value={interactive}
+            onChange={setInteractive}
+          />
+        </Field>
+        <Field label="Disabled" live hint="Cursor over disabled controls.">
+          <CursorSelect
+            ariaLabel="Disabled cursor"
+            value={disabled}
+            onChange={setDisabled}
+          />
+        </Field>
+      </Section>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspectors/elevation.tsx
+++ b/www/src/modules/create/studio/inspectors/elevation.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { BoxIcon, GlassWaterIcon, LayersIcon, SquareIcon } from 'lucide-react'
+
+import { Field, OptionGrid, Section, ValueSlider } from '../primitives'
+import {
+  BACKDROP_BLUR_VAR,
+  ELEVATION_STYLE_VAR,
+  SHADOW_INTENSITY_VAR,
+  useNumberToken,
+  useToken,
+} from '../tokens'
+
+const STYLES = [
+  {
+    value: 'flat',
+    label: 'Flat',
+    description: 'No shadow, hairline borders',
+    icon: SquareIcon,
+  },
+  {
+    value: 'soft',
+    label: 'Soft',
+    description: 'Subtle ambient shadow',
+    icon: LayersIcon,
+  },
+  {
+    value: 'depth',
+    label: '3D',
+    description: 'Pronounced layered depth',
+    icon: BoxIcon,
+  },
+  {
+    value: 'glass',
+    label: 'Glass',
+    description: 'Frosted, translucent',
+    icon: GlassWaterIcon,
+  },
+] as const
+
+export function ElevationInspector() {
+  const [style, setStyle] = useToken(ELEVATION_STYLE_VAR, 'soft')
+  const [intensity, setIntensity] = useNumberToken(SHADOW_INTENSITY_VAR, 0.5)
+  const [blur, setBlur] = useNumberToken(BACKDROP_BLUR_VAR, 0)
+
+  // A specimen card whose shadow tracks the chosen intensity + style.
+  const shadow =
+    style === 'flat'
+      ? 'none'
+      : style === 'glass'
+        ? `0 8px 32px rgba(0,0,0,${0.12 * intensity})`
+        : style === 'depth'
+          ? `0 1px 2px rgba(0,0,0,${0.2 * intensity}), 0 12px 24px -6px rgba(0,0,0,${0.35 * intensity})`
+          : `0 1px 3px rgba(0,0,0,${0.18 * intensity})`
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Section title="Surface style">
+        <OptionGrid value={style} onChange={setStyle} options={STYLES} />
+        {/* Specimen */}
+        <div className="flex items-center justify-center rounded-lg border bg-neutral p-6">
+          <div
+            className="flex h-20 w-32 items-center justify-center rounded-lg border bg-card text-xs text-fg-muted"
+            style={{
+              boxShadow: shadow,
+              backdropFilter: blur ? `blur(${blur}px)` : undefined,
+            }}
+          >
+            Card
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Shadow">
+        <Field label="Intensity" value={`${Math.round(intensity * 100)}%`}>
+          <ValueSlider
+            ariaLabel="Shadow intensity"
+            value={intensity}
+            min={0}
+            max={1}
+            step={0.05}
+            onChange={setIntensity}
+          />
+        </Field>
+        <Field
+          label="Backdrop blur"
+          value={`${blur}px`}
+          hint="Frost behind overlays, menus and popovers."
+        >
+          <ValueSlider
+            ariaLabel="Backdrop blur"
+            value={blur}
+            min={0}
+            max={24}
+            step={1}
+            onChange={setBlur}
+          />
+        </Field>
+      </Section>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspectors/icons.tsx
+++ b/www/src/modules/create/studio/inspectors/icons.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import * as icons from '@/registry/__generated__/icons'
+
+import { Field, OptionGrid, Section, ValueSlider } from '../primitives'
+import {
+  ICON_LIBRARY_VAR,
+  ICON_STROKE_VAR,
+  useNumberToken,
+  useToken,
+} from '../tokens'
+
+const LIBRARIES = [
+  { value: 'lucide', label: 'Lucide', description: 'Default — 1400+ icons' },
+  { value: 'tabler', label: 'Tabler', description: 'Crisp, consistent' },
+  { value: 'hugeicons', label: 'Hugeicons', description: 'Large, expressive' },
+  { value: 'remix', label: 'Remix', description: 'Filled + outline' },
+] as const
+
+const PREVIEW = Object.entries(icons)
+  .sort(([a], [b]) => a.localeCompare(b))
+  .slice(0, 24)
+
+export function IconsInspector() {
+  const [library, setLibrary] = useToken(ICON_LIBRARY_VAR, 'lucide')
+  const [stroke, setStroke] = useNumberToken(ICON_STROKE_VAR, 2)
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Section title="Library">
+        <OptionGrid value={library} onChange={setLibrary} options={LIBRARIES} />
+      </Section>
+
+      <Section title="Stroke">
+        <Field label="Stroke width" value={`${stroke}px`}>
+          <ValueSlider
+            ariaLabel="Icon stroke"
+            value={stroke}
+            min={1}
+            max={2.5}
+            step={0.25}
+            onChange={setStroke}
+          />
+        </Field>
+      </Section>
+
+      <Section title="Preview">
+        <div className="grid grid-cols-8 gap-2 rounded-lg border bg-card p-3 text-fg [&_svg]:size-5">
+          {PREVIEW.map(([name, Icon]) => (
+            <div
+              key={name}
+              className="flex items-center justify-center text-fg-muted"
+            >
+              <Icon strokeWidth={stroke} />
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspectors/motion.tsx
+++ b/www/src/modules/create/studio/inspectors/motion.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Switch } from '@/registry/ui/switch'
+
+import {
+  Field,
+  InlineRow,
+  OptionGrid,
+  Section,
+  ValueSlider,
+} from '../primitives'
+import {
+  MOTION_DURATION_VAR,
+  MOTION_EASING_VAR,
+  MOTION_ENABLED_VAR,
+  useNumberToken,
+  useToken,
+} from '../tokens'
+
+const EASINGS: ReadonlyArray<{ value: string; label: string; css: string }> = [
+  { value: 'standard', label: 'Standard', css: 'cubic-bezier(0.32,0.72,0,1)' },
+  { value: 'snappy', label: 'Snappy', css: 'cubic-bezier(0.5,0,0,1)' },
+  { value: 'gentle', label: 'Gentle', css: 'cubic-bezier(0.4,0,0.2,1)' },
+  { value: 'spring', label: 'Spring', css: 'cubic-bezier(0.34,1.56,0.64,1)' },
+]
+
+export function MotionInspector() {
+  const [duration, setDuration] = useNumberToken(MOTION_DURATION_VAR, 200)
+  const [easing, setEasing] = useToken(MOTION_EASING_VAR, 'standard')
+  const [enabled, setEnabled] = useToken(MOTION_ENABLED_VAR, 'true')
+  const easingCss =
+    EASINGS.find((e) => e.value === easing)?.css ??
+    'cubic-bezier(0.32,0.72,0,1)'
+
+  // Ping-pong a dot so the chosen duration + curve are felt, not just read.
+  const [toggled, setToggled] = useState(false)
+  useEffect(() => {
+    const id = window.setInterval(() => setToggled((t) => !t), 1100)
+    return () => window.clearInterval(id)
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-7">
+      {/* Live specimen — a travelling dot driven by the current settings. */}
+      <div className="rounded-lg border bg-card p-3">
+        <div className="relative h-8 rounded-md bg-neutral">
+          <div
+            className="absolute top-1 size-6 rounded-md bg-primary"
+            style={{
+              left: toggled && enabled === 'true' ? 'calc(100% - 28px)' : '4px',
+              transition:
+                enabled === 'true' ? `left ${duration}ms ${easingCss}` : 'none',
+            }}
+          />
+        </div>
+      </div>
+
+      <Section title="Timing">
+        <Field
+          label="Duration"
+          value={`${duration}ms`}
+          hint="Baseline transition speed."
+        >
+          <ValueSlider
+            ariaLabel="Duration"
+            value={duration}
+            min={0}
+            max={500}
+            step={10}
+            onChange={setDuration}
+          />
+        </Field>
+        <Field label="Easing curve">
+          <OptionGrid value={easing} onChange={setEasing} options={EASINGS} />
+        </Field>
+      </Section>
+
+      <Section title="Preferences">
+        <InlineRow label="Animations" hint="Global on/off for transitions">
+          <Switch
+            isSelected={enabled === 'true'}
+            onChange={(s) => setEnabled(String(s))}
+            aria-label="Animations"
+          />
+        </InlineRow>
+      </Section>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspectors/shape.tsx
+++ b/www/src/modules/create/studio/inspectors/shape.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { DEFAULT_RADIUS_FACTOR, RADIUS_FACTOR_VAR } from '../../layout'
+import { Field, Section, ValueSlider } from '../primitives'
+import { useNumberToken } from '../tokens'
+
+const RADIUS_PREVIEW = [
+  { label: 'sm', scale: 0.5 },
+  { label: 'md', scale: 1 },
+  { label: 'lg', scale: 1.5 },
+  { label: 'xl', scale: 2.5 },
+]
+
+export function ShapeInspector() {
+  const [factor, setFactor] = useNumberToken(
+    RADIUS_FACTOR_VAR,
+    Number.parseFloat(DEFAULT_RADIUS_FACTOR),
+  )
+  const [border, setBorder] = useNumberToken('--ds-border-width', 1)
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Section title="Corner radius">
+        <Field
+          label="Radius factor"
+          live
+          value={`${factor.toFixed(2)}×`}
+          hint="Scales the whole corner-radius ramp at once."
+        >
+          <ValueSlider
+            ariaLabel="Radius factor"
+            value={factor}
+            min={0}
+            max={2}
+            step={0.05}
+            onChange={setFactor}
+          />
+        </Field>
+        {/* Live specimen — each tile multiplies the base radius by the factor. */}
+        <div className="flex items-end justify-between gap-2 rounded-lg border bg-card p-3">
+          {RADIUS_PREVIEW.map((r) => (
+            <div key={r.label} className="flex flex-col items-center gap-1.5">
+              <div
+                className="size-11 border-2 border-primary/40 bg-primary/10"
+                style={{
+                  borderRadius: `calc(0.5rem * ${r.scale} * ${factor})`,
+                }}
+              />
+              <span className="font-mono text-[10px] text-fg-muted">
+                {r.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Borders">
+        <Field label="Border width" value={`${border}px`}>
+          <ValueSlider
+            ariaLabel="Border width"
+            value={border}
+            min={0}
+            max={3}
+            step={0.5}
+            onChange={setBorder}
+          />
+        </Field>
+      </Section>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspectors/spacing.tsx
+++ b/www/src/modules/create/studio/inspectors/spacing.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useDesignSystem } from '../../preset'
+import { Field, Section, Segmented, ValueSlider } from '../primitives'
+import { SPACING_SCALE_VAR, useNumberToken } from '../tokens'
+
+const DENSITY_GAP: Record<string, number> = {
+  compact: 4,
+  default: 7,
+  comfortable: 11,
+}
+
+export function SpacingInspector() {
+  const { designSystem, setDensity } = useDesignSystem()
+  const density = designSystem.density
+  const [scale, setScale] = useNumberToken(SPACING_SCALE_VAR, 1)
+  const gap = DENSITY_GAP[density] ?? 7
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Section title="Density">
+        <Field
+          label="Density"
+          live
+          hint="Global control heights, gaps and padding."
+        >
+          <Segmented
+            ariaLabel="Density"
+            value={density}
+            onChange={setDensity}
+            options={[
+              { value: 'compact', label: 'Compact' },
+              { value: 'default', label: 'Default' },
+              { value: 'comfortable', label: 'Cozy' },
+            ]}
+          />
+        </Field>
+        {/* Live specimen — stacked bars whose gap tracks the chosen density. */}
+        <div
+          className="flex flex-col rounded-lg border bg-card p-3"
+          style={{ gap: `${gap}px` }}
+        >
+          {[0.9, 0.6, 0.75].map((w, i) => (
+            <div
+              key={i}
+              className="h-2.5 rounded-full bg-fg-muted/25"
+              style={{ width: `${w * 100}%` }}
+            />
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Spacing scale">
+        <Field
+          label="Scale multiplier"
+          value={`${scale.toFixed(2)}×`}
+          hint="Stretch or tighten every spacing token together."
+        >
+          <ValueSlider
+            ariaLabel="Spacing scale"
+            value={scale}
+            min={0.75}
+            max={1.5}
+            step={0.05}
+            onChange={setScale}
+          />
+        </Field>
+      </Section>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspectors/typography.tsx
+++ b/www/src/modules/create/studio/inspectors/typography.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { ChevronDownIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+import { Popover } from '@/registry/ui/popover'
+import { Select, SelectValue } from '@/registry/ui/select'
+
+import { Field, OptionGrid, Section, ValueSlider } from '../primitives'
+import {
+  FONT_BODY_VAR,
+  FONT_HEADING_VAR,
+  LETTER_SPACING_VAR,
+  TYPE_BASE_VAR,
+  TYPE_SCALE_VAR,
+  useNumberToken,
+  useToken,
+} from '../tokens'
+
+const FONTS = [
+  'Geist',
+  'Inter',
+  'Satoshi',
+  'General Sans',
+  'IBM Plex Sans',
+  'Söhne',
+  'Instrument Serif',
+  'JetBrains Mono',
+]
+
+const PAIRINGS: ReadonlyArray<{
+  value: string
+  label: string
+  description: string
+}> = [
+  { value: 'Geist', label: 'Geist', description: 'Neutral & modern' },
+  { value: 'Inter', label: 'Inter', description: 'Workhorse UI' },
+  {
+    value: 'Instrument Serif',
+    label: 'Editorial',
+    description: 'Serif display',
+  },
+  { value: 'IBM Plex Sans', label: 'Technical', description: 'Plex family' },
+]
+
+function FontSelect({
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  value: string
+  onChange: (v: string) => void
+  ariaLabel: string
+}) {
+  return (
+    <Select
+      className="w-full"
+      selectedKey={value}
+      onSelectionChange={(k) => onChange(k as string)}
+      aria-label={ariaLabel}
+    >
+      <Button size="sm" className="w-full justify-between">
+        <SelectValue className="truncate" />
+        <ChevronDownIcon data-icon-end="" />
+      </Button>
+      <Popover>
+        <ListBox>
+          {FONTS.map((f) => (
+            <ListBoxItem key={f} id={f}>
+              {f}
+            </ListBoxItem>
+          ))}
+        </ListBox>
+      </Popover>
+    </Select>
+  )
+}
+
+export function TypographyInspector() {
+  const [heading, setHeading] = useToken(FONT_HEADING_VAR, 'Geist')
+  const [body, setBody] = useToken(FONT_BODY_VAR, 'Geist')
+  const [scale, setScale] = useNumberToken(TYPE_SCALE_VAR, 1.25)
+  const [base, setBase] = useNumberToken(TYPE_BASE_VAR, 16)
+  const [tracking, setTracking] = useNumberToken(LETTER_SPACING_VAR, 0)
+
+  return (
+    <div className="flex flex-col gap-7">
+      {/* Live specimen. */}
+      <div className="flex flex-col gap-2 rounded-lg border bg-card p-4">
+        <span
+          className="leading-none font-semibold"
+          style={{
+            fontFamily: heading,
+            fontSize: base * scale * scale,
+            letterSpacing: `${tracking}em`,
+          }}
+        >
+          The quick brown fox
+        </span>
+        <p
+          className="text-fg-muted"
+          style={{
+            fontFamily: body,
+            fontSize: base,
+            letterSpacing: `${tracking}em`,
+          }}
+        >
+          Jumps over the lazy dog — a complete component library, generated from
+          your brand and ready to ship anywhere.
+        </p>
+      </div>
+
+      <Section title="Quick pairings">
+        <OptionGrid
+          value={PAIRINGS.some((p) => p.value === heading) ? heading : ''}
+          onChange={(v) => {
+            setHeading(v)
+            setBody(v)
+          }}
+          options={PAIRINGS}
+        />
+      </Section>
+
+      <Section title="Fonts">
+        <Field label="Display / headings">
+          <FontSelect
+            ariaLabel="Heading font"
+            value={heading}
+            onChange={setHeading}
+          />
+        </Field>
+        <Field label="Body / UI">
+          <FontSelect ariaLabel="Body font" value={body} onChange={setBody} />
+        </Field>
+      </Section>
+
+      <Section title="Rhythm">
+        <Field
+          label="Scale ratio"
+          value={scale.toFixed(3)}
+          hint="Modular ratio between steps."
+        >
+          <ValueSlider
+            ariaLabel="Type scale ratio"
+            value={scale}
+            min={1.1}
+            max={1.5}
+            step={0.005}
+            onChange={setScale}
+          />
+        </Field>
+        <Field label="Base size" value={`${base}px`}>
+          <ValueSlider
+            ariaLabel="Base size"
+            value={base}
+            min={13}
+            max={18}
+            step={1}
+            onChange={setBase}
+          />
+        </Field>
+        <Field label="Letter spacing" value={`${tracking.toFixed(3)}em`}>
+          <ValueSlider
+            ariaLabel="Letter spacing"
+            value={tracking}
+            min={-0.03}
+            max={0.05}
+            step={0.005}
+            onChange={setTracking}
+          />
+        </Field>
+      </Section>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/navigator.tsx
+++ b/www/src/modules/create/studio/navigator.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { motion } from 'motion/react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { type Axis, AXES } from './axes'
+import { useStudio } from './store'
+
+const GROUPS: Array<{ key: string; items: Axis[] }> = [
+  { key: 'start', items: AXES.filter((a) => a.group === 'start') },
+  { key: 'foundations', items: AXES.filter((a) => a.group === 'foundations') },
+  { key: 'surface', items: AXES.filter((a) => a.group === 'surface') },
+]
+
+export function Navigator({ className }: { className?: string }) {
+  const { axis, setAxis } = useStudio()
+
+  return (
+    <nav
+      className={cn(
+        'flex shrink-0 flex-col items-center gap-1 rounded-xl border bg-card p-2',
+        className,
+      )}
+      aria-label="Design system axes"
+    >
+      {GROUPS.map((group, i) => (
+        <div key={group.key} className="flex flex-col items-center gap-1">
+          {i > 0 && <div className="my-1 h-px w-7 bg-border" />}
+          {group.items.map((item) => {
+            const active = axis === item.id
+            return (
+              <Tooltip key={item.id} delay={250}>
+                <ButtonPrimitives.Button
+                  onPress={() => setAxis(item.id)}
+                  data-active={active || undefined}
+                  className={cn(
+                    'group/nav relative flex w-[60px] flex-col items-center gap-1 rounded-lg py-2 focus-reset transition-colors focus-visible:focus-ring',
+                    active
+                      ? 'text-primary'
+                      : 'text-fg-muted hover:bg-neutral hover:text-fg',
+                  )}
+                >
+                  {active && (
+                    <motion.span
+                      layoutId="nav-active"
+                      transition={{
+                        type: 'spring',
+                        stiffness: 500,
+                        damping: 40,
+                      }}
+                      className="absolute inset-0 -z-10 rounded-lg bg-primary/10 ring-1 ring-primary/25"
+                    />
+                  )}
+                  <item.icon className="size-4.5" />
+                  <span className="text-[10px] leading-none font-medium">
+                    {item.label}
+                  </span>
+                </ButtonPrimitives.Button>
+                <TooltipContent placement="right">
+                  {item.tagline}
+                </TooltipContent>
+              </Tooltip>
+            )
+          })}
+        </div>
+      ))}
+    </nav>
+  )
+}

--- a/www/src/modules/create/studio/onboarding.tsx
+++ b/www/src/modules/create/studio/onboarding.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  ArrowRightIcon,
+  GlobeIcon,
+  ImageIcon,
+  WandSparklesIcon,
+  XIcon,
+} from 'lucide-react'
+import { motion } from 'motion/react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import type { Density } from '@/registry/types'
+import { Button } from '@/registry/ui/button'
+
+import { RADIUS_FACTOR_VAR } from '../layout'
+import { useDesignSystem } from '../preset'
+import { SwatchButton } from './primitives'
+import { useStudio } from './store'
+import { ELEVATION_STYLE_VAR } from './tokens'
+
+const SWATCHES = [
+  '#2563eb',
+  '#6366f1',
+  '#8b5cf6',
+  '#ec4899',
+  '#f43f5e',
+  '#f59e0b',
+  '#10b981',
+  '#06b6d4',
+  '#111827',
+]
+
+interface Vibe {
+  id: string
+  label: string
+  radius: number
+  density: Density
+  elevation: string
+}
+
+const VIBES: Vibe[] = [
+  {
+    id: 'minimal',
+    label: 'Minimal',
+    radius: 0.5,
+    density: 'compact',
+    elevation: 'flat',
+  },
+  {
+    id: 'modern',
+    label: 'Modern',
+    radius: 1,
+    density: 'default',
+    elevation: 'soft',
+  },
+  {
+    id: 'playful',
+    label: 'Playful',
+    radius: 2,
+    density: 'comfortable',
+    elevation: 'soft',
+  },
+  {
+    id: 'glass',
+    label: 'Soft glass',
+    radius: 1.5,
+    density: 'default',
+    elevation: 'glass',
+  },
+]
+
+export function Onboarding() {
+  const { setOnboardingOpen } = useStudio()
+  const { designSystem, setDesignSystem } = useDesignSystem()
+  const [accent, setAccent] = useState(
+    designSystem.color?.seeds.accent ?? DEFAULT_COLOR_CONFIG.seeds.accent,
+  )
+  const [vibe, setVibe] = useState<string>('modern')
+
+  function close() {
+    setOnboardingOpen(false)
+  }
+
+  function generate() {
+    const v = VIBES.find((x) => x.id === vibe)
+    if (!v) {
+      close()
+      return
+    }
+    setDesignSystem((prev) => {
+      const base = prev.color ?? DEFAULT_COLOR_CONFIG
+      return {
+        ...prev,
+        density: v.density,
+        tokens: {
+          ...prev.tokens,
+          [RADIUS_FACTOR_VAR]: String(v.radius),
+          [ELEVATION_STYLE_VAR]: v.elevation,
+        },
+        color: { ...base, seeds: { ...base.seeds, accent } },
+      }
+    })
+    close()
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+      className="absolute inset-0 z-40 flex items-center justify-center bg-bg/70 p-4 backdrop-blur-md"
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.97, y: 10 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.98, y: 6 }}
+        transition={{ duration: 0.24, ease: [0.32, 0.72, 0, 1] }}
+        className="relative flex w-full max-w-lg flex-col gap-6 rounded-2xl border bg-card p-6 shadow-2xl"
+      >
+        <Button
+          variant="quiet"
+          size="sm"
+          isIconOnly
+          onPress={close}
+          aria-label="Close generator"
+          className="absolute top-3 right-3"
+        >
+          <XIcon />
+        </Button>
+
+        <div className="flex flex-col items-center gap-2 pt-2 text-center">
+          <div className="flex size-11 items-center justify-center rounded-xl bg-primary text-fg-on-primary shadow-sm">
+            <WandSparklesIcon className="size-5.5" />
+          </div>
+          <h1 className="text-lg font-semibold">Generate your design system</h1>
+          <p className="max-w-sm text-[13px] text-fg-muted">
+            Start from a single color or your brand. Everything — palettes,
+            type, shape, depth — is generated, then yours to refine.
+          </p>
+        </div>
+
+        {/* Seed */}
+        <div className="flex flex-col gap-3">
+          <span className="text-[11px] font-semibold tracking-wider text-fg-muted uppercase">
+            Brand color
+          </span>
+          <div className="flex flex-wrap items-center gap-2">
+            {SWATCHES.map((hex) => (
+              <ButtonPrimitives.Button
+                key={hex}
+                onPress={() => setAccent(hex)}
+                aria-label={hex}
+                className={cn(
+                  'size-8 rounded-full border focus-reset transition-transform hover:scale-110 focus-visible:focus-ring',
+                  accent.toLowerCase() === hex.toLowerCase() &&
+                    'ring-2 ring-primary ring-offset-2 ring-offset-card',
+                )}
+                style={{ backgroundColor: hex }}
+              />
+            ))}
+            <div className="ml-1 w-32">
+              <SwatchButton
+                ariaLabel="Custom brand color"
+                value={accent}
+                onChange={setAccent}
+              />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-dashed py-2 text-[12px] text-fg-muted transition-colors hover:border-fg-muted/40 hover:bg-neutral"
+            >
+              <ImageIcon className="size-3.5" /> Upload logo
+            </button>
+            <button
+              type="button"
+              className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-dashed py-2 text-[12px] text-fg-muted transition-colors hover:border-fg-muted/40 hover:bg-neutral"
+            >
+              <GlobeIcon className="size-3.5" /> From URL
+            </button>
+          </div>
+        </div>
+
+        {/* Vibe */}
+        <div className="flex flex-col gap-3">
+          <span className="text-[11px] font-semibold tracking-wider text-fg-muted uppercase">
+            Vibe
+          </span>
+          <div className="grid grid-cols-4 gap-2">
+            {VIBES.map((v) => {
+              const active = v.id === vibe
+              return (
+                <ButtonPrimitives.Button
+                  key={v.id}
+                  onPress={() => setVibe(v.id)}
+                  className={cn(
+                    'flex flex-col items-center gap-2 rounded-lg border p-3 focus-reset transition-colors focus-visible:focus-ring',
+                    active
+                      ? 'border-primary bg-primary/8 ring-1 ring-primary/30'
+                      : 'hover:border-fg-muted/30 hover:bg-neutral',
+                  )}
+                >
+                  <span
+                    className="h-8 w-full border bg-card"
+                    style={{
+                      borderRadius: `calc(0.5rem * ${v.radius})`,
+                      backgroundColor: accent,
+                      opacity: active ? 1 : 0.55,
+                    }}
+                  />
+                  <span className="text-[11px] font-medium">{v.label}</span>
+                </ButtonPrimitives.Button>
+              )
+            })}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 pt-1">
+          <ButtonPrimitives.Button
+            onPress={close}
+            className="text-[13px] text-fg-muted underline-offset-2 focus-reset hover:text-fg hover:underline"
+          >
+            Start from scratch
+          </ButtonPrimitives.Button>
+          <Button variant="primary" onPress={generate} className="gap-1.5">
+            Generate system
+            <ArrowRightIcon data-icon-end="" />
+          </Button>
+        </div>
+      </motion.div>
+    </motion.div>
+  )
+}

--- a/www/src/modules/create/studio/presets.tsx
+++ b/www/src/modules/create/studio/presets.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { useState } from 'react'
+import { LayoutGridIcon } from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import type { AlgorithmId } from '@/registry/theme'
+import type { Density } from '@/registry/types'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Modal } from '@/registry/ui/modal'
+
+import { RADIUS_FACTOR_VAR } from '../layout'
+import { useDesignSystem } from '../preset'
+import { ELEVATION_STYLE_VAR } from './tokens'
+
+interface Preset {
+  id: string
+  name: string
+  tagline: string
+  accent: string
+  neutral?: string
+  algorithm: AlgorithmId
+  radius: number
+  density: Density
+  elevation: string
+}
+
+/* Curated starting points — each a complete, opinionated system you fork and
+   then refine. They cover the spread the builder is meant to reproduce: tight
+   product UIs, soft marketing systems, Material, monochrome, warm editorial. */
+const PRESETS: Preset[] = [
+  {
+    id: 'linear',
+    name: 'Aurora',
+    tagline: 'Tight, cool, product-grade',
+    accent: '#5b5bd6',
+    neutral: '#6e6e80',
+    algorithm: 'oklch',
+    radius: 0.75,
+    density: 'compact',
+    elevation: 'soft',
+  },
+  {
+    id: 'vercel',
+    name: 'Onyx',
+    tagline: 'Monochrome & sharp',
+    accent: '#0070f3',
+    neutral: '#808080',
+    algorithm: 'oklch',
+    radius: 0.4,
+    density: 'compact',
+    elevation: 'flat',
+  },
+  {
+    id: 'stripe',
+    name: 'Violet',
+    tagline: 'Friendly fintech',
+    accent: '#635bff',
+    algorithm: 'oklch',
+    radius: 1,
+    density: 'default',
+    elevation: 'soft',
+  },
+  {
+    id: 'supabase',
+    name: 'Forest',
+    tagline: 'Crisp developer green',
+    accent: '#3ecf8e',
+    algorithm: 'oklch',
+    radius: 0.5,
+    density: 'default',
+    elevation: 'flat',
+  },
+  {
+    id: 'material',
+    name: 'Tonal',
+    tagline: 'Material-style, generous',
+    accent: '#6750a4',
+    algorithm: 'material',
+    radius: 1.75,
+    density: 'comfortable',
+    elevation: 'depth',
+  },
+  {
+    id: 'editorial',
+    name: 'Terracotta',
+    tagline: 'Warm editorial calm',
+    accent: '#c2603f',
+    neutral: '#8a7f76',
+    algorithm: 'oklch',
+    radius: 0.4,
+    density: 'comfortable',
+    elevation: 'flat',
+  },
+  {
+    id: 'glass',
+    name: 'Frost',
+    tagline: 'Soft, translucent depth',
+    accent: '#06b6d4',
+    algorithm: 'oklch',
+    radius: 1.5,
+    density: 'default',
+    elevation: 'glass',
+  },
+  {
+    id: 'bold',
+    name: 'Punch',
+    tagline: 'High-contrast & loud',
+    accent: '#f43f5e',
+    algorithm: 'tailwind',
+    radius: 1,
+    density: 'default',
+    elevation: 'depth',
+  },
+]
+
+export function PresetsButton() {
+  const [open, setOpen] = useState(false)
+  const { setDesignSystem } = useDesignSystem()
+
+  function apply(preset: Preset) {
+    setDesignSystem((prev) => {
+      const base = prev.color ?? DEFAULT_COLOR_CONFIG
+      return {
+        ...prev,
+        density: preset.density,
+        tokens: {
+          ...prev.tokens,
+          [RADIUS_FACTOR_VAR]: String(preset.radius),
+          [ELEVATION_STYLE_VAR]: preset.elevation,
+        },
+        color: {
+          ...base,
+          algorithm: preset.algorithm,
+          seeds: {
+            ...base.seeds,
+            accent: preset.accent,
+            ...(preset.neutral ? { neutral: preset.neutral } : {}),
+          },
+        },
+      }
+    })
+    setOpen(false)
+  }
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="quiet"
+        onPress={() => setOpen(true)}
+        className="gap-1.5 max-sm:hidden"
+      >
+        <LayoutGridIcon />
+        Presets
+      </Button>
+
+      <Modal isOpen={open} onOpenChange={setOpen} isDismissable>
+        <DialogContent className="flex max-h-[80vh] w-full max-w-2xl flex-col gap-4 p-5">
+          <div className="flex flex-col gap-1">
+            <h2 className="text-base font-semibold">Start from a preset</h2>
+            <p className="text-[13px] text-fg-muted">
+              A complete, opinionated system — fork one and make it yours.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-3 overflow-y-auto sm:grid-cols-3">
+            {PRESETS.map((preset) => (
+              <ButtonPrimitives.Button
+                key={preset.id}
+                onPress={() => apply(preset)}
+                className="group/preset flex flex-col gap-3 rounded-xl border p-3 text-left focus-reset transition-colors hover:border-fg-muted/30 hover:bg-neutral focus-visible:focus-ring"
+              >
+                {/* Mini specimen — accent + radius + a faux control. */}
+                <div className="flex flex-col gap-2 rounded-lg border bg-card p-2.5">
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className="size-5 rounded-full border"
+                      style={{ backgroundColor: preset.accent }}
+                    />
+                    <span className="h-2 flex-1 rounded-full bg-fg-muted/20" />
+                  </div>
+                  <span
+                    className="h-6 w-full"
+                    style={{
+                      backgroundColor: preset.accent,
+                      borderRadius: `calc(0.5rem * ${preset.radius})`,
+                    }}
+                  />
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-[13px] font-medium">{preset.name}</span>
+                  <span className="text-[11px] leading-snug text-fg-muted">
+                    {preset.tagline}
+                  </span>
+                  <span className="mt-1 flex flex-wrap gap-1">
+                    {[preset.algorithm, preset.density].map((tag) => (
+                      <span
+                        key={tag}
+                        className={cn(
+                          'rounded-full bg-neutral px-1.5 py-0.5 text-[9px] tracking-wide text-fg-muted uppercase',
+                        )}
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </span>
+                </div>
+              </ButtonPrimitives.Button>
+            ))}
+          </div>
+        </DialogContent>
+      </Modal>
+    </>
+  )
+}

--- a/www/src/modules/create/studio/primitives.tsx
+++ b/www/src/modules/create/studio/primitives.tsx
@@ -1,0 +1,313 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+import { ColorArea } from '@/registry/ui/color-area'
+import { ColorField } from '@/registry/ui/color-field'
+import { ColorPicker } from '@/registry/ui/color-picker'
+import { ColorSlider } from '@/registry/ui/color-slider'
+import { ColorSwatch } from '@/registry/ui/color-swatch'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Input } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { Slider, SliderControl } from '@/registry/ui/slider'
+import { ToggleButton } from '@/registry/ui/toggle-button'
+import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+/* ----------------------------------------------------------------------------
+ * The studio's shared control vocabulary. Every inspector composes these so the
+ * whole surface reads as one instrument — same labels, same rhythm, same dots.
+ * -------------------------------------------------------------------------- */
+
+/** Honest wiring indicator: filled = drives the live preview, hollow = UI stub. */
+export function BindingDot({ live }: { live: boolean }) {
+  return (
+    <Tooltip delay={250}>
+      <span
+        className={cn(
+          'inline-block size-1.5 shrink-0 rounded-full',
+          live ? 'bg-success' : 'border border-fg-muted/50',
+        )}
+        aria-hidden
+      />
+      <TooltipContent>
+        {live
+          ? 'Live — drives the preview now'
+          : 'Designed — wires to the preview as the engine grows'}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+/** A titled block of related controls. */
+export function Section({
+  title,
+  aside,
+  children,
+  className,
+}: {
+  title: string
+  aside?: ReactNode
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <section className={cn('flex flex-col gap-3', className)}>
+      <div className="flex h-5 items-center justify-between">
+        <h3 className="text-[11px] font-semibold tracking-wider text-fg-muted uppercase">
+          {title}
+        </h3>
+        {aside}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+/** A labelled control, stacked. */
+export function Field({
+  label,
+  hint,
+  live,
+  value,
+  children,
+}: {
+  label: string
+  hint?: string
+  live?: boolean
+  /** Optional right-aligned readout next to the label. */
+  value?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[13px] font-medium text-fg">{label}</span>
+          {live != null && <BindingDot live={live} />}
+        </div>
+        {value != null && (
+          <span className="font-mono text-[11px] text-fg-muted tabular-nums">
+            {value}
+          </span>
+        )}
+      </div>
+      {children}
+      {hint && (
+        <p className="text-xs leading-snug text-balance text-fg-muted/80">
+          {hint}
+        </p>
+      )}
+    </div>
+  )
+}
+
+/** Segmented single-select — the workhorse for macro choices. */
+export function Segmented<T extends string>({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+}: {
+  value: T
+  onChange: (value: T) => void
+  options: ReadonlyArray<{ value: T; label: ReactNode }>
+  ariaLabel?: string
+}) {
+  return (
+    <ToggleButtonGroup
+      aria-label={ariaLabel}
+      selectionMode="single"
+      disallowEmptySelection
+      size="sm"
+      selectedKeys={[value]}
+      onSelectionChange={(keys) => {
+        const next = keys.values().next().value
+        if (next) onChange(next as T)
+      }}
+      className="w-full *:flex-1"
+    >
+      {options.map((opt) => (
+        <ToggleButton key={opt.value} id={opt.value}>
+          {opt.label}
+        </ToggleButton>
+      ))}
+    </ToggleButtonGroup>
+  )
+}
+
+/** Slider over a numeric range. The readout lives in the Field label via `value`. */
+export function ValueSlider({
+  value,
+  onChange,
+  min,
+  max,
+  step,
+  ariaLabel,
+}: {
+  value: number
+  onChange: (value: number) => void
+  min: number
+  max: number
+  step: number
+  ariaLabel?: string
+}) {
+  return (
+    <Slider
+      aria-label={ariaLabel}
+      value={value}
+      minValue={min}
+      maxValue={max}
+      step={step}
+      onChange={(v) => onChange(typeof v === 'number' ? v : (v[0] ?? min))}
+    >
+      <SliderControl />
+    </Slider>
+  )
+}
+
+/** A color swatch + hex that opens a full picker. The studio's seed control. */
+export function SwatchButton({
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  value: string
+  onChange: (hex: string) => void
+  ariaLabel?: string
+}) {
+  return (
+    <ColorPicker value={value} onChange={(c) => onChange(c.toString('hex'))}>
+      {({ color }) => (
+        <>
+          <Button
+            size="sm"
+            aria-label={ariaLabel}
+            className="w-full justify-start pl-2"
+          >
+            <ColorSwatch />
+            <span className="truncate font-mono text-xs">
+              {color.toString('hex')}
+            </span>
+          </Button>
+          <Popover>
+            <DialogContent className="flex flex-col gap-2">
+              <div className="flex gap-2">
+                <ColorArea
+                  colorSpace="hsb"
+                  xChannel="saturation"
+                  yChannel="brightness"
+                />
+                <ColorSlider
+                  orientation="vertical"
+                  colorSpace="hsb"
+                  channel="hue"
+                  className="h-auto self-stretch"
+                />
+              </div>
+              <ColorField aria-label="Hex" className="w-full">
+                <Input size="sm" className="w-full" />
+              </ColorField>
+            </DialogContent>
+          </Popover>
+        </>
+      )}
+    </ColorPicker>
+  )
+}
+
+/** A grid of selectable option cards — vibes, fonts, style families. */
+export function OptionGrid<T extends string>({
+  value,
+  onChange,
+  options,
+  columns = 2,
+}: {
+  value: T
+  onChange: (value: T) => void
+  options: ReadonlyArray<{
+    value: T
+    label: string
+    description?: string
+    icon?: LucideIcon
+    swatch?: ReactNode
+  }>
+  columns?: number
+}) {
+  return (
+    <div
+      className="grid gap-2"
+      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+    >
+      {options.map((opt) => {
+        const active = opt.value === value
+        const Icon = opt.icon
+        return (
+          <ButtonPrimitives.Button
+            key={opt.value}
+            onPress={() => onChange(opt.value)}
+            className={cn(
+              'group/card relative flex flex-col items-start gap-1.5 rounded-lg border p-2.5 text-left focus-reset transition-colors focus-visible:focus-ring',
+              active
+                ? 'border-primary bg-primary/8 ring-1 ring-primary/30'
+                : 'hover:border-fg-muted/30 hover:bg-neutral',
+            )}
+          >
+            {opt.swatch}
+            <div className="flex items-center gap-1.5">
+              {Icon && (
+                <Icon
+                  className={cn(
+                    'size-3.5',
+                    active ? 'text-primary' : 'text-fg-muted',
+                  )}
+                />
+              )}
+              <span className="text-[13px] font-medium">{opt.label}</span>
+            </div>
+            {opt.description && (
+              <span className="text-[11px] leading-snug text-fg-muted">
+                {opt.description}
+              </span>
+            )}
+          </ButtonPrimitives.Button>
+        )
+      })}
+    </div>
+  )
+}
+
+/** A flush row: label left, control right — for compact toggles and selects. */
+export function InlineRow({
+  label,
+  hint,
+  live,
+  children,
+}: {
+  label: string
+  hint?: string
+  live?: boolean
+  children: ReactNode
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex min-w-0 flex-col">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate text-[13px] font-medium text-fg">
+            {label}
+          </span>
+          {live != null && <BindingDot live={live} />}
+        </div>
+        {hint && (
+          <span className="truncate text-[11px] text-fg-muted/80">{hint}</span>
+        )}
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/store.tsx
+++ b/www/src/modules/create/studio/store.tsx
@@ -25,6 +25,8 @@ interface StudioContextValue {
   setSelectedComponent: (name: string | null) => void
   onboardingOpen: boolean
   setOnboardingOpen: (open: boolean) => void
+  commandOpen: boolean
+  setCommandOpen: (open: boolean) => void
   /** Mobile-only: which pane is visible when the two can't sit side by side. */
   mobilePane: 'design' | 'preview'
   setMobilePane: (pane: 'design' | 'preview') => void
@@ -44,6 +46,7 @@ export function StudioProvider({
     null,
   )
   const [onboardingOpen, setOnboardingOpen] = useState(initialOnboarding)
+  const [commandOpen, setCommandOpen] = useState(false)
   const [mobilePane, setMobilePane] = useState<'design' | 'preview'>('design')
 
   const value = useMemo<StudioContextValue>(
@@ -54,10 +57,12 @@ export function StudioProvider({
       setSelectedComponent,
       onboardingOpen,
       setOnboardingOpen,
+      commandOpen,
+      setCommandOpen,
       mobilePane,
       setMobilePane,
     }),
-    [axis, selectedComponent, onboardingOpen, mobilePane],
+    [axis, selectedComponent, onboardingOpen, commandOpen, mobilePane],
   )
 
   return (

--- a/www/src/modules/create/studio/store.tsx
+++ b/www/src/modules/create/studio/store.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+
+import type { AxisId } from './axes'
+
+/* ----------------------------------------------------------------------------
+ * Studio UI state — ephemeral view state only (which axis is open, which
+ * component is selected, the onboarding gate). The *design system itself* lives
+ * in the URL via `useDesignSystem`; this context never touches it. Keeping the
+ * two apart means every edit is shareable/persisted while the chrome stays local.
+ * -------------------------------------------------------------------------- */
+
+interface StudioContextValue {
+  axis: AxisId
+  setAxis: (axis: AxisId) => void
+  /** The component being tuned in the Components inspector (null = list view). */
+  selectedComponent: string | null
+  setSelectedComponent: (name: string | null) => void
+  onboardingOpen: boolean
+  setOnboardingOpen: (open: boolean) => void
+  /** Mobile-only: which pane is visible when the two can't sit side by side. */
+  mobilePane: 'design' | 'preview'
+  setMobilePane: (pane: 'design' | 'preview') => void
+}
+
+const StudioContext = createContext<StudioContextValue | null>(null)
+
+export function StudioProvider({
+  children,
+  initialOnboarding,
+}: {
+  children: ReactNode
+  initialOnboarding: boolean
+}) {
+  const [axis, setAxis] = useState<AxisId>('color')
+  const [selectedComponent, setSelectedComponent] = useState<string | null>(
+    null,
+  )
+  const [onboardingOpen, setOnboardingOpen] = useState(initialOnboarding)
+  const [mobilePane, setMobilePane] = useState<'design' | 'preview'>('design')
+
+  const value = useMemo<StudioContextValue>(
+    () => ({
+      axis,
+      setAxis,
+      selectedComponent,
+      setSelectedComponent,
+      onboardingOpen,
+      setOnboardingOpen,
+      mobilePane,
+      setMobilePane,
+    }),
+    [axis, selectedComponent, onboardingOpen, mobilePane],
+  )
+
+  return (
+    <StudioContext.Provider value={value}>{children}</StudioContext.Provider>
+  )
+}
+
+export function useStudio(): StudioContextValue {
+  const ctx = useContext(StudioContext)
+  if (!ctx) throw new Error('useStudio must be used within <StudioProvider>')
+  return ctx
+}

--- a/www/src/modules/create/studio/tokens-view.tsx
+++ b/www/src/modules/create/studio/tokens-view.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { CheckIcon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import {
+  DEFAULT_COLOR_CONFIG,
+  PALETTE_ORDER,
+  resolveColorConfig,
+} from '@/registry/theme'
+
+import { DEFAULT_RADIUS_FACTOR, RADIUS_FACTOR_VAR } from '../layout'
+import { useDesignSystem } from '../preset'
+import { Segmented } from './primitives'
+
+type Mode = 'light' | 'dark'
+
+/** A live, searchable browser of the resolved design tokens. */
+export function TokensView() {
+  const { designSystem } = useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const resolved = useMemo(() => resolveColorConfig(config), [config])
+  const [mode, setMode] = useState<Mode>('light')
+  const [query, setQuery] = useState('')
+  const [copied, setCopied] = useState<string | null>(null)
+
+  const ramps = mode === 'light' ? resolved.light : resolved.dark
+  const q = query.trim().toLowerCase()
+
+  function copy(token: string, value: string) {
+    navigator.clipboard?.writeText(value).then(
+      () => {
+        setCopied(token)
+        window.setTimeout(() => setCopied(null), 1200)
+      },
+      () => {},
+    )
+  }
+
+  const scalarTokens: Array<{ name: string; value: string }> = [
+    {
+      name: '--radius-factor',
+      value: designSystem.tokens[RADIUS_FACTOR_VAR] ?? DEFAULT_RADIUS_FACTOR,
+    },
+    { name: '--density', value: designSystem.density },
+    ...Object.entries(designSystem.tokens)
+      .filter(([name]) => name !== RADIUS_FACTOR_VAR)
+      .map(([name, value]) => ({ name, value })),
+  ].filter((t) => !q || t.name.toLowerCase().includes(q))
+
+  const palettes = PALETTE_ORDER.filter((p) => !q || p.includes(q))
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-3 border-b px-4 py-2.5">
+        <div className="flex flex-1 items-center gap-2 rounded-md border bg-bg px-2.5 focus-within:focus-ring">
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Filter tokens…"
+            className="h-7 w-full bg-transparent text-[13px] outline-none placeholder:text-fg-muted"
+          />
+        </div>
+        <div className="w-40">
+          <Segmented<Mode>
+            ariaLabel="Token mode"
+            value={mode}
+            onChange={setMode}
+            options={[
+              { value: 'light', label: 'Light' },
+              { value: 'dark', label: 'Dark' },
+            ]}
+          />
+        </div>
+        {copied && (
+          <span className="flex items-center gap-1 text-[11px] text-success">
+            <CheckIcon className="size-3" /> Copied
+          </span>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        <div className="mx-auto flex max-w-3xl flex-col gap-6">
+          {/* Color ramps */}
+          {palettes.length > 0 && (
+            <section className="flex flex-col gap-3">
+              <h3 className="text-[11px] font-semibold tracking-wider text-fg-muted uppercase">
+                Color · {PALETTE_ORDER.length} palettes
+              </h3>
+              <div className="flex flex-col gap-3">
+                {palettes.map((palette) => {
+                  const ramp = ramps[palette]
+                  if (!ramp) return null
+                  return (
+                    <div key={palette} className="flex flex-col gap-1">
+                      <span className="text-[11px] font-medium capitalize">
+                        {palette}
+                      </span>
+                      <div className="grid grid-cols-11 gap-1">
+                        {Object.entries(ramp).map(([step, value]) => {
+                          const token = `--${palette}-${step}`
+                          return (
+                            <button
+                              key={step}
+                              type="button"
+                              onClick={() => copy(token, value)}
+                              title={`${token}: ${value}`}
+                              className="group/swatch flex flex-col items-center gap-1"
+                            >
+                              <span
+                                className="h-9 w-full rounded-md border transition-transform group-hover/swatch:scale-105"
+                                style={{ backgroundColor: value }}
+                              />
+                              <span className="font-mono text-[9px] text-fg-muted">
+                                {step}
+                              </span>
+                            </button>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </section>
+          )}
+
+          {/* Scalar tokens */}
+          {scalarTokens.length > 0 && (
+            <section className="flex flex-col gap-3">
+              <h3 className="text-[11px] font-semibold tracking-wider text-fg-muted uppercase">
+                Foundation
+              </h3>
+              <div className="overflow-hidden rounded-lg border">
+                {scalarTokens.map((t, i) => (
+                  <button
+                    key={t.name}
+                    type="button"
+                    onClick={() => copy(t.name, t.value)}
+                    className={cn(
+                      'flex w-full items-center justify-between gap-4 px-3 py-2 text-left transition-colors hover:bg-neutral',
+                      i > 0 && 'border-t',
+                    )}
+                  >
+                    <span className="font-mono text-[12px] text-fg">
+                      {t.name}
+                    </span>
+                    <span className="truncate font-mono text-[12px] text-fg-muted">
+                      {t.value}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/tokens.ts
+++ b/www/src/modules/create/studio/tokens.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { useDesignSystem } from '../preset'
+
+/* ----------------------------------------------------------------------------
+ * Foundation tokens not yet owned by a component. These write real CSS vars
+ * through the same channel the live axes use — harmless until a component reads
+ * one, then instantly live. Names mirror the existing panel schema so nothing
+ * has to be renamed when the engine grows a consumer.
+ * -------------------------------------------------------------------------- */
+
+export const FONT_HEADING_VAR = '--ds-font-heading'
+export const FONT_BODY_VAR = '--ds-font-body'
+export const TYPE_SCALE_VAR = '--ds-type-scale'
+export const TYPE_BASE_VAR = '--ds-type-base'
+export const LETTER_SPACING_VAR = '--ds-letter-spacing'
+export const FONT_WEIGHT_VAR = '--ds-font-weight'
+
+export const BORDER_WIDTH_VAR = '--ds-border-width'
+export const SPACING_SCALE_VAR = '--ds-spacing-scale'
+
+export const ELEVATION_STYLE_VAR = '--ds-elevation-style'
+export const SHADOW_INTENSITY_VAR = '--ds-shadow-intensity'
+export const BACKDROP_BLUR_VAR = '--ds-backdrop-blur'
+
+export const MOTION_DURATION_VAR = '--ds-motion-duration'
+export const MOTION_EASING_VAR = '--ds-motion-easing'
+export const MOTION_ENABLED_VAR = '--ds-motion-enabled'
+
+export const FOCUS_RING_WIDTH_VAR = '--ds-focus-ring-width'
+
+export const ICON_LIBRARY_VAR = '--ds-icon-library'
+export const ICON_STROKE_VAR = '--ds-icon-stroke'
+
+/** Read+write one global token with a fallback when it's never been set. */
+export function useToken(name: string, fallback: string) {
+  const { designSystem, setToken } = useDesignSystem()
+  const value = designSystem.tokens[name] ?? fallback
+  const set = (v: string) => setToken(name, v)
+  return [value, set] as const
+}
+
+/** Same, parsed as a number. */
+export function useNumberToken(name: string, fallback: number) {
+  const [raw, setRaw] = useToken(name, String(fallback))
+  const value = Number.parseFloat(raw)
+  return [
+    Number.isFinite(value) ? value : fallback,
+    (v: number) => setRaw(String(v)),
+  ] as const
+}

--- a/www/src/modules/create/studio/top-bar.tsx
+++ b/www/src/modules/create/studio/top-bar.tsx
@@ -11,10 +11,14 @@ import {
   Undo2Icon,
 } from 'lucide-react'
 
+import { siteConfig } from '@/config/site'
 import { cn } from '@/registry/lib/utils'
-import { Button } from '@/registry/ui/button'
+import { Button, buttonStyles } from '@/registry/ui/button'
 import { Kbd } from '@/registry/ui/kbd'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+import { GitHubIcon } from '@/components/icons/github'
+import { Logo } from '@/components/layout/logo'
+import { ThemeToggle } from '@/components/theme-toggle'
 
 import { useStudioActions } from './actions'
 import { ExportMenu } from './export-menu'
@@ -66,23 +70,35 @@ export function TopBar() {
     }
   }
 
+  // This single bar replaces the site Header on /create. It stays visually
+  // continuous — same `--header-height`, sticky position, the site Logo (→home
+  // so you can step back out), and the same theme/github right cluster — so
+  // entering the builder reads as "same product, focused mode", not an app
+  // switch. The builder's primary controls live here; secondary tweaks stay in
+  // the panels below.
   return (
-    <header className="flex h-12 shrink-0 items-center gap-3 px-4">
-      {/* Identity */}
-      <div className="flex min-w-0 flex-1 items-center gap-2.5">
-        <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-gradient-to-br from-primary to-primary/70 text-fg-on-primary shadow-sm">
-          <span className="text-xs font-bold">d</span>
+    <header className="sticky top-0 z-30 flex h-(--header-height) shrink-0 items-center gap-3 border-b bg-bg px-4 sm:px-6">
+      {/* Left: site logo (exit → home) then the system identity. */}
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <Logo />
+
+        <div className="h-5 w-px bg-border max-sm:hidden" />
+
+        <div className="flex min-w-0 items-center gap-2">
+          <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-gradient-to-br from-primary to-primary/70 text-fg-on-primary shadow-sm max-sm:hidden">
+            <span className="text-xs font-bold">d</span>
+          </div>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            aria-label="System name"
+            spellCheck={false}
+            className="min-w-0 flex-1 truncate rounded-md bg-transparent px-1.5 py-1 text-sm font-semibold outline-none hover:bg-neutral focus:bg-neutral focus-visible:focus-ring sm:max-w-44 sm:flex-none"
+          />
+          <span className="hidden rounded-full border px-2 py-0.5 text-[10px] font-medium tracking-wide text-fg-muted uppercase sm:inline">
+            Draft
+          </span>
         </div>
-        <input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          aria-label="System name"
-          spellCheck={false}
-          className="min-w-0 flex-1 truncate rounded-md bg-transparent px-1.5 py-1 text-sm font-semibold outline-none hover:bg-neutral focus:bg-neutral focus-visible:focus-ring sm:max-w-44 sm:flex-none"
-        />
-        <span className="hidden rounded-full border px-2 py-0.5 text-[10px] font-medium tracking-wide text-fg-muted uppercase sm:inline">
-          Draft
-        </span>
       </div>
 
       {/* Actions */}
@@ -158,6 +174,23 @@ export function TopBar() {
           <span className="max-sm:hidden">{copied ? 'Copied' : 'Share'}</span>
         </Button>
         <ExportMenu />
+
+        {/* Site continuity cluster — mirrors the global header's right side so
+            stepping in and out of the builder feels seamless. */}
+        <div className="ml-1 flex items-center gap-1 max-sm:hidden">
+          <div className="mr-1 h-5 w-px bg-border" />
+          <a
+            aria-label="GitHub"
+            href={siteConfig.links.github}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-icon-only=""
+            className={buttonStyles({ variant: 'quiet', size: 'sm' })}
+          >
+            <GitHubIcon />
+          </a>
+          <ThemeToggle isIconOnly variant="quiet" size="sm" />
+        </div>
       </div>
     </header>
   )

--- a/www/src/modules/create/studio/top-bar.tsx
+++ b/www/src/modules/create/studio/top-bar.tsx
@@ -6,43 +6,28 @@ import {
   CheckIcon,
   Link2Icon,
   RotateCcwIcon,
+  SearchIcon,
   ShuffleIcon,
   Undo2Icon,
 } from 'lucide-react'
 
 import { cn } from '@/registry/lib/utils'
-import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
 import { Button } from '@/registry/ui/button'
+import { Kbd } from '@/registry/ui/kbd'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
 
-import { RADIUS_FACTOR_VAR } from '../layout'
-import { useDesignSystem } from '../preset'
+import { useStudioActions } from './actions'
 import { ExportMenu } from './export-menu'
-
-const SHUFFLE_ACCENTS = [
-  '#3b82f6',
-  '#6366f1',
-  '#8b5cf6',
-  '#ec4899',
-  '#f43f5e',
-  '#f59e0b',
-  '#22c55e',
-  '#14b8a6',
-  '#06b6d4',
-]
-const SHUFFLE_RADII = ['0', '0.5', '1', '1.5', '2']
-const SHUFFLE_DENSITIES = ['compact', 'default', 'comfortable'] as const
-
-function pick<T>(arr: readonly T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)] as T
-}
+import { PresetsButton } from './presets'
+import { useStudio } from './store'
 
 const routeApi = getRouteApi('/_app/create')
 
 export function TopBar() {
   const { preset } = routeApi.useSearch()
   const navigate = routeApi.useNavigate()
-  const { setDesignSystem } = useDesignSystem()
+  const { shuffle, reset } = useStudioActions()
+  const { setCommandOpen } = useStudio()
   const [name, setName] = useState('Untitled system')
   const [copied, setCopied] = useState(false)
 
@@ -69,25 +54,6 @@ export function TopBar() {
     undoing.current = true
     navigate({ search: (p) => ({ ...p, preset: previous }), replace: true })
     setCanUndo(history.current.length > 0)
-  }
-
-  function reset() {
-    navigate({ search: (p) => ({ ...p, preset: undefined }), replace: true })
-  }
-
-  function shuffle() {
-    const accent = pick(SHUFFLE_ACCENTS)
-    const radius = pick(SHUFFLE_RADII)
-    const density = pick(SHUFFLE_DENSITIES)
-    setDesignSystem((p) => {
-      const base = p.color ?? DEFAULT_COLOR_CONFIG
-      return {
-        ...p,
-        density,
-        tokens: { ...p.tokens, [RADIUS_FACTOR_VAR]: radius },
-        color: { ...base, seeds: { ...base.seeds, accent } },
-      }
-    })
   }
 
   async function share() {
@@ -121,6 +87,23 @@ export function TopBar() {
 
       {/* Actions */}
       <div className="flex shrink-0 items-center gap-1">
+        <PresetsButton />
+
+        {/* Command palette opener — keyboard ⌘K works anywhere. */}
+        <Button
+          size="sm"
+          variant="quiet"
+          onPress={() => setCommandOpen(true)}
+          aria-label="Open command palette"
+          className="gap-1.5 text-fg-muted max-sm:hidden"
+        >
+          <SearchIcon />
+          <span className="text-[12px]">Search</span>
+          <Kbd className="text-[10px]">⌘K</Kbd>
+        </Button>
+
+        <div className="mx-1 h-5 w-px bg-border max-sm:hidden" />
+
         {/* Secondary actions collapse first on narrow screens. */}
         <div className="flex items-center gap-1 max-sm:hidden">
           <Tooltip>

--- a/www/src/modules/create/studio/top-bar.tsx
+++ b/www/src/modules/create/studio/top-bar.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+import {
+  CheckIcon,
+  Link2Icon,
+  RotateCcwIcon,
+  ShuffleIcon,
+  Undo2Icon,
+} from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { RADIUS_FACTOR_VAR } from '../layout'
+import { useDesignSystem } from '../preset'
+import { ExportMenu } from './export-menu'
+
+const SHUFFLE_ACCENTS = [
+  '#3b82f6',
+  '#6366f1',
+  '#8b5cf6',
+  '#ec4899',
+  '#f43f5e',
+  '#f59e0b',
+  '#22c55e',
+  '#14b8a6',
+  '#06b6d4',
+]
+const SHUFFLE_RADII = ['0', '0.5', '1', '1.5', '2']
+const SHUFFLE_DENSITIES = ['compact', 'default', 'comfortable'] as const
+
+function pick<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)] as T
+}
+
+const routeApi = getRouteApi('/_app/create')
+
+export function TopBar() {
+  const { preset } = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+  const { setDesignSystem } = useDesignSystem()
+  const [name, setName] = useState('Untitled system')
+  const [copied, setCopied] = useState(false)
+
+  // Undo history over the encoded `?preset=` param (edits use replace:true, so
+  // the browser back button can't step through them — keep our own stack).
+  const history = useRef<(string | undefined)[]>([])
+  const prev = useRef<string | undefined>(preset)
+  const undoing = useRef(false)
+  const [canUndo, setCanUndo] = useState(false)
+
+  useEffect(() => {
+    if (prev.current === preset) return
+    if (undoing.current) undoing.current = false
+    else {
+      history.current.push(prev.current)
+      setCanUndo(true)
+    }
+    prev.current = preset
+  }, [preset])
+
+  function undo() {
+    if (history.current.length === 0) return
+    const previous = history.current.pop()
+    undoing.current = true
+    navigate({ search: (p) => ({ ...p, preset: previous }), replace: true })
+    setCanUndo(history.current.length > 0)
+  }
+
+  function reset() {
+    navigate({ search: (p) => ({ ...p, preset: undefined }), replace: true })
+  }
+
+  function shuffle() {
+    const accent = pick(SHUFFLE_ACCENTS)
+    const radius = pick(SHUFFLE_RADII)
+    const density = pick(SHUFFLE_DENSITIES)
+    setDesignSystem((p) => {
+      const base = p.color ?? DEFAULT_COLOR_CONFIG
+      return {
+        ...p,
+        density,
+        tokens: { ...p.tokens, [RADIUS_FACTOR_VAR]: radius },
+        color: { ...base, seeds: { ...base.seeds, accent } },
+      }
+    })
+  }
+
+  async function share() {
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* no-op */
+    }
+  }
+
+  return (
+    <header className="flex h-12 shrink-0 items-center gap-3 px-4">
+      {/* Identity */}
+      <div className="flex min-w-0 flex-1 items-center gap-2.5">
+        <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-gradient-to-br from-primary to-primary/70 text-fg-on-primary shadow-sm">
+          <span className="text-xs font-bold">d</span>
+        </div>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          aria-label="System name"
+          spellCheck={false}
+          className="min-w-0 flex-1 truncate rounded-md bg-transparent px-1.5 py-1 text-sm font-semibold outline-none hover:bg-neutral focus:bg-neutral focus-visible:focus-ring sm:max-w-44 sm:flex-none"
+        />
+        <span className="hidden rounded-full border px-2 py-0.5 text-[10px] font-medium tracking-wide text-fg-muted uppercase sm:inline">
+          Draft
+        </span>
+      </div>
+
+      {/* Actions */}
+      <div className="flex shrink-0 items-center gap-1">
+        {/* Secondary actions collapse first on narrow screens. */}
+        <div className="flex items-center gap-1 max-sm:hidden">
+          <Tooltip>
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              onPress={shuffle}
+              aria-label="Surprise me"
+            >
+              <ShuffleIcon />
+            </Button>
+            <TooltipContent>Surprise me</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              onPress={undo}
+              isDisabled={!canUndo}
+              aria-label="Undo"
+            >
+              <Undo2Icon />
+            </Button>
+            <TooltipContent>Undo</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              onPress={reset}
+              aria-label="Reset to defaults"
+            >
+              <RotateCcwIcon />
+            </Button>
+            <TooltipContent>Reset to defaults</TooltipContent>
+          </Tooltip>
+
+          <div className="mx-1 h-5 w-px bg-border" />
+        </div>
+
+        <Button
+          size="sm"
+          variant="default"
+          onPress={share}
+          aria-label="Share"
+          className={cn('gap-1.5', copied && 'text-success')}
+        >
+          {copied ? <CheckIcon /> : <Link2Icon />}
+          <span className="max-sm:hidden">{copied ? 'Copied' : 'Share'}</span>
+        </Button>
+        <ExportMenu />
+      </div>
+    </header>
+  )
+}

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -1,20 +1,14 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
 import { z } from 'zod'
 
-import { cn } from '@/registry/lib/utils'
-import { ToggleButton } from '@/registry/ui/toggle-button'
-import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
-import { CustomizerPanel } from '@/modules/create/customizer-panel'
 import { LabExperience } from '@/modules/create/panel'
 import { DEFAULTS, useDesignSystem } from '@/modules/create/preset'
 import {
   loadStoredPreset,
   saveStoredPreset,
 } from '@/modules/create/preset/storage'
-import { PreviewPanel } from '@/modules/create/preview/preview-panel'
-
-type MobilePane = 'customize' | 'preview'
+import { Studio } from '@/modules/create/studio'
 
 export const createSearchSchema = z.object({
   panel: z.string().optional().catch(undefined),
@@ -40,11 +34,6 @@ export const Route = createFileRoute('/_app/create')({
 function CreatePage() {
   const { lab, preset } = Route.useSearch()
   const { designSystem, setDesignSystem } = useDesignSystem()
-  // Below `lg` the customizer and the live preview can't sit side by side (the iframe
-  // would be a ~15px sliver), so they collapse into a single switchable pane toggled
-  // by the segmented control. Both stay mounted — only CSS-hidden, never unmounted —
-  // so switching never reloads the preview. Above `lg` this state is inert; both show.
-  const [mobilePane, setMobilePane] = useState<MobilePane>('customize')
 
   // The user's selected preset is persisted in localStorage so every docs
   // component demo renders in it. Seed the editor from it on open (unless a
@@ -69,33 +58,8 @@ function CreatePage() {
     saveStoredPreset(designSystem)
   }, [designSystem])
 
-  // Opt-in exploration of the redesigned control panel + floating panel lab.
+  // Opt-in exploration of the legacy data-driven control panel + floating lab.
   if (lab) return <LabExperience />
 
-  return (
-    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2">
-      {/* Mobile-only view switcher — hidden once the two panes fit side by side. */}
-      <ToggleButtonGroup
-        aria-label="Editor view"
-        selectionMode="single"
-        disallowEmptySelection
-        size="sm"
-        selectedKeys={[mobilePane]}
-        onSelectionChange={(keys) => {
-          const next = keys.values().next().value
-          if (next === 'customize' || next === 'preview') setMobilePane(next)
-        }}
-        className="w-full shrink-0 *:flex-1 lg:hidden"
-      >
-        <ToggleButton id="customize">Customize</ToggleButton>
-        <ToggleButton id="preview">Preview</ToggleButton>
-      </ToggleButtonGroup>
-      <CustomizerPanel
-        className={cn(mobilePane === 'preview' && 'max-lg:hidden')}
-      />
-      <PreviewPanel
-        className={cn(mobilePane === 'customize' && 'max-lg:hidden')}
-      />
-    </div>
-  )
+  return <Studio />
 }

--- a/www/src/routes/_app/route.tsx
+++ b/www/src/routes/_app/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeader } from '@tanstack/react-start/server'
 import type * as PageTree from 'fumadocs-core/page-tree'
@@ -37,9 +37,19 @@ function AppLayout() {
   const { pageTree } = Route.useLoaderData()
   const items = pageTree.children as PageTree.Node[]
 
+  // The /create builder is a focused "app" mode: it owns its own full-height
+  // top bar (logo→home, builder controls, theme/github) so the marketing/docs
+  // nav must not stack on top of it. The legacy `?lab=true` panel has no bar of
+  // its own, so it keeps the site Header. Matched on the parsed location rather
+  // than a route-tree match to read the child route's `lab` search param here.
+  const location = useLocation()
+  const onStudio =
+    location.pathname === '/create' &&
+    !(location.search as { lab?: boolean }).lab
+
   return (
     <div className="[--header-height:--spacing(14)]">
-      <Header items={items} />
+      {!onStudio && <Header items={items} />}
       <main id="content">
         <Outlet />
       </main>

--- a/www/src/styles.css
+++ b/www/src/styles.css
@@ -180,3 +180,25 @@
     opacity: 0;
   }
 }
+
+/* Studio inspector body enter — a quick rise+fade replayed on each axis switch
+   (the body is keyed per axis, so a remount re-runs the animation). CSS, not JS,
+   so it never strands content at opacity 0 the way an SSR'd motion enter can. */
+@keyframes studio-rise {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.studio-rise {
+  animation: studio-rise 0.22s cubic-bezier(0.32, 0.72, 0, 1) both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .studio-rise {
+    animation: none;
+  }
+}


### PR DESCRIPTION
> **Experiment, UI-only.** Gut the old left control panel and redesign the whole `/create` experience as an end-to-end design-system builder: brand in → complete, on-brand library out, openable anywhere.

## What changed
- The old 288px left `CustomizerPanel` is no longer rendered. `routes/_app/create.tsx` renders the new `<Studio/>`; `?lab=true` still serves the legacy `LabExperience`. Old files remain on disk but unwired.
- New module `www/src/modules/create/studio/` — a canvas-first **three-zone studio**.

## The experience
- **Top bar** — brand mark, editable name, Draft chip · Surprise-me / Undo / Reset · Share (deep-link) · **Export** popover (shadcn CLI + Open in v0 live; Bolt/Lovable/Claude/Figma "Soon").
- **Left rail** — the system's *axes* as a slim icon nav: Brand · Color · Type · Shape · Space · Depth · Motion · Icons · Cursor · Components.
- **Canvas** — the live iframe elevated: scene switcher, device sizes, zoom, **light/dark split view**, fullscreen. Token edits stream in over postMessage (no reload).
- **Inspector** — a purpose-built panel per axis, with honest binding dots (● live / ○ designed).
- **Generate overlay** — seed by one color / logo / URL, pick a vibe → applies color + radius + density + depth, then dissolves into the studio.

## Coverage (maps to the brief)
- **1 color → full system** (auto neutrals + status, real OKLCH engine), or **decide the structure** (seed strategy, algorithm + knobs, contrast readout).
- **Palettes or not** — Foundation toggle: full 50–950 ramps vs semantic-only roles.
- **Tweak any component** — searchable grouped list → real per-component params + synced-group awareness (Button ⇄ ToggleButton).
- **Control anything** — type, shape, space, depth, motion, icons, cursor each get an inspector with live specimens.

## Live vs designed
Live now (reuses the existing pure engine, no new logic): color, radius, density, cursor, component params, shuffle/undo/reset, export. Designed (write real `--ds-*` vars, marked ○, go live when a consumer reads them): typography, depth, motion, icon stroke, spacing scale, border width.

## Verification
`pnpm typecheck` passes; `pnpm check` clean (0 errors, 0 new warnings). Browser-tested end-to-end: onboarding, axis switching, color engine + ramps + foundation, Components → Alert with real params + canvas switch, light/dark split, mobile layout, and a live shuffle recoloring the preview.

Full report: `docs/research/2026-06-27-create-studio-redesign.md`.

## Notes
- Designed axes need engine consumers to become live (var names already aligned).
- Import-from-logo/URL and "More targets" exports are visual stubs; fonts apply by name only (no webfont loading); system name + vibe are local UI state (not yet persisted).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI-only surface on the primary `/create` route with layout/header behavior changes; core preset/preview pipeline is reused rather than rewritten.
> 
> **Overview**
> Replaces the default `/create` layout (288px `CustomizerPanel` + preview) with a new **Studio** module: top bar, left axis rail, center canvas, and per-axis inspector. `create.tsx` now renders `<Studio />`; `?lab=true` still loads the legacy `LabExperience`. The app layout hides the site `Header` on `/create` (except when `lab` is set) so the studio top bar owns the viewport.
> 
> The studio reuses the existing preset URL, `useDesignSystem`, iframe `postMessage` preview, color engine, component params, and export targets. New UI adds onboarding (brand color + vibe), per-axis inspectors with live vs “designed” binding dots, canvas **Preview / Tokens / Code** (iframe stays mounted when switching), device/zoom/light-dark split, color-vision simulation, ⌘K command palette, presets gallery, custom undo over `?preset=`, and a `.studio-rise` CSS enter animation instead of problematic Motion SSR patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2bc9acd3098d1c6ef4fc0817c7f64fdbfc56cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->