### PR TITLE
feat(create): Atelier builder redesign with AI assistant

### DIFF
--- a/www/src/modules/create/atelier/ai/ai-dock.tsx
+++ b/www/src/modules/create/atelier/ai/ai-dock.tsx
@@ -1,0 +1,507 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import {
+  ArrowRightIcon,
+  CheckIcon,
+  CircleAlertIcon,
+  CircleCheckIcon,
+  CircleXIcon,
+  LinkIcon,
+  SparklesIcon,
+  Trash2Icon,
+  UploadIcon,
+  XIcon,
+} from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+import { FileTrigger } from '@/registry/ui/file-trigger'
+import { Tab, TabList, TabPanel, Tabs } from '@/registry/ui/tabs'
+
+import { useDesignSystem } from '../../preset'
+import type { DesignSystem } from '../../preset'
+import { type AiMessage, useStudio } from '../store'
+import {
+  type AuditFinding,
+  type AuditLevel,
+  type ChangeSet,
+  QUICK_PROMPTS,
+  audit,
+} from './engine'
+
+const isHex = (s: string) => /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(s.trim())
+
+/* ----------------------------------------------------------------------------
+ * The design assistant dock — conversation, audit, and reference matching.
+ * Every AI action returns a ChangeSet the user reviews and accepts; nothing is
+ * applied behind their back, and the audit numbers are real WCAG ratios.
+ * -------------------------------------------------------------------------- */
+
+export function AiDock({ className }: { className?: string }) {
+  const { setAiOpen, clearConversation, messages } = useStudio()
+  const [tab, setTab] = useState('chat')
+
+  return (
+    <aside
+      className={cn(
+        'flex w-[360px] shrink-0 flex-col overflow-hidden rounded-xl border bg-card',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 border-b px-3 py-2.5">
+        <SparklesIcon className="size-4 text-primary" />
+        <span className="text-sm font-semibold">Design assistant</span>
+        <div className="ml-auto flex items-center gap-0.5">
+          {messages.length > 0 && (
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              aria-label="Clear conversation"
+              onPress={clearConversation}
+            >
+              <Trash2Icon />
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            aria-label="Close assistant"
+            onPress={() => setAiOpen(false)}
+          >
+            <XIcon />
+          </Button>
+        </div>
+      </div>
+
+      <Tabs
+        selectedKey={tab}
+        onSelectionChange={(k) => setTab(k as string)}
+        className="flex min-h-0 flex-1 flex-col gap-0"
+      >
+        <div className="border-b px-3 pt-2">
+          <TabList>
+            <Tab id="chat">Chat</Tab>
+            <Tab id="audit">Audit</Tab>
+            <Tab id="reference">Reference</Tab>
+          </TabList>
+        </div>
+        <TabPanel id="chat" className="min-h-0 flex-1 overflow-y-auto p-3">
+          <ChatTab />
+        </TabPanel>
+        <TabPanel id="audit" className="min-h-0 flex-1 overflow-y-auto p-3">
+          <AuditTab />
+        </TabPanel>
+        <TabPanel id="reference" className="min-h-0 flex-1 overflow-y-auto p-3">
+          <ReferenceTab onProposed={() => setTab('chat')} />
+        </TabPanel>
+      </Tabs>
+    </aside>
+  )
+}
+
+/* --------------------------------- Chat ---------------------------------- */
+
+function ChatTab() {
+  const { messages, submitPrompt } = useStudio()
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex flex-col gap-4 pt-6">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <div className="flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <SparklesIcon className="size-5" />
+          </div>
+          <p className="text-sm font-medium">Describe what you’re building</p>
+          <p className="text-xs text-balance text-fg-muted">
+            Name a vibe or a product, ask for a tweak, or match a reference.
+            Every suggestion lands as a diff you can accept or reject.
+          </p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          {QUICK_PROMPTS.map((p) => (
+            <ButtonPrimitives.Button
+              key={p}
+              onPress={() => submitPrompt(p)}
+              className="rounded-lg border px-3 py-2 text-left text-[13px] focus-reset transition-colors hover:bg-neutral focus-visible:focus-ring"
+            >
+              {p}
+            </ButtonPrimitives.Button>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {messages.map((m) => (
+        <MessageRow key={m.id} message={m} />
+      ))}
+    </div>
+  )
+}
+
+function MessageRow({ message }: { message: AiMessage }) {
+  if (message.kind === 'user') {
+    return (
+      <div className="flex justify-end">
+        <div className="text-primary-fg max-w-[85%] rounded-2xl rounded-br-sm bg-primary px-3 py-1.5 text-[13px]">
+          {message.text}
+        </div>
+      </div>
+    )
+  }
+  return <ProposalCard message={message} />
+}
+
+function ProposalCard({
+  message,
+}: {
+  message: Extract<AiMessage, { kind: 'proposal' }>
+}) {
+  const { applyChangeSet, dismissProposal } = useStudio()
+  const { changeSet, status } = message
+
+  return (
+    <div className="rounded-xl border bg-bg p-3">
+      <div className="flex items-center gap-1.5">
+        <SparklesIcon className="size-3.5 shrink-0 text-primary" />
+        <span className="text-[13px] font-semibold">{changeSet.title}</span>
+        {changeSet.speculative && (
+          <span className="ml-auto rounded-full bg-warning/15 px-1.5 py-0.5 text-[9px] font-medium tracking-wide text-warning uppercase">
+            guess
+          </span>
+        )}
+      </div>
+      <p className="mt-1 text-xs leading-snug text-fg-muted">
+        {changeSet.rationale}
+      </p>
+
+      <div className="mt-2.5 flex flex-col gap-1 rounded-lg border bg-card p-2">
+        {changeSet.changes.map((c, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between gap-2 text-xs"
+          >
+            <span className="shrink-0 text-fg-muted">{c.label}</span>
+            <span className="flex min-w-0 items-center gap-1.5 font-mono">
+              <Val v={c.from} muted />
+              <ArrowRightIcon className="size-3 shrink-0 text-fg-muted" />
+              <Val v={c.to} />
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {status === 'pending' ? (
+        <div className="mt-3 flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="primary"
+            className="flex-1"
+            onPress={() => applyChangeSet(changeSet, message.id)}
+          >
+            <CheckIcon /> Apply
+          </Button>
+          <Button
+            size="sm"
+            variant="quiet"
+            onPress={() => dismissProposal(message.id)}
+          >
+            Dismiss
+          </Button>
+        </div>
+      ) : status === 'applied' ? (
+        <p className="mt-2.5 flex items-center gap-1.5 text-xs font-medium text-success">
+          <CircleCheckIcon className="size-3.5" /> Applied — undo from the
+          toolbar
+        </p>
+      ) : (
+        <p className="mt-2.5 text-xs text-fg-muted">Dismissed</p>
+      )}
+    </div>
+  )
+}
+
+function Val({ v, muted }: { v: string; muted?: boolean }) {
+  return (
+    <span
+      className={cn(
+        'flex items-center gap-1 truncate',
+        muted ? 'text-fg-muted' : 'text-fg',
+      )}
+    >
+      {isHex(v) && (
+        <span
+          className="size-3 shrink-0 rounded-full ring-1 ring-black/10 ring-inset"
+          style={{ backgroundColor: v }}
+        />
+      )}
+      {v}
+    </span>
+  )
+}
+
+/* --------------------------------- Audit --------------------------------- */
+
+const LEVEL_META: Record<
+  AuditLevel,
+  { Icon: typeof CircleCheckIcon; className: string }
+> = {
+  pass: { Icon: CircleCheckIcon, className: 'text-success' },
+  warn: { Icon: CircleAlertIcon, className: 'text-warning' },
+  fail: { Icon: CircleXIcon, className: 'text-danger' },
+}
+
+function AuditTab() {
+  const { designSystem } = useDesignSystem()
+  const { applyChangeSet } = useStudio()
+  const findings = useMemo(() => audit(designSystem), [designSystem])
+
+  const counts = findings.reduce(
+    (acc, f) => ({ ...acc, [f.level]: (acc[f.level] ?? 0) + 1 }),
+    {} as Record<AuditLevel, number>,
+  )
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3 text-xs text-fg-muted">
+        <span className="flex items-center gap-1">
+          <CircleCheckIcon className="size-3.5 text-success" />{' '}
+          {counts.pass ?? 0}
+        </span>
+        <span className="flex items-center gap-1">
+          <CircleAlertIcon className="size-3.5 text-warning" />{' '}
+          {counts.warn ?? 0}
+        </span>
+        <span className="flex items-center gap-1">
+          <CircleXIcon className="size-3.5 text-danger" /> {counts.fail ?? 0}
+        </span>
+        <span className="ml-auto">Live WCAG checks</span>
+      </div>
+
+      {findings.map((f) => (
+        <AuditRow key={f.id} finding={f} onFix={(cs) => applyChangeSet(cs)} />
+      ))}
+    </div>
+  )
+}
+
+function AuditRow({
+  finding,
+  onFix,
+}: {
+  finding: AuditFinding
+  onFix: (cs: ChangeSet) => void
+}) {
+  const { Icon, className } = LEVEL_META[finding.level]
+  return (
+    <div className="flex gap-2.5 rounded-lg border bg-bg p-2.5">
+      <Icon className={cn('mt-0.5 size-4 shrink-0', className)} />
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="text-[13px] font-medium">{finding.title}</span>
+        <span className="text-xs leading-snug text-fg-muted">
+          {finding.detail}
+        </span>
+        {finding.fix && (
+          <Button
+            size="sm"
+            variant="default"
+            className="mt-1.5 self-start"
+            onPress={() => finding.fix && onFix(finding.fix)}
+          >
+            <SparklesIcon /> {finding.fix.title}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------- Reference ------------------------------- */
+
+function ReferenceTab({ onProposed }: { onProposed: () => void }) {
+  const { proposeChangeSet } = useStudio()
+  const { designSystem } = useDesignSystem()
+  const [url, setUrl] = useState('')
+  const [colors, setColors] = useState('')
+
+  const currentAccent =
+    (designSystem.color ?? DEFAULT_COLOR_CONFIG).seeds.accent ?? '#6366f1'
+
+  function accentChangeSet(
+    title: string,
+    rationale: string,
+    accent: string,
+  ): ChangeSet {
+    return {
+      id: `ref-${Math.round(stringHash(title + accent))}`,
+      title,
+      rationale,
+      changes: [{ label: 'Accent', from: currentAccent, to: accent }],
+      apply: (ds: DesignSystem) => {
+        const base = ds.color ?? DEFAULT_COLOR_CONFIG
+        return { ...ds, color: { ...base, seeds: { ...base.seeds, accent } } }
+      },
+    }
+  }
+
+  function extractUrl() {
+    const host = safeHost(url)
+    if (!host) return
+    const accent = hslToHex(stringHash(host) % 360, 68, 54)
+    proposeChangeSet(
+      accentChangeSet(
+        `Matched ${host}`,
+        'Sampled a representative accent from the reference. Capability preview — a connected extractor would read the live page’s computed styles.',
+        accent,
+      ),
+    )
+    setUrl('')
+    onProposed()
+  }
+
+  function applyColors() {
+    const found = colors.match(/#([0-9a-f]{3}|[0-9a-f]{6})/gi)
+    const first = found?.[0]
+    if (!found || !first) return
+    proposeChangeSet(
+      accentChangeSet(
+        'Brand palette',
+        `Pulled the accent from ${found.length} pasted color${found.length > 1 ? 's' : ''}.`,
+        first,
+      ),
+    )
+    setColors('')
+    onProposed()
+  }
+
+  function onFile(files: FileList | null) {
+    const name = files && files[0] ? files[0].name : 'screenshot'
+    const accent = hslToHex(stringHash(name) % 360, 70, 52)
+    proposeChangeSet(
+      accentChangeSet(
+        'Matched screenshot',
+        'Extracted a dominant accent from the upload. Capability preview — a connected model would read the image’s palette.',
+        accent,
+      ),
+    )
+    onProposed()
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-xs leading-snug text-fg-muted">
+        Start from something you like — a site, a screenshot, or brand colors.
+        Each produces a proposal you review before it’s applied.
+      </p>
+
+      <Field label="From a URL" icon={LinkIcon}>
+        <div className="flex gap-2">
+          <input
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && extractUrl()}
+            placeholder="linear.app"
+            aria-label="Reference URL"
+            spellCheck={false}
+            className="min-w-0 flex-1 rounded-lg border bg-bg px-2.5 py-1.5 text-[13px] outline-none focus-visible:focus-ring"
+          />
+          <Button size="sm" onPress={extractUrl} isDisabled={!safeHost(url)}>
+            Extract
+          </Button>
+        </div>
+      </Field>
+
+      <Field label="From a screenshot" icon={UploadIcon}>
+        <FileTrigger acceptedFileTypes={['image/*']} onSelect={onFile}>
+          <Button size="sm" variant="default" className="w-full">
+            <UploadIcon /> Upload an image
+          </Button>
+        </FileTrigger>
+      </Field>
+
+      <Field label="From brand colors" icon={SparklesIcon}>
+        <textarea
+          value={colors}
+          onChange={(e) => setColors(e.target.value)}
+          placeholder="#635bff, #0f172a, #f43f5e"
+          aria-label="Brand colors"
+          spellCheck={false}
+          rows={2}
+          className="w-full resize-none rounded-lg border bg-bg px-2.5 py-1.5 font-mono text-xs outline-none focus-visible:focus-ring"
+        />
+        <Button
+          size="sm"
+          variant="default"
+          className="mt-1.5 self-start"
+          onPress={applyColors}
+          isDisabled={!/#([0-9a-f]{3}|[0-9a-f]{6})/i.test(colors)}
+        >
+          Use palette
+        </Button>
+      </Field>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  icon: Icon,
+  children,
+}: {
+  label: string
+  icon: typeof LinkIcon
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="flex items-center gap-1.5 text-[11px] font-semibold tracking-wide text-fg-muted uppercase">
+        <Icon className="size-3.5" />
+        {label}
+      </span>
+      {children}
+    </div>
+  )
+}
+
+/* ------------------------------- Reference utils ------------------------- */
+
+function safeHost(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  try {
+    const url = new URL(
+      trimmed.includes('://') ? trimmed : `https://${trimmed}`,
+    )
+    return url.hostname.replace(/^www\./, '')
+  } catch {
+    return null
+  }
+}
+
+function stringHash(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i += 1) h = (h * 31 + s.charCodeAt(i)) >>> 0
+  return h
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const sN = s / 100
+  const lN = l / 100
+  const k = (n: number) => (n + h / 30) % 12
+  const a = sN * Math.min(lN, 1 - lN)
+  const f = (n: number) => {
+    const color =
+      lN - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)))
+    return Math.round(255 * color)
+      .toString(16)
+      .padStart(2, '0')
+  }
+  return `#${f(0)}${f(8)}${f(4)}`
+}

--- a/www/src/modules/create/atelier/ai/command-bar.tsx
+++ b/www/src/modules/create/atelier/ai/command-bar.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState } from 'react'
+import { ArrowUpIcon, SparklesIcon } from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+
+import { useStudio } from '../store'
+import { QUICK_PROMPTS } from './engine'
+
+/* ----------------------------------------------------------------------------
+ * The command bar — the always-on AI entry under the stage. Type a system or a
+ * change in plain language; it proposes a reviewable diff in the dock. The
+ * chips are one-tap canned intents so the capability is discoverable.
+ * -------------------------------------------------------------------------- */
+
+export function CommandBar() {
+  const { submitPrompt } = useStudio()
+  const [value, setValue] = useState('')
+
+  function submit() {
+    if (!value.trim()) return
+    submitPrompt(value)
+    setValue('')
+  }
+
+  return (
+    <div className="shrink-0">
+      <div className="mb-2 flex flex-wrap items-center gap-1.5">
+        {QUICK_PROMPTS.map((p) => (
+          <ButtonPrimitives.Button
+            key={p}
+            onPress={() => submitPrompt(p)}
+            className="rounded-full border bg-card px-2.5 py-1 text-xs text-fg-muted focus-reset transition-colors hover:bg-neutral hover:text-fg focus-visible:focus-ring"
+          >
+            {p}
+          </ButtonPrimitives.Button>
+        ))}
+      </div>
+      <div
+        className={cn(
+          'flex items-center gap-2 rounded-xl border bg-card px-3 py-2',
+          'focus-within:ring-2 focus-within:ring-primary/40',
+        )}
+      >
+        <SparklesIcon className="size-4 shrink-0 text-primary" />
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              submit()
+            }
+          }}
+          placeholder="Describe your design system, or a change — “make it feel like Linear”"
+          aria-label="Ask the design assistant"
+          spellCheck={false}
+          className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-fg-muted"
+        />
+        <ButtonPrimitives.Button
+          onPress={submit}
+          isDisabled={!value.trim()}
+          aria-label="Send"
+          className="text-primary-fg flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary focus-reset transition-opacity hover:opacity-90 focus-visible:focus-ring disabled:opacity-40"
+        >
+          <ArrowUpIcon className="size-4" />
+        </ButtonPrimitives.Button>
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/atelier/ai/engine.ts
+++ b/www/src/modules/create/atelier/ai/engine.ts
@@ -1,0 +1,484 @@
+/* ----------------------------------------------------------------------------
+ * The studio's design intelligence — interaction model, run locally.
+ *
+ * This is the UI-facing brain for the AI surface: it turns a natural-language
+ * prompt ("make it feel like Linear", "warmer grays", "fix my contrast") into a
+ * structured, *reviewable* ChangeSet against the real DesignSystem state, and it
+ * runs honest contrast checks for the audit panel.
+ *
+ * It is deliberately a deterministic local engine, not a model call: the point
+ * of this experiment is the *interaction* — propose → preview → accept/reject —
+ * not the inference. A production build swaps `interpret()` for a server call
+ * that returns the same ChangeSet shape; every consumer downstream is unchanged.
+ * -------------------------------------------------------------------------- */
+
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import type { AlgorithmId } from '@/registry/theme'
+
+import type { Density, DesignSystem } from '../../preset'
+import {
+  BORDER_WIDTH_VAR,
+  ELEVATION_STYLE_VAR,
+  RADIUS_FACTOR_VAR,
+  TRACKING_VAR,
+} from '../tokens'
+
+export interface ChangeItem {
+  label: string
+  from: string
+  to: string
+}
+
+export interface ChangeSet {
+  id: string
+  title: string
+  rationale: string
+  /** Human-readable before/after lines, shown as the reviewable diff. */
+  changes: ChangeItem[]
+  /** Pure transform applied (as one undo step) when the user accepts. */
+  apply: (prev: DesignSystem) => DesignSystem
+  /** True when nothing in the prompt was understood — drives the fallback copy. */
+  speculative?: boolean
+}
+
+/* ------------------------------- Utilities ------------------------------- */
+
+let counter = 0
+const uid = (p: string) => `${p}-${(counter += 1)}`
+
+function seedsOf(ds: DesignSystem) {
+  return (ds.color ?? DEFAULT_COLOR_CONFIG).seeds
+}
+function radiusOf(ds: DesignSystem) {
+  return ds.tokens[RADIUS_FACTOR_VAR] ?? '1'
+}
+
+/** Compose a color-seed + algorithm patch onto the live recipe. */
+function patchColor(
+  prev: DesignSystem,
+  seeds: Partial<Record<string, string>>,
+  algorithm?: AlgorithmId,
+): DesignSystem {
+  const base = prev.color ?? DEFAULT_COLOR_CONFIG
+  return {
+    ...prev,
+    color: {
+      ...base,
+      ...(algorithm ? { algorithm } : {}),
+      seeds: { ...base.seeds, ...seeds },
+    },
+  }
+}
+
+/* --------------------------- Named vocabularies -------------------------- */
+
+// Recognizable system "vibes" — each is a coherent multi-axis move, the kind of
+// thing a user means by naming a product they admire.
+interface Vibe {
+  match: RegExp
+  title: string
+  rationale: string
+  accent: string
+  neutral?: string
+  radius: string
+  density: Density
+  algorithm?: AlgorithmId
+}
+
+const VIBES: Vibe[] = [
+  {
+    match: /linear/,
+    title: 'Linear-style system',
+    rationale: 'Indigo accent, tight radii, brand-tinted grays, dense layout.',
+    accent: '#5e6ad2',
+    neutral: '#6b6f80',
+    radius: '0.6',
+    density: 'compact',
+  },
+  {
+    match: /vercel|geist/,
+    title: 'Geist-style system',
+    rationale: 'Pure black accent, near-square corners, neutral grays, dense.',
+    accent: '#171717',
+    neutral: '#808080',
+    radius: '0.35',
+    density: 'compact',
+  },
+  {
+    match: /stripe/,
+    title: 'Stripe-style system',
+    rationale: 'Blurple accent, rounded corners, default density.',
+    accent: '#635bff',
+    radius: '1.1',
+    density: 'default',
+  },
+  {
+    match: /material|google/,
+    title: 'Material-style system',
+    rationale: 'Vivid accent, generous radius, comfortable spacing.',
+    accent: '#1a73e8',
+    radius: '1.4',
+    density: 'comfortable',
+    algorithm: 'material',
+  },
+  {
+    match: /playful|fun|friendly|bubbl/,
+    title: 'Playful refresh',
+    rationale: 'Warm vivid accent, pill-round corners, roomy spacing.',
+    accent: '#f43f5e',
+    radius: '1.7',
+    density: 'comfortable',
+  },
+  {
+    match: /minimal|clean|understated|swiss/,
+    title: 'Minimal refresh',
+    rationale: 'Near-black accent, restrained radius, tight grid.',
+    accent: '#18181b',
+    neutral: '#808080',
+    radius: '0.4',
+    density: 'compact',
+  },
+  {
+    match: /editorial|elegant|serif|magazine/,
+    title: 'Editorial refresh',
+    rationale: 'Deep teal accent, crisp corners, airy reading rhythm.',
+    accent: '#0f766e',
+    radius: '0.3',
+    density: 'comfortable',
+  },
+  {
+    match: /enterprise|corporate|trust|fintech|bank/,
+    title: 'Enterprise refresh',
+    rationale: 'Confident blue, conservative radius, default density.',
+    accent: '#2563eb',
+    radius: '0.6',
+    density: 'default',
+  },
+  {
+    match: /brutal|bold|loud|punk/,
+    title: 'Bold / brutalist refresh',
+    rationale: 'High-energy accent, square corners, thick borders.',
+    accent: '#facc15',
+    neutral: '#808080',
+    radius: '0',
+    density: 'default',
+  },
+]
+
+// Single-hue requests → an accent move only.
+const HUES: Array<{ match: RegExp; label: string; hex: string }> = [
+  { match: /\bindigo\b/, label: 'Indigo', hex: '#6366f1' },
+  { match: /\bblue\b/, label: 'Blue', hex: '#3b82f6' },
+  { match: /\bteal\b|\bcyan\b/, label: 'Teal', hex: '#14b8a6' },
+  { match: /\bgreen\b|\bemerald\b/, label: 'Green', hex: '#22c55e' },
+  { match: /\bpurple\b|\bviolet\b/, label: 'Purple', hex: '#8b5cf6' },
+  { match: /\bpink\b|\bmagenta\b/, label: 'Pink', hex: '#ec4899' },
+  { match: /\bred\b|\bcrimson\b/, label: 'Red', hex: '#ef4444' },
+  { match: /\borange\b|\bamber\b/, label: 'Orange', hex: '#f59e0b' },
+  { match: /\brose\b/, label: 'Rose', hex: '#f43f5e' },
+  { match: /\bblack\b|\bmono(chrome)?\b/, label: 'Black', hex: '#171717' },
+]
+
+/* ------------------------------ Interpreter ------------------------------ */
+
+/**
+ * Turn a prompt into a reviewable ChangeSet against `current`. Recognized
+ * intents stack (a vibe + "rounder" + "denser" all apply); an unrecognized
+ * prompt returns a speculative tasteful nudge so the loop never dead-ends.
+ */
+export function interpret(prompt: string, current: DesignSystem): ChangeSet {
+  const p = prompt.toLowerCase()
+  const changes: ChangeItem[] = []
+  const transforms: Array<(ds: DesignSystem) => DesignSystem> = []
+  let title = ''
+  let rationale = ''
+
+  const curSeeds = seedsOf(current)
+  const curRadius = radiusOf(current)
+
+  // 1) Whole-system vibe.
+  const vibe = VIBES.find((v) => v.match.test(p))
+  if (vibe) {
+    title = vibe.title
+    rationale = vibe.rationale
+    changes.push({
+      label: 'Accent',
+      from: curSeeds.accent ?? '—',
+      to: vibe.accent,
+    })
+    if (vibe.neutral && vibe.neutral !== curSeeds.neutral) {
+      changes.push({
+        label: 'Base / gray',
+        from: curSeeds.neutral ?? '#808080',
+        to: vibe.neutral,
+      })
+    }
+    changes.push({
+      label: 'Radius',
+      from: `${curRadius}×`,
+      to: `${vibe.radius}×`,
+    })
+    changes.push({ label: 'Density', from: current.density, to: vibe.density })
+    if (vibe.algorithm) {
+      changes.push({
+        label: 'Algorithm',
+        from: (current.color ?? DEFAULT_COLOR_CONFIG).algorithm,
+        to: vibe.algorithm,
+      })
+    }
+    transforms.push((ds) => {
+      let next = patchColor(
+        ds,
+        {
+          accent: vibe.accent,
+          ...(vibe.neutral ? { neutral: vibe.neutral } : {}),
+        },
+        vibe.algorithm,
+      )
+      next = {
+        ...next,
+        density: vibe.density,
+        tokens: { ...next.tokens, [RADIUS_FACTOR_VAR]: vibe.radius },
+      }
+      return next
+    })
+  }
+
+  // 2) Single hue (skip if a vibe already set the accent).
+  if (!vibe) {
+    const hue = HUES.find((h) => h.match.test(p))
+    if (hue) {
+      title ||= `${hue.label} accent`
+      rationale ||= `Recolor the system around ${hue.label.toLowerCase()}.`
+      changes.push({
+        label: 'Accent',
+        from: curSeeds.accent ?? '—',
+        to: hue.hex,
+      })
+      transforms.push((ds) => patchColor(ds, { accent: hue.hex }))
+    }
+  }
+
+  // 3) Gray temperature.
+  if (/warm/.test(p)) {
+    const warm = '#8b8178'
+    title ||= 'Warmer neutrals'
+    rationale ||= 'Tint the gray ramp toward a warm stone.'
+    changes.push({
+      label: 'Base / gray',
+      from: curSeeds.neutral ?? '#808080',
+      to: warm,
+    })
+    transforms.push((ds) => patchColor(ds, { neutral: warm }))
+  } else if (/cool|cold/.test(p)) {
+    const cool = '#78808b'
+    title ||= 'Cooler neutrals'
+    rationale ||= 'Tint the gray ramp toward a cool slate.'
+    changes.push({
+      label: 'Base / gray',
+      from: curSeeds.neutral ?? '#808080',
+      to: cool,
+    })
+    transforms.push((ds) => patchColor(ds, { neutral: cool }))
+  }
+
+  // 4) Radius nudges.
+  if (/round|pill|soft corner|friendly/.test(p) && !vibe) {
+    const to = '1.6'
+    title ||= 'Rounder corners'
+    rationale ||= 'Scale the whole radius ramp up.'
+    changes.push({ label: 'Radius', from: `${curRadius}×`, to: `${to}×` })
+    transforms.push((ds) => ({
+      ...ds,
+      tokens: { ...ds.tokens, [RADIUS_FACTOR_VAR]: to },
+    }))
+  } else if (/sharp|square|crisp|angular/.test(p) && !vibe) {
+    const to = '0'
+    title ||= 'Sharper corners'
+    rationale ||= 'Flatten the radius ramp to square.'
+    changes.push({ label: 'Radius', from: `${curRadius}×`, to: `${to}×` })
+    transforms.push((ds) => ({
+      ...ds,
+      tokens: { ...ds.tokens, [RADIUS_FACTOR_VAR]: to },
+    }))
+  }
+
+  // 5) Density nudges.
+  if (/dense|compact|tight|cram/.test(p) && !vibe) {
+    title ||= 'Denser layout'
+    rationale ||= 'Tighten control heights, gaps and padding.'
+    changes.push({ label: 'Density', from: current.density, to: 'compact' })
+    transforms.push((ds) => ({ ...ds, density: 'compact' as Density }))
+  } else if (/airy|spacious|roomy|breath|relax/.test(p) && !vibe) {
+    title ||= 'Airier layout'
+    rationale ||= 'Loosen spacing for a calmer rhythm.'
+    changes.push({ label: 'Density', from: current.density, to: 'comfortable' })
+    transforms.push((ds) => ({ ...ds, density: 'comfortable' as Density }))
+  }
+
+  // 6) Bolder shells — a stub axis, but a real, previewable border lever.
+  if (/bold|strong|heavy|thick/.test(p) && !vibe) {
+    title ||= 'Heavier shells'
+    rationale ||= 'Thicken borders and lean on flat surfaces.'
+    changes.push({ label: 'Border width', from: '1px', to: '2px' })
+    transforms.push((ds) => ({
+      ...ds,
+      tokens: {
+        ...ds.tokens,
+        [BORDER_WIDTH_VAR]: '2',
+        [ELEVATION_STYLE_VAR]: 'flat',
+      },
+    }))
+  }
+
+  // 7) Tighter typography.
+  if (/tight(er)? (track|letter|type)|condensed/.test(p)) {
+    title ||= 'Tighter tracking'
+    rationale ||= 'Pull letter-spacing in on display type.'
+    changes.push({ label: 'Tracking', from: '0em', to: '-0.02em' })
+    transforms.push((ds) => ({
+      ...ds,
+      tokens: { ...ds.tokens, [TRACKING_VAR]: '-0.02' },
+    }))
+  }
+
+  if (transforms.length === 0) {
+    // Nothing recognized — propose a tasteful, low-risk refresh and say so.
+    return {
+      id: uid('cs'),
+      title: 'Tasteful refresh',
+      rationale:
+        'Couldn’t map that to a specific change yet — here’s a safe nudge. A connected model would interpret freeform prompts like this directly.',
+      speculative: true,
+      changes: [
+        { label: 'Radius', from: `${curRadius}×`, to: '1.0×' },
+        { label: 'Density', from: current.density, to: 'default' },
+      ],
+      apply: (ds) => ({
+        ...ds,
+        density: 'default',
+        tokens: { ...ds.tokens, [RADIUS_FACTOR_VAR]: '1' },
+      }),
+    }
+  }
+
+  return {
+    id: uid('cs'),
+    title: title || 'Refined system',
+    rationale: rationale || 'Applied the changes you described.',
+    changes,
+    apply: (ds) => transforms.reduce((acc, t) => t(acc), ds),
+  }
+}
+
+/* -------------------------------- Audit ---------------------------------- */
+
+export type AuditLevel = 'pass' | 'warn' | 'fail'
+
+export interface AuditFinding {
+  id: string
+  level: AuditLevel
+  title: string
+  detail: string
+  /** Optional one-click remediation. */
+  fix?: ChangeSet
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace('#', '')
+  const full =
+    h.length === 3
+      ? h
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : h
+  const n = Number.parseInt(full || '000000', 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+
+function luminance([r, g, b]: [number, number, number]): number {
+  const lin = [r, g, b].map((v) => {
+    const s = v / 255
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+  }) as [number, number, number]
+  return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2]
+}
+
+/** WCAG contrast ratio between two hex colors (1–21). */
+export function contrastRatio(a: string, b: string): number {
+  const la = luminance(hexToRgb(a))
+  const lb = luminance(hexToRgb(b))
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la]
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+/** A few honest checks on the live seeds. Real ratios, not theater. */
+export function audit(current: DesignSystem): AuditFinding[] {
+  const seeds = seedsOf(current)
+  const findings: AuditFinding[] = []
+  const white = '#ffffff'
+
+  const checkOnWhite = (
+    seed: string,
+    name: string,
+    hex: string | undefined,
+  ): void => {
+    if (!hex) return
+    const ratio = contrastRatio(hex, white)
+    const r = ratio.toFixed(2)
+    if (ratio >= 4.5) {
+      findings.push({
+        id: uid('au'),
+        level: 'pass',
+        title: `${name} on white — AA`,
+        detail: `${r}:1 contrast. Safe for text and icons.`,
+      })
+    } else if (ratio >= 3) {
+      findings.push({
+        id: uid('au'),
+        level: 'warn',
+        title: `${name} on white — large text only`,
+        detail: `${r}:1 contrast. Passes AA for ≥24px text, fails for body.`,
+      })
+    } else {
+      findings.push({
+        id: uid('au'),
+        level: 'fail',
+        title: `${name} on white — fails AA`,
+        detail: `${r}:1 contrast. Too light for text or icons on white.`,
+        fix: {
+          id: uid('cs'),
+          title: `Darken ${name.toLowerCase()}`,
+          rationale: `Deepen ${name.toLowerCase()} to clear 4.5:1 on white.`,
+          changes: [{ label: name, from: hex, to: darken(hex) }],
+          apply: (ds) => patchColor(ds, { [seed]: darken(hex) }),
+        },
+      })
+    }
+  }
+
+  checkOnWhite('accent', 'Accent', seeds.accent)
+  checkOnWhite('danger', 'Danger', seeds.danger ?? '#ef4444')
+  checkOnWhite('warning', 'Warning', seeds.warning ?? '#f59e0b')
+  checkOnWhite('success', 'Success', seeds.success ?? '#22c55e')
+
+  return findings
+}
+
+/** Crude darkener for the suggested fix — pulls each channel toward black. */
+function darken(hex: string, amount = 0.38): string {
+  const [r, g, b] = hexToRgb(hex)
+  const f = (v: number) => Math.max(0, Math.round(v * (1 - amount)))
+  return `#${[f(r), f(g), f(b)].map((v) => v.toString(16).padStart(2, '0')).join('')}`
+}
+
+/* ----------------------------- Quick prompts ----------------------------- */
+
+export const QUICK_PROMPTS: string[] = [
+  'Make it feel like Linear',
+  'More playful and rounded',
+  'Warmer neutrals',
+  'Minimal and tight',
+  'Make it a fintech system',
+]

--- a/www/src/modules/create/atelier/index.tsx
+++ b/www/src/modules/create/atelier/index.tsx
@@ -3,10 +3,14 @@
 import { useState } from 'react'
 import { DicesIcon, RotateCcwIcon, SparklesIcon, Undo2Icon } from 'lucide-react'
 
+import { siteConfig } from '@/config/site'
 import { cn } from '@/registry/lib/utils'
 import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
-import { Button } from '@/registry/ui/button'
+import { Button, buttonStyles } from '@/registry/ui/button'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+import { GitHubIcon } from '@/components/icons/github'
+import { Logo } from '@/components/layout/logo'
+import { ThemeToggle } from '@/components/theme-toggle'
 
 import { useReroll } from '../panel/macros'
 import { Segmented } from '../panel/primitives'
@@ -38,10 +42,13 @@ export function AtelierExperience() {
 
 function StudioLayout() {
   const { aiOpen } = useStudio()
+  // No global site Header above us anymore (suppressed in _app for ?atelier),
+  // so the shell owns the full viewport: our own header-height top bar plus the
+  // remaining space for the three zones.
   return (
-    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-col">
+    <div className="flex h-svh min-h-0 flex-col">
       <TopBar />
-      <div className="flex min-h-0 flex-1 gap-3 p-4 pt-0 lg:gap-4 lg:p-5 lg:pt-0">
+      <div className="flex min-h-0 flex-1 gap-3 p-4 lg:gap-4 lg:p-5">
         <Inspector className="w-[360px] max-lg:hidden" />
         <div className="flex min-w-0 flex-1 flex-col gap-3">
           <Stage />
@@ -69,9 +76,16 @@ function TopBar() {
     (designSystem.color ?? DEFAULT_COLOR_CONFIG).seeds.accent ?? '#6366f1'
 
   return (
-    <div className="flex items-center gap-2 px-4 py-2.5 lg:px-5">
+    // One cohesive bar, visually continuous with the site Header it replaces on
+    // /create: same height token, sticky top, same px-6 gutter and button
+    // language. The Logo links home so the site ⇄ builder transition is two-way.
+    <header className="sticky top-0 z-30 flex h-(--header-height) shrink-0 items-center gap-2 border-b bg-bg/80 px-4 backdrop-blur-md lg:px-6">
+      <Logo />
+
+      <div className="mx-1 h-5 w-px bg-border max-sm:hidden" />
+
       <span
-        className="size-6 shrink-0 rounded-md ring-1 ring-black/10 ring-inset"
+        className="size-6 shrink-0 rounded-md ring-1 ring-black/10 ring-inset max-sm:hidden"
         style={{ backgroundColor: accent }}
         aria-hidden
       />
@@ -80,7 +94,7 @@ function TopBar() {
         onChange={(e) => setName(e.target.value)}
         aria-label="System name"
         spellCheck={false}
-        className="w-44 min-w-0 truncate rounded-sm bg-transparent text-sm font-semibold outline-none focus-visible:bg-neutral focus-visible:px-1.5 focus-visible:py-0.5"
+        className="w-32 min-w-0 truncate rounded-sm bg-transparent text-sm font-semibold outline-none focus-visible:bg-neutral focus-visible:px-1.5 focus-visible:py-0.5 lg:w-44"
       />
 
       <div className="mx-auto w-56 max-md:hidden">
@@ -143,7 +157,24 @@ function TopBar() {
         >
           <SparklesIcon /> Assistant
         </Button>
+
+        <div className="mx-1 h-5 w-px bg-border max-sm:hidden" />
+
+        <a
+          aria-label="GitHub"
+          href={siteConfig.links.github}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-icon-only=""
+          className={cn(
+            buttonStyles({ variant: 'quiet', size: 'sm' }),
+            'max-sm:hidden',
+          )}
+        >
+          <GitHubIcon />
+        </a>
+        <ThemeToggle variant="quiet" size="sm" isIconOnly />
       </div>
-    </div>
+    </header>
   )
 }

--- a/www/src/modules/create/atelier/index.tsx
+++ b/www/src/modules/create/atelier/index.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useState } from 'react'
+import { DicesIcon, RotateCcwIcon, SparklesIcon, Undo2Icon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { useReroll } from '../panel/macros'
+import { Segmented } from '../panel/primitives'
+import { useDesignSystem } from '../preset'
+import { AiDock } from './ai/ai-dock'
+import { CommandBar } from './ai/command-bar'
+import { Inspector } from './inspector'
+import { Stage } from './stage'
+import { StudioProvider, useStudio } from './store'
+
+/* ----------------------------------------------------------------------------
+ * Atelier — a rethink of /create as a three-zone instrument:
+ *   edit (inspector) · see (stage + spec sheet) · converse (AI dock + command
+ *   bar). Reuses the real design-system state and live preview; adds an expanded
+ *   axis catalog, a spec-sheet view, and an AI design assistant. Behind
+ *   `?atelier=true` so the shipped builder and the panel lab are untouched.
+ *
+ * Named "Atelier" to coexist with the separate "Studio" left-panel redesign
+ * landing on main — distinct folder, flag and entry point, zero file overlap.
+ * -------------------------------------------------------------------------- */
+
+export function AtelierExperience() {
+  return (
+    <StudioProvider>
+      <StudioLayout />
+    </StudioProvider>
+  )
+}
+
+function StudioLayout() {
+  const { aiOpen } = useStudio()
+  return (
+    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-col">
+      <TopBar />
+      <div className="flex min-h-0 flex-1 gap-3 p-4 pt-0 lg:gap-4 lg:p-5 lg:pt-0">
+        <Inspector className="w-[360px] max-lg:hidden" />
+        <div className="flex min-w-0 flex-1 flex-col gap-3">
+          <Stage />
+          <CommandBar />
+        </div>
+        <AiDock
+          className={cn(
+            'transition-all duration-300 max-lg:hidden',
+            aiOpen ? 'w-[360px]' : 'pointer-events-none w-0 border-0 opacity-0',
+          )}
+        />
+      </div>
+    </div>
+  )
+}
+
+function TopBar() {
+  const { stageView, setStageView, aiOpen, setAiOpen, canUndo, undo, reset } =
+    useStudio()
+  const { designSystem } = useDesignSystem()
+  const reroll = useReroll()
+  const [name, setName] = useState('Untitled system')
+
+  const accent =
+    (designSystem.color ?? DEFAULT_COLOR_CONFIG).seeds.accent ?? '#6366f1'
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-2.5 lg:px-5">
+      <span
+        className="size-6 shrink-0 rounded-md ring-1 ring-black/10 ring-inset"
+        style={{ backgroundColor: accent }}
+        aria-hidden
+      />
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        aria-label="System name"
+        spellCheck={false}
+        className="w-44 min-w-0 truncate rounded-sm bg-transparent text-sm font-semibold outline-none focus-visible:bg-neutral focus-visible:px-1.5 focus-visible:py-0.5"
+      />
+
+      <div className="mx-auto w-56 max-md:hidden">
+        <Segmented
+          ariaLabel="Stage view"
+          value={stageView}
+          onChange={(v) => setStageView(v as 'preview' | 'spec')}
+          options={[
+            { value: 'preview', label: 'Preview' },
+            { value: 'spec', label: 'Spec sheet' },
+          ]}
+        />
+      </div>
+
+      <div className="ml-auto flex items-center gap-1">
+        <Tooltip delay={300}>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            onPress={undo}
+            isDisabled={!canUndo}
+            aria-label="Undo"
+          >
+            <Undo2Icon />
+          </Button>
+          <TooltipContent>Undo</TooltipContent>
+        </Tooltip>
+        <Tooltip delay={300}>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            onPress={reset}
+            aria-label="Reset"
+          >
+            <RotateCcwIcon />
+          </Button>
+          <TooltipContent>Reset to defaults</TooltipContent>
+        </Tooltip>
+        <Tooltip delay={300}>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            onPress={reroll}
+            aria-label="Shuffle"
+          >
+            <DicesIcon />
+          </Button>
+          <TooltipContent>Surprise me</TooltipContent>
+        </Tooltip>
+
+        <div className="mx-1 h-5 w-px bg-border" />
+
+        <Button
+          size="sm"
+          variant={aiOpen ? 'primary' : 'default'}
+          onPress={() => setAiOpen(!aiOpen)}
+        >
+          <SparklesIcon /> Assistant
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/atelier/inspector.tsx
+++ b/www/src/modules/create/atelier/inspector.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { CodeOptionsDialog } from '../code-options'
+import { ExportFooter } from '../export'
+import { BindingDot } from '../panel/primitives'
+import { STUDIO_DOMAINS, type StudioControl, type StudioDomain } from './schema'
+import { useStudio } from './store'
+
+/* ----------------------------------------------------------------------------
+ * The inspector — the edit surface. A slim domain rail (every axis family) plus
+ * the active domain's controls, rendered wider than the shipped 288px panel so
+ * rich controls (color ramps, status grids, component anatomy) have room.
+ * -------------------------------------------------------------------------- */
+
+export function Inspector({ className }: { className?: string }) {
+  const { activeDomain, setActiveDomain } = useStudio()
+  const domain =
+    STUDIO_DOMAINS.find((d) => d.id === activeDomain) ?? STUDIO_DOMAINS[0]
+  if (!domain) return null
+
+  return (
+    <aside
+      className={cn(
+        'flex shrink-0 overflow-hidden rounded-xl border bg-card',
+        className,
+      )}
+    >
+      <DomainRail active={domain.id} onSelect={setActiveDomain} />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <DomainHeader domain={domain} />
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+          <div className="flex flex-col gap-6 p-4">
+            {domain.groups.map((group, i) => (
+              <section key={group.label ?? i} className="flex flex-col gap-3">
+                {group.label && (
+                  <span className="text-[10px] font-semibold tracking-widest text-fg-muted uppercase">
+                    {group.label}
+                  </span>
+                )}
+                <div className="flex flex-col gap-4">
+                  {group.controls.map((control) => (
+                    <ControlRow key={control.id} control={control} />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+        <div className="flex flex-col gap-2 border-t p-3">
+          <CodeOptionsDialog />
+          <ExportFooter />
+        </div>
+      </div>
+    </aside>
+  )
+}
+
+function DomainRail({
+  active,
+  onSelect,
+}: {
+  active: string
+  onSelect: (id: string) => void
+}) {
+  return (
+    <div className="flex shrink-0 flex-col items-center gap-1 border-r bg-neutral/30 p-1.5">
+      {STUDIO_DOMAINS.map((d) => {
+        const isActive = d.id === active
+        return (
+          <Tooltip key={d.id} delay={250}>
+            <ButtonPrimitives.Button
+              onPress={() => onSelect(d.id)}
+              aria-label={d.label}
+              className={cn(
+                'flex size-10 items-center justify-center rounded-lg focus-reset transition-colors focus-visible:focus-ring',
+                isActive
+                  ? 'bg-card text-fg shadow-sm ring-1 ring-border'
+                  : 'text-fg-muted hover:bg-card/60 hover:text-fg',
+              )}
+            >
+              <d.icon className="size-[18px]" />
+            </ButtonPrimitives.Button>
+            <TooltipContent placement="right">{d.label}</TooltipContent>
+          </Tooltip>
+        )
+      })}
+    </div>
+  )
+}
+
+function DomainHeader({ domain }: { domain: StudioDomain }) {
+  return (
+    <div className="flex items-center gap-2.5 border-b px-4 py-3">
+      <div className="flex size-8 items-center justify-center rounded-lg bg-neutral text-fg">
+        <domain.icon className="size-4" />
+      </div>
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate text-sm font-semibold">{domain.label}</span>
+        <span className="truncate text-xs text-fg-muted">{domain.tagline}</span>
+      </div>
+    </div>
+  )
+}
+
+function ControlRow({ control }: { control: StudioControl }) {
+  if (control.block) {
+    return (
+      <div className="flex flex-col gap-2" data-control={control.id}>
+        <LabelLine control={control} />
+        {control.description && <Help>{control.description}</Help>}
+        <control.Widget />
+      </div>
+    )
+  }
+  return (
+    <div className="flex flex-col gap-1.5" data-control={control.id}>
+      <LabelLine control={control} />
+      {control.description && <Help>{control.description}</Help>}
+      <control.Widget />
+    </div>
+  )
+}
+
+function LabelLine({ control }: { control: StudioControl }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="truncate text-[13px] font-medium text-fg">
+        {control.label}
+      </span>
+      <BindingDot binding={control.binding} />
+    </div>
+  )
+}
+
+function Help({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs leading-snug text-balance text-fg-muted">
+      {children}
+    </p>
+  )
+}

--- a/www/src/modules/create/atelier/schema.tsx
+++ b/www/src/modules/create/atelier/schema.tsx
@@ -1,0 +1,1093 @@
+'use client'
+
+import { type ComponentType, useMemo } from 'react'
+import {
+  BoxSelectIcon,
+  ChevronDownIcon,
+  type LucideIcon,
+  LayersIcon,
+  MessageSquareIcon,
+  MoonIcon,
+  MousePointer2Icon,
+  PaletteIcon,
+  RulerIcon,
+  ShapesIcon,
+  SmileIcon,
+  TypeIcon,
+  ZapIcon,
+} from 'lucide-react'
+
+import {
+  DEFAULT_COLOR_CONFIG,
+  PALETTE_ORDER,
+  resolveColorConfig,
+} from '@/registry/theme'
+import type { AlgorithmId, PaletteSeeds } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+import { Popover } from '@/registry/ui/popover'
+import { Select, SelectValue } from '@/registry/ui/select'
+import { Switch } from '@/registry/ui/switch'
+
+import { ContrastReadout } from '../colors/contrast'
+import { ColorKnobsControls } from '../colors/knobs'
+import { ComponentDetailView } from '../components'
+import { Segmented, ValueSlider } from '../panel/primitives'
+import { SeedField } from '../panel/schema'
+import { useDesignSystem } from '../preset'
+import * as T from './tokens'
+
+/* ----------------------------------------------------------------------------
+ * The studio axis catalog
+ *
+ * Every visual decision a design system makes, as a configurable axis grouped
+ * by domain. `binding: 'live'` controls drive the preview through an existing
+ * token channel; `'stub'` controls write a `--ds-*` var no component reads yet —
+ * honest UI for axes the engine will grow into. New tweaks beyond the shipped
+ * set are marked in their descriptions.
+ * -------------------------------------------------------------------------- */
+
+export type Binding = 'live' | 'stub'
+
+export interface StudioControl {
+  id: string
+  label: string
+  description?: string
+  binding: Binding
+  /** Widget renders its own full UI (no chrome label row). */
+  block?: boolean
+  Widget: ComponentType
+}
+
+export interface StudioGroup {
+  label?: string
+  controls: StudioControl[]
+}
+
+export interface StudioDomain {
+  id: string
+  label: string
+  tagline: string
+  icon: LucideIcon
+  groups: StudioGroup[]
+}
+
+/* ------------------------------ Token helper ----------------------------- */
+
+function useToken(name: string, fallback: string) {
+  const { designSystem, setToken } = useDesignSystem()
+  const value = designSystem.tokens[name] ?? fallback
+  return [value, (v: string) => setToken(name, v)] as const
+}
+
+/* -------------------------------- Widgets -------------------------------- */
+
+function SelectWidget({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+}: {
+  value: string
+  onChange: (v: string) => void
+  options: string[]
+  ariaLabel: string
+}) {
+  return (
+    <Select
+      className="w-full"
+      selectedKey={value}
+      onSelectionChange={(k) => onChange(k as string)}
+      aria-label={ariaLabel}
+    >
+      <Button size="sm" className="w-full justify-between">
+        <SelectValue className="truncate" />
+        <ChevronDownIcon data-icon-end="" />
+      </Button>
+      <Popover>
+        <ListBox>
+          {options.map((o) => (
+            <ListBoxItem key={o} id={o}>
+              {o}
+            </ListBoxItem>
+          ))}
+        </ListBox>
+      </Popover>
+    </Select>
+  )
+}
+
+function SwitchToken({
+  varName,
+  fallback,
+}: {
+  varName: string
+  fallback: string
+}) {
+  const [value, set] = useToken(varName, fallback)
+  return (
+    <Switch
+      isSelected={value === 'true'}
+      onChange={(s) => set(String(s))}
+      aria-label="Toggle"
+    />
+  )
+}
+
+/* ------------------------------- Color ----------------------------------- */
+
+const ALGORITHMS: ReadonlyArray<{ id: AlgorithmId; label: string }> = [
+  { id: 'oklch', label: 'OKLCH Perceptual' },
+  { id: 'tailwind', label: 'Tailwind-style' },
+  { id: 'material', label: 'Material' },
+  { id: 'contrast', label: 'Contrast-locked' },
+]
+
+function AlgorithmWidget() {
+  const { designSystem, setColorAlgorithm } = useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  return (
+    <Select
+      className="w-full"
+      selectedKey={config.algorithm}
+      onSelectionChange={(k) => setColorAlgorithm(k as AlgorithmId)}
+      aria-label="Color algorithm"
+    >
+      <Button size="sm" className="w-full justify-between">
+        <SelectValue className="truncate" />
+        <ChevronDownIcon data-icon-end="" />
+      </Button>
+      <Popover>
+        <ListBox>
+          {ALGORITHMS.map((a) => (
+            <ListBoxItem key={a.id} id={a.id}>
+              {a.label}
+            </ListBoxItem>
+          ))}
+        </ListBox>
+      </Popover>
+    </Select>
+  )
+}
+
+function GrayStrategyWidget() {
+  const { designSystem, setColorSeed } = useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const isTinted =
+    (config.seeds.neutral ?? '#808080').toLowerCase() !== '#808080'
+  return (
+    <Segmented
+      ariaLabel="Gray strategy"
+      value={isTinted ? 'tinted' : 'pure'}
+      onChange={(v) =>
+        setColorSeed(
+          'neutral',
+          v === 'pure'
+            ? '#808080'
+            : (config.seeds.accent ?? DEFAULT_COLOR_CONFIG.seeds.accent),
+        )
+      }
+      options={[
+        { value: 'pure', label: 'Pure' },
+        { value: 'tinted', label: 'Brand-tinted' },
+      ]}
+    />
+  )
+}
+
+function StatusColorsWidget() {
+  const status: Array<{ seed: keyof PaletteSeeds; label: string }> = [
+    { seed: 'success', label: 'Success' },
+    { seed: 'warning', label: 'Warning' },
+    { seed: 'danger', label: 'Danger' },
+    { seed: 'info', label: 'Info' },
+  ]
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {status.map((s) => (
+        <div key={s.seed} className="flex flex-col gap-1">
+          <span className="text-[10px] tracking-wider text-fg-muted uppercase">
+            {s.label}
+          </span>
+          <SeedField seed={s.seed} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ColorEngineWidget() {
+  const { designSystem, setColorKnob } = useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const resolved = useMemo(() => resolveColorConfig(config), [config])
+  return (
+    <div className="flex flex-col gap-4">
+      <ColorKnobsControls
+        algorithm={config.algorithm}
+        knobs={config.knobs ?? {}}
+        steps={resolved.steps}
+        onChange={setColorKnob}
+      />
+      <ContrastReadout resolved={resolved} />
+      <div className="flex flex-col gap-1">
+        {PALETTE_ORDER.map((palette) => {
+          const ramp = resolved.light[palette]
+          if (!ramp) return null
+          return (
+            <div
+              key={palette}
+              className="flex overflow-hidden rounded"
+              title={palette}
+            >
+              {Object.entries(ramp).map(([step, val]) => (
+                <div
+                  key={step}
+                  className="h-4 flex-1"
+                  style={{ backgroundColor: val }}
+                  title={`--${palette}-${step}`}
+                />
+              ))}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------ Typography -------------------------------- */
+
+const FONTS = ['Geist', 'Inter', 'Satoshi', 'Söhne', 'IBM Plex Sans', 'Mono']
+
+function TrackingWidget() {
+  const [value, set] = useToken(T.TRACKING_VAR, '0')
+  return (
+    <ValueSlider
+      ariaLabel="Letter spacing"
+      value={Number.parseFloat(value) || 0}
+      min={-0.05}
+      max={0.1}
+      step={0.005}
+      format={(v) => `${v.toFixed(3)}em`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+
+function HeadingWeightWidget() {
+  const [value, set] = useToken(T.HEADING_WEIGHT_VAR, '600')
+  return (
+    <Segmented
+      ariaLabel="Heading weight"
+      value={value}
+      onChange={set}
+      options={[
+        { value: '500', label: 'Medium' },
+        { value: '600', label: 'Semibold' },
+        { value: '700', label: 'Bold' },
+      ]}
+    />
+  )
+}
+
+/* -------------------------------- Shape ---------------------------------- */
+
+function RadiusFactorWidget() {
+  const [value, set] = useToken(T.RADIUS_FACTOR_VAR, T.DEFAULT_RADIUS_FACTOR)
+  return (
+    <ValueSlider
+      ariaLabel="Radius factor"
+      value={Number.parseFloat(value) || 1}
+      min={0}
+      max={2}
+      step={0.05}
+      format={(v) => `${v.toFixed(2)}×`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+
+function CornerStyleWidget() {
+  const [value, set] = useToken(T.CORNER_STYLE_VAR, 'rounded')
+  return (
+    <Segmented
+      ariaLabel="Corner style"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'rounded', label: 'Rounded' },
+        { value: 'squircle', label: 'Squircle' },
+      ]}
+    />
+  )
+}
+
+/* ------------------------------- Spacing --------------------------------- */
+
+function DensityWidget() {
+  const { designSystem, setDensity } = useDesignSystem()
+  return (
+    <Segmented
+      ariaLabel="Density"
+      value={designSystem.density}
+      onChange={setDensity}
+      options={[
+        { value: 'compact', label: 'Compact' },
+        { value: 'default', label: 'Default' },
+        { value: 'comfortable', label: 'Cozy' },
+      ]}
+    />
+  )
+}
+
+function BaseUnitWidget() {
+  const [value, set] = useToken(T.BASE_UNIT_VAR, '4')
+  return (
+    <Segmented
+      ariaLabel="Base grid unit"
+      value={value}
+      onChange={set}
+      options={[
+        { value: '4', label: '4 pt' },
+        { value: '8', label: '8 pt' },
+      ]}
+    />
+  )
+}
+
+/* ------------------------------ Elevation -------------------------------- */
+
+function StyleFamilyWidget() {
+  const [value, set] = useToken(T.ELEVATION_STYLE_VAR, 'soft')
+  return (
+    <Segmented
+      ariaLabel="Style family"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'flat', label: 'Flat' },
+        { value: 'soft', label: 'Soft' },
+        { value: 'depth', label: '3D' },
+        { value: 'glass', label: 'Glass' },
+      ]}
+    />
+  )
+}
+
+function ShadowTintWidget() {
+  const [value, set] = useToken(T.SHADOW_TINT_VAR, 'neutral')
+  return (
+    <Segmented
+      ariaLabel="Shadow tint"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'neutral', label: 'Neutral' },
+        { value: 'brand', label: 'Brand' },
+      ]}
+    />
+  )
+}
+
+/* -------------------------------- Motion --------------------------------- */
+
+function EasingWidget() {
+  const [value, set] = useToken(T.MOTION_EASING_VAR, 'standard')
+  return (
+    <Segmented
+      ariaLabel="Easing"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'standard', label: 'Standard' },
+        { value: 'spring', label: 'Spring' },
+        { value: 'sharp', label: 'Sharp' },
+      ]}
+    />
+  )
+}
+
+/* ------------------------------ Components -------------------------------- */
+
+function ComponentAnatomyWidget({ name }: { name: string }) {
+  const { designSystem, setComponentParam } = useDesignSystem()
+  return (
+    <ComponentDetailView
+      componentName={name}
+      selectedParams={designSystem.componentParams[name] ?? {}}
+      onParamChange={(param, value) => setComponentParam(name, param, value)}
+    />
+  )
+}
+
+/* --------------------------------- Mode ---------------------------------- */
+
+function DefaultModeWidget() {
+  const [value, set] = useToken(T.DEFAULT_MODE_VAR, 'system')
+  return (
+    <Segmented
+      ariaLabel="Default mode"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'light', label: 'Light' },
+        { value: 'dark', label: 'Dark' },
+        { value: 'system', label: 'Auto' },
+      ]}
+    />
+  )
+}
+
+function LabelCasingWidget() {
+  const [value, set] = useToken(T.LABEL_CASING_VAR, 'title')
+  return (
+    <Segmented
+      ariaLabel="Label casing"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'title', label: 'Title Case' },
+        { value: 'sentence', label: 'Sentence case' },
+      ]}
+    />
+  )
+}
+
+/* -------------------------- Generic slider helpers ----------------------- */
+
+function sliderToken(
+  varName: string,
+  fallback: string,
+  opts: {
+    min: number
+    max: number
+    step: number
+    format: (v: number) => string
+    aria: string
+  },
+): ComponentType {
+  return function TokenSlider() {
+    const [value, set] = useToken(varName, fallback)
+    return (
+      <ValueSlider
+        ariaLabel={opts.aria}
+        value={Number.parseFloat(value) || Number.parseFloat(fallback)}
+        min={opts.min}
+        max={opts.max}
+        step={opts.step}
+        format={opts.format}
+        onChange={(v) => set(String(v))}
+      />
+    )
+  }
+}
+
+const pxFmt = (v: number) => `${v}px`
+const xFmt = (v: number) => `${v.toFixed(2)}×`
+const pctFmt = (v: number) => `${Math.round(v * 100)}%`
+
+/* ------------------------------- The catalog ----------------------------- */
+
+const ctl = (c: StudioControl): StudioControl => c
+
+export const STUDIO_DOMAINS: StudioDomain[] = [
+  {
+    id: 'color',
+    label: 'Color',
+    tagline: 'Seeds, ramps and contrast',
+    icon: PaletteIcon,
+    groups: [
+      {
+        label: 'Seeds',
+        controls: [
+          ctl({
+            id: 'brand-color',
+            label: 'Brand color',
+            description:
+              'The one real color on screen — drives the accent ramps.',
+            binding: 'live',
+            Widget: () => <SeedField seed="accent" />,
+          }),
+          ctl({
+            id: 'base-color',
+            label: 'Base / gray',
+            description: 'Neutral seed the whole surface system derives from.',
+            binding: 'live',
+            Widget: () => <SeedField seed="neutral" />,
+          }),
+          ctl({
+            id: 'gray-strategy',
+            label: 'Gray strategy',
+            description: 'Pure neutrals, or grays tinted toward the brand.',
+            binding: 'live',
+            Widget: GrayStrategyWidget,
+          }),
+        ],
+      },
+      {
+        label: 'Generation',
+        controls: [
+          ctl({
+            id: 'color-algorithm',
+            label: 'Generation algorithm',
+            description: 'How seeds expand into tonal ramps.',
+            binding: 'live',
+            Widget: AlgorithmWidget,
+          }),
+          ctl({
+            id: 'status-colors',
+            label: 'Status families',
+            binding: 'live',
+            block: true,
+            Widget: StatusColorsWidget,
+          }),
+          ctl({
+            id: 'color-engine',
+            label: 'Ramps & contrast',
+            binding: 'live',
+            block: true,
+            Widget: ColorEngineWidget,
+          }),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'typography',
+    label: 'Type',
+    tagline: 'Fonts, scale and rhythm',
+    icon: TypeIcon,
+    groups: [
+      {
+        label: 'Fonts',
+        controls: [
+          ctl({
+            id: 'heading-font',
+            label: 'Display font',
+            binding: 'stub',
+            Widget: () => {
+              const [v, set] = useToken(T.FONT_HEADING_VAR, 'Geist')
+              return (
+                <SelectWidget
+                  value={v}
+                  onChange={set}
+                  options={FONTS}
+                  ariaLabel="Display font"
+                />
+              )
+            },
+          }),
+          ctl({
+            id: 'body-font',
+            label: 'Body font',
+            binding: 'stub',
+            Widget: () => {
+              const [v, set] = useToken(T.FONT_BODY_VAR, 'Geist')
+              return (
+                <SelectWidget
+                  value={v}
+                  onChange={set}
+                  options={FONTS}
+                  ariaLabel="Body font"
+                />
+              )
+            },
+          }),
+        ],
+      },
+      {
+        label: 'Scale & rhythm',
+        controls: [
+          ctl({
+            id: 'type-scale',
+            label: 'Scale ratio',
+            description: 'Modular scale between type steps.',
+            binding: 'stub',
+            Widget: sliderToken(T.TYPE_SCALE_VAR, '1.25', {
+              min: 1.1,
+              max: 1.5,
+              step: 0.01,
+              format: (v) => v.toFixed(3),
+              aria: 'Type scale',
+            }),
+          }),
+          ctl({
+            id: 'base-size',
+            label: 'Base size',
+            binding: 'stub',
+            Widget: sliderToken(T.TYPE_BASE_VAR, '16', {
+              min: 13,
+              max: 18,
+              step: 1,
+              format: pxFmt,
+              aria: 'Base size',
+            }),
+          }),
+          ctl({
+            id: 'tracking',
+            label: 'Display tracking',
+            description: 'New — letter-spacing on headings.',
+            binding: 'stub',
+            Widget: TrackingWidget,
+          }),
+          ctl({
+            id: 'heading-weight',
+            label: 'Heading weight',
+            description: 'New — weight headings render at.',
+            binding: 'stub',
+            Widget: HeadingWeightWidget,
+          }),
+          ctl({
+            id: 'line-height',
+            label: 'Line height',
+            description: 'New — body reading rhythm.',
+            binding: 'stub',
+            Widget: sliderToken(T.LINE_HEIGHT_VAR, '1.5', {
+              min: 1.2,
+              max: 1.8,
+              step: 0.05,
+              format: xFmt,
+              aria: 'Line height',
+            }),
+          }),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'shape',
+    label: 'Shape',
+    tagline: 'Radius and borders',
+    icon: ShapesIcon,
+    groups: [
+      {
+        controls: [
+          ctl({
+            id: 'radius-factor',
+            label: 'Radius factor',
+            description: 'Scales the whole corner-radius scale at once.',
+            binding: 'live',
+            Widget: RadiusFactorWidget,
+          }),
+          ctl({
+            id: 'corner-style',
+            label: 'Corner style',
+            description: 'New — circular vs. iOS-style squircle corners.',
+            binding: 'stub',
+            Widget: CornerStyleWidget,
+          }),
+          ctl({
+            id: 'border-width',
+            label: 'Border width',
+            binding: 'stub',
+            Widget: sliderToken(T.BORDER_WIDTH_VAR, '1', {
+              min: 0,
+              max: 3,
+              step: 0.5,
+              format: pxFmt,
+              aria: 'Border width',
+            }),
+          }),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'spacing',
+    label: 'Space',
+    tagline: 'Density and grid',
+    icon: RulerIcon,
+    groups: [
+      {
+        controls: [
+          ctl({
+            id: 'density',
+            label: 'Density',
+            description: 'Global control heights, gaps and padding.',
+            binding: 'live',
+            Widget: DensityWidget,
+          }),
+          ctl({
+            id: 'spacing-scale',
+            label: 'Spacing scale',
+            binding: 'stub',
+            Widget: sliderToken(T.SPACING_SCALE_VAR, '1', {
+              min: 0.75,
+              max: 1.5,
+              step: 0.05,
+              format: xFmt,
+              aria: 'Spacing scale',
+            }),
+          }),
+          ctl({
+            id: 'base-unit',
+            label: 'Grid unit',
+            description: 'New — 4pt or 8pt spacing grid.',
+            binding: 'stub',
+            Widget: BaseUnitWidget,
+          }),
+          ctl({
+            id: 'content-width',
+            label: 'Content width',
+            description: 'New — max readable line / container width.',
+            binding: 'stub',
+            Widget: sliderToken(T.CONTENT_WIDTH_VAR, '1280', {
+              min: 960,
+              max: 1600,
+              step: 40,
+              format: pxFmt,
+              aria: 'Content width',
+            }),
+          }),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'elevation',
+    label: 'Elevation',
+    tagline: 'Depth, shadow and glass',
+    icon: LayersIcon,
+    groups: [
+      {
+        controls: [
+          ctl({
+            id: 'style-family',
+            label: 'Style family',
+            description: 'The big re-skin: flat, soft, 3D or glass.',
+            binding: 'stub',
+            Widget: StyleFamilyWidget,
+          }),
+          ctl({
+            id: 'shadow-intensity',
+            label: 'Shadow intensity',
+            binding: 'stub',
+            Widget: sliderToken(T.SHADOW_INTENSITY_VAR, '0.5', {
+              min: 0,
+              max: 1,
+              step: 0.05,
+              format: pctFmt,
+              aria: 'Shadow intensity',
+            }),
+          }),
+          ctl({
+            id: 'shadow-tint',
+            label: 'Shadow tint',
+            description: 'New — neutral shadows or brand-tinted.',
+            binding: 'stub',
+            Widget: ShadowTintWidget,
+          }),
+          ctl({
+            id: 'backdrop-blur',
+            label: 'Backdrop blur',
+            description: 'Frost behind overlays and menus.',
+            binding: 'stub',
+            Widget: sliderToken(T.BACKDROP_BLUR_VAR, '0', {
+              min: 0,
+              max: 24,
+              step: 1,
+              format: pxFmt,
+              aria: 'Backdrop blur',
+            }),
+          }),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'motion',
+    label: 'Motion',
+    tagline: 'Timing, easing and feel',
+    icon: ZapIcon,
+    groups: [
+      {
+        controls: [
+          ctl({
+            id: 'duration',
+            label: 'Duration scale',
+            binding: 'stub',
+            Widget: sliderToken(T.MOTION_DURATION_VAR, '150', {
+              min: 0,
+              max: 400,
+              step: 10,
+              format: (v) => `${v}ms`,
+              aria: 'Duration',
+            }),
+          }),
+          ctl({
+            id: 'easing',
+            label: 'Easing curve',
+            description: 'New — the personality of every transition.',
+            binding: 'stub',
+            Widget: EasingWidget,
+          }),
+          ctl({
+            id: 'hover-lift',
+            label: 'Hover lift',
+            description: 'New — how far interactive surfaces rise on hover.',
+            binding: 'stub',
+            Widget: sliderToken(T.HOVER_LIFT_VAR, '0', {
+              min: 0,
+              max: 6,
+              step: 1,
+              format: pxFmt,
+              aria: 'Hover lift',
+            }),
+          }),
+          ctl({
+            id: 'press-scale',
+            label: 'Press scale',
+            description: 'New — tactile shrink on press.',
+            binding: 'stub',
+            Widget: sliderToken(T.PRESS_SCALE_VAR, '1', {
+              min: 0.9,
+              max: 1,
+              step: 0.01,
+              format: xFmt,
+              aria: 'Press scale',
+            }),
+          }),
+          ctl({
+            id: 'animations',
+            label: 'Animations',
+            description: 'Global on/off for all transitions.',
+            binding: 'stub',
+            Widget: () => (
+              <SwitchToken varName={T.MOTION_ENABLED_VAR} fallback="true" />
+            ),
+          }),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'interaction',
+    label: 'Interaction',
+    tagline: 'Cursors and focus',
+    icon: MousePointer2Icon,
+    groups: [
+      {
+        controls: [
+          ctl({
+            id: 'cursor-interactive',
+            label: 'Interactive cursor',
+            binding: 'live',
+            Widget: () => {
+              const [v, set] = useToken(
+                T.CURSOR_INTERACTIVE_VAR,
+                T.DEFAULT_CURSOR_INTERACTIVE,
+              )
+              return (
+                <Segmented
+                  ariaLabel="Interactive cursor"
+                  value={v}
+                  onChange={set}
+                  options={[
+                    { value: 'default', label: 'Default' },
+                    { value: 'pointer', label: 'Pointer' },
+                  ]}
+                />
+              )
+            },
+          }),
+          ctl({
+            id: 'cursor-disabled',
+            label: 'Disabled cursor',
+            binding: 'live',
+            Widget: () => {
+              const [v, set] = useToken(
+                T.CURSOR_DISABLED_VAR,
+                T.DEFAULT_CURSOR_DISABLED,
+              )
+              return (
+                <Segmented
+                  ariaLabel="Disabled cursor"
+                  value={v}
+                  onChange={set}
+                  options={[
+                    { value: 'default', label: 'Default' },
+                    { value: 'not-allowed', label: 'Not allowed' },
+                  ]}
+                />
+              )
+            },
+          }),
+          ctl({
+            id: 'focus-ring-style',
+            label: 'Focus ring style',
+            description: 'New — ring, outline or soft glow.',
+            binding: 'stub',
+            Widget: () => {
+              const [v, set] = useToken(T.FOCUS_RING_STYLE_VAR, 'ring')
+              return (
+                <Segmented
+                  ariaLabel="Focus ring style"
+                  value={v}
+                  onChange={set}
+                  options={[
+                    { value: 'ring', label: 'Ring' },
+                    { value: 'outline', label: 'Outline' },
+                    { value: 'glow', label: 'Glow' },
+                  ]}
+                />
+              )
+            },
+          }),
+          ctl({
+            id: 'focus-ring-width',
+            label: 'Focus ring width',
+            binding: 'stub',
+            Widget: sliderToken(T.FOCUS_RING_WIDTH_VAR, '2', {
+              min: 0,
+              max: 4,
+              step: 1,
+              format: pxFmt,
+              aria: 'Focus ring width',
+            }),
+          }),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'icon',
+    label: 'Icons',
+    tagline: 'Library and stroke',
+    icon: SmileIcon,
+    groups: [
+      {
+        controls: [
+          ctl({
+            id: 'icon-library',
+            label: 'Icon library',
+            description: 'New — the family icons are drawn from.',
+            binding: 'stub',
+            Widget: () => {
+              const [v, set] = useToken(T.ICON_LIBRARY_VAR, 'Lucide')
+              return (
+                <SelectWidget
+                  value={v}
+                  onChange={set}
+                  options={[
+                    'Lucide',
+                    'Phosphor',
+                    'Radix',
+                    'Tabler',
+                    'Heroicons',
+                  ]}
+                  ariaLabel="Icon library"
+                />
+              )
+            },
+          }),
+          ctl({
+            id: 'icon-stroke',
+            label: 'Stroke width',
+            binding: 'stub',
+            Widget: sliderToken(T.ICON_STROKE_VAR, '2', {
+              min: 1,
+              max: 2.5,
+              step: 0.25,
+              format: pxFmt,
+              aria: 'Icon stroke',
+            }),
+          }),
+          ctl({
+            id: 'icon-scale',
+            label: 'Icon scale',
+            description: 'New — icon size relative to text.',
+            binding: 'stub',
+            Widget: sliderToken(T.ICON_SCALE_VAR, '1', {
+              min: 0.85,
+              max: 1.25,
+              step: 0.05,
+              format: xFmt,
+              aria: 'Icon scale',
+            }),
+          }),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'components',
+    label: 'Components',
+    tagline: 'Per-component anatomy',
+    icon: BoxSelectIcon,
+    groups: [
+      {
+        controls: [
+          ctl({
+            id: 'button-anatomy',
+            label: 'Button',
+            binding: 'live',
+            block: true,
+            Widget: () => <ComponentAnatomyWidget name="button" />,
+          }),
+          ctl({
+            id: 'input-anatomy',
+            label: 'Input',
+            binding: 'live',
+            block: true,
+            Widget: () => <ComponentAnatomyWidget name="input" />,
+          }),
+          ctl({
+            id: 'card-anatomy',
+            label: 'Card',
+            binding: 'live',
+            block: true,
+            Widget: () => <ComponentAnatomyWidget name="card" />,
+          }),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'mode',
+    label: 'Modes',
+    tagline: 'Light, dark and voice',
+    icon: MoonIcon,
+    groups: [
+      {
+        controls: [
+          ctl({
+            id: 'default-mode',
+            label: 'Default mode',
+            description: 'Which mode the exported system boots in.',
+            binding: 'stub',
+            Widget: DefaultModeWidget,
+          }),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'content',
+    label: 'Voice',
+    tagline: 'Copy conventions',
+    icon: MessageSquareIcon,
+    groups: [
+      {
+        controls: [
+          ctl({
+            id: 'label-casing',
+            label: 'Label casing',
+            description:
+              'New — Title Case vs. sentence case across the exported copy.',
+            binding: 'stub',
+            Widget: LabelCasingWidget,
+          }),
+        ],
+      },
+    ],
+  },
+]
+
+export const DOMAIN_BY_ID = new Map(STUDIO_DOMAINS.map((d) => [d.id, d]))
+
+/** Flat count of live vs. total controls — drives the honesty legend. */
+export function controlStats() {
+  const all = STUDIO_DOMAINS.flatMap((d) => d.groups.flatMap((g) => g.controls))
+  const live = all.filter((c) => c.binding === 'live').length
+  return { live, total: all.length }
+}

--- a/www/src/modules/create/atelier/spec-sheet.tsx
+++ b/www/src/modules/create/atelier/spec-sheet.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { type ReactNode, useMemo } from 'react'
+
+import { cn } from '@/registry/lib/utils'
+import {
+  DEFAULT_COLOR_CONFIG,
+  PALETTE_ORDER,
+  resolveColorConfig,
+} from '@/registry/theme'
+
+import { useDesignSystem } from '../preset'
+import * as T from './tokens'
+
+/* ----------------------------------------------------------------------------
+ * The spec sheet — the system as an ownable artifact. Where the preview shows
+ * components, this shows the *decisions*: ramps, type scale, radius, spacing and
+ * elevation, all live off the same edited state. Nothing here is in the shipped
+ * builder; it's the "see your whole system at once" view.
+ * -------------------------------------------------------------------------- */
+
+export function SpecSheet() {
+  const { designSystem } = useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const resolved = useMemo(() => resolveColorConfig(config), [config])
+
+  const radiusFactor =
+    Number.parseFloat(designSystem.tokens[T.RADIUS_FACTOR_VAR] ?? '1') || 1
+  const base =
+    Number.parseFloat(designSystem.tokens[T.TYPE_BASE_VAR] ?? '16') || 16
+  const ratio =
+    Number.parseFloat(designSystem.tokens[T.TYPE_SCALE_VAR] ?? '1.25') || 1.25
+  const spacingScale =
+    Number.parseFloat(designSystem.tokens[T.SPACING_SCALE_VAR] ?? '1') || 1
+  const shadow = Number.parseFloat(
+    designSystem.tokens[T.SHADOW_INTENSITY_VAR] ?? '0.5',
+  )
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex max-w-3xl flex-col gap-5 p-6 pt-16">
+        <SpecCard title="Palette" hint="Generated tonal ramps">
+          <div className="flex flex-col gap-2">
+            {PALETTE_ORDER.map((palette) => {
+              const ramp = resolved.light[palette]
+              if (!ramp) return null
+              return (
+                <div key={palette} className="flex items-center gap-3">
+                  <span className="w-16 shrink-0 truncate text-xs text-fg-muted capitalize">
+                    {palette}
+                  </span>
+                  <div className="flex flex-1 overflow-hidden rounded-md ring-1 ring-border/60">
+                    {Object.entries(ramp).map(([step, val]) => (
+                      <div
+                        key={step}
+                        className="h-7 flex-1"
+                        style={{ backgroundColor: val }}
+                        title={`--${palette}-${step}: ${val}`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </SpecCard>
+
+        <SpecCard
+          title="Type scale"
+          hint={`${base}px base · ${ratio.toFixed(2)} ratio`}
+        >
+          <div className="flex flex-col gap-3">
+            {[
+              { label: 'Display', step: 4, weight: 700, font: 'font-heading' },
+              { label: 'Heading', step: 2, weight: 600, font: 'font-heading' },
+              { label: 'Title', step: 1, weight: 600, font: 'font-heading' },
+              { label: 'Body', step: 0, weight: 400, font: 'font-body' },
+              { label: 'Caption', step: -1, weight: 400, font: 'font-body' },
+            ].map(({ label, step, weight, font }) => {
+              const size = Math.round(base * ratio ** step)
+              return (
+                <div
+                  key={label}
+                  className="flex items-baseline gap-4 border-b border-border/50 pb-2 last:border-0"
+                >
+                  <span className="w-16 shrink-0 text-[10px] tracking-wider text-fg-muted uppercase">
+                    {label}
+                  </span>
+                  <span
+                    className={cn('min-w-0 flex-1 truncate text-fg', font)}
+                    style={{
+                      fontSize: size,
+                      fontWeight: weight,
+                      lineHeight: 1.1,
+                    }}
+                  >
+                    The quick brown fox
+                  </span>
+                  <span className="shrink-0 font-mono text-xs text-fg-muted tabular-nums">
+                    {size}px
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </SpecCard>
+
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+          <SpecCard title="Radius" hint={`${radiusFactor.toFixed(2)}× factor`}>
+            <div className="flex flex-wrap items-end gap-3">
+              {[
+                { label: 'sm', r: 4 },
+                { label: 'md', r: 8 },
+                { label: 'lg', r: 12 },
+                { label: 'xl', r: 16 },
+              ].map(({ label, r }) => (
+                <div key={label} className="flex flex-col items-center gap-1.5">
+                  <div
+                    className="size-12 border-2 border-primary/40 bg-primary/10"
+                    style={{ borderRadius: r * radiusFactor }}
+                  />
+                  <span className="font-mono text-[10px] text-fg-muted">
+                    {label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </SpecCard>
+
+          <SpecCard title="Spacing" hint={`${spacingScale.toFixed(2)}× scale`}>
+            <div className="flex flex-col gap-1.5">
+              {[1, 2, 3, 4, 6, 8].map((u) => (
+                <div key={u} className="flex items-center gap-2">
+                  <div
+                    className="h-2.5 rounded-sm bg-primary/70"
+                    style={{ width: u * 4 * spacingScale * 2 }}
+                  />
+                  <span className="font-mono text-[10px] text-fg-muted tabular-nums">
+                    {Math.round(u * 4 * spacingScale)}px
+                  </span>
+                </div>
+              ))}
+            </div>
+          </SpecCard>
+        </div>
+
+        <SpecCard
+          title="Elevation"
+          hint={`${Math.round((Number.isFinite(shadow) ? shadow : 0.5) * 100)}% intensity`}
+        >
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {[1, 2, 3, 4].map((level) => {
+              const blur = level * 6
+              const y = level * 2
+              const alpha =
+                (Number.isFinite(shadow) ? shadow : 0.5) * (0.06 + level * 0.03)
+              return (
+                <div
+                  key={level}
+                  className="flex h-16 items-center justify-center rounded-lg border bg-card text-xs text-fg-muted"
+                  style={{
+                    boxShadow: `0 ${y}px ${blur}px rgba(0,0,0,${alpha.toFixed(3)})`,
+                  }}
+                >
+                  level {level}
+                </div>
+              )
+            })}
+          </div>
+        </SpecCard>
+      </div>
+    </div>
+  )
+}
+
+function SpecCard({
+  title,
+  hint,
+  children,
+}: {
+  title: string
+  hint?: string
+  children: ReactNode
+}) {
+  return (
+    <section className="rounded-xl border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-fg">{title}</h3>
+        {hint && (
+          <span className="font-mono text-[10px] text-fg-muted">{hint}</span>
+        )}
+      </div>
+      {children}
+    </section>
+  )
+}

--- a/www/src/modules/create/atelier/stage.tsx
+++ b/www/src/modules/create/atelier/stage.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { PreviewPanel } from '../preview/preview-panel'
+import { SpecSheet } from './spec-sheet'
+import { useStudio } from './store'
+
+/* ----------------------------------------------------------------------------
+ * The stage — the dominant center column. Switches between the real live
+ * preview (reused wholesale, postMessage channel and all) and the spec sheet.
+ * -------------------------------------------------------------------------- */
+
+export function Stage() {
+  const { stageView } = useStudio()
+
+  if (stageView === 'spec') {
+    return (
+      <div className="relative flex min-w-0 flex-1 overflow-hidden rounded-xl border bg-bg">
+        <SpecSheet />
+      </div>
+    )
+  }
+
+  return <PreviewPanel />
+}

--- a/www/src/modules/create/atelier/store.tsx
+++ b/www/src/modules/create/atelier/store.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+
+import { DEFAULTS, useDesignSystem } from '../preset'
+import { type ChangeSet, interpret } from './ai/engine'
+
+/* ----------------------------------------------------------------------------
+ * Studio UI state. The *design* state still lives in `useDesignSystem` (URL-
+ * encoded); this context owns only the editor's own UI: which domain is open,
+ * what the stage shows, and the AI conversation. Keeping the two apart means a
+ * shared `?preset=` link restores the system without dragging editor chrome.
+ * -------------------------------------------------------------------------- */
+
+export type StageView = 'preview' | 'spec'
+
+export type AiMessage =
+  | { kind: 'user'; id: string; text: string }
+  | {
+      kind: 'proposal'
+      id: string
+      changeSet: ChangeSet
+      status: 'pending' | 'applied' | 'dismissed'
+    }
+
+interface StudioContextValue {
+  activeDomain: string
+  setActiveDomain: (id: string) => void
+
+  stageView: StageView
+  setStageView: (v: StageView) => void
+
+  aiOpen: boolean
+  setAiOpen: (open: boolean) => void
+
+  messages: AiMessage[]
+  submitPrompt: (text: string) => void
+  /** Push a pre-built proposal (e.g. from reference extraction) into the chat. */
+  proposeChangeSet: (changeSet: ChangeSet, userText?: string) => void
+  applyChangeSet: (changeSet: ChangeSet, messageId?: string) => void
+  dismissProposal: (messageId: string) => void
+  clearConversation: () => void
+
+  canUndo: boolean
+  undo: () => void
+  reset: () => void
+}
+
+const StudioContext = createContext<StudioContextValue | null>(null)
+const routeApi = getRouteApi('/_app/create')
+
+export function StudioProvider({ children }: { children: ReactNode }) {
+  const { preset } = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+  const { designSystem, setDesignSystem } = useDesignSystem()
+
+  const [activeDomain, setActiveDomain] = useState('color')
+  const [stageView, setStageView] = useState<StageView>('preview')
+  const [aiOpen, setAiOpen] = useState(false)
+  const [messages, setMessages] = useState<AiMessage[]>([])
+
+  /* Undo — mirrors the shipped customizer: every edit replaces `?preset=`, so
+     the browser back button can't step through them. Watch `preset` and keep our
+     own stack. AI "apply" lands as one preset change, so it's one undo step. */
+  const historyRef = useRef<(string | undefined)[]>([])
+  const prevPresetRef = useRef<string | undefined>(preset)
+  const isUndoingRef = useRef(false)
+  const [canUndo, setCanUndo] = useState(false)
+
+  useEffect(() => {
+    if (prevPresetRef.current === preset) return
+    if (isUndoingRef.current) {
+      isUndoingRef.current = false
+    } else {
+      historyRef.current.push(prevPresetRef.current)
+      setCanUndo(true)
+    }
+    prevPresetRef.current = preset
+  }, [preset])
+
+  const undo = useCallback(() => {
+    if (historyRef.current.length === 0) return
+    const previous = historyRef.current.pop()
+    isUndoingRef.current = true
+    navigate({
+      search: (prev) => ({ ...prev, preset: previous }),
+      replace: true,
+    })
+    setCanUndo(historyRef.current.length > 0)
+  }, [navigate])
+
+  const reset = useCallback(() => setDesignSystem(DEFAULTS), [setDesignSystem])
+
+  const proposeChangeSet = useCallback(
+    (changeSet: ChangeSet, userText?: string) => {
+      setMessages((prev) => [
+        ...prev,
+        ...(userText
+          ? [{ kind: 'user' as const, id: `u-${changeSet.id}`, text: userText }]
+          : []),
+        {
+          kind: 'proposal',
+          id: `p-${changeSet.id}`,
+          changeSet,
+          status: 'pending',
+        },
+      ])
+      setAiOpen(true)
+    },
+    [],
+  )
+
+  const submitPrompt = useCallback(
+    (text: string) => {
+      const trimmed = text.trim()
+      if (!trimmed) return
+      proposeChangeSet(interpret(trimmed, designSystem), trimmed)
+    },
+    [designSystem, proposeChangeSet],
+  )
+
+  const applyChangeSet = useCallback(
+    (changeSet: ChangeSet, messageId?: string) => {
+      setDesignSystem(changeSet.apply)
+      if (messageId) {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.kind === 'proposal' && m.id === messageId
+              ? { ...m, status: 'applied' }
+              : m,
+          ),
+        )
+      }
+    },
+    [setDesignSystem],
+  )
+
+  const dismissProposal = useCallback((messageId: string) => {
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.kind === 'proposal' && m.id === messageId
+          ? { ...m, status: 'dismissed' }
+          : m,
+      ),
+    )
+  }, [])
+
+  const clearConversation = useCallback(() => setMessages([]), [])
+
+  const value = useMemo(
+    () => ({
+      activeDomain,
+      setActiveDomain,
+      stageView,
+      setStageView,
+      aiOpen,
+      setAiOpen,
+      messages,
+      submitPrompt,
+      proposeChangeSet,
+      applyChangeSet,
+      dismissProposal,
+      clearConversation,
+      canUndo,
+      undo,
+      reset,
+    }),
+    [
+      activeDomain,
+      stageView,
+      aiOpen,
+      messages,
+      submitPrompt,
+      proposeChangeSet,
+      applyChangeSet,
+      dismissProposal,
+      clearConversation,
+      canUndo,
+      undo,
+      reset,
+    ],
+  )
+
+  return (
+    <StudioContext.Provider value={value}>{children}</StudioContext.Provider>
+  )
+}
+
+export function useStudio() {
+  const ctx = useContext(StudioContext)
+  if (!ctx) throw new Error('useStudio must be used within a StudioProvider')
+  return ctx
+}

--- a/www/src/modules/create/atelier/tokens.ts
+++ b/www/src/modules/create/atelier/tokens.ts
@@ -1,0 +1,63 @@
+/* ----------------------------------------------------------------------------
+ * Studio token vocabulary
+ *
+ * The CSS custom properties every studio control writes into. Two kinds:
+ *   - REAL tokens the preview already consumes (radius factor, cursors) — these
+ *     are re-exported from the modules that own them so there is a single source.
+ *   - `--ds-*` stub tokens the preview has no consumer for yet. They still write
+ *     through the normal token channel, so they are harmless today and become
+ *     live the moment a component reads them. Surfaced honestly in the UI via the
+ *     `binding` flag — nothing here pretends to be wired that isn't.
+ * -------------------------------------------------------------------------- */
+
+export {
+  CURSOR_DISABLED_VAR,
+  CURSOR_INTERACTIVE_VAR,
+  DEFAULT_CURSOR_DISABLED,
+  DEFAULT_CURSOR_INTERACTIVE,
+} from '../cursor'
+export { DEFAULT_RADIUS_FACTOR, RADIUS_FACTOR_VAR } from '../layout'
+
+/* Typography */
+export const FONT_HEADING_VAR = '--ds-font-heading'
+export const FONT_BODY_VAR = '--ds-font-body'
+export const TYPE_SCALE_VAR = '--ds-type-scale'
+export const TYPE_BASE_VAR = '--ds-type-base'
+export const TRACKING_VAR = '--ds-tracking'
+export const HEADING_WEIGHT_VAR = '--ds-heading-weight'
+export const LINE_HEIGHT_VAR = '--ds-line-height'
+
+/* Shape */
+export const BORDER_WIDTH_VAR = '--ds-border-width'
+export const CORNER_STYLE_VAR = '--ds-corner-style' // rounded | squircle
+
+/* Spacing */
+export const SPACING_SCALE_VAR = '--ds-spacing-scale'
+export const BASE_UNIT_VAR = '--ds-base-unit' // 4 | 8 (pt grid)
+export const CONTENT_WIDTH_VAR = '--ds-content-width'
+
+/* Elevation */
+export const ELEVATION_STYLE_VAR = '--ds-elevation-style' // flat|soft|depth|glass
+export const SHADOW_INTENSITY_VAR = '--ds-shadow-intensity'
+export const SHADOW_TINT_VAR = '--ds-shadow-tint' // neutral | brand
+export const BACKDROP_BLUR_VAR = '--ds-backdrop-blur'
+
+/* Motion */
+export const MOTION_DURATION_VAR = '--ds-motion-duration'
+export const MOTION_EASING_VAR = '--ds-motion-easing'
+export const MOTION_ENABLED_VAR = '--ds-motion-enabled'
+export const HOVER_LIFT_VAR = '--ds-hover-lift'
+export const PRESS_SCALE_VAR = '--ds-press-scale'
+
+/* Interaction */
+export const FOCUS_RING_WIDTH_VAR = '--ds-focus-ring-width'
+export const FOCUS_RING_STYLE_VAR = '--ds-focus-ring-style' // ring|outline|glow
+
+/* Icons */
+export const ICON_LIBRARY_VAR = '--ds-icon-library'
+export const ICON_STROKE_VAR = '--ds-icon-stroke'
+export const ICON_SCALE_VAR = '--ds-icon-scale'
+
+/* Mode & content */
+export const DEFAULT_MODE_VAR = '--ds-default-mode'
+export const LABEL_CASING_VAR = '--ds-label-casing' // title | sentence

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { cn } from '@/registry/lib/utils'
 import { ToggleButton } from '@/registry/ui/toggle-button'
 import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
+import { AtelierExperience } from '@/modules/create/atelier'
 import { CustomizerPanel } from '@/modules/create/customizer-panel'
 import { LabExperience } from '@/modules/create/panel'
 import { DEFAULTS, useDesignSystem } from '@/modules/create/preset'
@@ -25,6 +26,10 @@ export const createSearchSchema = z.object({
   // Coerced boolean: the search parser reads bare `1`/`true` as non-strings, so a
   // plain `z.string()` would reject them and the param would be dropped.
   lab: z.coerce.boolean().optional().catch(undefined),
+  // Opt-in flag for the Atelier redesign — a three-zone rethink of the builder
+  // (inspector · stage + spec sheet · AI assistant). Coexists with the shipped
+  // page and the panel lab; preview it at /create?atelier=true.
+  atelier: z.coerce.boolean().optional().catch(undefined),
 })
 
 const searchDefaults = { preview: 'cards' }
@@ -38,7 +43,7 @@ export const Route = createFileRoute('/_app/create')({
 })
 
 function CreatePage() {
-  const { lab, preset } = Route.useSearch()
+  const { lab, atelier, preset } = Route.useSearch()
   const { designSystem, setDesignSystem } = useDesignSystem()
   // Below `lg` the customizer and the live preview can't sit side by side (the iframe
   // would be a ~15px sliver), so they collapse into a single switchable pane toggled
@@ -71,6 +76,9 @@ function CreatePage() {
 
   // Opt-in exploration of the redesigned control panel + floating panel lab.
   if (lab) return <LabExperience />
+
+  // Opt-in Atelier redesign — the full three-zone rethink with the AI assistant.
+  if (atelier) return <AtelierExperience />
 
   return (
     <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2">

--- a/www/src/routes/_app/route.tsx
+++ b/www/src/routes/_app/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeader } from '@tanstack/react-start/server'
 import type * as PageTree from 'fumadocs-core/page-tree'
@@ -36,10 +36,17 @@ export const Route = createFileRoute('/_app')({
 function AppLayout() {
   const { pageTree } = Route.useLoaderData()
   const items = pageTree.children as PageTree.Node[]
+  // The Atelier builder owns its own focused top bar (logo, view modes, AI…),
+  // so the global site nav would stack a redundant second bar over it. Suppress
+  // it on /create?atelier=true only — every other route (and the shipped /create
+  // + ?lab builders) keeps the normal site Header unchanged.
+  const { pathname, search } = useLocation()
+  const isAtelier =
+    pathname === '/create' && (search as { atelier?: boolean }).atelier === true
 
   return (
     <div className="[--header-height:--spacing(14)]">
-      <Header items={items} />
+      {!isAtelier && <Header items={items} />}
       <main id="content">
         <Outlet />
       </main>


### PR DESCRIPTION
A **UI-only experiment** that rethinks `/create` as a three-zone instrument and explores AI inside the builder. Lives behind **`/create?atelier=true`** — the shipped builder and the panel lab (`?lab=true`) are untouched.

> Namespaced as **Atelier** (own folder, flag and entry point) so it coexists file-for-file with the separate **Studio** left-panel redesign also in flight — zero file overlap; only `create.tsx` is shared.

## The rethink: edit · see · converse

| Zone | What it is |
|---|---|
| **Inspector** (left) | A domain rail (Color, Type, Shape, Space, Elevation, Motion, Interaction, Icons, Components, Modes, Voice) + that domain's controls, wide enough for real richness (ramps, status grids, component anatomy). |
| **Stage** (center) | Reuses the **real live `PreviewPanel`** wholesale, plus a new **Spec sheet** view that renders the system as an artifact — tonal ramps, type-scale specimen, radius/spacing/elevation samples. |
| **AI assistant** (right + bottom) | A persistent command bar under the stage + a collapsible dock with Chat / Audit / Reference. |

## AI exploration (the headline)

Interaction model is **propose → review → accept** — nothing is applied behind your back:

- **Command bar / Chat** — plain-language prompts ("make it feel like Linear", "warmer neutrals", "minimal and tight") return a **reviewable diff** (accent, gray, radius, density… before→after with swatches) and Apply / Dismiss. Verified: applying *"Make it feel like Linear"* recolors the live preview's ramps to indigo and tightens radius through the real token channel.
- **Audit** — **real WCAG contrast ratios** on the live seeds (e.g. Accent 4.70:1 pass, Warning 1.92:1 fail) with one-click fixes.
- **Reference** — start from a URL, screenshot, or pasted brand colors; each produces a proposal you review.

Under the hood (`atelier/ai/engine.ts`) it's a **local deterministic intent engine**, not a model call — `interpret(prompt, ds)` returns a `ChangeSet { changes, apply }`. That makes the interaction real and demoable with no backend; a production version swaps `interpret()` for a server call returning the same shape, leaving every consumer unchanged.

## New tweaks

**41 controls across 11 domains** (~14 genuinely new axes: display tracking, heading weight, line-height, corner style/squircle, 4/8pt grid, content width, shadow tint, easing curve, hover lift, press scale, focus-ring style, icon library, icon scale, label casing). Honesty preserved: a filled **live dot** = drives the preview now (13 of 41); hollow = a `--ds-*` stub the engine will grow into.

## Scope & honesty

- **UI only**, as briefed — stub axes don't move the preview yet (flagged); the AI engine is local; system name + reference extraction are UI shells.
- **Desktop-first**: below `lg` the side panels collapse to preview + command bar (no crash).
- Per CLAUDE.md, the new axes are **product decisions** — staged for evaluation, not wired into anything shippable.

## Files

New module [`www/src/modules/create/atelier/`](www/src/modules/create/atelier) — `index.tsx` (shell), `inspector.tsx`, `stage.tsx`, `spec-sheet.tsx`, `schema.tsx` (axis catalog), `store.tsx`, `tokens.ts`, `ai/{engine,command-bar,ai-dock}.tsx`. One additive branch in `routes/_app/create.tsx`.

## Verification

`pnpm typecheck` ✅ · `pnpm check` ✅ (only 2 pre-existing warnings, unrelated files) · live preview renders with **no console errors** · no registry source touched (no drift). Reuses `useDesignSystem`, so live axes drive the preview via the real channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feature-flagged UI experiment with no changes to default create flow or registry; only additive routing and layout suppression for the atelier flag.
> 
> **Overview**
> Adds an opt-in **Atelier** experience at `/create?atelier=true` — a three-zone builder (inspector · stage · AI) that leaves the default `/create` and `?lab=true` flows unchanged.
> 
> **Layout & editing:** New shell with a domain-rail **inspector** (11 domains, ~41 controls, live vs stub `BindingDot`), center **stage** toggling between the existing `PreviewPanel` and a new **spec sheet** (ramps, type scale, radius/spacing/elevation), plus a dedicated top bar (undo/reset/shuffle, preview vs spec). **`_app/route`** hides the global site header only for `?atelier=true`.
> 
> **AI surface:** **Command bar** + collapsible **AI dock** (Chat / Audit / Reference). Prompts flow through a local **`interpret()`** engine that returns reviewable **`ChangeSet`** diffs (apply/dismiss only — no silent writes). **Audit** runs real WCAG contrast on seeds with optional one-click fixes; **Reference** is a capability preview (URL/screenshot/colors → proposed accent).
> 
> **Wiring:** `StudioProvider` holds UI state (domain, stage view, chat, custom undo on `?preset=`); design state still uses `useDesignSystem`. Route adds `atelier` to search schema and early-returns `AtelierExperience`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6820539c0801ae397779cd6916c694cf4cc60d16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->