### PR TITLE
feat(create): add AI-native Studio builder behind ?studio flag

### DIFF
--- a/www/src/modules/create/studio/ai/command-bar.tsx
+++ b/www/src/modules/create/studio/ai/command-bar.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import {
+  ArrowUpIcon,
+  CheckIcon,
+  ChevronUpIcon,
+  SparklesIcon,
+  XIcon,
+} from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+
+import { useStudio } from '../studio-context'
+import { COPILOT_SUGGESTIONS } from './interpret'
+import { MessageList } from './thread'
+
+/* The persistent copilot — docked over the bottom of the canvas so a tweak is
+ * always one sentence away, whatever section you're in. Expands into the full
+ * conversation; collapses to a single input with a transient "applied" toast. */
+
+export function CommandBar() {
+  const { thread, send, isThinking, flash, clearFlash } = useStudio()
+  const [value, setValue] = useState('')
+  const [focused, setFocused] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+
+  // Auto-dismiss the applied-change toast.
+  useEffect(() => {
+    if (!flash || expanded) return
+    const t = window.setTimeout(clearFlash, 3500)
+    return () => window.clearTimeout(t)
+  }, [flash, expanded, clearFlash])
+
+  function submit() {
+    if (!value.trim() || isThinking) return
+    send(value)
+    setValue('')
+    clearFlash()
+  }
+
+  const showSuggestions = focused && !value && !expanded
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex justify-center px-4 pb-4">
+      <div className="pointer-events-auto flex w-full max-w-xl flex-col gap-2">
+        {/* Expanded conversation */}
+        <AnimatePresence>
+          {expanded && (
+            <motion.div
+              initial={{ opacity: 0, y: 12, height: 0 }}
+              animate={{ opacity: 1, y: 0, height: 'auto' }}
+              exit={{ opacity: 0, y: 12, height: 0 }}
+              transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+              className="overflow-hidden rounded-2xl border bg-card shadow-xl"
+            >
+              <div className="flex items-center justify-between border-b px-3 py-2">
+                <span className="flex items-center gap-1.5 text-xs font-semibold">
+                  <SparklesIcon className="size-3.5 text-fg-accent" />
+                  Copilot
+                </span>
+                <Button
+                  size="sm"
+                  variant="quiet"
+                  isIconOnly
+                  aria-label="Collapse"
+                  onPress={() => setExpanded(false)}
+                >
+                  <XIcon />
+                </Button>
+              </div>
+              <div className="max-h-[42vh] overflow-y-auto p-3">
+                {thread.length > 0 ? (
+                  <MessageList messages={thread} />
+                ) : (
+                  <p className="py-6 text-center text-xs text-fg-muted">
+                    Ask for any change — “make it rounder”, “calmer accent”,
+                    “increase contrast”.
+                  </p>
+                )}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Applied-change toast (collapsed only) */}
+        <AnimatePresence>
+          {flash && !expanded && (
+            <motion.button
+              type="button"
+              onClick={() => setExpanded(true)}
+              initial={{ opacity: 0, y: 8, scale: 0.97 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 8, scale: 0.97 }}
+              transition={{ duration: 0.2, ease: [0.32, 0.72, 0, 1] }}
+              className="flex items-center gap-2 self-center rounded-full border bg-card px-3 py-1.5 text-xs shadow-lg"
+            >
+              <CheckIcon className="size-3.5 text-fg-success" />
+              <span className="font-medium">{flash.title}</span>
+              {flash.changes[0] && (
+                <span className="font-mono text-[11px] text-fg-muted">
+                  {flash.changes[0]}
+                </span>
+              )}
+            </motion.button>
+          )}
+        </AnimatePresence>
+
+        {/* Suggestion chips */}
+        <AnimatePresence>
+          {showSuggestions && (
+            <motion.div
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 6 }}
+              transition={{ duration: 0.16 }}
+              className="flex flex-wrap justify-center gap-1.5"
+            >
+              {COPILOT_SUGGESTIONS.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  // onMouseDown (not onClick) so it fires before the input blur.
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    send(s)
+                  }}
+                  className="rounded-full border bg-card px-2.5 py-1 text-xs shadow-sm transition-colors hover:bg-neutral"
+                >
+                  {s}
+                </button>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Input */}
+        <div className="flex items-center gap-2 rounded-full border bg-card/95 py-1.5 pr-1.5 pl-3 shadow-xl backdrop-blur-sm focus-within:border-border-focus">
+          <SparklesIcon className="size-4 shrink-0 text-fg-accent" />
+          <input
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                submit()
+              }
+            }}
+            placeholder="Ask AI to change anything…"
+            aria-label="Ask the copilot"
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-fg-muted"
+          />
+          {thread.length > 0 && (
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              aria-label={
+                expanded ? 'Collapse conversation' : 'Expand conversation'
+              }
+              onPress={() => setExpanded((e) => !e)}
+              className={cn(expanded && 'bg-neutral')}
+            >
+              <ChevronUpIcon
+                className={cn('transition-transform', expanded && 'rotate-180')}
+              />
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="primary"
+            isIconOnly
+            aria-label="Send"
+            onPress={submit}
+            isDisabled={!value.trim() || isThinking}
+          >
+            <ArrowUpIcon />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/ai/generate-panel.tsx
+++ b/www/src/modules/create/studio/ai/generate-panel.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useState } from 'react'
+import { ArrowUpIcon, ImageIcon, SparklesIcon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+
+import { useStudio } from '../studio-context'
+import { MessageList } from './thread'
+import { VIBES } from './vibes'
+
+export function GeneratePanel() {
+  const { thread, generate, applyVibe, isThinking } = useStudio()
+  const [value, setValue] = useState('')
+
+  function submit() {
+    if (!value.trim() || isThinking) return
+    generate(value)
+    setValue('')
+  }
+
+  const hasThread = thread.length > 0
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-col gap-4 border-b p-4">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="flex size-6 items-center justify-center rounded-md bg-accent text-fg-on-accent">
+              <SparklesIcon className="size-3.5" />
+            </span>
+            <h2 className="text-sm font-semibold">Generate with AI</h2>
+          </div>
+          <p className="text-xs text-pretty text-fg-muted">
+            Describe the system you want — I'll set the palette, shape, density
+            and type, then you refine.
+          </p>
+        </div>
+
+        {/* Prompt */}
+        <div className="flex flex-col gap-2 rounded-xl border bg-bg p-2 focus-within:border-border-focus">
+          <textarea
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault()
+                submit()
+              }
+            }}
+            rows={3}
+            placeholder="A trustworthy fintech dashboard, dense and calm…"
+            className="w-full resize-none bg-transparent px-1.5 py-1 text-sm outline-none placeholder:text-fg-muted"
+          />
+          <div className="flex items-center justify-between">
+            <label className="flex cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-xs text-fg-muted transition-colors hover:bg-neutral hover:text-fg">
+              <ImageIcon className="size-3.5" />
+              Image
+              <input type="file" accept="image/*" className="sr-only" />
+            </label>
+            <Button
+              size="sm"
+              variant="primary"
+              isIconOnly
+              aria-label="Generate"
+              onPress={submit}
+              isDisabled={!value.trim() || isThinking}
+            >
+              <ArrowUpIcon />
+            </Button>
+          </div>
+        </div>
+
+        {/* Vibe chips */}
+        <div className="flex flex-col gap-2">
+          <span className="text-[10px] font-semibold tracking-wider text-fg-muted uppercase">
+            Or start from a vibe
+          </span>
+          <div className="flex flex-wrap gap-1.5">
+            {VIBES.map((vibe) => (
+              <button
+                key={vibe.id}
+                type="button"
+                onClick={() => applyVibe(vibe)}
+                title={vibe.summary}
+                className={cn(
+                  'group flex items-center gap-1.5 rounded-full border py-1 pr-2.5 pl-1 text-xs font-medium focus-reset transition-colors hover:bg-neutral focus-visible:focus-ring',
+                )}
+              >
+                <span
+                  className="size-4 rounded-full ring-1 ring-black/10 ring-inset"
+                  style={{
+                    backgroundImage: `linear-gradient(135deg, ${vibe.swatch[0]}, ${vibe.swatch[1]})`,
+                  }}
+                />
+                {vibe.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Conversation */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
+        {hasThread ? (
+          <MessageList messages={thread} />
+        ) : (
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
+            <SparklesIcon className="size-5 text-fg-muted/50" />
+            <p className="max-w-[22ch] text-xs text-balance text-fg-muted">
+              Your generations and edits will show up here as a conversation.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/ai/interpret.ts
+++ b/www/src/modules/create/studio/ai/interpret.ts
@@ -1,0 +1,350 @@
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import type { ColorConfig } from '@/registry/theme'
+
+import { DEFAULT_RADIUS_FACTOR, RADIUS_FACTOR_VAR } from '../../layout'
+import { DEFAULTS } from '../../preset'
+import type { Density, DesignSystem } from '../../preset'
+import {
+  DEFAULT_MODE_VAR,
+  STYLE_FAMILY_VAR,
+  VIBES,
+  type Vibe,
+  vibeToMutate,
+} from './vibes'
+
+/* ----------------------------------------------------------------------------
+ * Intent matching — a deliberately small, legible NL layer.
+ *
+ * It maps a prompt / chat message to a DesignSystem updater plus a human
+ * summary of what changed. It's keyword-driven on purpose: a real deployment
+ * swaps this for a model call returning the same {mutate, changes} shape, and
+ * none of the UI has to change.
+ * -------------------------------------------------------------------------- */
+
+export type Mutate = (prev: DesignSystem) => DesignSystem
+
+export interface AiResult {
+  mutate: Mutate
+  /** Short title for the result card / assistant line. */
+  title: string
+  /** Bulleted, human-readable list of what changed. */
+  changes: string[]
+  /** The vibe this resolved to, if any (for chip highlighting). */
+  vibeId?: string
+}
+
+const COLOR_WORDS: Record<string, string> = {
+  black: '#171717',
+  white: '#fafafa',
+  slate: '#475569',
+  gray: '#6b7280',
+  grey: '#6b7280',
+  red: '#ef4444',
+  crimson: '#dc2626',
+  orange: '#f97316',
+  amber: '#f59e0b',
+  yellow: '#eab308',
+  gold: '#ca8a04',
+  lime: '#84cc16',
+  green: '#22c55e',
+  emerald: '#10b981',
+  teal: '#14b8a6',
+  cyan: '#06b6d4',
+  sky: '#0ea5e9',
+  blue: '#3b82f6',
+  indigo: '#6366f1',
+  violet: '#8b5cf6',
+  purple: '#a855f7',
+  fuchsia: '#d946ef',
+  pink: '#ec4899',
+  rose: '#f43f5e',
+}
+
+const ALGO_LABELS: Record<string, string> = {
+  oklch: 'OKLCH Perceptual',
+  tailwind: 'Tailwind-style',
+  material: 'Material',
+  contrast: 'Contrast-locked',
+}
+
+function radiusOf(ds: DesignSystem): number {
+  return (
+    Number.parseFloat(ds.tokens[RADIUS_FACTOR_VAR] ?? DEFAULT_RADIUS_FACTOR) ||
+    1
+  )
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n))
+}
+
+function withColor(
+  ds: DesignSystem,
+  patch: Partial<ColorConfig['seeds']>,
+): ColorConfig {
+  const base = ds.color ?? DEFAULT_COLOR_CONFIG
+  return { ...base, seeds: { ...base.seeds, ...patch } }
+}
+
+/** Find the best-matching vibe for free text, or null if nothing scores. */
+export function matchVibe(text: string): Vibe | null {
+  const t = text.toLowerCase()
+  let best: Vibe | null = null
+  let bestScore = 0
+  for (const vibe of VIBES) {
+    let score = 0
+    for (const tag of vibe.tags) {
+      if (t.includes(tag)) score += tag.length > 4 ? 2 : 1
+    }
+    if (score > bestScore) {
+      bestScore = score
+      best = vibe
+    }
+  }
+  return bestScore > 0 ? best : null
+}
+
+function extractColor(text: string): { word: string; hex: string } | null {
+  const t = text.toLowerCase()
+  for (const [word, hex] of Object.entries(COLOR_WORDS)) {
+    if (new RegExp(`\\b${word}\\b`).test(t)) return { word, hex }
+  }
+  const hexMatch = t.match(/#([0-9a-f]{6}|[0-9a-f]{3})\b/)
+  if (hexMatch) return { word: hexMatch[0], hex: hexMatch[0] }
+  return null
+}
+
+/* ------------------------------ Generate -------------------------------- */
+
+/** Interpret a from-scratch "describe your design system" prompt. */
+export function interpretPrompt(text: string): AiResult {
+  const vibe = matchVibe(text)
+  const color = extractColor(text)
+
+  if (vibe) {
+    const base = vibeToMutate(vibe)
+    const changes = [
+      `Accent → ${color?.hex ?? vibe.accent}`,
+      `Neutrals → ${vibe.neutral}`,
+      `Radius → ${Number.parseFloat(vibe.radius).toFixed(1)}×`,
+      `Density → ${vibe.density}`,
+      `Ramps → ${ALGO_LABELS[vibe.algorithm]}`,
+    ]
+    const mutate: Mutate = color
+      ? (prev) => {
+          const next = base(prev)
+          return { ...next, color: withColor(next, { accent: color.hex }) }
+        }
+      : base
+    return {
+      mutate,
+      title: `${vibe.label} — ${vibe.summary}`,
+      changes,
+      vibeId: vibe.id,
+    }
+  }
+
+  // No vibe matched — at least honor an explicit color, else a sensible default.
+  if (color) {
+    return {
+      mutate: (prev) => ({
+        ...prev,
+        color: withColor(prev, { accent: color.hex }),
+      }),
+      title: `A ${color.word} system`,
+      changes: [`Accent → ${color.hex}`],
+    }
+  }
+
+  const fallback = VIBES[0] as Vibe
+  return {
+    mutate: vibeToMutate(fallback),
+    title: `${fallback.label} — a clean starting point`,
+    changes: [`Accent → ${fallback.accent}`, `Radius → ${fallback.radius}×`],
+  }
+}
+
+/* ------------------------------- Copilot -------------------------------- */
+
+/** Interpret a conversational tweak against the current system. */
+export function interpretChat(text: string, ds: DesignSystem): AiResult | null {
+  const t = text.toLowerCase()
+
+  // Whole-direction switches win first (they re-skin everything).
+  const vibe = matchVibe(t)
+  if (vibe && /(make it|like|feel|vibe|theme|more)/.test(t)) {
+    return interpretPrompt(text)
+  }
+
+  if (/\b(reset|default|start over|clear)\b/.test(t)) {
+    return {
+      mutate: () => DEFAULTS,
+      title: 'Reset to defaults',
+      changes: ['Everything → defaults'],
+    }
+  }
+
+  // Radius
+  if (/\b(round|rounder|softer corners|more rounded|pill)\b/.test(t)) {
+    const next = clamp(radiusOf(ds) + 0.5, 0, 2)
+    return {
+      mutate: (p) => ({
+        ...p,
+        tokens: { ...p.tokens, [RADIUS_FACTOR_VAR]: String(next) },
+      }),
+      title: 'Rounded the corners',
+      changes: [`Radius → ${next.toFixed(1)}×`],
+    }
+  }
+  if (/\b(sharp|sharper|square|less round|crisp corners|boxy)\b/.test(t)) {
+    const next = clamp(radiusOf(ds) - 0.5, 0, 2)
+    return {
+      mutate: (p) => ({
+        ...p,
+        tokens: { ...p.tokens, [RADIUS_FACTOR_VAR]: String(next) },
+      }),
+      title: 'Sharpened the corners',
+      changes: [`Radius → ${next.toFixed(1)}×`],
+    }
+  }
+
+  // Density
+  if (/\b(dense|denser|tighter|compact|tight)\b/.test(t)) {
+    return {
+      mutate: (p) => ({ ...p, density: 'compact' as Density }),
+      title: 'Tightened spacing',
+      changes: ['Density → compact'],
+    }
+  }
+  if (
+    /\b(air|airy|airier|roomier|spacious|breathing|comfortable|cozy|relax)\b/.test(
+      t,
+    )
+  ) {
+    return {
+      mutate: (p) => ({ ...p, density: 'comfortable' as Density }),
+      title: 'Opened up the spacing',
+      changes: ['Density → comfortable'],
+    }
+  }
+
+  // Chroma / energy
+  if (
+    /\b(bolder|punchier|vivid|saturated|pop|vibrant|energetic|louder)\b/.test(t)
+  ) {
+    const base = ds.color ?? DEFAULT_COLOR_CONFIG
+    const next = clamp((base.knobs?.chromaMult ?? 1) + 0.3, 0, 2)
+    return {
+      mutate: (p) => {
+        const c = p.color ?? DEFAULT_COLOR_CONFIG
+        return {
+          ...p,
+          color: { ...c, knobs: { ...c.knobs, chromaMult: next } },
+        }
+      },
+      title: 'Turned up the saturation',
+      changes: [`Chroma → ${next.toFixed(1)}×`],
+    }
+  }
+  if (
+    /\b(calmer|calm|muted|subtle|desaturate|softer|quieter|gentle|tone down)\b/.test(
+      t,
+    )
+  ) {
+    const base = ds.color ?? DEFAULT_COLOR_CONFIG
+    const next = clamp((base.knobs?.chromaMult ?? 1) - 0.3, 0, 2)
+    return {
+      mutate: (p) => {
+        const c = p.color ?? DEFAULT_COLOR_CONFIG
+        return {
+          ...p,
+          color: { ...c, knobs: { ...c.knobs, chromaMult: next } },
+        }
+      },
+      title: 'Calmed the palette',
+      changes: [`Chroma → ${next.toFixed(1)}×`],
+    }
+  }
+
+  // Mode
+  if (/\b(dark mode|darker|dark theme|go dark|night)\b/.test(t)) {
+    return {
+      mutate: (p) => ({
+        ...p,
+        tokens: { ...p.tokens, [DEFAULT_MODE_VAR]: 'dark' },
+      }),
+      title: 'Defaulted to dark',
+      changes: ['Default mode → dark'],
+    }
+  }
+  if (/\b(light mode|lighter|light theme|go light)\b/.test(t)) {
+    return {
+      mutate: (p) => ({
+        ...p,
+        tokens: { ...p.tokens, [DEFAULT_MODE_VAR]: 'light' },
+      }),
+      title: 'Defaulted to light',
+      changes: ['Default mode → light'],
+    }
+  }
+
+  // Accessibility / contrast
+  if (
+    /\b(contrast|accessible|accessibility|a11y|wcag|legible|readable)\b/.test(t)
+  ) {
+    return {
+      mutate: (p) => {
+        const c = p.color ?? DEFAULT_COLOR_CONFIG
+        return { ...p, color: { ...c, algorithm: 'contrast' } }
+      },
+      title: 'Switched to contrast-locked ramps',
+      changes: ['Ramps → Contrast-locked'],
+    }
+  }
+
+  // Style family
+  if (/\b(glass|frosted|frost|translucent|blur)\b/.test(t)) {
+    return {
+      mutate: (p) => ({
+        ...p,
+        tokens: { ...p.tokens, [STYLE_FAMILY_VAR]: 'glass' },
+      }),
+      title: 'Made surfaces glassy',
+      changes: ['Style family → glass'],
+    }
+  }
+  if (/\b(flat|flatten|no shadow)\b/.test(t)) {
+    return {
+      mutate: (p) => ({
+        ...p,
+        tokens: { ...p.tokens, [STYLE_FAMILY_VAR]: 'flat' },
+      }),
+      title: 'Flattened the surfaces',
+      changes: ['Style family → flat'],
+    }
+  }
+
+  // Explicit color
+  const color = extractColor(t)
+  if (color) {
+    return {
+      mutate: (p) => ({ ...p, color: withColor(p, { accent: color.hex }) }),
+      title: `Set the accent to ${color.word}`,
+      changes: [`Accent → ${color.hex}`],
+    }
+  }
+
+  // Catch-all vibe match (without the trigger words above)
+  if (vibe) return interpretPrompt(text)
+
+  return null
+}
+
+export const COPILOT_SUGGESTIONS = [
+  'Make it feel like Linear',
+  'Rounder corners',
+  'Calmer accent',
+  'Increase contrast',
+  'A warm editorial blog',
+  'Go dark',
+]

--- a/www/src/modules/create/studio/ai/thread.tsx
+++ b/www/src/modules/create/studio/ai/thread.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { SparklesIcon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+
+import type { ChatMessage } from '../studio-context'
+
+/* The shared conversation view — used by the Generate panel and the canvas
+ * command bar so they read from one thread. */
+
+export function MessageList({
+  messages,
+  className,
+}: {
+  messages: ChatMessage[]
+  className?: string
+}) {
+  const endRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+  }, [messages])
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      {messages.map((m) =>
+        m.role === 'user' ? (
+          <UserBubble key={m.id} text={m.text} />
+        ) : (
+          <AssistantBubble key={m.id} message={m} />
+        ),
+      )}
+      <div ref={endRef} />
+    </div>
+  )
+}
+
+function UserBubble({ text }: { text: string }) {
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-[85%] rounded-2xl rounded-br-sm bg-neutral px-3 py-1.5 text-sm">
+        {text}
+      </div>
+    </div>
+  )
+}
+
+function AssistantBubble({ message }: { message: ChatMessage }) {
+  return (
+    <div className="flex gap-2">
+      <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-accent-muted text-fg-accent">
+        <SparklesIcon className="size-3" />
+      </span>
+      <div className="flex min-w-0 flex-col gap-1.5">
+        {message.pending ? (
+          <ThinkingDots />
+        ) : (
+          <>
+            <p className="text-sm text-pretty">{message.text}</p>
+            {message.changes && message.changes.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {message.changes.map((change) => (
+                  <span
+                    key={change}
+                    className="rounded-md bg-neutral px-1.5 py-0.5 font-mono text-[11px] text-fg-muted tabular-nums"
+                  >
+                    {change}
+                  </span>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function ThinkingDots() {
+  return (
+    <span className="flex h-5 items-center gap-1" aria-label="Thinking">
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          className="size-1.5 animate-bounce rounded-full bg-fg-muted/70"
+          style={{ animationDelay: `${i * 0.15}s`, animationDuration: '0.9s' }}
+        />
+      ))}
+    </span>
+  )
+}

--- a/www/src/modules/create/studio/ai/vibes.ts
+++ b/www/src/modules/create/studio/ai/vibes.ts
@@ -1,0 +1,327 @@
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import type { AlgorithmId, ColorConfig } from '@/registry/theme'
+
+import { RADIUS_FACTOR_VAR } from '../../layout'
+import type { Density, DesignSystem } from '../../preset'
+
+/* ----------------------------------------------------------------------------
+ * Vibes — the AI's curated palette of whole-system directions.
+ *
+ * Each vibe is a recognizable look the prompt / copilot can land on. Applying
+ * one mutates the *real* DesignSystem (accent, neutral, radius, density,
+ * algorithm + a few forward-looking stub tokens), so the live preview actually
+ * transforms. This is the UI of an AI feature; a real model would emit the same
+ * shape from a server function (the codebase already exposes that pattern).
+ * -------------------------------------------------------------------------- */
+
+export interface Vibe {
+  id: string
+  label: string
+  /** One-line description shown on the result card and chips. */
+  summary: string
+  /** Match terms for the prompt / copilot intent matcher. */
+  tags: string[]
+  accent: string
+  neutral: string
+  radius: string
+  density: Density
+  algorithm: AlgorithmId
+  /** Forward-looking axes the preview doesn't consume yet (honest stubs). */
+  tokens?: Record<string, string>
+  /** Two swatch hexes for the chip's mini gradient. */
+  swatch: [string, string]
+}
+
+export const STYLE_FAMILY_VAR = '--ds-elevation-style'
+export const FONT_HEADING_VAR = '--ds-font-heading'
+export const FONT_BODY_VAR = '--ds-font-body'
+export const DEFAULT_MODE_VAR = '--ds-default-mode'
+export const BG_TEXTURE_VAR = '--ds-bg-texture'
+
+export const VIBES: Vibe[] = [
+  {
+    id: 'linear',
+    label: 'Linear',
+    summary: 'Crisp, fast, focused — indigo on a cool near-black.',
+    tags: [
+      'linear',
+      'crisp',
+      'fast',
+      'focused',
+      'productivity',
+      'saas',
+      'sharp',
+    ],
+    accent: '#5e6ad2',
+    neutral: '#6b7280',
+    radius: '0.7',
+    density: 'compact',
+    algorithm: 'oklch',
+    tokens: {
+      [STYLE_FAMILY_VAR]: 'flat',
+      [FONT_HEADING_VAR]: 'Inter',
+      [FONT_BODY_VAR]: 'Inter',
+    },
+    swatch: ['#5e6ad2', '#1c1c28'],
+  },
+  {
+    id: 'geist',
+    label: 'Geist',
+    summary: 'Stark monochrome — black, hairline borders, maximum contrast.',
+    tags: [
+      'geist',
+      'vercel',
+      'mono',
+      'monochrome',
+      'black',
+      'minimal',
+      'stark',
+      'clean',
+    ],
+    accent: '#171717',
+    neutral: '#808080',
+    radius: '0.5',
+    density: 'compact',
+    algorithm: 'oklch',
+    tokens: {
+      [STYLE_FAMILY_VAR]: 'flat',
+      [FONT_HEADING_VAR]: 'Geist',
+      [FONT_BODY_VAR]: 'Geist',
+    },
+    swatch: ['#171717', '#a3a3a3'],
+  },
+  {
+    id: 'stripe',
+    label: 'Stripe',
+    summary: 'Trustworthy fintech polish — indigo, soft shadows, rounded.',
+    tags: [
+      'stripe',
+      'fintech',
+      'finance',
+      'trust',
+      'corporate',
+      'payment',
+      'professional',
+    ],
+    accent: '#635bff',
+    neutral: '#6772a9',
+    radius: '1.1',
+    density: 'default',
+    algorithm: 'oklch',
+    tokens: {
+      [STYLE_FAMILY_VAR]: 'soft',
+      [FONT_HEADING_VAR]: 'Söhne',
+      [FONT_BODY_VAR]: 'Inter',
+    },
+    swatch: ['#635bff', '#0a2540'],
+  },
+  {
+    id: 'editorial',
+    label: 'Editorial',
+    summary: 'Magazine feel — forest green, serif headings, generous space.',
+    tags: [
+      'editorial',
+      'magazine',
+      'blog',
+      'serif',
+      'reading',
+      'content',
+      'elegant',
+      'warm',
+    ],
+    accent: '#0f766e',
+    neutral: '#78716c',
+    radius: '0.3',
+    density: 'comfortable',
+    algorithm: 'oklch',
+    tokens: {
+      [STYLE_FAMILY_VAR]: 'flat',
+      [FONT_HEADING_VAR]: 'Lora',
+      [FONT_BODY_VAR]: 'Inter',
+    },
+    swatch: ['#0f766e', '#44403c'],
+  },
+  {
+    id: 'playful',
+    label: 'Playful',
+    summary: 'Friendly and rounded — rose pink, big radius, airy.',
+    tags: [
+      'playful',
+      'fun',
+      'friendly',
+      'rounded',
+      'consumer',
+      'bubbly',
+      'soft',
+      'pink',
+    ],
+    accent: '#f43f5e',
+    neutral: '#7c7c8a',
+    radius: '1.8',
+    density: 'comfortable',
+    algorithm: 'oklch',
+    tokens: {
+      [STYLE_FAMILY_VAR]: 'soft',
+      [FONT_HEADING_VAR]: 'Satoshi',
+      [FONT_BODY_VAR]: 'Satoshi',
+    },
+    swatch: ['#f43f5e', '#fb923c'],
+  },
+  {
+    id: 'brutalist',
+    label: 'Brutalist',
+    summary: 'Raw and sharp — pure black, zero radius, vivid accents.',
+    tags: [
+      'brutalist',
+      'raw',
+      'sharp',
+      'square',
+      'bold',
+      'harsh',
+      'edgy',
+      'punk',
+    ],
+    accent: '#1d4ed8',
+    neutral: '#737373',
+    radius: '0',
+    density: 'compact',
+    algorithm: 'tailwind',
+    tokens: {
+      [STYLE_FAMILY_VAR]: 'flat',
+      [FONT_HEADING_VAR]: 'Geist',
+      [FONT_BODY_VAR]: 'Mono',
+    },
+    swatch: ['#1d4ed8', '#000000'],
+  },
+  {
+    id: 'supabase',
+    label: 'Developer',
+    summary: 'Dev-grade — emerald green on a dark, dense grid.',
+    tags: [
+      'developer',
+      'supabase',
+      'green',
+      'emerald',
+      'terminal',
+      'dev',
+      'technical',
+      'dark',
+    ],
+    accent: '#3ecf8e',
+    neutral: '#64748b',
+    radius: '0.6',
+    density: 'compact',
+    algorithm: 'oklch',
+    tokens: {
+      [STYLE_FAMILY_VAR]: 'flat',
+      [DEFAULT_MODE_VAR]: 'dark',
+      [FONT_HEADING_VAR]: 'Geist',
+      [FONT_BODY_VAR]: 'Geist',
+    },
+    swatch: ['#3ecf8e', '#11181c'],
+  },
+  {
+    id: 'neon',
+    label: 'Neon',
+    summary: 'Neon on black — electric cyan, vivid ramps, glow.',
+    tags: [
+      'neon',
+      'cyberpunk',
+      'cyber',
+      'electric',
+      'glow',
+      'vivid',
+      'futuristic',
+      'cyan',
+      'dark',
+    ],
+    accent: '#22d3ee',
+    neutral: '#5b6472',
+    radius: '0.9',
+    density: 'default',
+    algorithm: 'tailwind',
+    tokens: {
+      [STYLE_FAMILY_VAR]: 'glass',
+      [DEFAULT_MODE_VAR]: 'dark',
+      [FONT_HEADING_VAR]: 'Geist',
+      [FONT_BODY_VAR]: 'Inter',
+    },
+    swatch: ['#22d3ee', '#a855f7'],
+  },
+  {
+    id: 'warm',
+    label: 'Warm',
+    summary: 'Warm and inviting — sunset amber, brand-tinted grays.',
+    tags: [
+      'warm',
+      'sunset',
+      'amber',
+      'orange',
+      'cozy',
+      'inviting',
+      'earthy',
+      'golden',
+    ],
+    accent: '#ea7317',
+    neutral: '#a8907a',
+    radius: '1.2',
+    density: 'default',
+    algorithm: 'oklch',
+    tokens: {
+      [STYLE_FAMILY_VAR]: 'soft',
+      [FONT_HEADING_VAR]: 'Satoshi',
+      [FONT_BODY_VAR]: 'Inter',
+    },
+    swatch: ['#ea7317', '#f59e0b'],
+  },
+  {
+    id: 'material',
+    label: 'Material',
+    summary: 'Google Material baseline — blue, tonal ramps, soft depth.',
+    tags: [
+      'material',
+      'google',
+      'android',
+      'tonal',
+      'baseline',
+      'blue',
+      'corporate',
+    ],
+    accent: '#1a73e8',
+    neutral: '#5f6368',
+    radius: '1.4',
+    density: 'default',
+    algorithm: 'material',
+    tokens: {
+      [STYLE_FAMILY_VAR]: 'depth',
+      [FONT_HEADING_VAR]: 'Inter',
+      [FONT_BODY_VAR]: 'Inter',
+    },
+    swatch: ['#1a73e8', '#7baaf7'],
+  },
+]
+
+/** Build a DesignSystem updater from a vibe — merges onto whatever's current. */
+export function vibeToMutate(vibe: Vibe) {
+  return (prev: DesignSystem): DesignSystem => {
+    const baseColor: ColorConfig = prev.color ?? DEFAULT_COLOR_CONFIG
+    return {
+      ...prev,
+      density: vibe.density,
+      tokens: {
+        ...prev.tokens,
+        [RADIUS_FACTOR_VAR]: vibe.radius,
+        ...vibe.tokens,
+      },
+      color: {
+        ...baseColor,
+        algorithm: vibe.algorithm,
+        seeds: {
+          ...baseColor.seeds,
+          accent: vibe.accent,
+          neutral: vibe.neutral,
+        },
+      },
+    }
+  }
+}

--- a/www/src/modules/create/studio/color-widgets.tsx
+++ b/www/src/modules/create/studio/color-widgets.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useMemo } from 'react'
+import { ChevronDownIcon } from 'lucide-react'
+
+import {
+  DEFAULT_COLOR_CONFIG,
+  PALETTE_ORDER,
+  resolveColorConfig,
+} from '@/registry/theme'
+import type { AlgorithmId, PaletteSeeds } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+import { Popover } from '@/registry/ui/popover'
+import { Select, SelectValue } from '@/registry/ui/select'
+
+import { ContrastReadout } from '../colors/contrast'
+import { ColorKnobsControls } from '../colors/knobs'
+import { Segmented } from '../panel/primitives'
+import { SeedField } from '../panel/schema'
+import { useDesignSystem } from '../preset'
+
+/* Color widgets reused by the Studio inspector. They wrap the real color recipe
+ * (seeds, algorithm, per-producer knobs) and the live contrast readout, so the
+ * whole Color section genuinely drives the preview. */
+
+export { SeedField }
+
+const ALGORITHMS: ReadonlyArray<{ id: AlgorithmId; label: string }> = [
+  { id: 'oklch', label: 'OKLCH Perceptual' },
+  { id: 'tailwind', label: 'Tailwind-style' },
+  { id: 'material', label: 'Material' },
+  { id: 'contrast', label: 'Contrast-locked' },
+]
+
+export function AlgorithmWidget() {
+  const { designSystem, setColorAlgorithm } = useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  return (
+    <Select
+      className="w-full"
+      selectedKey={config.algorithm}
+      onSelectionChange={(key) => setColorAlgorithm(key as AlgorithmId)}
+      aria-label="Color algorithm"
+    >
+      <Button size="sm" className="w-full justify-between">
+        <SelectValue className="truncate" />
+        <ChevronDownIcon data-icon-end="" />
+      </Button>
+      <Popover>
+        <ListBox>
+          {ALGORITHMS.map((a) => (
+            <ListBoxItem key={a.id} id={a.id}>
+              {a.label}
+            </ListBoxItem>
+          ))}
+        </ListBox>
+      </Popover>
+    </Select>
+  )
+}
+
+export function StatusColorsWidget() {
+  const status: Array<{ seed: keyof PaletteSeeds; label: string }> = [
+    { seed: 'success', label: 'Success' },
+    { seed: 'warning', label: 'Warning' },
+    { seed: 'danger', label: 'Danger' },
+    { seed: 'info', label: 'Info' },
+  ]
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {status.map((s) => (
+        <div key={s.seed} className="flex flex-col gap-1">
+          <span className="text-[10px] tracking-wider text-fg-muted uppercase">
+            {s.label}
+          </span>
+          <SeedField seed={s.seed} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function GrayStrategyWidget() {
+  const { designSystem, setColorSeed } = useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const isTinted =
+    (config.seeds.neutral ?? '#808080').toLowerCase() !== '#808080'
+  return (
+    <Segmented
+      ariaLabel="Gray strategy"
+      value={isTinted ? 'tinted' : 'pure'}
+      onChange={(v) =>
+        setColorSeed(
+          'neutral',
+          v === 'pure'
+            ? '#808080'
+            : (config.seeds.accent ?? DEFAULT_COLOR_CONFIG.seeds.accent),
+        )
+      }
+      options={[
+        { value: 'pure', label: 'Pure' },
+        { value: 'tinted', label: 'Brand-tinted' },
+      ]}
+    />
+  )
+}
+
+/** Per-algorithm knobs + WCAG readout + the generated ramps. */
+export function ColorEngineWidget() {
+  const { designSystem, setColorKnob } = useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const resolved = useMemo(() => resolveColorConfig(config), [config])
+  return (
+    <div className="flex flex-col gap-4">
+      <ColorKnobsControls
+        algorithm={config.algorithm}
+        knobs={config.knobs ?? {}}
+        steps={resolved.steps}
+        onChange={setColorKnob}
+      />
+      <ContrastReadout resolved={resolved} />
+      <div className="flex flex-col gap-1">
+        {PALETTE_ORDER.map((palette) => {
+          const ramp = resolved.light[palette]
+          if (!ramp) return null
+          return (
+            <div
+              key={palette}
+              className="flex overflow-hidden rounded"
+              title={palette}
+            >
+              {Object.entries(ramp).map(([step, val]) => (
+                <div
+                  key={step}
+                  className="h-4 flex-1"
+                  style={{ backgroundColor: val }}
+                  title={`--${palette}-${step}`}
+                />
+              ))}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/controls.tsx
+++ b/www/src/modules/create/studio/controls.tsx
@@ -1,0 +1,387 @@
+'use client'
+
+import { ChevronDownIcon, UploadIcon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+import { Popover } from '@/registry/ui/popover'
+import { Select, SelectValue } from '@/registry/ui/select'
+import { Switch } from '@/registry/ui/switch'
+
+import { Segmented, ValueSlider } from '../panel/primitives'
+import { useDesignSystem } from '../preset'
+
+/* ----------------------------------------------------------------------------
+ * New-axis widgets.
+ *
+ * These extend the builder past the shipped axes — surface translucency,
+ * background texture, shadow tint, motion easing, hover/press feedback,
+ * accessibility targets, finer typography and brand. Each writes a CSS var
+ * through the existing token channel; the preview has no consumer for most yet
+ * (honest "Planned" pips in the inspector), but they persist and serialize and
+ * go live the moment a token consumer lands.
+ * -------------------------------------------------------------------------- */
+
+export const TRANSLUCENT_VAR = '--ds-translucent-surfaces'
+export const BG_TEXTURE_VAR = '--ds-bg-texture'
+export const SHADOW_TINT_VAR = '--ds-shadow-tint'
+export const EASING_VAR = '--ds-ease'
+export const HOVER_EFFECT_VAR = '--ds-hover-effect'
+export const PRESS_SCALE_VAR = '--ds-press-scale'
+export const CONTRAST_TARGET_VAR = '--ds-contrast-target'
+export const COLORBLIND_VAR = '--ds-colorblind-safe'
+export const TAP_TARGET_VAR = '--ds-tap-target'
+export const FONT_WEIGHT_VAR = '--ds-font-weight'
+export const TRACKING_VAR = '--ds-tracking'
+export const LINE_HEIGHT_VAR = '--ds-line-height'
+export const FONT_HEADING_VAR = '--ds-font-heading'
+export const FONT_BODY_VAR = '--ds-font-body'
+
+function useToken(name: string, fallback: string) {
+  const { designSystem, setToken } = useDesignSystem()
+  const value = designSystem.tokens[name] ?? fallback
+  return [value, (v: string) => setToken(name, v)] as const
+}
+
+/* ------------------------------- Surface -------------------------------- */
+
+export function TranslucentSurfacesWidget() {
+  const [value, set] = useToken(TRANSLUCENT_VAR, 'false')
+  return (
+    <Switch
+      isSelected={value === 'true'}
+      onChange={(s) => set(String(s))}
+      aria-label="Translucent menus & popovers"
+    />
+  )
+}
+
+export function BackgroundTextureWidget() {
+  const [value, set] = useToken(BG_TEXTURE_VAR, 'none')
+  const options = [
+    { value: 'none', label: 'None' },
+    { value: 'grid', label: 'Grid' },
+    { value: 'dots', label: 'Dots' },
+    { value: 'noise', label: 'Grain' },
+  ] as const
+  return (
+    <div className="flex flex-col gap-2">
+      <Segmented
+        ariaLabel="Background texture"
+        value={value}
+        onChange={set}
+        options={options}
+      />
+      <div
+        className="h-10 rounded-md border bg-bg"
+        style={textureStyle(value)}
+        aria-hidden
+      />
+    </div>
+  )
+}
+
+function textureStyle(kind: string): React.CSSProperties {
+  if (kind === 'grid')
+    return {
+      backgroundImage:
+        'linear-gradient(var(--color-border) 1px, transparent 1px), linear-gradient(90deg, var(--color-border) 1px, transparent 1px)',
+      backgroundSize: '12px 12px',
+    }
+  if (kind === 'dots')
+    return {
+      backgroundImage:
+        'radial-gradient(var(--color-border) 1px, transparent 1px)',
+      backgroundSize: '10px 10px',
+    }
+  if (kind === 'noise')
+    return {
+      backgroundImage:
+        "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.4'/%3E%3C/svg%3E\")",
+    }
+  return {}
+}
+
+/* ------------------------------ Elevation ------------------------------- */
+
+export function ShadowTintWidget() {
+  const [value, set] = useToken(SHADOW_TINT_VAR, 'neutral')
+  return (
+    <Segmented
+      ariaLabel="Shadow tint"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'neutral', label: 'Neutral' },
+        { value: 'warm', label: 'Warm' },
+        { value: 'cool', label: 'Cool' },
+        { value: 'brand', label: 'Brand' },
+      ]}
+    />
+  )
+}
+
+/* ------------------------------- Motion --------------------------------- */
+
+const EASINGS: Record<string, [number, number, number, number]> = {
+  snappy: [0.2, 0, 0, 1],
+  smooth: [0.4, 0, 0.2, 1],
+  spring: [0.34, 1.4, 0.64, 1],
+  linear: [0, 0, 1, 1],
+}
+
+export function EasingWidget() {
+  const [value, set] = useToken(EASING_VAR, 'smooth')
+  const curve: [number, number, number, number] = EASINGS[value] ?? [
+    0.4, 0, 0.2, 1,
+  ]
+  return (
+    <div className="flex items-center gap-3">
+      <EasingCurve curve={curve} />
+      <Select
+        className="flex-1"
+        selectedKey={value}
+        onSelectionChange={(k) => set(k as string)}
+        aria-label="Easing curve"
+      >
+        <Button size="sm" className="w-full justify-between">
+          <SelectValue className="truncate capitalize" />
+          <ChevronDownIcon data-icon-end="" />
+        </Button>
+        <Popover>
+          <ListBox>
+            {Object.keys(EASINGS).map((id) => (
+              <ListBoxItem key={id} id={id} className="capitalize">
+                {id}
+              </ListBoxItem>
+            ))}
+          </ListBox>
+        </Popover>
+      </Select>
+    </div>
+  )
+}
+
+function EasingCurve({ curve }: { curve: [number, number, number, number] }) {
+  const [x1, y1, x2, y2] = curve
+  const s = 40
+  // Unit bezier with y flipped into SVG space; clamp the overshoot into view.
+  const px = (n: number) => 4 + n * (s - 8)
+  const py = (n: number) => s - 4 - n * (s - 8)
+  const d = `M ${px(0)} ${py(0)} C ${px(x1)} ${py(y1)} ${px(x2)} ${py(y2)} ${px(1)} ${py(1)}`
+  return (
+    <svg
+      width={s}
+      height={s}
+      viewBox={`0 0 ${s} ${s}`}
+      className="shrink-0 rounded-md border bg-neutral/40"
+    >
+      <path
+        d={d}
+        fill="none"
+        stroke="var(--color-primary)"
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+export function HoverEffectWidget() {
+  const [value, set] = useToken(HOVER_EFFECT_VAR, 'none')
+  return (
+    <Segmented
+      ariaLabel="Hover effect"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'none', label: 'None' },
+        { value: 'lift', label: 'Lift' },
+        { value: 'glow', label: 'Glow' },
+        { value: 'scale', label: 'Scale' },
+      ]}
+    />
+  )
+}
+
+export function PressScaleWidget() {
+  const [value, set] = useToken(PRESS_SCALE_VAR, '0.98')
+  return (
+    <ValueSlider
+      ariaLabel="Press scale"
+      value={Number.parseFloat(value) || 0.98}
+      min={0.9}
+      max={1}
+      step={0.01}
+      format={(v) => `${Math.round(v * 100)}%`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+
+/* --------------------------- Accessibility ------------------------------ */
+
+export function ContrastTargetWidget() {
+  const [value, set] = useToken(CONTRAST_TARGET_VAR, 'AA')
+  return (
+    <Segmented
+      ariaLabel="Contrast target"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'AA', label: 'AA' },
+        { value: 'AAA', label: 'AAA' },
+      ]}
+    />
+  )
+}
+
+export function ColorblindSafeWidget() {
+  const [value, set] = useToken(COLORBLIND_VAR, 'false')
+  return (
+    <Switch
+      isSelected={value === 'true'}
+      onChange={(s) => set(String(s))}
+      aria-label="Color-blind safe palette"
+    />
+  )
+}
+
+export function TapTargetWidget() {
+  const [value, set] = useToken(TAP_TARGET_VAR, '40')
+  return (
+    <ValueSlider
+      ariaLabel="Minimum tap target"
+      value={Number.parseFloat(value) || 40}
+      min={24}
+      max={56}
+      step={2}
+      format={(v) => `${v}px`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+
+/* ----------------------------- Typography ------------------------------- */
+
+const PAIRINGS = [
+  { id: 'geist', heading: 'Geist', body: 'Geist', note: 'Neutral & modern' },
+  { id: 'inter', heading: 'Inter', body: 'Inter', note: 'Workhorse UI' },
+  {
+    id: 'editorial',
+    heading: 'Lora',
+    body: 'Inter',
+    note: 'Serif display, clean body',
+  },
+  {
+    id: 'expressive',
+    heading: 'Satoshi',
+    body: 'Inter',
+    note: 'Characterful headings',
+  },
+  { id: 'technical', heading: 'Söhne', body: 'Mono', note: 'Grotesk + mono' },
+] as const
+
+export function FontPairingWidget() {
+  const { designSystem, setToken } = useDesignSystem()
+  const heading = designSystem.tokens[FONT_HEADING_VAR] ?? 'Geist'
+  const body = designSystem.tokens[FONT_BODY_VAR] ?? 'Geist'
+  const activeId = PAIRINGS.find(
+    (p) => p.heading === heading && p.body === body,
+  )?.id
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {PAIRINGS.map((p) => {
+        const active = p.id === activeId
+        return (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => {
+              setToken(FONT_HEADING_VAR, p.heading)
+              setToken(FONT_BODY_VAR, p.body)
+            }}
+            className={cn(
+              'flex items-center justify-between rounded-lg border px-3 py-2 text-left focus-reset transition-colors focus-visible:focus-ring',
+              active
+                ? 'border-border-focus bg-accent-muted'
+                : 'hover:bg-neutral',
+            )}
+          >
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium">
+                {p.heading}
+                <span className="text-fg-muted"> / {p.body}</span>
+              </span>
+              <span className="text-xs text-fg-muted">{p.note}</span>
+            </div>
+            <span className="text-2xl leading-none text-fg-muted">Ag</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export function FontWeightWidget() {
+  const [value, set] = useToken(FONT_WEIGHT_VAR, 'regular')
+  return (
+    <Segmented
+      ariaLabel="Base font weight"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'light', label: 'Light' },
+        { value: 'regular', label: 'Regular' },
+        { value: 'medium', label: 'Medium' },
+      ]}
+    />
+  )
+}
+
+export function TrackingWidget() {
+  const [value, set] = useToken(TRACKING_VAR, '0')
+  return (
+    <ValueSlider
+      ariaLabel="Letter spacing"
+      value={Number.parseFloat(value) || 0}
+      min={-0.05}
+      max={0.05}
+      step={0.005}
+      format={(v) => `${v > 0 ? '+' : ''}${(v * 100).toFixed(1)}%`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+
+export function LineHeightWidget() {
+  const [value, set] = useToken(LINE_HEIGHT_VAR, '1.5')
+  return (
+    <ValueSlider
+      ariaLabel="Body line height"
+      value={Number.parseFloat(value) || 1.5}
+      min={1.2}
+      max={1.9}
+      step={0.05}
+      format={(v) => v.toFixed(2)}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+
+/* -------------------------------- Brand --------------------------------- */
+
+export function BrandLogoWidget() {
+  return (
+    <label className="flex cursor-pointer flex-col items-center justify-center gap-1.5 rounded-lg border border-dashed py-5 text-center transition-colors hover:bg-neutral/50">
+      <UploadIcon className="size-4 text-fg-muted" />
+      <span className="text-xs font-medium">Drop a logo or screenshot</span>
+      <span className="text-[11px] text-fg-muted">
+        SVG / PNG — we'll extract a palette
+      </span>
+      <input type="file" accept="image/*" className="sr-only" />
+    </label>
+  )
+}

--- a/www/src/modules/create/studio/index.tsx
+++ b/www/src/modules/create/studio/index.tsx
@@ -18,7 +18,10 @@ import { StudioHeader } from './studio-header'
 export function StudioExperience() {
   return (
     <StudioProvider>
-      <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-col overflow-hidden">
+      {/* The Studio owns the whole viewport: the global site Header is skipped
+          on /create?studio (see _app/route.tsx), so StudioHeader is the only
+          top bar and the shell fills 100svh rather than subtracting it. */}
+      <div className="flex h-svh min-h-0 flex-col overflow-hidden">
         <StudioHeader />
         <div className="flex min-h-0 flex-1">
           <Rail />

--- a/www/src/modules/create/studio/index.tsx
+++ b/www/src/modules/create/studio/index.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { PreviewPanel } from '../preview/preview-panel'
+import { CommandBar } from './ai/command-bar'
+import { Inspector } from './inspector'
+import { Rail } from './rail'
+import { StudioProvider } from './studio-context'
+import { StudioHeader } from './studio-header'
+
+/**
+ * The `/create?studio` experience — an AI-native rethink of the builder.
+ *
+ * One opinionated three-zone layout: an icon rail of sections, a rich
+ * inspector, and a big live canvas with a persistent AI copilot docked over it.
+ * Everything writes the same DesignSystem state the shipped page does, so live
+ * axes genuinely drive the reused preview and the export stays intact.
+ */
+export function StudioExperience() {
+  return (
+    <StudioProvider>
+      <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-col overflow-hidden">
+        <StudioHeader />
+        <div className="flex min-h-0 flex-1">
+          <Rail />
+          <Inspector />
+          <div className="relative flex min-w-0 flex-1 flex-col bg-bg p-3">
+            <PreviewPanel />
+            <CommandBar />
+          </div>
+        </div>
+      </div>
+    </StudioProvider>
+  )
+}

--- a/www/src/modules/create/studio/inspector.tsx
+++ b/www/src/modules/create/studio/inspector.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { WandSparklesIcon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { GeneratePanel } from './ai/generate-panel'
+import { VIBES } from './ai/vibes'
+import { type StudioControl, STUDIO_SECTIONS } from './sections'
+import { useStudio } from './studio-context'
+
+export function Inspector() {
+  const { activeSection, applyVibe } = useStudio()
+
+  if (activeSection === 'generate') {
+    return (
+      <Panel>
+        <GeneratePanel />
+      </Panel>
+    )
+  }
+
+  const section = STUDIO_SECTIONS.find((s) => s.id === activeSection)
+  if (!section) return null
+
+  return (
+    <Panel>
+      <div className="flex flex-col gap-1 border-b px-4 py-3.5">
+        <div className="flex items-center gap-2">
+          <section.icon className="size-4 text-fg-muted" />
+          <h2 className="text-sm font-semibold">{section.label}</h2>
+        </div>
+        <p className="text-xs text-fg-muted">{section.tagline}</p>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-5 overflow-y-auto p-4">
+        {section.id === 'color' && (
+          <Button
+            variant="default"
+            size="sm"
+            className="w-full gap-2"
+            onPress={() => {
+              const vibe = VIBES[Math.floor(Math.random() * VIBES.length)]
+              if (vibe) applyVibe(vibe)
+            }}
+          >
+            <WandSparklesIcon className="size-3.5 text-fg-accent" />
+            Suggest a palette
+          </Button>
+        )}
+        {section.controls.map((control) => (
+          <ControlRow key={control.id} control={control} />
+        ))}
+      </div>
+    </Panel>
+  )
+}
+
+function Panel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex w-[340px] shrink-0 flex-col overflow-hidden border-r bg-card">
+      {children}
+    </div>
+  )
+}
+
+function ControlRow({ control }: { control: StudioControl }) {
+  return (
+    <div className="flex flex-col gap-2" data-control={control.id}>
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm font-medium text-fg">{control.label}</span>
+            <BindingPip binding={control.binding} />
+          </div>
+          {control.description && (
+            <p className="text-xs leading-snug text-pretty text-fg-muted">
+              {control.description}
+            </p>
+          )}
+        </div>
+      </div>
+      <control.Widget />
+    </div>
+  )
+}
+
+function BindingPip({ binding }: { binding: StudioControl['binding'] }) {
+  const live = binding === 'live'
+  return (
+    <Tooltip delay={300}>
+      <span
+        className={cn(
+          'inline-block size-1.5 shrink-0 rounded-full',
+          live ? 'bg-success' : 'border border-warning/70',
+        )}
+        aria-hidden
+      />
+      <TooltipContent>
+        {live ? 'Live — drives the preview' : 'Planned — UI only for now'}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/www/src/modules/create/studio/rail.tsx
+++ b/www/src/modules/create/studio/rail.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { SparklesIcon } from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+
+import { STUDIO_SECTIONS } from './sections'
+import { useStudio } from './studio-context'
+
+/* The left rail — one opinionated, ordered set of sections. "Generate" leads
+ * (the AI front door) and is visually distinct; the rest are the design axes. */
+
+export function Rail() {
+  const { activeSection, setActiveSection } = useStudio()
+
+  return (
+    <nav
+      aria-label="Sections"
+      className="scrollbar-none flex w-16 shrink-0 flex-col items-stretch gap-1 overflow-y-auto border-r bg-card p-2"
+    >
+      <RailItem
+        id="generate"
+        label="Generate"
+        active={activeSection === 'generate'}
+        onPress={() => setActiveSection('generate')}
+        accent
+        icon={<SparklesIcon className="size-[18px]" />}
+      />
+      <div className="my-1 h-px bg-border" />
+      {STUDIO_SECTIONS.map((section) => {
+        const Icon = section.icon
+        return (
+          <RailItem
+            key={section.id}
+            id={section.id}
+            label={section.label}
+            active={activeSection === section.id}
+            onPress={() => setActiveSection(section.id)}
+            icon={<Icon className="size-[18px]" />}
+          />
+        )
+      })}
+    </nav>
+  )
+}
+
+function RailItem({
+  label,
+  active,
+  onPress,
+  icon,
+  accent,
+}: {
+  id: string
+  label: string
+  active: boolean
+  onPress: () => void
+  icon: React.ReactNode
+  accent?: boolean
+}) {
+  return (
+    <ButtonPrimitives.Button
+      onPress={onPress}
+      aria-current={active ? 'true' : undefined}
+      className={cn(
+        'group flex flex-col items-center gap-1 rounded-lg py-2 text-[10px] font-medium focus-reset transition-colors focus-visible:focus-ring',
+        active
+          ? accent
+            ? 'bg-accent-muted text-fg-accent'
+            : 'bg-neutral text-fg'
+          : cn(
+              'text-fg-muted hover:bg-neutral/60 hover:text-fg',
+              accent && 'text-fg-accent',
+            ),
+      )}
+    >
+      <span
+        className={cn(
+          'flex size-8 items-center justify-center rounded-md transition-colors',
+          accent && !active && 'bg-accent-muted/60',
+          accent && active && 'bg-accent text-fg-on-accent',
+        )}
+      >
+        {icon}
+      </span>
+      <span className="w-full truncate text-center leading-none">{label}</span>
+    </ButtonPrimitives.Button>
+  )
+}

--- a/www/src/modules/create/studio/sections.tsx
+++ b/www/src/modules/create/studio/sections.tsx
@@ -1,0 +1,816 @@
+'use client'
+
+import type { ComponentType } from 'react'
+import {
+  AccessibilityIcon,
+  BoxSelectIcon,
+  ChevronDownIcon,
+  ImageIcon,
+  LayersIcon,
+  type LucideIcon,
+  MousePointer2Icon,
+  PaletteIcon,
+  RulerIcon,
+  ShapesIcon,
+  SmileIcon,
+  TypeIcon,
+  ZapIcon,
+} from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+import { Popover } from '@/registry/ui/popover'
+import { Select, SelectValue } from '@/registry/ui/select'
+import { Switch } from '@/registry/ui/switch'
+
+import { ComponentDetailView } from '../components'
+import {
+  CURSOR_DISABLED_VAR,
+  CURSOR_INTERACTIVE_VAR,
+  DEFAULT_CURSOR_DISABLED,
+  DEFAULT_CURSOR_INTERACTIVE,
+} from '../cursor'
+import { DEFAULT_RADIUS_FACTOR, RADIUS_FACTOR_VAR } from '../layout'
+import { Segmented, ValueSlider } from '../panel/primitives'
+import { useDesignSystem } from '../preset'
+import {
+  AlgorithmWidget,
+  ColorEngineWidget,
+  GrayStrategyWidget,
+  SeedField,
+  StatusColorsWidget,
+} from './color-widgets'
+import {
+  BackgroundTextureWidget,
+  BrandLogoWidget,
+  ColorblindSafeWidget,
+  ContrastTargetWidget,
+  EasingWidget,
+  FONT_BODY_VAR,
+  FONT_HEADING_VAR,
+  FontPairingWidget,
+  FontWeightWidget,
+  HoverEffectWidget,
+  LineHeightWidget,
+  PressScaleWidget,
+  ShadowTintWidget,
+  TapTargetWidget,
+  TrackingWidget,
+  TranslucentSurfacesWidget,
+} from './controls'
+
+/* ----------------------------------------------------------------------------
+ * The Studio inspector schema.
+ *
+ * `live` controls drive the preview through the real token channel; `planned`
+ * controls write a forward-looking CSS var the preview has no consumer for yet
+ * (surfaced honestly in the inspector). The shape is intentionally flatter than
+ * the lab's tri-axis schema — Studio has one opinionated layout, not five.
+ * -------------------------------------------------------------------------- */
+
+export type Binding = 'live' | 'planned'
+
+export interface StudioControl {
+  id: string
+  label: string
+  description?: string
+  binding: Binding
+  /** Widget owns its full layout (no inline label row). */
+  block?: boolean
+  Widget: ComponentType
+}
+
+export interface StudioSection {
+  id: string
+  label: string
+  icon: LucideIcon
+  tagline: string
+  controls: StudioControl[]
+}
+
+/* --------------------------- Small token widgets ------------------------- */
+
+function useToken(name: string, fallback: string) {
+  const { designSystem, setToken } = useDesignSystem()
+  const value = designSystem.tokens[name] ?? fallback
+  return [value, (v: string) => setToken(name, v)] as const
+}
+
+function SelectToken({
+  value,
+  onChange,
+  options,
+  capitalize,
+}: {
+  value: string
+  onChange: (v: string) => void
+  options: ReadonlyArray<{ id: string; label: string }>
+  capitalize?: boolean
+}) {
+  return (
+    <Select
+      className="w-full"
+      selectedKey={value}
+      onSelectionChange={(k) => onChange(k as string)}
+      aria-label="Option"
+    >
+      <Button size="sm" className="w-full justify-between">
+        <SelectValue
+          className={capitalize ? 'truncate capitalize' : 'truncate'}
+        />
+        <ChevronDownIcon data-icon-end="" />
+      </Button>
+      <Popover>
+        <ListBox>
+          {options.map((o) => (
+            <ListBoxItem
+              key={o.id}
+              id={o.id}
+              className={capitalize ? 'capitalize' : undefined}
+            >
+              {o.label}
+            </ListBoxItem>
+          ))}
+        </ListBox>
+      </Popover>
+    </Select>
+  )
+}
+
+/* live core */
+function RadiusWidget() {
+  const [value, set] = useToken(RADIUS_FACTOR_VAR, DEFAULT_RADIUS_FACTOR)
+  return (
+    <ValueSlider
+      ariaLabel="Radius factor"
+      value={Number.parseFloat(value) || 1}
+      min={0}
+      max={2}
+      step={0.05}
+      format={(v) => `${v.toFixed(2)}×`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+
+function DensityWidget() {
+  const { designSystem, setDensity } = useDesignSystem()
+  return (
+    <Segmented
+      ariaLabel="Density"
+      value={designSystem.density}
+      onChange={setDensity}
+      options={[
+        { value: 'compact', label: 'Compact' },
+        { value: 'default', label: 'Default' },
+        { value: 'comfortable', label: 'Cozy' },
+      ]}
+    />
+  )
+}
+
+const CURSORS = [
+  'default',
+  'pointer',
+  'not-allowed',
+  'wait',
+  'progress',
+  'text',
+  'grab',
+]
+
+function CursorWidget({
+  varName,
+  fallback,
+}: {
+  varName: string
+  fallback: string
+}) {
+  const [value, set] = useToken(varName, fallback)
+  return (
+    <SelectToken
+      value={value}
+      onChange={set}
+      options={CURSORS.map((c) => ({ id: c, label: c }))}
+    />
+  )
+}
+
+/* planned stubs */
+function BorderWidthWidget() {
+  const [value, set] = useToken('--ds-border-width', '1')
+  return (
+    <ValueSlider
+      ariaLabel="Border width"
+      value={Number.parseFloat(value) || 1}
+      min={0}
+      max={3}
+      step={0.5}
+      format={(v) => `${v}px`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+function SpacingScaleWidget() {
+  const [value, set] = useToken('--ds-spacing-scale', '1')
+  return (
+    <ValueSlider
+      ariaLabel="Spacing scale"
+      value={Number.parseFloat(value) || 1}
+      min={0.75}
+      max={1.5}
+      step={0.05}
+      format={(v) => `${v.toFixed(2)}×`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+function StyleFamilyWidget() {
+  const [value, set] = useToken('--ds-elevation-style', 'soft')
+  return (
+    <Segmented
+      ariaLabel="Style family"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'flat', label: 'Flat' },
+        { value: 'soft', label: 'Soft' },
+        { value: 'depth', label: '3D' },
+        { value: 'glass', label: 'Glass' },
+      ]}
+    />
+  )
+}
+function ShadowIntensityWidget() {
+  const [value, set] = useToken('--ds-shadow-intensity', '0.5')
+  return (
+    <ValueSlider
+      ariaLabel="Shadow intensity"
+      value={Number.parseFloat(value) || 0.5}
+      min={0}
+      max={1}
+      step={0.05}
+      format={(v) => `${Math.round(v * 100)}%`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+function BackdropBlurWidget() {
+  const [value, set] = useToken('--ds-backdrop-blur', '0')
+  return (
+    <ValueSlider
+      ariaLabel="Backdrop blur"
+      value={Number.parseFloat(value) || 0}
+      min={0}
+      max={24}
+      step={1}
+      format={(v) => `${v}px`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+function DurationWidget() {
+  const [value, set] = useToken('--ds-motion-duration', '150')
+  return (
+    <ValueSlider
+      ariaLabel="Duration scale"
+      value={Number.parseFloat(value) || 150}
+      min={0}
+      max={400}
+      step={10}
+      format={(v) => `${v}ms`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+function BoolToken({
+  varName,
+  fallback,
+}: {
+  varName: string
+  fallback: string
+}) {
+  const [value, set] = useToken(varName, fallback)
+  return (
+    <Switch
+      isSelected={value === 'true'}
+      onChange={(s) => set(String(s))}
+      aria-label="Toggle"
+    />
+  )
+}
+function FocusRingWidthWidget() {
+  const [value, set] = useToken('--ds-focus-ring-width', '2')
+  return (
+    <ValueSlider
+      ariaLabel="Focus ring width"
+      value={Number.parseFloat(value) || 2}
+      min={0}
+      max={4}
+      step={1}
+      format={(v) => `${v}px`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+function TypeScaleWidget() {
+  const [value, set] = useToken('--ds-type-scale', '1.25')
+  return (
+    <ValueSlider
+      ariaLabel="Scale ratio"
+      value={Number.parseFloat(value) || 1.25}
+      min={1.1}
+      max={1.5}
+      step={0.01}
+      format={(v) => v.toFixed(3)}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+function BaseSizeWidget() {
+  const [value, set] = useToken('--ds-type-base', '16')
+  return (
+    <ValueSlider
+      ariaLabel="Base size"
+      value={Number.parseFloat(value) || 16}
+      min={13}
+      max={18}
+      step={1}
+      format={(v) => `${v}px`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+function DisplayFontWidget() {
+  const { designSystem, setToken } = useDesignSystem()
+  const value = designSystem.tokens[FONT_HEADING_VAR] ?? 'Geist'
+  return (
+    <SelectToken
+      value={value}
+      onChange={(v) => setToken(FONT_HEADING_VAR, v)}
+      options={FONTS}
+    />
+  )
+}
+function BodyFontWidget() {
+  const { designSystem, setToken } = useDesignSystem()
+  const value = designSystem.tokens[FONT_BODY_VAR] ?? 'Geist'
+  return (
+    <SelectToken
+      value={value}
+      onChange={(v) => setToken(FONT_BODY_VAR, v)}
+      options={FONTS}
+    />
+  )
+}
+const FONTS = ['Geist', 'Inter', 'Satoshi', 'Söhne', 'Lora', 'Mono'].map(
+  (f) => ({ id: f, label: f }),
+)
+
+function IconLibraryWidget() {
+  const [value, set] = useToken('--ds-icon-library', 'lucide')
+  return (
+    <SelectToken
+      value={value}
+      onChange={set}
+      capitalize
+      options={[
+        { id: 'lucide', label: 'Lucide' },
+        { id: 'remix', label: 'Remix' },
+        { id: 'tabler', label: 'Tabler' },
+        { id: 'hugeicons', label: 'Hugeicons' },
+      ]}
+    />
+  )
+}
+function IconStrokeWidget() {
+  const [value, set] = useToken('--ds-icon-stroke', '2')
+  return (
+    <ValueSlider
+      ariaLabel="Icon stroke"
+      value={Number.parseFloat(value) || 2}
+      min={1}
+      max={2.5}
+      step={0.25}
+      format={(v) => `${v}px`}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+function DefaultModeWidget() {
+  const [value, set] = useToken('--ds-default-mode', 'system')
+  return (
+    <Segmented
+      ariaLabel="Default mode"
+      value={value}
+      onChange={set}
+      options={[
+        { value: 'light', label: 'Light' },
+        { value: 'dark', label: 'Dark' },
+        { value: 'system', label: 'Auto' },
+      ]}
+    />
+  )
+}
+
+function ComponentAnatomy({ name }: { name: string }) {
+  const { designSystem, setComponentParam } = useDesignSystem()
+  return (
+    <ComponentDetailView
+      componentName={name}
+      selectedParams={designSystem.componentParams[name] ?? {}}
+      onParamChange={(param, value) => setComponentParam(name, param, value)}
+    />
+  )
+}
+
+/* -------------------------------- Schema -------------------------------- */
+
+export const STUDIO_SECTIONS: StudioSection[] = [
+  {
+    id: 'color',
+    label: 'Color',
+    icon: PaletteIcon,
+    tagline: 'Seeds, ramps & contrast',
+    controls: [
+      {
+        id: 'brand-color',
+        label: 'Brand color',
+        description: 'The one real color — drives every accent ramp.',
+        binding: 'live',
+        Widget: () => <SeedField seed="accent" />,
+      },
+      {
+        id: 'base-color',
+        label: 'Base / gray',
+        description: 'Neutral seed the whole surface system derives from.',
+        binding: 'live',
+        Widget: () => <SeedField seed="neutral" />,
+      },
+      {
+        id: 'gray-strategy',
+        label: 'Gray strategy',
+        description: 'Pure neutrals, or grays tinted toward the brand.',
+        binding: 'live',
+        Widget: GrayStrategyWidget,
+      },
+      {
+        id: 'algorithm',
+        label: 'Generation algorithm',
+        description: 'How seeds expand into tonal ramps.',
+        binding: 'live',
+        Widget: AlgorithmWidget,
+      },
+      {
+        id: 'status-colors',
+        label: 'Status families',
+        binding: 'live',
+        block: true,
+        Widget: StatusColorsWidget,
+      },
+      {
+        id: 'color-engine',
+        label: 'Ramps & contrast',
+        binding: 'live',
+        block: true,
+        Widget: ColorEngineWidget,
+      },
+    ],
+  },
+  {
+    id: 'typography',
+    label: 'Typography',
+    icon: TypeIcon,
+    tagline: 'Pairing, scale & rhythm',
+    controls: [
+      {
+        id: 'font-pairing',
+        label: 'Font pairing',
+        binding: 'planned',
+        block: true,
+        Widget: FontPairingWidget,
+      },
+      {
+        id: 'display-font',
+        label: 'Display font',
+        binding: 'planned',
+        Widget: DisplayFontWidget,
+      },
+      {
+        id: 'body-font',
+        label: 'Body font',
+        binding: 'planned',
+        Widget: BodyFontWidget,
+      },
+      {
+        id: 'type-scale',
+        label: 'Scale ratio',
+        description: 'Modular scale between type steps.',
+        binding: 'planned',
+        Widget: TypeScaleWidget,
+      },
+      {
+        id: 'base-size',
+        label: 'Base size',
+        binding: 'planned',
+        Widget: BaseSizeWidget,
+      },
+      {
+        id: 'font-weight',
+        label: 'Base weight',
+        binding: 'planned',
+        Widget: FontWeightWidget,
+      },
+      {
+        id: 'tracking',
+        label: 'Letter spacing',
+        binding: 'planned',
+        Widget: TrackingWidget,
+      },
+      {
+        id: 'line-height',
+        label: 'Line height',
+        binding: 'planned',
+        Widget: LineHeightWidget,
+      },
+    ],
+  },
+  {
+    id: 'icons',
+    label: 'Icons',
+    icon: SmileIcon,
+    tagline: 'Library & stroke',
+    controls: [
+      {
+        id: 'icon-library',
+        label: 'Icon library',
+        binding: 'planned',
+        Widget: IconLibraryWidget,
+      },
+      {
+        id: 'icon-stroke',
+        label: 'Stroke width',
+        binding: 'planned',
+        Widget: IconStrokeWidget,
+      },
+    ],
+  },
+  {
+    id: 'shape',
+    label: 'Shape',
+    icon: ShapesIcon,
+    tagline: 'Corners & borders',
+    controls: [
+      {
+        id: 'radius-factor',
+        label: 'Radius factor',
+        description: 'Scales the whole corner-radius scale at once.',
+        binding: 'live',
+        Widget: RadiusWidget,
+      },
+      {
+        id: 'border-width',
+        label: 'Border width',
+        binding: 'planned',
+        Widget: BorderWidthWidget,
+      },
+    ],
+  },
+  {
+    id: 'spacing',
+    label: 'Spacing',
+    icon: RulerIcon,
+    tagline: 'Density & scale',
+    controls: [
+      {
+        id: 'density',
+        label: 'Density',
+        description: 'Global control heights, gaps and padding.',
+        binding: 'live',
+        Widget: DensityWidget,
+      },
+      {
+        id: 'spacing-scale',
+        label: 'Spacing scale',
+        binding: 'planned',
+        Widget: SpacingScaleWidget,
+      },
+    ],
+  },
+  {
+    id: 'depth',
+    label: 'Depth',
+    icon: LayersIcon,
+    tagline: 'Elevation & surfaces',
+    controls: [
+      {
+        id: 'style-family',
+        label: 'Style family',
+        description: 'The big re-skin: flat, soft, 3D or glass.',
+        binding: 'planned',
+        Widget: StyleFamilyWidget,
+      },
+      {
+        id: 'shadow-intensity',
+        label: 'Shadow intensity',
+        binding: 'planned',
+        Widget: ShadowIntensityWidget,
+      },
+      {
+        id: 'shadow-tint',
+        label: 'Shadow tint',
+        binding: 'planned',
+        Widget: ShadowTintWidget,
+      },
+      {
+        id: 'backdrop-blur',
+        label: 'Backdrop blur',
+        description: 'Frost behind overlays and menus.',
+        binding: 'planned',
+        Widget: BackdropBlurWidget,
+      },
+      {
+        id: 'translucent',
+        label: 'Translucent surfaces',
+        description: 'Menus and popovers blur what is behind them.',
+        binding: 'planned',
+        Widget: TranslucentSurfacesWidget,
+      },
+      {
+        id: 'bg-texture',
+        label: 'Background texture',
+        binding: 'planned',
+        block: true,
+        Widget: BackgroundTextureWidget,
+      },
+    ],
+  },
+  {
+    id: 'motion',
+    label: 'Motion',
+    icon: ZapIcon,
+    tagline: 'Timing & feedback',
+    controls: [
+      {
+        id: 'duration',
+        label: 'Duration scale',
+        description: 'Baseline transition speed.',
+        binding: 'planned',
+        Widget: DurationWidget,
+      },
+      {
+        id: 'easing',
+        label: 'Easing curve',
+        binding: 'planned',
+        Widget: EasingWidget,
+      },
+      {
+        id: 'hover-effect',
+        label: 'Hover effect',
+        binding: 'planned',
+        Widget: HoverEffectWidget,
+      },
+      {
+        id: 'press-scale',
+        label: 'Press feedback',
+        description: 'How far controls scale on press.',
+        binding: 'planned',
+        Widget: PressScaleWidget,
+      },
+      {
+        id: 'animations',
+        label: 'Animations',
+        description: 'Global on/off for all transitions.',
+        binding: 'planned',
+        Widget: () => (
+          <BoolToken varName="--ds-motion-enabled" fallback="true" />
+        ),
+      },
+    ],
+  },
+  {
+    id: 'interaction',
+    label: 'Interaction',
+    icon: MousePointer2Icon,
+    tagline: 'Cursors & focus',
+    controls: [
+      {
+        id: 'cursor-interactive',
+        label: 'Interactive cursor',
+        description: 'Pointer on actionable elements.',
+        binding: 'live',
+        Widget: () => (
+          <CursorWidget
+            varName={CURSOR_INTERACTIVE_VAR}
+            fallback={DEFAULT_CURSOR_INTERACTIVE}
+          />
+        ),
+      },
+      {
+        id: 'cursor-disabled',
+        label: 'Disabled cursor',
+        binding: 'live',
+        Widget: () => (
+          <CursorWidget
+            varName={CURSOR_DISABLED_VAR}
+            fallback={DEFAULT_CURSOR_DISABLED}
+          />
+        ),
+      },
+      {
+        id: 'focus-ring',
+        label: 'Focus ring width',
+        description: 'Keyboard focus outline thickness.',
+        binding: 'planned',
+        Widget: FocusRingWidthWidget,
+      },
+    ],
+  },
+  {
+    id: 'a11y',
+    label: 'Accessibility',
+    icon: AccessibilityIcon,
+    tagline: 'Targets & safety',
+    controls: [
+      {
+        id: 'contrast-target',
+        label: 'Contrast target',
+        description: 'Minimum WCAG ratio ramps must clear.',
+        binding: 'planned',
+        Widget: ContrastTargetWidget,
+      },
+      {
+        id: 'colorblind-safe',
+        label: 'Color-blind safe',
+        description: 'Bias status hues for deuteranopia.',
+        binding: 'planned',
+        Widget: ColorblindSafeWidget,
+      },
+      {
+        id: 'tap-target',
+        label: 'Min tap target',
+        binding: 'planned',
+        Widget: TapTargetWidget,
+      },
+      {
+        id: 'reduced-motion',
+        label: 'Respect reduced-motion',
+        binding: 'planned',
+        Widget: () => (
+          <BoolToken varName="--ds-reduced-motion" fallback="true" />
+        ),
+      },
+    ],
+  },
+  {
+    id: 'components',
+    label: 'Components',
+    icon: BoxSelectIcon,
+    tagline: 'Per-component anatomy',
+    controls: [
+      {
+        id: 'button',
+        label: 'Button',
+        binding: 'live',
+        block: true,
+        Widget: () => <ComponentAnatomy name="button" />,
+      },
+      {
+        id: 'input',
+        label: 'Input',
+        binding: 'live',
+        block: true,
+        Widget: () => <ComponentAnatomy name="input" />,
+      },
+      {
+        id: 'card',
+        label: 'Card',
+        binding: 'live',
+        block: true,
+        Widget: () => <ComponentAnatomy name="card" />,
+      },
+    ],
+  },
+  {
+    id: 'brand',
+    label: 'Brand',
+    icon: ImageIcon,
+    tagline: 'Logo & defaults',
+    controls: [
+      {
+        id: 'brand-logo',
+        label: 'Brand logo',
+        binding: 'planned',
+        block: true,
+        Widget: BrandLogoWidget,
+      },
+      {
+        id: 'default-mode',
+        label: 'Default mode',
+        description: 'Which mode the exported system boots in.',
+        binding: 'planned',
+        Widget: DefaultModeWidget,
+      },
+    ],
+  },
+]

--- a/www/src/modules/create/studio/studio-context.tsx
+++ b/www/src/modules/create/studio/studio-context.tsx
@@ -1,0 +1,209 @@
+'use client'
+
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+
+import { useDesignSystem } from '../preset'
+import { interpretChat, interpretPrompt } from './ai/interpret'
+import { type Vibe, vibeToMutate } from './ai/vibes'
+
+/* ----------------------------------------------------------------------------
+ * One provider for the whole Studio: which section is open, the editable system
+ * name, and the AI thread + apply logic. Centralising the AI here lets the
+ * generate panel, the canvas command bar, the copilot and the inline
+ * "Fix with AI" buttons all share one conversation and one apply path.
+ * -------------------------------------------------------------------------- */
+
+export interface ChatMessage {
+  id: string
+  role: 'user' | 'assistant'
+  text: string
+  changes?: string[]
+  /** true while the assistant is "thinking". */
+  pending?: boolean
+}
+
+export interface AppliedFlash {
+  id: string
+  title: string
+  changes: string[]
+}
+
+interface StudioContextValue {
+  activeSection: string
+  setActiveSection: (id: string) => void
+  name: string
+  setName: (name: string) => void
+
+  thread: ChatMessage[]
+  isThinking: boolean
+  /** The most recent applied change — drives the transient canvas flash. */
+  flash: AppliedFlash | null
+  clearFlash: () => void
+
+  /** Conversational tweak (copilot + canvas command bar). */
+  send: (text: string) => void
+  /** From-scratch generation (the Generate panel prompt). */
+  generate: (text: string) => void
+  /** Apply a named vibe directly (chip click). */
+  applyVibe: (vibe: Vibe) => void
+}
+
+const StudioContext = createContext<StudioContextValue | null>(null)
+
+let counter = 0
+const uid = (prefix: string) => `${prefix}-${++counter}-${Date.now()}`
+
+const THINK_MS = 650
+
+export function StudioProvider({ children }: { children: ReactNode }) {
+  const { designSystem, setDesignSystem } = useDesignSystem()
+  const designSystemRef = useRef(designSystem)
+  designSystemRef.current = designSystem
+
+  const [activeSection, setActiveSection] = useState('generate')
+  const [name, setName] = useState('Untitled system')
+  const [thread, setThread] = useState<ChatMessage[]>([])
+  const [isThinking, setIsThinking] = useState(false)
+  const [flash, setFlash] = useState<AppliedFlash | null>(null)
+
+  const clearFlash = useCallback(() => setFlash(null), [])
+
+  // Shared apply path: push the user line + a pending assistant line, then after a
+  // short "thinking" beat run the interpreter, apply the mutation to the live
+  // system, and resolve the assistant line with the human-readable changes.
+  const run = useCallback(
+    (
+      text: string,
+      interpret: (t: string) => ReturnType<typeof interpretChat>,
+    ) => {
+      const userId = uid('u')
+      const botId = uid('a')
+      setThread((t) => [
+        ...t,
+        { id: userId, role: 'user', text },
+        { id: botId, role: 'assistant', text: '', pending: true },
+      ])
+      setIsThinking(true)
+
+      window.setTimeout(() => {
+        const result = interpret(text)
+        if (result) {
+          setDesignSystem(result.mutate)
+          setThread((t) =>
+            t.map((m) =>
+              m.id === botId
+                ? {
+                    ...m,
+                    pending: false,
+                    text: result.title,
+                    changes: result.changes,
+                  }
+                : m,
+            ),
+          )
+          setFlash({ id: botId, title: result.title, changes: result.changes })
+        } else {
+          setThread((t) =>
+            t.map((m) =>
+              m.id === botId
+                ? {
+                    ...m,
+                    pending: false,
+                    text: "I couldn't map that to a change yet — try “rounder”, “calmer accent”, “increase contrast”, or a vibe like “Linear”.",
+                  }
+                : m,
+            ),
+          )
+        }
+        setIsThinking(false)
+      }, THINK_MS)
+    },
+    [setDesignSystem],
+  )
+
+  const send = useCallback(
+    (text: string) => {
+      const trimmed = text.trim()
+      if (!trimmed) return
+      run(trimmed, (t) => interpretChat(t, designSystemRef.current))
+    },
+    [run],
+  )
+
+  const generate = useCallback(
+    (text: string) => {
+      const trimmed = text.trim()
+      if (!trimmed) return
+      run(trimmed, (t) => interpretPrompt(t))
+    },
+    [run],
+  )
+
+  const applyVibe = useCallback(
+    (vibe: Vibe) => {
+      setDesignSystem(vibeToMutate(vibe))
+      const changes = [
+        `Accent → ${vibe.accent}`,
+        `Radius → ${Number.parseFloat(vibe.radius).toFixed(1)}×`,
+        `Density → ${vibe.density}`,
+      ]
+      setThread((t) => [
+        ...t,
+        { id: uid('u'), role: 'user', text: `Apply the ${vibe.label} vibe` },
+        {
+          id: uid('a'),
+          role: 'assistant',
+          text: `${vibe.label} — ${vibe.summary}`,
+          changes,
+        },
+      ])
+      setFlash({ id: uid('f'), title: vibe.label, changes })
+    },
+    [setDesignSystem],
+  )
+
+  const value = useMemo<StudioContextValue>(
+    () => ({
+      activeSection,
+      setActiveSection,
+      name,
+      setName,
+      thread,
+      isThinking,
+      flash,
+      clearFlash,
+      send,
+      generate,
+      applyVibe,
+    }),
+    [
+      activeSection,
+      name,
+      thread,
+      isThinking,
+      flash,
+      clearFlash,
+      send,
+      generate,
+      applyVibe,
+    ],
+  )
+
+  return (
+    <StudioContext.Provider value={value}>{children}</StudioContext.Provider>
+  )
+}
+
+export function useStudio(): StudioContextValue {
+  const ctx = useContext(StudioContext)
+  if (!ctx) throw new Error('useStudio must be used within StudioProvider')
+  return ctx
+}

--- a/www/src/modules/create/studio/studio-header.tsx
+++ b/www/src/modules/create/studio/studio-header.tsx
@@ -2,33 +2,47 @@
 
 import { DicesIcon, DownloadIcon, SparklesIcon } from 'lucide-react'
 
-import { Button } from '@/registry/ui/button'
+import { siteConfig } from '@/config/site'
+import { Button, buttonStyles } from '@/registry/ui/button'
 import { Dialog, DialogContent } from '@/registry/ui/dialog'
 import { Overlay } from '@/registry/ui/overlay'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+import { GitHubIcon } from '@/components/icons/github'
+import { Logo } from '@/components/layout/logo'
+import { ThemeToggle } from '@/components/theme-toggle'
 
 import { CodeOptionsDialog } from '../code-options'
 import { ExportFooter } from '../export'
 import { useReroll } from '../panel/macros'
 import { useStudio } from './studio-context'
 
+/**
+ * The Studio top bar — the single, full-width chrome on /create?studio. The
+ * global site Header is skipped on this route (see _app/route.tsx), so this bar
+ * carries the continuity language itself: the site Logo (linking home, the exit
+ * door), the shared --header-height and px-6 gutter, plus theme + GitHub on the
+ * right. Between those bookends sit the builder's genuinely-primary controls —
+ * editable name, surprise-me re-roll, Ask AI, and Export. Everything else stays
+ * in the inspector. Moving site → Studio → site stays one continuous product.
+ */
 export function StudioHeader() {
   const { name, setName, setActiveSection } = useStudio()
   const reroll = useReroll()
 
   return (
-    <header className="flex h-12 shrink-0 items-center gap-3 border-b bg-card px-3">
-      {/* Brand + editable name */}
-      <div className="flex min-w-0 items-center gap-2">
-        <span className="size-5 shrink-0 rounded-md bg-accent" aria-hidden />
-        <input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          aria-label="Design system name"
-          spellCheck={false}
-          className="max-w-56 min-w-0 truncate rounded-md bg-transparent px-1.5 py-1 text-sm font-medium outline-none hover:bg-neutral/60 focus:bg-neutral focus:ring-2 focus:ring-border-focus"
-        />
-      </div>
+    <header className="flex h-(--header-height) shrink-0 items-center gap-3 border-b bg-card px-6">
+      {/* Logo links home — the two-way door back out to the site. */}
+      <Logo />
+      <div className="h-5 w-px shrink-0 bg-border" aria-hidden />
+
+      {/* Editable system name */}
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        aria-label="Design system name"
+        spellCheck={false}
+        className="max-w-56 min-w-0 truncate rounded-md bg-transparent px-1.5 py-1 text-sm font-medium outline-none hover:bg-neutral/60 focus:bg-neutral focus:ring-2 focus:ring-border-focus"
+      />
 
       <div className="ml-auto flex items-center gap-1.5">
         <Tooltip>
@@ -78,6 +92,20 @@ export function StudioHeader() {
             </DialogContent>
           </Overlay>
         </Dialog>
+
+        {/* Continuity with the site header: same theme + GitHub affordances. */}
+        <div className="mx-1 h-5 w-px shrink-0 bg-border" aria-hidden />
+        <a
+          aria-label="GitHub"
+          href={siteConfig.links.github}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-icon-only=""
+          className={buttonStyles({ variant: 'quiet', size: 'sm' })}
+        >
+          <GitHubIcon />
+        </a>
+        <ThemeToggle isIconOnly />
       </div>
     </header>
   )

--- a/www/src/modules/create/studio/studio-header.tsx
+++ b/www/src/modules/create/studio/studio-header.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { DicesIcon, DownloadIcon, SparklesIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { Dialog, DialogContent } from '@/registry/ui/dialog'
+import { Overlay } from '@/registry/ui/overlay'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { CodeOptionsDialog } from '../code-options'
+import { ExportFooter } from '../export'
+import { useReroll } from '../panel/macros'
+import { useStudio } from './studio-context'
+
+export function StudioHeader() {
+  const { name, setName, setActiveSection } = useStudio()
+  const reroll = useReroll()
+
+  return (
+    <header className="flex h-12 shrink-0 items-center gap-3 border-b bg-card px-3">
+      {/* Brand + editable name */}
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="size-5 shrink-0 rounded-md bg-accent" aria-hidden />
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          aria-label="Design system name"
+          spellCheck={false}
+          className="max-w-56 min-w-0 truncate rounded-md bg-transparent px-1.5 py-1 text-sm font-medium outline-none hover:bg-neutral/60 focus:bg-neutral focus:ring-2 focus:ring-border-focus"
+        />
+      </div>
+
+      <div className="ml-auto flex items-center gap-1.5">
+        <Tooltip>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            aria-label="Re-roll"
+            onPress={reroll}
+          >
+            <DicesIcon />
+          </Button>
+          <TooltipContent>Surprise me</TooltipContent>
+        </Tooltip>
+
+        <Button
+          size="sm"
+          variant="default"
+          className="gap-1.5"
+          onPress={() => setActiveSection('generate')}
+        >
+          <SparklesIcon className="size-3.5 text-fg-accent" />
+          Ask AI
+        </Button>
+
+        <Dialog>
+          <Button size="sm" variant="primary" className="gap-1.5">
+            <DownloadIcon data-icon-start="" />
+            Export
+          </Button>
+          <Overlay
+            type="modal"
+            mobileType="drawer"
+            modalProps={{ className: 'w-[min(28rem,92vw)]' }}
+          >
+            <DialogContent showCloseButton aria-label="Export" className="p-5">
+              <h2 className="text-base font-semibold">
+                Export your design system
+              </h2>
+              <p className="mt-0.5 mb-4 text-sm text-fg-muted">
+                Install via the shadcn CLI, or open it straight in v0.
+              </p>
+              <ExportFooter />
+              <div className="mt-3 border-t pt-3">
+                <CodeOptionsDialog />
+              </div>
+            </DialogContent>
+          </Overlay>
+        </Dialog>
+      </div>
+    </header>
+  )
+}

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -13,6 +13,7 @@ import {
   saveStoredPreset,
 } from '@/modules/create/preset/storage'
 import { PreviewPanel } from '@/modules/create/preview/preview-panel'
+import { StudioExperience } from '@/modules/create/studio'
 
 type MobilePane = 'customize' | 'preview'
 
@@ -25,6 +26,9 @@ export const createSearchSchema = z.object({
   // Coerced boolean: the search parser reads bare `1`/`true` as non-strings, so a
   // plain `z.string()` would reject them and the param would be dropped.
   lab: z.coerce.boolean().optional().catch(undefined),
+  // Opt-in flag for the AI-native "Studio" rethink of /create. Same coercion
+  // rationale as `lab`; keeps the shipped page and the lab untouched.
+  studio: z.coerce.boolean().optional().catch(undefined),
 })
 
 const searchDefaults = { preview: 'cards' }
@@ -38,7 +42,7 @@ export const Route = createFileRoute('/_app/create')({
 })
 
 function CreatePage() {
-  const { lab, preset } = Route.useSearch()
+  const { lab, studio, preset } = Route.useSearch()
   const { designSystem, setDesignSystem } = useDesignSystem()
   // Below `lg` the customizer and the live preview can't sit side by side (the iframe
   // would be a ~15px sliver), so they collapse into a single switchable pane toggled
@@ -71,6 +75,9 @@ function CreatePage() {
 
   // Opt-in exploration of the redesigned control panel + floating panel lab.
   if (lab) return <LabExperience />
+
+  // Opt-in AI-native rethink of the builder.
+  if (studio) return <StudioExperience />
 
   return (
     <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2">

--- a/www/src/routes/_app/route.tsx
+++ b/www/src/routes/_app/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeader } from '@tanstack/react-start/server'
 import type * as PageTree from 'fumadocs-core/page-tree'
@@ -37,9 +37,18 @@ function AppLayout() {
   const { pageTree } = Route.useLoaderData()
   const items = pageTree.children as PageTree.Node[]
 
+  // The /create Studio builder owns its full-height shell, including its own top
+  // bar that carries the site Logo + theme/github for continuity. Rendering the
+  // global site Header there too would stack two bars, so skip it for that one
+  // route+flag — every other route (and the default /create + ?lab variants,
+  // which have no bar of their own) keeps the normal site Header unchanged.
+  const location = useLocation()
+  const search = location.search as { studio?: boolean }
+  const ownsShell = location.pathname === '/create' && Boolean(search.studio)
+
   return (
     <div className="[--header-height:--spacing(14)]">
-      <Header items={items} />
+      {!ownsShell && <Header items={items} />}
       <main id="content">
         <Outlet />
       </main>


### PR DESCRIPTION
## Summary

An experimental, AI-native rethink of the `/create` builder, gated on `?studio=true`. The shipped page and the `?lab` experiment are untouched — this is purely additive.

- **New three-zone layout** — section rail + rich inspector + big live canvas, replacing the 288px drill-in column. Plus a studio header (editable name, re-roll, Ask AI, Export).
- **AI woven through** — a Generate panel (prompt + 10 vibe chips like Linear/Geist/Stripe/Playful), a persistent copilot command bar ("rounder", "calmer accent", "make it feel like Linear", "go dark"), and inline suggestions. All drive the real `DesignSystem` live and report an honest "what changed" diff with a flash toast.
- **New tweak axes** — shadow tint, translucent surfaces, background texture (with a live swatch), easing curve (SVG viz), hover/press feedback, finer typography (pairing/weight/tracking/line-height), accessibility targets (AA/AAA, color-blind-safe, min tap target), and brand logo.

## Live vs planned

- **Live:** color (seeds, algorithm, status families, OKLCH engine + contrast), radius, density, cursors, per-component anatomy — and all the AI, which mutates those real axes. Reuses the real `useDesignSystem` setters, the preview iframe, and the export footer.
- **Planned (UI only):** the new axes write forward-looking CSS vars the preview has no consumer for yet — the same honest-stub pattern as `?lab` — surfaced with "planned" pips so nothing pretends to be wired.

## For reviewers

- **UI-only experiment behind a flag.** Nothing changes on the default `/create`. Try it at `/create?studio=true`.
- **Adding axes is a product decision** per CLAUDE.md — the new axes are exploratory and would need sign-off plus real token consumers before any promotion.
- **AI is a local interpreter** (`studio/ai/interpret.ts` + `vibes.ts`) today, deliberately shaped so a real `createServerFn` model call returning the same `{ mutate, changes }` shape drops in with no UI changes.
- **No registry changes** (no `build:registry` needed). `typecheck` and `check` (oxlint + oxfmt) are clean.
- All new code is isolated under `www/src/modules/create/studio/`; the only edit outside it is the `?studio` branch in `routes/_app/create.tsx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive surface area and shared `DesignSystem`/localStorage persistence, but gated behind a query flag with no registry or auth changes.
> 
> **Overview**
> Adds an opt-in **`/create?studio`** experience: a full-viewport **Studio** shell (custom header, section rail, 340px inspector, live preview) while default `/create` and `?lab` stay unchanged.
> 
> **AI** is wired through a shared `StudioProvider` thread: **Generate** (prompt + vibe chips), a canvas **CommandBar** copilot with suggestions and apply toasts, and a keyword **`interpret.ts`** layer that returns `{ mutate, changes }` into the real **`DesignSystem`** (vibes in **`vibes.ts`**). **Inspector** sections are schema-driven with **live vs planned** binding pips; many new axes only persist CSS vars until consumers exist.
> 
> Routing: **`studio`** search param on `create.tsx`; **`_app/route.tsx`** omits the global **Header** when `pathname === '/create'` and `studio` is set so Studio owns `100svh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e013d86ff1e31beb5eaa478acf4797e805d22a93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->