### PR TITLE
feat(create): add AI-native Studio builder experiment

### DIFF
--- a/www/src/modules/create/panel/types.ts
+++ b/www/src/modules/create/panel/types.ts
@@ -24,6 +24,11 @@ export type Domain =
   | 'component'
   | 'icon'
   | 'mode'
+  // Extra domains exercised only by the /create?studio experiment (see studio/tweaks).
+  | 'brand'
+  | 'surface'
+  | 'a11y'
+  | 'states'
 
 /** Token altitude — the "by tier" grouping (primitive → semantic → component). */
 export type Tier = 'primitive' | 'semantic' | 'component'

--- a/www/src/modules/create/studio/ai/color-utils.ts
+++ b/www/src/modules/create/studio/ai/color-utils.ts
@@ -1,0 +1,122 @@
+/* ----------------------------------------------------------------------------
+ * Tiny self-contained color math for the (simulated) AI engine.
+ *
+ * The engine maps natural-language intents onto the live color recipe, so it
+ * needs to nudge a seed hex by hue / saturation. We deliberately stay in HSL
+ * with no dependencies — the kernel (`@dotui/colors`) owns perceptual ramp
+ * generation downstream; here we only need a believable seed to hand it.
+ * -------------------------------------------------------------------------- */
+
+export interface Hsl {
+  h: number // 0..360
+  s: number // 0..100
+  l: number // 0..100
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n))
+}
+
+export function hexToHsl(hex: string): Hsl {
+  let h = hex.replace('#', '').trim()
+  if (h.length === 3) {
+    h = h
+      .split('')
+      .map((c) => c + c)
+      .join('')
+  }
+  const r = parseInt(h.slice(0, 2), 16) / 255
+  const g = parseInt(h.slice(2, 4), 16) / 255
+  const b = parseInt(h.slice(4, 6), 16) / 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const d = max - min
+  let hue = 0
+  if (d !== 0) {
+    if (max === r) hue = ((g - b) / d) % 6
+    else if (max === g) hue = (b - r) / d + 2
+    else hue = (r - g) / d + 4
+    hue *= 60
+    if (hue < 0) hue += 360
+  }
+  const l = (max + min) / 2
+  const s = d === 0 ? 0 : d / (1 - Math.abs(2 * l - 1))
+  return { h: Math.round(hue), s: Math.round(s * 100), l: Math.round(l * 100) }
+}
+
+export function hslToHex({ h, s, l }: Hsl): string {
+  const sn = clamp(s, 0, 100) / 100
+  const ln = clamp(l, 0, 100) / 100
+  const c = (1 - Math.abs(2 * ln - 1)) * sn
+  const hp = (((h % 360) + 360) % 360) / 60
+  const x = c * (1 - Math.abs((hp % 2) - 1))
+  let r = 0
+  let g = 0
+  let b = 0
+  if (hp >= 0 && hp < 1) [r, g, b] = [c, x, 0]
+  else if (hp < 2) [r, g, b] = [x, c, 0]
+  else if (hp < 3) [r, g, b] = [0, c, x]
+  else if (hp < 4) [r, g, b] = [0, x, c]
+  else if (hp < 5) [r, g, b] = [x, 0, c]
+  else [r, g, b] = [c, 0, x]
+  const m = ln - c / 2
+  const to = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, '0')
+  return `#${to(r)}${to(g)}${to(b)}`
+}
+
+/** Rotate a hex's hue by `deg` (positive = toward warm/red→…→cool depending on start). */
+export function shiftHue(hex: string, deg: number): string {
+  const hsl = hexToHsl(hex)
+  return hslToHex({ ...hsl, h: hsl.h + deg })
+}
+
+/** Multiply saturation, keeping hue + lightness. */
+export function scaleSaturation(hex: string, mult: number): string {
+  const hsl = hexToHsl(hex)
+  return hslToHex({ ...hsl, s: clamp(hsl.s * mult, 6, 100) })
+}
+
+/** Set a fresh, legible seed for a named hue while preserving a sensible S/L. */
+export function seedForHue(hue: number): string {
+  return hslToHex({ h: hue, s: 68, l: 54 })
+}
+
+/**
+ * The shortest signed rotation from `hex`'s hue toward `targetHue` — used to
+ * "warm" / "cool" by a bounded amount rather than snapping to an absolute hue.
+ */
+export function rotationToward(hex: string, targetHue: number): number {
+  const { h } = hexToHsl(hex)
+  let diff = (targetHue - h) % 360
+  if (diff > 180) diff -= 360
+  if (diff < -180) diff += 360
+  return diff
+}
+
+/** Canonical hue per common color word — lets "make it teal" map to a seed. */
+export const HUE_WORDS: Record<string, number> = {
+  red: 2,
+  crimson: 350,
+  rose: 345,
+  pink: 330,
+  fuchsia: 305,
+  magenta: 310,
+  purple: 282,
+  violet: 268,
+  indigo: 246,
+  blue: 220,
+  sky: 205,
+  cyan: 190,
+  teal: 175,
+  emerald: 155,
+  green: 142,
+  lime: 95,
+  yellow: 52,
+  amber: 42,
+  gold: 46,
+  orange: 28,
+  coral: 14,
+}

--- a/www/src/modules/create/studio/ai/engine.ts
+++ b/www/src/modules/create/studio/ai/engine.ts
@@ -1,0 +1,388 @@
+/* ----------------------------------------------------------------------------
+ * The Studio AI engine — a *simulated*, fully local intent parser.
+ *
+ * This is the "do only the UI" stand-in for a real model: it turns a natural
+ * language prompt ("make it warmer and rounder", "feel like Linear", "teal
+ * brand, more contrast") into concrete mutations of the SAME live design-system
+ * state the manual controls edit. No network, no keys — but the live preview
+ * genuinely reacts, so the experience of an AI-native builder is real to the
+ * touch. A production version swaps `interpret()` for a model call that returns
+ * the same `Action[]` shape.
+ * -------------------------------------------------------------------------- */
+
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import type { AlgorithmId } from '@/registry/theme'
+
+import { RADIUS_FACTOR_VAR } from '../../layout'
+import type { DesignSystem } from '../../preset'
+import {
+  HUE_WORDS,
+  hexToHsl,
+  rotationToward,
+  scaleSaturation,
+  seedForHue,
+  shiftHue,
+} from './color-utils'
+
+/** A single, human-readable change the engine wants to make. */
+export interface Action {
+  /** Short past-tense clause for the activity log, e.g. "warmed the brand hue 22°". */
+  label: string
+  /** Pure transform on the design system. */
+  apply: (ds: DesignSystem) => DesignSystem
+}
+
+export interface Interpretation {
+  /** Conversational reply shown in the copilot thread. */
+  reply: string
+  /** The concrete changes (already composed into one apply by the caller). */
+  actions: Action[]
+  /** True when nothing matched and we only offered guidance. */
+  noop?: boolean
+}
+
+/* ------------------------------- DS helpers ------------------------------- */
+
+function accentOf(ds: DesignSystem): string {
+  return (ds.color ?? DEFAULT_COLOR_CONFIG).seeds.accent ?? '#438cd6'
+}
+
+function setAccent(ds: DesignSystem, accent: string): DesignSystem {
+  const base = ds.color ?? DEFAULT_COLOR_CONFIG
+  return { ...ds, color: { ...base, seeds: { ...base.seeds, accent } } }
+}
+
+function setNeutral(ds: DesignSystem, neutral: string): DesignSystem {
+  const base = ds.color ?? DEFAULT_COLOR_CONFIG
+  return { ...ds, color: { ...base, seeds: { ...base.seeds, neutral } } }
+}
+
+function setAlgorithm(ds: DesignSystem, algorithm: AlgorithmId): DesignSystem {
+  const base = ds.color ?? DEFAULT_COLOR_CONFIG
+  return { ...ds, color: { ...base, algorithm } }
+}
+
+function setChromaMult(ds: DesignSystem, mult: number): DesignSystem {
+  const base = ds.color ?? DEFAULT_COLOR_CONFIG
+  const current = base.knobs?.chromaMult ?? 1
+  return {
+    ...ds,
+    color: {
+      ...base,
+      knobs: {
+        ...base.knobs,
+        chromaMult:
+          Math.round(Math.min(1.8, Math.max(0.2, current * mult)) * 100) / 100,
+      },
+    },
+  }
+}
+
+function setRadius(ds: DesignSystem, factor: number): DesignSystem {
+  return {
+    ...ds,
+    tokens: { ...ds.tokens, [RADIUS_FACTOR_VAR]: String(factor) },
+  }
+}
+
+function radiusOf(ds: DesignSystem): number {
+  return Number.parseFloat(ds.tokens[RADIUS_FACTOR_VAR] ?? '1') || 1
+}
+
+/* ------------------------------ Named looks ------------------------------ */
+
+interface NamedLook {
+  keys: string[]
+  reply: string
+  build: (ds: DesignSystem) => DesignSystem
+}
+
+const NAMED_LOOKS: NamedLook[] = [
+  {
+    keys: ['linear'],
+    reply:
+      'Channeling Linear — indigo brand, tight corners, compact density, perceptual ramps.',
+    build: (ds) => ({
+      ...setRadius(setAlgorithm(setAccent(ds, '#5e6ad2'), 'oklch'), 0.5),
+      density: 'compact',
+    }),
+  },
+  {
+    keys: ['vercel', 'geist'],
+    reply:
+      'Geist/Vercel mode — near-black brand, crisp square corners, compact.',
+    build: (ds) => ({
+      ...setRadius(setAccent(ds, '#171717'), 0.35),
+      density: 'compact',
+    }),
+  },
+  {
+    keys: ['stripe'],
+    reply:
+      'Stripe-leaning — that signature indigo-violet, soft-but-tidy corners.',
+    build: (ds) => ({
+      ...setRadius(setAccent(ds, '#635bff'), 0.85),
+      density: 'default',
+    }),
+  },
+  {
+    keys: ['supabase'],
+    reply: 'Supabase vibe — emerald brand on a neutral backbone.',
+    build: (ds) => ({
+      ...setRadius(setAccent(ds, '#3ecf8e'), 0.5),
+      density: 'default',
+    }),
+  },
+  {
+    keys: ['material', 'google'],
+    reply:
+      'Material 3 — tonal generation algorithm, purple brand, generous radius.',
+    build: (ds) => ({
+      ...setRadius(setAlgorithm(setAccent(ds, '#6750a4'), 'material'), 1.2),
+      density: 'comfortable',
+    }),
+  },
+  {
+    keys: ['notion'],
+    reply: 'Notion-like — restrained near-black accent, gentle corners, roomy.',
+    build: (ds) => ({
+      ...setRadius(setAccent(ds, '#2f2f2f'), 0.4),
+      density: 'comfortable',
+    }),
+  },
+  {
+    keys: ['editorial', 'magazine', 'classic'],
+    reply: 'Editorial — deep teal, near-square corners, comfortable rhythm.',
+    build: (ds) => ({
+      ...setRadius(setAccent(ds, '#0f766e'), 0.25),
+      density: 'comfortable',
+    }),
+  },
+  {
+    keys: ['playful', 'fun', 'friendly', 'candy'],
+    reply: 'Playful — punchy rose, big pill radius, cozy spacing.',
+    build: (ds) => ({
+      ...setRadius(setChromaMult(setAccent(ds, '#f43f5e'), 1.2), 1.8),
+      density: 'comfortable',
+    }),
+  },
+  {
+    keys: ['minimal', 'monochrome', 'brutal', 'swiss'],
+    reply: 'Minimal — monochrome brand, hard square corners, compact.',
+    build: (ds) => ({
+      ...setRadius(setAccent(ds, '#111111'), 0),
+      density: 'compact',
+    }),
+  },
+  {
+    keys: ['enterprise', 'corporate', 'b2b'],
+    reply: 'Enterprise — trustworthy blue, modest radius, default density.',
+    build: (ds) => ({
+      ...setRadius(setAccent(ds, '#2563eb'), 0.6),
+      density: 'default',
+    }),
+  },
+]
+
+/* ----------------------------- Adjective rules ---------------------------- */
+
+interface AdjRule {
+  test: RegExp
+  run: (ds: DesignSystem) => Action | null
+}
+
+// "Warmer" must always read as a move toward red. Routing along the shorter arc
+// to orange fails for blues (it passes through cyan, which reads *cooler*), so we
+// move toward the red point (0/360) splitting at hue 180 — blues go up through
+// magenta, greens/yellows go down toward orange.
+function warmStep(hex: string, step = 28): number {
+  return hexToHsl(hex).h <= 180 ? -step : step
+}
+// "Cooler" toward the azure pole (210) along the shorter arc reads correctly from
+// every starting hue, so a bounded step toward 210 is enough.
+function coolStep(hex: string, max = 28): number {
+  return Math.round(Math.max(-max, Math.min(max, rotationToward(hex, 210))))
+}
+
+const ADJECTIVES: AdjRule[] = [
+  {
+    test: /\b(warm(er)?|cozier|sunset|earthy)\b/,
+    run: (ds) => {
+      const deg = warmStep(accentOf(ds))
+      return {
+        label: `warmed the brand hue ${Math.abs(deg)}°`,
+        apply: (d) =>
+          setAccent(d, shiftHue(accentOf(d), warmStep(accentOf(d)))),
+      }
+    },
+  },
+  {
+    test: /\b(cool(er)?|icy|colder|fresh)\b/,
+    run: (ds) => {
+      const deg = coolStep(accentOf(ds))
+      if (deg === 0) return null
+      return {
+        label: `cooled the brand hue ${Math.abs(deg)}°`,
+        apply: (d) =>
+          setAccent(d, shiftHue(accentOf(d), coolStep(accentOf(d)))),
+      }
+    },
+  },
+  {
+    test: /\b(vibrant|bold(er)?|punch(y|ier)?|saturated|vivid|pop)\b/,
+    run: () => ({
+      label: 'boosted brand saturation',
+      apply: (d) =>
+        setChromaMult(setAccent(d, scaleSaturation(accentOf(d), 1.25)), 1.2),
+    }),
+  },
+  {
+    test: /\b(muted|subtle|calm(er)?|desaturated|understated|quiet)\b/,
+    run: () => ({
+      label: 'softened brand saturation',
+      apply: (d) =>
+        setChromaMult(setAccent(d, scaleSaturation(accentOf(d), 0.72)), 0.8),
+    }),
+  },
+  {
+    test: /\b(round(er)?|soft(er)?|pill|bubbly|friendl(y|ier))\b/,
+    run: (ds) => {
+      const next = Math.min(2, radiusOf(ds) + 0.6)
+      return {
+        label: `rounded corners to ${next.toFixed(2)}×`,
+        apply: (d) => setRadius(d, Math.min(2, radiusOf(d) + 0.6)),
+      }
+    },
+  },
+  {
+    test: /\b(sharp(er)?|square|boxy|crisp|tight(er)? corners|angular|technical)\b/,
+    run: (ds) => {
+      const next = Math.max(0, radiusOf(ds) - 0.6)
+      return {
+        label: `sharpened corners to ${next.toFixed(2)}×`,
+        apply: (d) => setRadius(d, Math.max(0, radiusOf(d) - 0.6)),
+      }
+    },
+  },
+  {
+    test: /\b(dense(r)?|compact|tight(er)?|condensed)\b/,
+    run: () => ({
+      label: 'set density to compact',
+      apply: (d) => ({ ...d, density: 'compact' }),
+    }),
+  },
+  {
+    test: /\b(airy|spacious|roomy|breath|relaxed|comfortable|cozy)\b/,
+    run: () => ({
+      label: 'set density to comfortable',
+      apply: (d) => ({ ...d, density: 'comfortable' }),
+    }),
+  },
+  {
+    test: /\b(accessible|contrast|legible|readable|wcag|a11y)\b/,
+    run: () => ({
+      label: 'switched to the contrast-locked algorithm',
+      apply: (d) => setAlgorithm(d, 'contrast'),
+    }),
+  },
+  {
+    test: /\b(tinted|brand[- ]?tint|warm gray|colou?red gray)\b/,
+    run: () => ({
+      label: 'tinted the grays toward the brand',
+      apply: (d) => setNeutral(d, accentOf(d)),
+    }),
+  },
+]
+
+/* ------------------------------- Interpret -------------------------------- */
+
+function pick<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)] as T
+}
+
+const RANDOM_HUES = [220, 246, 268, 282, 330, 345, 28, 142, 175, 190]
+const RANDOM_RADII = [0, 0.5, 1, 1.5]
+
+export function interpret(prompt: string, ds: DesignSystem): Interpretation {
+  const text = prompt.toLowerCase().trim()
+  if (!text)
+    return { reply: 'Tell me how it should feel.', actions: [], noop: true }
+
+  // Reroll / surprise — one decisive shuffle.
+  if (
+    /\b(surprise|random|inspire|shuffle|reroll|re-roll|something new)\b/.test(
+      text,
+    )
+  ) {
+    const hue = pick(RANDOM_HUES)
+    const radius = pick(RANDOM_RADII)
+    const density = pick(['compact', 'default', 'comfortable'] as const)
+    return {
+      reply: 'Rolled a fresh direction for you — keep it or roll again.',
+      actions: [
+        {
+          label: 'rolled a new look',
+          apply: (d) => ({
+            ...setRadius(setAccent(d, seedForHue(hue)), radius),
+            density,
+          }),
+        },
+      ],
+    }
+  }
+
+  // Named look — exclusive, wins over adjectives.
+  const look = NAMED_LOOKS.find((l) => l.keys.some((k) => text.includes(k)))
+  if (look) {
+    return {
+      reply: look.reply,
+      actions: [{ label: look.reply, apply: look.build }],
+    }
+  }
+
+  // Explicit color word → set the brand seed to that hue.
+  const colorActions: Action[] = []
+  for (const [word, hue] of Object.entries(HUE_WORDS)) {
+    if (new RegExp(`\\b${word}\\b`).test(text)) {
+      colorActions.push({
+        label: `set the brand to ${word}`,
+        apply: (d) => setAccent(d, seedForHue(hue)),
+      })
+      break // one brand hue
+    }
+  }
+
+  // Adjectives — compose every match so "warmer and rounder" does both.
+  const adjActions = ADJECTIVES.map((r) =>
+    r.test.test(text) ? r.run(ds) : null,
+  ).filter((a): a is Action => a != null)
+
+  const actions = [...colorActions, ...adjActions]
+
+  if (actions.length === 0) {
+    return {
+      reply:
+        "I didn't catch a direction in that. Try a vibe (“warmer”, “more playful”), a brand color (“teal”), a reference (“like Linear”), or “surprise me”.",
+      actions: [],
+      noop: true,
+    }
+  }
+
+  const clause = actions.map((a) => a.label).join(', ')
+  return {
+    reply: `Done — ${clause}.`,
+    actions,
+  }
+}
+
+/** Curated one-tap prompts surfaced as chips in the copilot. */
+export const QUICK_PROMPTS: { label: string; prompt: string }[] = [
+  { label: 'Warmer', prompt: 'make it warmer' },
+  { label: 'More contrast', prompt: 'more accessible contrast' },
+  { label: 'Rounder', prompt: 'rounder, friendlier corners' },
+  { label: 'Like Linear', prompt: 'feel like Linear' },
+  { label: 'Editorial', prompt: 'editorial look' },
+  { label: 'More vibrant', prompt: 'bolder and more vibrant' },
+  { label: 'Calmer', prompt: 'muted and calmer' },
+  { label: 'Surprise me', prompt: 'surprise me' },
+]

--- a/www/src/modules/create/studio/ai/generators.ts
+++ b/www/src/modules/create/studio/ai/generators.ts
@@ -1,0 +1,102 @@
+/* ----------------------------------------------------------------------------
+ * "Generate from …" — the inputs a real model would accept (an image, a URL, a
+ * raw vibe). Here each is a *curated demo*: a believable, undoable result that
+ * shows what extracting-a-system-from-anything feels like. Production swaps the
+ * baked `mutate` for a vision/scrape call returning the same shape.
+ * -------------------------------------------------------------------------- */
+
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+
+import { RADIUS_FACTOR_VAR } from '../../layout'
+import type { Density, DesignSystem } from '../../preset'
+
+function build(
+  ds: DesignSystem,
+  opts: {
+    accent?: string
+    neutral?: string
+    radius?: number
+    density?: Density
+  },
+): DesignSystem {
+  const base = ds.color ?? DEFAULT_COLOR_CONFIG
+  return {
+    ...ds,
+    density: opts.density ?? ds.density,
+    tokens:
+      opts.radius != null
+        ? { ...ds.tokens, [RADIUS_FACTOR_VAR]: String(opts.radius) }
+        : ds.tokens,
+    color: {
+      ...base,
+      seeds: {
+        ...base.seeds,
+        ...(opts.accent ? { accent: opts.accent } : {}),
+        ...(opts.neutral ? { neutral: opts.neutral } : {}),
+      },
+    },
+  }
+}
+
+export interface Generator {
+  id: 'image' | 'url' | 'screenshot'
+  label: string
+  userText: string
+  assistantText: string
+  mutate: (ds: DesignSystem) => DesignSystem
+}
+
+/** Rotating demo results so repeated taps feel generative, not canned. */
+export const GENERATORS: Record<Generator['id'], Generator[]> = {
+  image: [
+    {
+      id: 'image',
+      label: 'sunset.jpg',
+      userText: 'Extract a system from sunset.jpg',
+      assistantText:
+        'Pulled a warm 5-color palette from your image — coral brand on warm-tinted grays, soft corners.',
+      mutate: (ds) =>
+        build(ds, { accent: '#fb6f54', neutral: '#8a807c', radius: 1 }),
+    },
+    {
+      id: 'image',
+      label: 'forest.png',
+      userText: 'Extract a system from forest.png',
+      assistantText:
+        'Read a cool, organic palette — emerald brand, faintly green-tinted neutrals.',
+      mutate: (ds) =>
+        build(ds, { accent: '#2f9e64', neutral: '#7c847e', radius: 0.6 }),
+    },
+  ],
+  url: [
+    {
+      id: 'url',
+      label: 'stripe.com',
+      userText: 'Match the brand at stripe.com',
+      assistantText:
+        'Scraped stripe.com — indigo-violet brand, tidy 0.85× corners, default density.',
+      mutate: (ds) =>
+        build(ds, { accent: '#635bff', radius: 0.85, density: 'default' }),
+    },
+    {
+      id: 'url',
+      label: 'vercel.com',
+      userText: 'Match the brand at vercel.com',
+      assistantText:
+        'Scraped vercel.com — monochrome brand, crisp square corners, compact.',
+      mutate: (ds) =>
+        build(ds, { accent: '#171717', radius: 0.35, density: 'compact' }),
+    },
+  ],
+  screenshot: [
+    {
+      id: 'screenshot',
+      label: 'dribbble shot',
+      userText: 'Rebuild the look in this screenshot',
+      assistantText:
+        'Matched the screenshot — violet brand, generous radius, comfortable spacing.',
+      mutate: (ds) =>
+        build(ds, { accent: '#7c5cff', radius: 1.4, density: 'comfortable' }),
+    },
+  ],
+}

--- a/www/src/modules/create/studio/canvas.tsx
+++ b/www/src/modules/create/studio/canvas.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { ScanSearchIcon } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+
+import { PreviewPanel } from '../preview/preview-panel'
+import { useStudio } from './store'
+
+/* ----------------------------------------------------------------------------
+ * The canvas — the hero. It reuses the real live `PreviewPanel` (iframe +
+ * device / zoom / mode toolbar) and layers an "inspect" overlay on top: tap a
+ * region of the design and jump straight to the controls that shape it. This is
+ * the "edit the thing you see" affordance, without coupling to the iframe's DOM.
+ * -------------------------------------------------------------------------- */
+
+interface Hotspot {
+  domain: string
+  label: string
+  /** Position as CSS percentages over the canvas. */
+  top: string
+  left: string
+}
+
+const HOTSPOTS: Hotspot[] = [
+  { domain: 'color', label: 'Color', top: '16%', left: '24%' },
+  { domain: 'states', label: 'Buttons & states', top: '40%', left: '60%' },
+  { domain: 'shape', label: 'Radius & shape', top: '64%', left: '30%' },
+  { domain: 'typography', label: 'Type', top: '26%', left: '74%' },
+  { domain: 'surface', label: 'Surface', top: '76%', left: '68%' },
+]
+
+export function Canvas() {
+  const { inspectMode, setInspectMode, setActiveDomain } = useStudio()
+
+  return (
+    <div className="relative min-w-0 flex-1 p-3">
+      <PreviewPanel className="h-full" />
+
+      <AnimatePresence>
+        {inspectMode && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="absolute inset-3 z-30 overflow-hidden rounded-xl"
+          >
+            {/* Dim the canvas slightly so the pins read. Click-through closes. */}
+            <button
+              type="button"
+              aria-label="Exit inspect mode"
+              onClick={() => setInspectMode(false)}
+              className="absolute inset-0 cursor-crosshair bg-primary/[0.06] backdrop-saturate-[1.05]"
+            />
+
+            <div className="pointer-events-none absolute inset-x-0 top-0 flex justify-center pt-4">
+              <span className="pointer-events-none flex items-center gap-1.5 rounded-full border bg-card/90 px-3 py-1.5 text-xs font-medium shadow-sm backdrop-blur-sm">
+                <ScanSearchIcon className="size-3.5 text-primary" />
+                Inspect — tap a region to edit its tokens
+              </span>
+            </div>
+
+            {HOTSPOTS.map((h) => (
+              <Pin
+                key={h.domain}
+                hotspot={h}
+                onPress={() => {
+                  setActiveDomain(h.domain)
+                  setInspectMode(false)
+                }}
+              />
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
+
+function Pin({ hotspot, onPress }: { hotspot: Hotspot; onPress: () => void }) {
+  return (
+    <ButtonPrimitives.Button
+      onPress={onPress}
+      style={{ top: hotspot.top, left: hotspot.left }}
+      className={cn(
+        'group absolute flex -translate-x-1/2 -translate-y-1/2 items-center gap-2 rounded-full border bg-card/95 py-1 pr-3 pl-1 text-xs font-medium shadow-lg transition-transform outline-none hover:scale-105 focus-visible:focus-ring',
+      )}
+    >
+      <span className="relative flex size-5 items-center justify-center">
+        <span className="absolute size-2.5 rounded-full bg-primary" />
+        <span className="absolute size-5 animate-ping rounded-full bg-primary/40 [animation-duration:2s]" />
+      </span>
+      {hotspot.label}
+    </ButtonPrimitives.Button>
+  )
+}

--- a/www/src/modules/create/studio/copilot.tsx
+++ b/www/src/modules/create/studio/copilot.tsx
@@ -1,0 +1,337 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ArrowUpIcon,
+  ImageIcon,
+  LinkIcon,
+  MonitorIcon,
+  PanelRightCloseIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+  TriangleAlertIcon,
+  Undo2Icon,
+} from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { DEFAULT_COLOR_CONFIG, resolveColorConfig } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { solidContrastReport } from '../colors/contrast'
+import { useDesignSystem } from '../preset'
+import { QUICK_PROMPTS } from './ai/engine'
+import { GENERATORS, type Generator } from './ai/generators'
+import { type ChatMessage, useStudio } from './store'
+
+/* ----------------------------------------------------------------------------
+ * The AI copilot — the headline of the rethink. Natural language in, live
+ * design-system changes out, each turn undoable. It also volunteers insight
+ * (real WCAG contrast on the current palette) and accepts richer inputs
+ * ("generate from" an image / URL / screenshot). The "model" here is local and
+ * simulated, but every change it makes is real and visible on the canvas.
+ * -------------------------------------------------------------------------- */
+
+export function Copilot() {
+  const { thread, thinking, setCopilotOpen, clearThread } = useStudio()
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({
+      top: scrollRef.current.scrollHeight,
+      behavior: 'smooth',
+    })
+  }, [thread, thinking])
+
+  return (
+    <aside className="z-20 flex w-[340px] shrink-0 flex-col border-l bg-card">
+      <header className="flex items-center gap-2 border-b px-4 py-3">
+        <span className="flex size-6 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <SparklesIcon className="size-3.5" />
+        </span>
+        <div className="flex-1">
+          <h2 className="text-sm leading-none font-medium">Copilot</h2>
+          <p className="mt-1 text-[11px] leading-none text-fg-muted">
+            Describe it — I'll tune it live
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="quiet"
+          className="h-7 px-2 text-xs text-fg-muted"
+          onPress={clearThread}
+        >
+          Clear
+        </Button>
+        <Button
+          size="sm"
+          variant="quiet"
+          isIconOnly
+          aria-label="Collapse copilot"
+          onPress={() => setCopilotOpen(false)}
+        >
+          <PanelRightCloseIcon />
+        </Button>
+      </header>
+
+      <ContrastInsight />
+
+      <div
+        ref={scrollRef}
+        className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-4"
+      >
+        <div className="flex flex-col gap-4">
+          {thread.map((message) => (
+            <MessageBubble key={message.id} message={message} />
+          ))}
+          {thinking && <Thinking />}
+        </div>
+      </div>
+
+      <Composer />
+    </aside>
+  )
+}
+
+/* ------------------------------- Insight -------------------------------- */
+
+function ContrastInsight() {
+  const { designSystem, setColorAlgorithm } = useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const report = useMemo(
+    () => solidContrastReport(resolveColorConfig(config)),
+    [config],
+  )
+  const fails = report.filter((r) => r.level === 'fail')
+
+  if (report.length === 0) return null
+
+  if (fails.length === 0) {
+    return (
+      <div className="flex items-center gap-2 border-b bg-success/5 px-4 py-2.5 text-xs">
+        <ShieldCheckIcon className="size-4 shrink-0 text-success" />
+        <span className="text-fg-muted">
+          All <span className="font-medium text-fg">{report.length}</span>{' '}
+          palettes pass WCAG AA.
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 border-b bg-warning/5 px-4 py-2.5 text-xs">
+      <TriangleAlertIcon className="size-4 shrink-0 text-warning" />
+      <span className="flex-1 text-fg-muted">
+        <span className="font-medium text-fg">{fails.length}</span>{' '}
+        {fails.map((f) => f.name).join(', ')} fail AA on text.
+      </span>
+      <Button
+        size="sm"
+        variant="default"
+        className="h-6 px-2 text-[11px]"
+        onPress={() => setColorAlgorithm('contrast')}
+      >
+        Fix
+      </Button>
+    </div>
+  )
+}
+
+/* ------------------------------- Messages ------------------------------- */
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  const { undoTurn } = useStudio()
+  const isUser = message.role === 'user'
+
+  if (isUser) {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[85%] rounded-2xl rounded-br-md bg-primary px-3 py-2 text-sm text-fg-on-primary">
+          {message.text}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-1.5">
+      <div className="flex items-start gap-2">
+        <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <SparklesIcon className="size-3" />
+        </span>
+        <p className="text-sm leading-relaxed text-balance text-fg">
+          {message.text}
+        </p>
+      </div>
+      {message.changed && (
+        <ButtonPrimitives.Button
+          onPress={() => undoTurn(message)}
+          className="ml-7 flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-fg-muted focus-reset transition-colors hover:bg-neutral hover:text-fg focus-visible:focus-ring"
+        >
+          <Undo2Icon className="size-3" />
+          Undo this change
+        </ButtonPrimitives.Button>
+      )}
+    </div>
+  )
+}
+
+function Thinking() {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+        <SparklesIcon className="size-3" />
+      </span>
+      <div className="flex gap-1">
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            className="size-1.5 animate-bounce rounded-full bg-fg-muted/60"
+            style={{
+              animationDelay: `${i * 0.15}s`,
+              animationDuration: '0.9s',
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------- Composer ------------------------------- */
+
+function Composer() {
+  const { runPrompt, runAction, thinking } = useStudio()
+  const [value, setValue] = useState('')
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const rotations = useRef<Record<string, number>>({})
+
+  function submit() {
+    const text = value.trim()
+    if (!text || thinking) return
+    runPrompt(text)
+    setValue('')
+  }
+
+  function generate(id: Generator['id']) {
+    const pool = GENERATORS[id]
+    const n = rotations.current[id] ?? 0
+    rotations.current[id] = n + 1
+    const gen = pool[n % pool.length]
+    if (gen) runAction(gen.userText, gen.assistantText, gen.mutate)
+  }
+
+  return (
+    <div className="border-t p-3">
+      {/* Quick prompts */}
+      <div className="mb-2.5 flex flex-wrap gap-1.5">
+        {QUICK_PROMPTS.map((q) => (
+          <ButtonPrimitives.Button
+            key={q.label}
+            isDisabled={thinking}
+            onPress={() => runPrompt(q.prompt)}
+            className="rounded-full border px-2.5 py-1 text-xs text-fg-muted focus-reset transition-colors hover:bg-neutral hover:text-fg focus-visible:focus-ring disabled:opacity-50"
+          >
+            {q.label}
+          </ButtonPrimitives.Button>
+        ))}
+      </div>
+
+      {/* Generate from */}
+      <div className="mb-2.5 flex items-center gap-1.5">
+        <span className="text-[10px] tracking-wider text-fg-muted/70 uppercase">
+          Generate from
+        </span>
+        <div className="flex items-center gap-1">
+          <GenButton
+            icon={ImageIcon}
+            label="Image"
+            onPress={() => generate('image')}
+          />
+          <GenButton
+            icon={LinkIcon}
+            label="URL"
+            onPress={() => generate('url')}
+          />
+          <GenButton
+            icon={MonitorIcon}
+            label="Screenshot"
+            onPress={() => generate('screenshot')}
+          />
+        </div>
+      </div>
+
+      {/* Input */}
+      <div className="flex items-end gap-2 rounded-xl border bg-bg p-2 focus-within:border-border-focus">
+        <textarea
+          ref={inputRef}
+          value={value}
+          rows={1}
+          placeholder="Make it warmer, more editorial…"
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              submit()
+            }
+          }}
+          className="max-h-28 min-h-[24px] flex-1 resize-none bg-transparent px-1 text-sm outline-none placeholder:text-fg-muted"
+        />
+        <Button
+          size="sm"
+          isIconOnly
+          aria-label="Send"
+          isDisabled={!value.trim() || thinking}
+          onPress={submit}
+        >
+          <ArrowUpIcon />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function GenButton({
+  icon: Icon,
+  label,
+  onPress,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  onPress: () => void
+}) {
+  const { thinking } = useStudio()
+  return (
+    <Tooltip delay={300}>
+      <ButtonPrimitives.Button
+        isDisabled={thinking}
+        onPress={onPress}
+        aria-label={`Generate from ${label}`}
+        className="flex size-7 items-center justify-center rounded-md border text-fg-muted focus-reset transition-colors hover:bg-neutral hover:text-fg focus-visible:focus-ring disabled:opacity-50"
+      >
+        <Icon className="size-3.5" />
+      </ButtonPrimitives.Button>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+/* ------------------------------ Collapsed rail ------------------------------ */
+
+export function CopilotRail() {
+  const { setCopilotOpen } = useStudio()
+  return (
+    <div className="z-20 flex w-12 shrink-0 flex-col items-center border-l bg-card py-3">
+      <Tooltip delay={250}>
+        <ButtonPrimitives.Button
+          onPress={() => setCopilotOpen(true)}
+          aria-label="Open copilot"
+          className="flex size-9 items-center justify-center rounded-lg bg-primary/10 text-primary focus-reset transition-colors hover:bg-primary/20 focus-visible:focus-ring"
+        >
+          <SparklesIcon className="size-[18px]" />
+        </ButtonPrimitives.Button>
+        <TooltipContent placement="left">Open copilot</TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/dock.tsx
+++ b/www/src/modules/create/studio/dock.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { EXPERIMENTAL_IDS, STUDIO_SECTIONS } from './sections'
+import { useStudio } from './store'
+
+/* ----------------------------------------------------------------------------
+ * The dock — a thin, always-present rail of domain icons. Clicking one opens its
+ * inspector; clicking the active one closes it. This replaces the shipped
+ * builder's fixed wall of controls: the canvas stays the hero, controls are one
+ * tap away. Experimental axes are drawn below a divider with a brand-dot marker.
+ * -------------------------------------------------------------------------- */
+
+export function Dock() {
+  const { activeDomain, toggleDomain } = useStudio()
+
+  const core = STUDIO_SECTIONS.filter((s) => !EXPERIMENTAL_IDS.has(s.id))
+  const extra = STUDIO_SECTIONS.filter((s) => EXPERIMENTAL_IDS.has(s.id))
+
+  return (
+    <nav
+      aria-label="Design system domains"
+      className="z-20 scrollbar-none flex w-14 shrink-0 flex-col items-center gap-1 overflow-y-auto border-r bg-card py-2.5"
+    >
+      {core.map((section) => (
+        <DockButton
+          key={section.id}
+          id={section.id}
+          label={section.label}
+          Icon={section.icon}
+          active={activeDomain === section.id}
+          onPress={() => toggleDomain(section.id)}
+        />
+      ))}
+
+      <div className="my-1.5 h-px w-6 bg-border" />
+
+      {extra.map((section) => (
+        <DockButton
+          key={section.id}
+          id={section.id}
+          label={section.label}
+          Icon={section.icon}
+          active={activeDomain === section.id}
+          experimental
+          onPress={() => toggleDomain(section.id)}
+        />
+      ))}
+    </nav>
+  )
+}
+
+function DockButton({
+  id,
+  label,
+  Icon,
+  active,
+  experimental,
+  onPress,
+}: {
+  id: string
+  label: string
+  Icon: React.ComponentType<{ className?: string }>
+  active: boolean
+  experimental?: boolean
+  onPress: () => void
+}) {
+  return (
+    <Tooltip delay={250}>
+      <ButtonPrimitives.Button
+        data-domain={id}
+        onPress={onPress}
+        aria-pressed={active}
+        className={cn(
+          'relative flex size-10 items-center justify-center rounded-lg focus-reset transition-colors focus-visible:focus-ring',
+          active
+            ? 'bg-primary text-fg-on-primary'
+            : 'text-fg-muted hover:bg-neutral hover:text-fg',
+        )}
+      >
+        <Icon className="size-[18px]" />
+        {experimental && !active && (
+          <span
+            aria-hidden
+            className="absolute top-1.5 right-1.5 size-1.5 rounded-full bg-primary"
+          />
+        )}
+      </ButtonPrimitives.Button>
+      <TooltipContent placement="right">
+        {label}
+        {experimental && <span className="ml-1.5 text-fg-muted">· new</span>}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/www/src/modules/create/studio/index.tsx
+++ b/www/src/modules/create/studio/index.tsx
@@ -32,8 +32,10 @@ export function StudioExperience() {
 
 function StudioShell() {
   const { copilotOpen } = useStudio()
+  // The global site header is suppressed on /create?studio (see _app/route.tsx),
+  // so the studio owns the full viewport and its own TopBar is the only bar.
   return (
-    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-col bg-bg">
+    <div className="flex h-svh min-h-0 flex-col bg-bg">
       <TopBar />
       <div className="relative flex min-h-0 flex-1">
         <Dock />

--- a/www/src/modules/create/studio/index.tsx
+++ b/www/src/modules/create/studio/index.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { Canvas } from './canvas'
+import { Copilot, CopilotRail } from './copilot'
+import { Dock } from './dock'
+import { Inspector } from './inspector'
+import { StatusBar } from './status-bar'
+import { StudioProvider, useStudio } from './store'
+import { TopBar } from './top-bar'
+
+/* ----------------------------------------------------------------------------
+ * Studio — the `/create?studio` experiment: a canvas-first, AI-native rethink
+ * of the builder.
+ *
+ *   ┌───────────────────────── top bar · identity · ⌘K AI · export ─────────┐
+ *   │ dock │   inspector   │            canvas (hero, live)        │ copilot │
+ *   └───────────────────────────── status bar · health ────────────────────┘
+ *
+ * The design-system state and the live preview are the *existing* ones, so
+ * every control and AI action is genuinely wired; only the shell + the AI layer
+ * are new. Gated behind a flag so the shipped builder and the panel lab are
+ * untouched.
+ * -------------------------------------------------------------------------- */
+
+export function StudioExperience() {
+  return (
+    <StudioProvider>
+      <StudioShell />
+    </StudioProvider>
+  )
+}
+
+function StudioShell() {
+  const { copilotOpen } = useStudio()
+  return (
+    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-col bg-bg">
+      <TopBar />
+      <div className="relative flex min-h-0 flex-1">
+        <Dock />
+        <Inspector />
+        <Canvas />
+        {copilotOpen ? <Copilot /> : <CopilotRail />}
+      </div>
+      <StatusBar />
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspector.tsx
+++ b/www/src/modules/create/studio/inspector.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { XIcon } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+
+import { Button } from '@/registry/ui/button'
+
+import { BindingDot } from '../panel/primitives'
+import type { Control } from '../panel/types'
+import { sectionById } from './sections'
+import { useStudio } from './store'
+
+/* ----------------------------------------------------------------------------
+ * The inspector — a docked, collapsible column showing the active domain's
+ * controls. It reuses the panel-lab control *widgets* (every input already wired
+ * to the live design system) but renders its own row chrome, so it's decoupled
+ * from the lab's PanelConfig. Slides in from the dock; the canvas reflows.
+ * -------------------------------------------------------------------------- */
+
+export function Inspector() {
+  const { activeDomain, setActiveDomain } = useStudio()
+  const section = sectionById(activeDomain)
+
+  // One persistent panel: it animates only on open/close (width). Switching
+  // domains swaps the content in place — no keyed exit/enter — which keeps the
+  // panel put (the Figma/Linear feel) and avoids stranded half-collapsed panes.
+  return (
+    <AnimatePresence initial={false}>
+      {section && (
+        <motion.aside
+          key="inspector"
+          initial={{ width: 0, opacity: 0 }}
+          animate={{ width: 304, opacity: 1 }}
+          exit={{ width: 0, opacity: 0 }}
+          transition={{
+            type: 'tween',
+            duration: 0.28,
+            ease: [0.32, 0.72, 0, 1],
+          }}
+          className="z-20 shrink-0 overflow-hidden border-r bg-card"
+        >
+          <div className="flex h-full w-[304px] flex-col">
+            <header className="flex items-center gap-2 border-b px-4 py-3">
+              <section.icon className="size-4 text-fg-muted" />
+              <h2 className="flex-1 text-sm font-medium">{section.label}</h2>
+              <span className="font-mono text-[10px] text-fg-muted/70 tabular-nums">
+                {section.controls.length}
+              </span>
+              <Button
+                size="sm"
+                variant="quiet"
+                isIconOnly
+                className="size-6"
+                aria-label="Close inspector"
+                onPress={() => setActiveDomain(null)}
+              >
+                <XIcon />
+              </Button>
+            </header>
+
+            <div
+              key={section.id}
+              className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4"
+            >
+              <div className="flex flex-col gap-5">
+                {section.controls.map((control) => (
+                  <StudioControlRow key={control.id} control={control} />
+                ))}
+              </div>
+            </div>
+          </div>
+        </motion.aside>
+      )}
+    </AnimatePresence>
+  )
+}
+
+/**
+ * One control's chrome. `block` widgets own their full layout (e.g. the color
+ * engine, component anatomy); the rest get a stacked label + description + input.
+ */
+function StudioControlRow({ control }: { control: Control }) {
+  if (control.block) {
+    return (
+      <div className="flex flex-col gap-2.5" data-control={control.id}>
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm font-medium text-fg">{control.label}</span>
+          <BindingDot binding={control.binding} />
+        </div>
+        {control.description && (
+          <p className="text-xs leading-snug text-fg-muted">
+            {control.description}
+          </p>
+        )}
+        <control.Widget />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5" data-control={control.id}>
+      <div className="flex items-center gap-1.5">
+        <span className="text-sm font-medium text-fg">{control.label}</span>
+        <BindingDot binding={control.binding} />
+      </div>
+      {control.description && (
+        <p className="text-xs leading-snug text-fg-muted">
+          {control.description}
+        </p>
+      )}
+      <control.Widget />
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/sections.ts
+++ b/www/src/modules/create/studio/sections.ts
@@ -1,0 +1,43 @@
+import { SECTIONS } from '../panel/schema'
+import type { Section } from '../panel/types'
+import { STUDIO_EXTRA_SECTIONS } from './tweaks'
+
+/* ----------------------------------------------------------------------------
+ * The studio's domain set = the panel-lab schema's sections + the experimental
+ * extras, re-ordered so related axes sit next to each other in the dock. The
+ * lab keeps its own untouched `SECTIONS`; this ordering is studio-only.
+ * -------------------------------------------------------------------------- */
+
+const ORDER = [
+  'color',
+  'brand',
+  'typography',
+  'icons',
+  'shape',
+  'spacing',
+  'surface',
+  'elevation',
+  'motion',
+  'states',
+  'interaction',
+  'a11y',
+  'components',
+  'mode',
+]
+
+/** Sections authored only as experiments (drawn apart in the dock). */
+export const EXPERIMENTAL_IDS = new Set(STUDIO_EXTRA_SECTIONS.map((s) => s.id))
+
+export const STUDIO_SECTIONS: Section[] = [
+  ...SECTIONS,
+  ...STUDIO_EXTRA_SECTIONS,
+].sort((a, b) => {
+  const ai = ORDER.indexOf(a.id)
+  const bi = ORDER.indexOf(b.id)
+  return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi)
+})
+
+export function sectionById(id: string | null): Section | undefined {
+  if (!id) return undefined
+  return STUDIO_SECTIONS.find((s) => s.id === id)
+}

--- a/www/src/modules/create/studio/status-bar.tsx
+++ b/www/src/modules/create/studio/status-bar.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useMemo } from 'react'
+import { DicesIcon } from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { DEFAULT_COLOR_CONFIG, resolveColorConfig } from '@/registry/theme'
+
+import { solidContrastReport } from '../colors/contrast'
+import { RADIUS_FACTOR_VAR } from '../layout'
+import { useDesignSystem } from '../preset'
+import { useStudio } from './store'
+
+/* ----------------------------------------------------------------------------
+ * The status bar — an always-visible read on the system's health: live binding,
+ * WCAG pass rate on the real generated palette, the headline scalars, and a
+ * count of how far the system has drifted from the defaults. "Surprise me"
+ * lives here as the lowest-commitment way to explore.
+ * -------------------------------------------------------------------------- */
+
+export function StatusBar() {
+  const { designSystem } = useDesignSystem()
+  const { runPrompt, thinking } = useStudio()
+
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const report = useMemo(
+    () => solidContrastReport(resolveColorConfig(config)),
+    [config],
+  )
+  const passing = report.filter((r) => r.level !== 'fail').length
+
+  const radius =
+    Number.parseFloat(designSystem.tokens[RADIUS_FACTOR_VAR] ?? '1') || 1
+  const customizations =
+    Object.keys(designSystem.tokens).length +
+    Object.values(designSystem.componentParams).reduce(
+      (sum, params) => sum + Object.keys(params).length,
+      0,
+    ) +
+    (designSystem.color ? 1 : 0)
+
+  return (
+    <footer className="flex h-8 shrink-0 items-center gap-3 border-t bg-card px-4 text-xs text-fg-muted">
+      <span className="flex items-center gap-1.5">
+        <span className="size-1.5 animate-pulse rounded-full bg-success" />
+        Live
+      </span>
+
+      <Divider />
+
+      <span className="tabular-nums">
+        WCAG AA{' '}
+        <span
+          className={
+            passing === report.length ? 'text-success' : 'text-warning'
+          }
+        >
+          {passing}/{report.length}
+        </span>
+      </span>
+
+      <Divider />
+
+      <span className="tabular-nums">radius {radius.toFixed(2)}×</span>
+
+      <Divider />
+
+      <span className="capitalize">{designSystem.density} density</span>
+
+      <Divider />
+
+      <span className="tabular-nums">
+        {customizations} customization{customizations === 1 ? '' : 's'}
+      </span>
+
+      <ButtonPrimitives.Button
+        isDisabled={thinking}
+        onPress={() => runPrompt('surprise me')}
+        className="ml-auto flex items-center gap-1.5 rounded-md px-2 py-1 focus-reset transition-colors hover:bg-neutral hover:text-fg focus-visible:focus-ring disabled:opacity-50"
+      >
+        <DicesIcon className="size-3.5" />
+        Surprise me
+      </ButtonPrimitives.Button>
+    </footer>
+  )
+}
+
+function Divider() {
+  return <span className="h-3 w-px bg-border" aria-hidden />
+}

--- a/www/src/modules/create/studio/store.tsx
+++ b/www/src/modules/create/studio/store.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+
+import type { DesignSystem } from '../preset'
+import { useDesignSystem } from '../preset'
+import { interpret } from './ai/engine'
+
+/* ----------------------------------------------------------------------------
+ * Studio store — the *UI* state of the new builder shell (which inspector is
+ * open, is the copilot docked, inspect mode) plus the AI conversation thread.
+ *
+ * The design system itself stays in `useDesignSystem` (the URL preset) so the
+ * live preview and every existing control keep working untouched. The store
+ * only orchestrates: it snapshots the preset before an AI edit so each assistant
+ * turn can be undone in one tap.
+ * -------------------------------------------------------------------------- */
+
+export interface ChatMessage {
+  id: string
+  role: 'user' | 'assistant'
+  text: string
+  /** Preset value *before* this turn's edit — enables one-tap undo. */
+  prevPreset?: string
+  /** Whether this assistant turn actually changed the system. */
+  changed?: boolean
+}
+
+interface StudioContextValue {
+  name: string
+  setName: (name: string) => void
+  activeDomain: string | null
+  setActiveDomain: (domain: string | null) => void
+  toggleDomain: (domain: string) => void
+  copilotOpen: boolean
+  setCopilotOpen: (open: boolean) => void
+  inspectMode: boolean
+  setInspectMode: (on: boolean) => void
+  thread: ChatMessage[]
+  thinking: boolean
+  runPrompt: (prompt: string) => void
+  /** Apply a pre-baked change (e.g. a "generate from" result) as a logged, undoable turn. */
+  runAction: (
+    userText: string,
+    assistantText: string,
+    mutate: (ds: DesignSystem) => DesignSystem,
+  ) => void
+  undoTurn: (message: ChatMessage) => void
+  clearThread: () => void
+}
+
+const StudioContext = createContext<StudioContextValue | null>(null)
+
+const routeApi = getRouteApi('/_app/create')
+
+let counter = 0
+const nextId = () => `m${++counter}`
+
+const WELCOME: ChatMessage = {
+  id: 'welcome',
+  role: 'assistant',
+  text: "Describe how your system should feel and I'll tune it live — a vibe, a brand color, or a reference like “make it feel like Linear”.",
+}
+
+export function StudioProvider({ children }: { children: ReactNode }) {
+  const { designSystem, setDesignSystem } = useDesignSystem()
+  const { preset } = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+
+  const [name, setName] = useState('Untitled system')
+  const [activeDomain, setActiveDomain] = useState<string | null>('color')
+  const [copilotOpen, setCopilotOpen] = useState(true)
+  const [inspectMode, setInspectMode] = useState(false)
+  const [thread, setThread] = useState<ChatMessage[]>([WELCOME])
+  const [thinking, setThinking] = useState(false)
+
+  const toggleDomain = useCallback((domain: string) => {
+    setActiveDomain((prev) => (prev === domain ? null : domain))
+  }, [])
+
+  const runPrompt = useCallback(
+    (prompt: string) => {
+      const trimmed = prompt.trim()
+      if (!trimmed || thinking) return
+
+      const snapshot = preset
+      const userMsg: ChatMessage = {
+        id: nextId(),
+        role: 'user',
+        text: trimmed,
+      }
+      setThread((t) => [...t, userMsg])
+      setThinking(true)
+
+      // A short, deliberate "thinking" beat sells the AI illusion and lets the
+      // user read their own message land before the system reshapes.
+      const result = interpret(trimmed, designSystem)
+      window.setTimeout(() => {
+        if (result.actions.length > 0) {
+          setDesignSystem((prev: DesignSystem) =>
+            result.actions.reduce((acc, action) => action.apply(acc), prev),
+          )
+        }
+        setThread((t) => [
+          ...t,
+          {
+            id: nextId(),
+            role: 'assistant',
+            text: result.reply,
+            prevPreset: result.actions.length > 0 ? snapshot : undefined,
+            changed: result.actions.length > 0,
+          },
+        ])
+        setThinking(false)
+      }, 480)
+    },
+    [designSystem, preset, setDesignSystem, thinking],
+  )
+
+  const runAction = useCallback(
+    (
+      userText: string,
+      assistantText: string,
+      mutate: (ds: DesignSystem) => DesignSystem,
+    ) => {
+      if (thinking) return
+      const snapshot = preset
+      setThread((t) => [...t, { id: nextId(), role: 'user', text: userText }])
+      setThinking(true)
+      window.setTimeout(() => {
+        setDesignSystem((prev) => mutate(prev))
+        setThread((t) => [
+          ...t,
+          {
+            id: nextId(),
+            role: 'assistant',
+            text: assistantText,
+            prevPreset: snapshot,
+            changed: true,
+          },
+        ])
+        setThinking(false)
+      }, 480)
+    },
+    [preset, setDesignSystem, thinking],
+  )
+
+  const undoTurn = useCallback(
+    (message: ChatMessage) => {
+      if (!message.changed) return
+      navigate({
+        search: (prev) => ({ ...prev, preset: message.prevPreset }),
+        replace: true,
+      })
+      setThread((t) =>
+        t.map((m) =>
+          m.id === message.id
+            ? { ...m, changed: false, text: `${m.text} (reverted)` }
+            : m,
+        ),
+      )
+    },
+    [navigate],
+  )
+
+  const clearThread = useCallback(() => setThread([WELCOME]), [])
+
+  const value = useMemo(
+    () => ({
+      name,
+      setName,
+      activeDomain,
+      setActiveDomain,
+      toggleDomain,
+      copilotOpen,
+      setCopilotOpen,
+      inspectMode,
+      setInspectMode,
+      thread,
+      thinking,
+      runPrompt,
+      runAction,
+      undoTurn,
+      clearThread,
+    }),
+    [
+      name,
+      activeDomain,
+      toggleDomain,
+      copilotOpen,
+      inspectMode,
+      thread,
+      thinking,
+      runPrompt,
+      runAction,
+      undoTurn,
+      clearThread,
+    ],
+  )
+
+  return (
+    <StudioContext.Provider value={value}>{children}</StudioContext.Provider>
+  )
+}
+
+export function useStudio() {
+  const ctx = useContext(StudioContext)
+  if (!ctx) throw new Error('useStudio must be used within a StudioProvider')
+  return ctx
+}

--- a/www/src/modules/create/studio/top-bar.tsx
+++ b/www/src/modules/create/studio/top-bar.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  ArrowUpRightIcon,
+  MoonIcon,
+  ScanSearchIcon,
+  SparklesIcon,
+  SunIcon,
+} from 'lucide-react'
+import { useTheme } from 'starter-themes'
+
+import { cn } from '@/registry/lib/utils'
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+import { Dialog, DialogContent } from '@/registry/ui/dialog'
+import { Overlay } from '@/registry/ui/overlay'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { ExportFooter } from '../export'
+import { useDesignSystem } from '../preset'
+import { useStudio } from './store'
+
+/* ----------------------------------------------------------------------------
+ * The top bar — identity on the left, an always-on AI command field in the
+ * middle (⌘K), and view + export actions on the right. The AI field is the
+ * fastest path to a change from anywhere on the page; it routes into the same
+ * copilot thread so history stays in one place.
+ * -------------------------------------------------------------------------- */
+
+export function TopBar() {
+  const { name, setName } = useStudio()
+  const { designSystem } = useDesignSystem()
+  const accent =
+    (designSystem.color ?? DEFAULT_COLOR_CONFIG).seeds.accent ?? '#438cd6'
+
+  return (
+    <header className="flex h-14 shrink-0 items-center gap-3 border-b bg-card px-3">
+      {/* Identity */}
+      <div className="flex min-w-0 items-center gap-2.5">
+        <span
+          className="size-6 shrink-0 rounded-md ring-1 ring-black/10 ring-inset"
+          style={{ backgroundColor: accent }}
+          aria-hidden
+        />
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          aria-label="System name"
+          spellCheck={false}
+          className="max-w-[12rem] min-w-0 truncate rounded-sm bg-transparent text-sm font-medium outline-none focus-visible:bg-neutral focus-visible:px-1.5 focus-visible:py-0.5"
+        />
+        <span className="hidden rounded-full border px-2 py-0.5 text-[10px] font-medium tracking-wide text-fg-muted uppercase sm:inline-block">
+          Studio
+        </span>
+      </div>
+
+      <CommandField />
+
+      <div className="flex shrink-0 items-center gap-1">
+        <InspectToggle />
+        <ModeToggle />
+        <div className="mx-1 h-5 w-px bg-border" />
+        <ExportButton />
+      </div>
+    </header>
+  )
+}
+
+/* ---------------------------- AI command field ---------------------------- */
+
+function CommandField() {
+  const { runPrompt, setCopilotOpen, thinking } = useStudio()
+  const [value, setValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // ⌘K / Ctrl-K focuses the command field from anywhere.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        inputRef.current?.focus()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  function submit() {
+    const text = value.trim()
+    if (!text || thinking) return
+    setCopilotOpen(true)
+    runPrompt(text)
+    setValue('')
+    inputRef.current?.blur()
+  }
+
+  return (
+    <div className="mx-auto flex h-9 w-full max-w-xl items-center gap-2 rounded-full border bg-bg px-3 transition-colors focus-within:border-border-focus">
+      <SparklesIcon className="size-4 shrink-0 text-primary" />
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') submit()
+        }}
+        placeholder="Ask AI to change anything — “make it feel like Linear”"
+        aria-label="Ask AI"
+        className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-fg-muted"
+      />
+      <kbd className="hidden shrink-0 rounded border bg-card px-1.5 py-0.5 font-mono text-[10px] text-fg-muted sm:block">
+        ⌘K
+      </kbd>
+    </div>
+  )
+}
+
+/* ------------------------------- View toggles ------------------------------- */
+
+function InspectToggle() {
+  const { inspectMode, setInspectMode } = useStudio()
+  return (
+    <Tooltip delay={300}>
+      <Button
+        size="sm"
+        variant="quiet"
+        isIconOnly
+        aria-label="Inspect mode"
+        aria-pressed={inspectMode}
+        onPress={() => setInspectMode(!inspectMode)}
+        className={cn(inspectMode && 'bg-primary/10 text-primary')}
+      >
+        <ScanSearchIcon />
+      </Button>
+      <TooltipContent>Inspect — edit on the canvas</TooltipContent>
+    </Tooltip>
+  )
+}
+
+function ModeToggle() {
+  const { resolvedTheme, setTheme } = useTheme()
+  return (
+    <Tooltip delay={300}>
+      <Button
+        size="sm"
+        variant="quiet"
+        isIconOnly
+        aria-label="Toggle theme"
+        onPress={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+      >
+        {resolvedTheme === 'dark' ? <SunIcon /> : <MoonIcon />}
+      </Button>
+      <TooltipContent>Toggle light / dark</TooltipContent>
+    </Tooltip>
+  )
+}
+
+function ExportButton() {
+  return (
+    <Dialog>
+      <Button size="sm" variant="primary">
+        <ArrowUpRightIcon data-icon-start="" />
+        Export
+      </Button>
+      <Overlay type="modal" mobileType="drawer">
+        <DialogContent
+          aria-label="Export"
+          className="w-[min(28rem,92vw)] gap-0 p-0"
+        >
+          <div className="flex flex-col gap-1 border-b p-4">
+            <h2 className="text-sm font-medium">Export your system</h2>
+            <p className="text-xs text-fg-muted">
+              Install via the shadcn CLI, or open it straight in v0.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 p-4">
+            <ExportFooter />
+          </div>
+        </DialogContent>
+      </Overlay>
+    </Dialog>
+  )
+}

--- a/www/src/modules/create/studio/top-bar.tsx
+++ b/www/src/modules/create/studio/top-bar.tsx
@@ -10,22 +10,29 @@ import {
 } from 'lucide-react'
 import { useTheme } from 'starter-themes'
 
+import { siteConfig } from '@/config/site'
 import { cn } from '@/registry/lib/utils'
 import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
-import { Button } from '@/registry/ui/button'
+import { Button, buttonStyles } from '@/registry/ui/button'
 import { Dialog, DialogContent } from '@/registry/ui/dialog'
 import { Overlay } from '@/registry/ui/overlay'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+import { GitHubIcon } from '@/components/icons/github'
+import { Logo } from '@/components/layout/logo'
 
 import { ExportFooter } from '../export'
 import { useDesignSystem } from '../preset'
 import { useStudio } from './store'
 
 /* ----------------------------------------------------------------------------
- * The top bar — identity on the left, an always-on AI command field in the
- * middle (⌘K), and view + export actions on the right. The AI field is the
+ * The top bar — the studio's single, app-like chrome. It replaces the global
+ * site nav on /create?studio (the site header is suppressed there), so it leads
+ * with the dotUI logo (→ home, for a smooth two-way transition) and carries the
+ * builder's primary controls instead: system identity, an always-on AI command
+ * field (⌘K), view toggles, theme, GitHub, and export. The AI field is the
  * fastest path to a change from anywhere on the page; it routes into the same
- * copilot thread so history stays in one place.
+ * copilot thread so history stays in one place. The shared `--header-height`,
+ * sticky chrome, and button language keep it visually continuous with the site.
  * -------------------------------------------------------------------------- */
 
 export function TopBar() {
@@ -35,8 +42,12 @@ export function TopBar() {
     (designSystem.color ?? DEFAULT_COLOR_CONFIG).seeds.accent ?? '#438cd6'
 
   return (
-    <header className="flex h-14 shrink-0 items-center gap-3 border-b bg-card px-3">
-      {/* Identity */}
+    <header className="flex h-(--header-height) shrink-0 items-center gap-3 border-b bg-card px-3">
+      {/* Logo links home so leaving the builder feels like the same product. */}
+      <Logo className="shrink-0 max-sm:[&_[data-wordmark]]:hidden" />
+      <div className="h-5 w-px shrink-0 bg-border" />
+
+      {/* System identity */}
       <div className="flex min-w-0 items-center gap-2.5">
         <span
           className="size-6 shrink-0 rounded-md ring-1 ring-black/10 ring-inset"
@@ -60,6 +71,16 @@ export function TopBar() {
       <div className="flex shrink-0 items-center gap-1">
         <InspectToggle />
         <ModeToggle />
+        <a
+          aria-label="GitHub"
+          href={siteConfig.links.github}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-icon-only=""
+          className={buttonStyles({ variant: 'quiet', size: 'sm' })}
+        >
+          <GitHubIcon />
+        </a>
         <div className="mx-1 h-5 w-px bg-border" />
         <ExportButton />
       </div>

--- a/www/src/modules/create/studio/tweaks.tsx
+++ b/www/src/modules/create/studio/tweaks.tsx
@@ -1,0 +1,539 @@
+'use client'
+
+import {
+  AccessibilityIcon,
+  BlendIcon,
+  ChevronDownIcon,
+  MousePointerClickIcon,
+  SparklesIcon,
+} from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+import { Popover } from '@/registry/ui/popover'
+import { Select, SelectValue } from '@/registry/ui/select'
+import { Switch } from '@/registry/ui/switch'
+
+import { Segmented, ValueSlider } from '../panel/primitives'
+import type { Section } from '../panel/types'
+import { useDesignSystem } from '../preset'
+
+/* ----------------------------------------------------------------------------
+ * New experimental axes that extend the builder toward "recreate anything".
+ *
+ * Like the panel lab's invented tokens, these write `--ds-*` CSS vars through
+ * the existing token channel — honest stubs (hollow binding dot) until a preview
+ * component consumes them, at which point they go live with no rewiring. They
+ * exist to prove the *shape* of a complete builder: surface texture, brand
+ * expression, accessibility posture and interaction feedback are all axes two
+ * real design systems would disagree on.
+ * -------------------------------------------------------------------------- */
+
+function useToken(name: string, fallback: string) {
+  const { designSystem, setToken } = useDesignSystem()
+  const value = designSystem.tokens[name] ?? fallback
+  return [value, (v: string) => setToken(name, v)] as const
+}
+
+function SelectToken({
+  varName,
+  fallback,
+  options,
+  ariaLabel,
+}: {
+  varName: string
+  fallback: string
+  options: { id: string; label: string }[]
+  ariaLabel: string
+}) {
+  const [value, set] = useToken(varName, fallback)
+  return (
+    <Select
+      className="w-full"
+      selectedKey={value}
+      onSelectionChange={(k) => set(k as string)}
+      aria-label={ariaLabel}
+    >
+      <Button size="sm" className="w-full justify-between">
+        <SelectValue className="truncate" />
+        <ChevronDownIcon data-icon-end="" />
+      </Button>
+      <Popover>
+        <ListBox>
+          {options.map((o) => (
+            <ListBoxItem key={o.id} id={o.id}>
+              {o.label}
+            </ListBoxItem>
+          ))}
+        </ListBox>
+      </Popover>
+    </Select>
+  )
+}
+
+function SegToken({
+  varName,
+  fallback,
+  options,
+  ariaLabel,
+}: {
+  varName: string
+  fallback: string
+  options: { value: string; label: string }[]
+  ariaLabel: string
+}) {
+  const [value, set] = useToken(varName, fallback)
+  return (
+    <Segmented
+      ariaLabel={ariaLabel}
+      value={value}
+      onChange={set}
+      options={options}
+    />
+  )
+}
+
+function SliderToken({
+  varName,
+  fallback,
+  min,
+  max,
+  step,
+  format,
+  ariaLabel,
+}: {
+  varName: string
+  fallback: string
+  min: number
+  max: number
+  step: number
+  format: (v: number) => string
+  ariaLabel: string
+}) {
+  const [value, set] = useToken(varName, fallback)
+  return (
+    <ValueSlider
+      ariaLabel={ariaLabel}
+      value={Number.parseFloat(value) || Number.parseFloat(fallback)}
+      min={min}
+      max={max}
+      step={step}
+      format={format}
+      onChange={(v) => set(String(v))}
+    />
+  )
+}
+
+function BoolToken({
+  varName,
+  fallback,
+}: {
+  varName: string
+  fallback: string
+}) {
+  const [value, set] = useToken(varName, fallback)
+  return (
+    <Switch
+      isSelected={value === 'true'}
+      onChange={(s) => set(String(s))}
+      aria-label="Toggle"
+    />
+  )
+}
+
+/* ------------------------------- Sections -------------------------------- */
+
+export const STUDIO_EXTRA_SECTIONS: Section[] = [
+  {
+    id: 'brand',
+    label: 'Brand expression',
+    domain: 'brand',
+    icon: SparklesIcon,
+    controls: [
+      {
+        id: 'accent-fill',
+        label: 'Accent fill',
+        description: 'Solid, a brand gradient, or a soft mesh.',
+        domain: 'brand',
+        tier: 'semantic',
+        tempo: 'macro',
+        binding: 'stub',
+        keywords: ['gradient', 'mesh'],
+        Widget: () => (
+          <SegToken
+            varName="--ds-accent-fill"
+            fallback="solid"
+            ariaLabel="Accent fill"
+            options={[
+              { value: 'solid', label: 'Solid' },
+              { value: 'gradient', label: 'Gradient' },
+              { value: 'mesh', label: 'Mesh' },
+            ]}
+          />
+        ),
+      },
+      {
+        id: 'gradient-angle',
+        label: 'Gradient angle',
+        domain: 'brand',
+        tier: 'primitive',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SliderToken
+            varName="--ds-gradient-angle"
+            fallback="135"
+            min={0}
+            max={360}
+            step={15}
+            format={(v) => `${v}°`}
+            ariaLabel="Gradient angle"
+          />
+        ),
+      },
+      {
+        id: 'brand-emphasis',
+        label: 'Brand emphasis',
+        description: 'How loudly the accent shows up across the UI.',
+        domain: 'brand',
+        tier: 'semantic',
+        tempo: 'macro',
+        binding: 'stub',
+        Widget: () => (
+          <SegToken
+            varName="--ds-brand-emphasis"
+            fallback="balanced"
+            ariaLabel="Brand emphasis"
+            options={[
+              { value: 'reserved', label: 'Reserved' },
+              { value: 'balanced', label: 'Balanced' },
+              { value: 'loud', label: 'Loud' },
+            ]}
+          />
+        ),
+      },
+      {
+        id: 'mark-radius',
+        label: 'Logo-mark radius',
+        domain: 'brand',
+        tier: 'primitive',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SliderToken
+            varName="--ds-mark-radius"
+            fallback="6"
+            min={0}
+            max={20}
+            step={1}
+            format={(v) => `${v}px`}
+            ariaLabel="Logo-mark radius"
+          />
+        ),
+      },
+    ],
+  },
+  {
+    id: 'surface',
+    label: 'Surface & texture',
+    domain: 'surface',
+    icon: BlendIcon,
+    controls: [
+      {
+        id: 'translucency',
+        label: 'Translucency',
+        description: 'Frost behind menus, popovers and sheets.',
+        domain: 'surface',
+        tier: 'semantic',
+        tempo: 'macro',
+        binding: 'stub',
+        keywords: ['glass', 'blur', 'frosted'],
+        Widget: () => (
+          <SliderToken
+            varName="--ds-surface-translucency"
+            fallback="0"
+            min={0}
+            max={100}
+            step={5}
+            format={(v) => `${v}%`}
+            ariaLabel="Translucency"
+          />
+        ),
+      },
+      {
+        id: 'surface-tint',
+        label: 'Surface tint',
+        description: 'Tint panels neutral, cool, warm, or toward the brand.',
+        domain: 'surface',
+        tier: 'semantic',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SelectToken
+            varName="--ds-surface-tint"
+            fallback="none"
+            ariaLabel="Surface tint"
+            options={[
+              { id: 'none', label: 'Neutral' },
+              { id: 'cool', label: 'Cool' },
+              { id: 'warm', label: 'Warm' },
+              { id: 'brand', label: 'Brand-tinted' },
+            ]}
+          />
+        ),
+      },
+      {
+        id: 'grain',
+        label: 'Grain / noise',
+        description: 'Subtle film grain over backgrounds.',
+        domain: 'surface',
+        tier: 'primitive',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SliderToken
+            varName="--ds-grain"
+            fallback="0"
+            min={0}
+            max={100}
+            step={5}
+            format={(v) => `${v}%`}
+            ariaLabel="Grain"
+          />
+        ),
+      },
+      {
+        id: 'bg-pattern',
+        label: 'Background pattern',
+        domain: 'surface',
+        tier: 'primitive',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SegToken
+            varName="--ds-bg-pattern"
+            fallback="none"
+            ariaLabel="Background pattern"
+            options={[
+              { value: 'none', label: 'None' },
+              { value: 'dots', label: 'Dots' },
+              { value: 'grid', label: 'Grid' },
+            ]}
+          />
+        ),
+      },
+      {
+        id: 'separators',
+        label: 'Separators',
+        domain: 'surface',
+        tier: 'semantic',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SegToken
+            varName="--ds-separator"
+            fallback="hairline"
+            ariaLabel="Separators"
+            options={[
+              { value: 'hairline', label: 'Hairline' },
+              { value: 'solid', label: 'Solid' },
+              { value: 'none', label: 'None' },
+            ]}
+          />
+        ),
+      },
+    ],
+  },
+  {
+    id: 'a11y',
+    label: 'Accessibility',
+    domain: 'a11y',
+    icon: AccessibilityIcon,
+    controls: [
+      {
+        id: 'contrast-target',
+        label: 'Contrast target',
+        description: 'Minimum text-on-surface ratio the generator must hit.',
+        domain: 'a11y',
+        tier: 'semantic',
+        tempo: 'macro',
+        binding: 'stub',
+        keywords: ['wcag', 'aa', 'aaa'],
+        Widget: () => (
+          <SegToken
+            varName="--ds-contrast-target"
+            fallback="aa"
+            ariaLabel="Contrast target"
+            options={[
+              { value: 'aa', label: 'AA' },
+              { value: 'aaa', label: 'AAA' },
+            ]}
+          />
+        ),
+      },
+      {
+        id: 'focus-style',
+        label: 'Focus style',
+        description: 'How keyboard focus is drawn.',
+        domain: 'a11y',
+        tier: 'semantic',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SegToken
+            varName="--ds-focus-style"
+            fallback="ring"
+            ariaLabel="Focus style"
+            options={[
+              { value: 'ring', label: 'Ring' },
+              { value: 'solid', label: 'Solid' },
+              { value: 'glow', label: 'Glow' },
+            ]}
+          />
+        ),
+      },
+      {
+        id: 'link-underline',
+        label: 'Link underline',
+        domain: 'a11y',
+        tier: 'semantic',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SegToken
+            varName="--ds-link-underline"
+            fallback="hover"
+            ariaLabel="Link underline"
+            options={[
+              { value: 'always', label: 'Always' },
+              { value: 'hover', label: 'Hover' },
+              { value: 'none', label: 'None' },
+            ]}
+          />
+        ),
+      },
+      {
+        id: 'min-tap',
+        label: 'Min tap target',
+        description: 'Floor on the hit area of interactive controls.',
+        domain: 'a11y',
+        tier: 'primitive',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SliderToken
+            varName="--ds-min-tap"
+            fallback="36"
+            min={24}
+            max={48}
+            step={2}
+            format={(v) => `${v}px`}
+            ariaLabel="Min tap target"
+          />
+        ),
+      },
+      {
+        id: 'reduce-transparency',
+        label: 'Honor reduce-transparency',
+        domain: 'a11y',
+        tier: 'semantic',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <BoolToken varName="--ds-reduce-transparency" fallback="true" />
+        ),
+      },
+    ],
+  },
+  {
+    id: 'states',
+    label: 'Interaction states',
+    domain: 'states',
+    icon: MousePointerClickIcon,
+    controls: [
+      {
+        id: 'hover-effect',
+        label: 'Hover effect',
+        description: 'What interactive surfaces do on hover.',
+        domain: 'states',
+        tier: 'semantic',
+        tempo: 'macro',
+        binding: 'stub',
+        keywords: ['lift', 'glow', 'tint'],
+        Widget: () => (
+          <SegToken
+            varName="--ds-hover-effect"
+            fallback="tint"
+            ariaLabel="Hover effect"
+            options={[
+              { value: 'none', label: 'None' },
+              { value: 'tint', label: 'Tint' },
+              { value: 'lift', label: 'Lift' },
+              { value: 'glow', label: 'Glow' },
+            ]}
+          />
+        ),
+      },
+      {
+        id: 'press-depth',
+        label: 'Press depth',
+        description: 'How far controls sink when pressed.',
+        domain: 'states',
+        tier: 'primitive',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SliderToken
+            varName="--ds-press-depth"
+            fallback="1"
+            min={0}
+            max={4}
+            step={0.5}
+            format={(v) => `${v}px`}
+            ariaLabel="Press depth"
+          />
+        ),
+      },
+      {
+        id: 'selection-color',
+        label: 'Selection color',
+        domain: 'states',
+        tier: 'semantic',
+        tempo: 'micro',
+        binding: 'stub',
+        Widget: () => (
+          <SegToken
+            varName="--ds-selection"
+            fallback="brand"
+            ariaLabel="Selection color"
+            options={[
+              { value: 'brand', label: 'Brand' },
+              { value: 'neutral', label: 'Neutral' },
+            ]}
+          />
+        ),
+      },
+      {
+        id: 'transition-curve',
+        label: 'Transition curve',
+        description: 'The personality of every animation.',
+        domain: 'states',
+        tier: 'semantic',
+        tempo: 'macro',
+        binding: 'stub',
+        Widget: () => (
+          <SegToken
+            varName="--ds-ease"
+            fallback="smooth"
+            ariaLabel="Transition curve"
+            options={[
+              { value: 'snappy', label: 'Snappy' },
+              { value: 'smooth', label: 'Smooth' },
+              { value: 'spring', label: 'Spring' },
+            ]}
+          />
+        ),
+      },
+    ],
+  },
+]

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -13,6 +13,7 @@ import {
   saveStoredPreset,
 } from '@/modules/create/preset/storage'
 import { PreviewPanel } from '@/modules/create/preview/preview-panel'
+import { StudioExperience } from '@/modules/create/studio'
 
 type MobilePane = 'customize' | 'preview'
 
@@ -25,6 +26,9 @@ export const createSearchSchema = z.object({
   // Coerced boolean: the search parser reads bare `1`/`true` as non-strings, so a
   // plain `z.string()` would reject them and the param would be dropped.
   lab: z.coerce.boolean().optional().catch(undefined),
+  // Opt-in flag for the canvas-first, AI-native builder rethink at
+  // /create?studio=true. Same isolation contract as `lab`.
+  studio: z.coerce.boolean().optional().catch(undefined),
 })
 
 const searchDefaults = { preview: 'cards' }
@@ -38,7 +42,7 @@ export const Route = createFileRoute('/_app/create')({
 })
 
 function CreatePage() {
-  const { lab, preset } = Route.useSearch()
+  const { lab, studio, preset } = Route.useSearch()
   const { designSystem, setDesignSystem } = useDesignSystem()
   // Below `lg` the customizer and the live preview can't sit side by side (the iframe
   // would be a ~15px sliver), so they collapse into a single switchable pane toggled
@@ -68,6 +72,9 @@ function CreatePage() {
     }
     saveStoredPreset(designSystem)
   }, [designSystem])
+
+  // Opt-in exploration of the canvas-first, AI-native builder rethink.
+  if (studio) return <StudioExperience />
 
   // Opt-in exploration of the redesigned control panel + floating panel lab.
   if (lab) return <LabExperience />

--- a/www/src/routes/_app/route.tsx
+++ b/www/src/routes/_app/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeader } from '@tanstack/react-start/server'
 import type * as PageTree from 'fumadocs-core/page-tree'
@@ -37,9 +37,20 @@ function AppLayout() {
   const { pageTree } = Route.useLoaderData()
   const items = pageTree.children as PageTree.Node[]
 
+  // The `/create?studio` builder is a focused, app-like shell that owns its own
+  // top bar (logo → home, AI command, theme, export), so the site nav doesn't
+  // belong over it — it would stack a second bar. Suppress the global header
+  // there only; every other route (including the default /create) keeps it.
+  // `--header-height` stays defined so the builder's height math is unaffected.
+  const isStudio = useLocation({
+    select: (loc) =>
+      loc.pathname === '/create' &&
+      (loc.search as { studio?: boolean }).studio === true,
+  })
+
   return (
     <div className="[--header-height:--spacing(14)]">
-      <Header items={items} />
+      {!isStudio && <Header items={items} />}
       <main id="content">
         <Outlet />
       </main>


### PR DESCRIPTION
> **Experiment.** A canvas-first, AI-native rethink of `/create`, opt-in behind `?studio=true`. The shipped builder and the `?lab` panel experiment are untouched.

## What & why

The shipped `/create` is a fixed ~288px control panel beside a preview. **Studio** inverts that into a **canvas-first** layout where the live preview is the hero and everything else is contextual, and adds an **AI copilot** as a first-class input method — the direction the product wants (the builder should let you "make anything", and AI is the fastest path there).

Try it: `pnpm dev:www` → **`/create?studio=true`**.

```
┌─ top bar ── ◆ name · STUDIO ──┊ ✦ Ask AI to change anything (⌘K) ┊── inspect · ☾ · Export ─┐
│ dock │  inspector  │              CANVAS (live preview, hero)            │   AI COPILOT       │
└─ status bar ── ● Live · WCAG AA 6/6 · radius · density · N customizations ──── 🎲 Surprise me ─┘
```

## Highlights

- **Canvas-first shell** — a thin domain **dock** + a collapsible **inspector** on the left, the live preview centered as the hero, an **AI copilot** on the right, and a system-health **status bar** (live binding, real WCAG pass rate, radius/density, customization count). The inspector reuses the panel-lab control widgets (already wired to the live design system) with its own row chrome, and stays mounted across domain switches — content swaps in place (the Figma/Linear feel).
- **AI copilot + omnipresent ⌘K command field** — natural-language prompts (`warmer`, `feel like Linear`, `teal brand, more contrast`, `surprise me`) mutate the **same live design-system state** the manual controls edit, so the preview re-themes instantly. Each turn is **undoable**. Also: proactive **WCAG contrast insight** on the generated palette, and **"generate from"** image / URL / screenshot demos.
- **New experimental axes** — Brand expression, Surface & texture, Accessibility, Interaction states (~18 controls), authored as honest `--ds-*` **stub tokens** (hollow binding dot = "UI only for now"), exactly like the existing lab. They prove the *shape* of a complete builder.

## Notes for reviewers

- **UI only / no model.** The copilot's "AI" is a local, simulated intent parser ([`studio/ai/engine.ts`](../blob/claude/youthful-varahamihira-d0d9b7/www/src/modules/create/studio/ai/engine.ts)) — no network, no keys — that returns an `Action[]` shape a real model call can later produce. The mutations it makes are real and live, though.
- **Isolated.** www-side only; **no registry/publisher changes**. Gated behind `?studio=true` with the same contract as `?lab`. The only edits outside the new `studio/` module are the `studio` flag in `routes/_app/create.tsx` and four studio-only members added to the `Domain` union in `panel/types.ts`.
- New tweaks are explicitly experimental and stubbed, not wired into export — surfaced for the product discussion, not shipped.
- `pnpm typecheck` and `pnpm check` pass.
- **Spotted separately:** the existing panel lab (`?lab`) has a latent `text-primary-fg` typo (no backing token → invisible active sidebar icon + personality pill); not fixed here to keep this diff focused.

## Verified

`feel like Linear` → indigo brand `#5E6AD2` + radius 0.5 + compact, with reply + undo. `warmer` → hue shifted toward magenta and the live preview's selected date turned violet. Domain switching (Color → Surface) renders the new tweaks cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> WWW-only, feature-flagged behind `?studio=true`, with no registry/publisher changes; AI edits use the same preset path as existing controls, with per-turn undo.
> 
> **Overview**
> Adds an opt-in **`/create?studio=true`** experiment: a canvas-first builder shell that leaves the shipped `/create` and **`?lab`** flows unchanged.
> 
> **Studio layout** centers the existing live **`PreviewPanel`**, with a domain **dock**, slide-in **inspector** (reuses panel-lab control widgets + new row chrome), **top bar** (identity, ⌘K AI field, inspect, theme, export), **status bar** (WCAG pass rate, radius, density, customization count), and a collapsible **AI copilot**. **Inspect mode** overlays hotspot pins on the canvas to jump to token domains without iframe coupling.
> 
> **AI layer** is fully local: **`interpret()`** maps prompts to **`Action[]`** mutations on the same **`DesignSystem`** as manual controls (named looks, adjectives, color words, “surprise me”), plus rotating **“generate from”** image/URL/screenshot demos. Copilot turns are **undoable** via URL **`preset`** snapshots. WCAG contrast insight can switch the color algorithm to **contrast**.
> 
> **New experimental domains** (`brand`, `surface`, `a11y`, `states`) extend the **`Domain`** union and add ~18 **stub** `--ds-*` controls in **`tweaks.tsx`**, merged into studio-only section ordering.
> 
> **Routing**: **`studio`** coerced boolean on create search; app layout **hides the global header** on studio create so Studio’s top bar owns the viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d1eef91a36cb94479243b179536c41fa92c1ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->