### PR TITLE
feat(presets): gallery with live design-system modal

### DIFF
--- a/www/src/components/page-hero.tsx
+++ b/www/src/components/page-hero.tsx
@@ -1,0 +1,48 @@
+import type * as React from 'react'
+
+import { Eyebrow } from '@/components/eyebrow'
+
+interface PageHeroProps {
+  /** Optional pill above the headline (e.g. the /charts "Built on Recharts" note). */
+  eyebrow?: React.ReactNode
+  /** The headline. Rich markup is welcome (italic / bold spans). */
+  title: React.ReactNode
+  /** Supporting line under the headline. */
+  description?: React.ReactNode
+  /** Call-to-action row (buttons); laid out responsively. */
+  children?: React.ReactNode
+}
+
+/**
+ * The centered marketing hero shared by the landing-style pages (/charts,
+ * /presets): an optional eyebrow pill, a tracking-tight headline, a muted
+ * supporting line, and a responsive row of actions. Mirrors the landing page's
+ * hero so these pages read as one family.
+ */
+export function PageHero({
+  eyebrow,
+  title,
+  description,
+  children,
+}: PageHeroProps) {
+  return (
+    <section className="container flex flex-col pt-6 sm:pt-8 md:pt-12">
+      <div className="flex flex-col items-center gap-3 text-center md:gap-4">
+        {eyebrow ? <Eyebrow>{eyebrow}</Eyebrow> : null}
+        <h1 className="text-3xl leading-tight tracking-tighter text-balance max-lg:font-medium md:text-4xl lg:text-5xl">
+          {title}
+        </h1>
+        {description ? (
+          <p className="max-w-xl text-sm text-balance text-fg-muted sm:text-base">
+            {description}
+          </p>
+        ) : null}
+        {children ? (
+          <div className="flex w-full flex-col gap-2 pt-1 sm:w-auto sm:flex-row sm:items-center sm:gap-3">
+            {children}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/www/src/components/showcase-card.tsx
+++ b/www/src/components/showcase-card.tsx
@@ -1,0 +1,42 @@
+import type * as React from 'react'
+
+import { cn } from '@/registry/lib/utils'
+
+interface ShowcaseCardProps extends React.ComponentProps<'div'> {
+  /** Quiet label shown at the left of the header row. */
+  label: React.ReactNode
+  /** Optional element pinned to the right of the header row (an action, swatches…). */
+  action?: React.ReactNode
+}
+
+/**
+ * The gallery card shell shared by /charts and /presets: a quiet header row
+ * (label left, optional action right) above a fixed-height framed box that holds
+ * a live preview. Extra props spread onto the framed box, so callers can pass
+ * `inert aria-hidden` (the decorative chart previews) or wire interactions.
+ */
+export function ShowcaseCard({
+  label,
+  action,
+  className,
+  children,
+  ...props
+}: ShowcaseCardProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2 pl-1">
+        <span className="text-sm text-fg-muted capitalize">{label}</span>
+        {action}
+      </div>
+      <div
+        className={cn(
+          'relative h-60 overflow-hidden rounded-2xl border bg-card',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/www/src/config/site.ts
+++ b/www/src/config/site.ts
@@ -55,5 +55,6 @@ export const navItems: {
     params: { _splat: 'components' },
   },
   { name: 'Charts', match: '/charts', to: '/charts' },
+  { name: 'Presets', match: '/presets', to: '/presets' },
   { name: 'Create', match: '/create', to: '/create' },
 ]

--- a/www/src/modules/charts/chart-card.tsx
+++ b/www/src/modules/charts/chart-card.tsx
@@ -3,6 +3,7 @@
 import { Suspense } from 'react'
 
 import { cn } from '@/registry/lib/utils'
+import { ShowcaseCard } from '@/components/showcase-card'
 
 import { ChartCodeModal } from './chart-code-modal'
 import { getDemoComponent, POLAR_FAMILIES } from './data'
@@ -32,33 +33,26 @@ export function ChartCard({ familyId, demoKey, label }: ChartCardProps) {
   const isPolar = POLAR_FAMILIES.has(familyId)
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-between gap-2 pl-1">
-        <span className="text-sm text-fg-muted capitalize">{label}</span>
-        <ChartCodeModal demoKey={demoKey} label={label} />
-      </div>
-      <div
-        inert
-        aria-hidden="true"
-        className="h-60 overflow-hidden rounded-2xl border bg-card"
-      >
-        {/* Skeleton fills the whole box edge-to-edge; padding lives on the chart
-            wrapper so it never insets the fallback. */}
-        <Suspense
-          fallback={<div className="size-full animate-pulse bg-muted" />}
+    <ShowcaseCard
+      label={label}
+      action={<ChartCodeModal demoKey={demoKey} label={label} />}
+      inert
+      aria-hidden="true"
+    >
+      {/* Skeleton fills the whole box edge-to-edge; padding lives on the chart
+          wrapper so it never insets the fallback. */}
+      <Suspense fallback={<div className="size-full animate-pulse bg-muted" />}>
+        <div
+          className={cn(
+            'flex size-full items-center justify-center [&_*]:pointer-events-none [&_[data-slot=chart]]:h-full! [&_[data-slot=chart]]:min-h-0!',
+            isPolar
+              ? 'p-2 [&_[data-slot=chart]]:mx-auto! [&_[data-slot=chart]]:aspect-square! [&_[data-slot=chart]]:w-auto!'
+              : 'p-4 [&_[data-slot=chart]]:aspect-auto! [&_[data-slot=chart]]:w-full!',
+          )}
         >
-          <div
-            className={cn(
-              'flex size-full items-center justify-center [&_*]:pointer-events-none [&_[data-slot=chart]]:h-full! [&_[data-slot=chart]]:min-h-0!',
-              isPolar
-                ? 'p-2 [&_[data-slot=chart]]:mx-auto! [&_[data-slot=chart]]:aspect-square! [&_[data-slot=chart]]:w-auto!'
-                : 'p-4 [&_[data-slot=chart]]:aspect-auto! [&_[data-slot=chart]]:w-full!',
-            )}
-          >
-            <Component />
-          </div>
-        </Suspense>
-      </div>
-    </div>
+          <Component />
+        </div>
+      </Suspense>
+    </ShowcaseCard>
   )
 }

--- a/www/src/modules/charts/charts-page.tsx
+++ b/www/src/modules/charts/charts-page.tsx
@@ -1,6 +1,6 @@
 import { LinkButton } from '@/registry/ui/button'
-import { Eyebrow } from '@/components/eyebrow'
 import { Footer } from '@/components/layout/footer'
+import { PageHero } from '@/components/page-hero'
 
 import { ChartShowcase } from './chart-showcase'
 import { totalVariantCount } from './data'
@@ -11,32 +11,23 @@ export function ChartsPage() {
       {/* The <main> landmark lives in the shared _app layout; use a fragment here
           so we don't nest a second one. */}
       <>
-        {/* Hero — mirrors the landing page's centered, tracking-tight headline. */}
-        <section className="container flex flex-col pt-6 sm:pt-8 md:pt-12">
-          <div className="flex flex-col items-center gap-3 text-center md:gap-4">
-            <Eyebrow>Built on Recharts · themed by your design system</Eyebrow>
-            <h1 className="text-3xl leading-tight tracking-tighter text-balance max-lg:font-medium md:text-4xl lg:text-5xl">
+        <PageHero
+          eyebrow="Built on Recharts · themed by your design system"
+          title={
+            <>
               Charts that look like{' '}
               <span className="font-bold italic">your product</span>.
-            </h1>
-            <p className="max-w-xl text-sm text-balance text-fg-muted sm:text-base">
-              {totalVariantCount()} copy-paste chart variants, themed by your
-              design system.
-            </p>
-            <div className="flex w-full flex-col gap-2 pt-1 sm:w-auto sm:flex-row sm:items-center sm:gap-3">
-              <LinkButton href="/create" variant="primary" size="lg">
-                Launch the editor
-              </LinkButton>
-              <LinkButton
-                href="/docs/components/chart"
-                variant="default"
-                size="lg"
-              >
-                View documentation
-              </LinkButton>
-            </div>
-          </div>
-        </section>
+            </>
+          }
+          description={`${totalVariantCount()} copy-paste chart variants, themed by your design system.`}
+        >
+          <LinkButton href="/create" variant="primary" size="lg">
+            Launch the editor
+          </LinkButton>
+          <LinkButton href="/docs/components/chart" variant="default" size="lg">
+            View documentation
+          </LinkButton>
+        </PageHero>
 
         {/* Showcase — a tabbed grid of every variant, one family per tab. */}
         <section className="container mt-12 sm:mt-16">

--- a/www/src/modules/presets/preset-card.tsx
+++ b/www/src/modules/presets/preset-card.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import { ShowcaseCard } from '@/components/showcase-card'
+
+import { PresetThumbnail } from './preset-thumbnail'
+import type { Preset } from './presets-data'
+
+/** The seed swatches shown at the right of the card header, in a fixed order. */
+function PaletteSwatches({ preset }: { preset: Preset }) {
+  const seeds = preset.designSystem.color?.seeds ?? DEFAULT_COLOR_CONFIG.seeds
+  const swatches = [seeds.accent, seeds.neutral, seeds.success, seeds.danger]
+  return (
+    <div className="flex shrink-0 items-center -space-x-1">
+      {swatches.map((color, i) => (
+        <span
+          key={i}
+          className="size-3.5 rounded-full border border-bg"
+          style={{ backgroundColor: color }}
+        />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * One preset in the gallery — same shape as a /charts card: a quiet header row
+ * (name + palette) over a framed live preview. The preview is a scaled, themed
+ * render of the showcase; it's decorative (`inert`) and a transparent button
+ * overlays the whole box to open the presentation modal. The preview contains
+ * its own buttons, so the box itself can't be a <button> (nested buttons are
+ * invalid HTML) — hence the overlay sibling.
+ */
+export function PresetCard({
+  preset,
+  onSelect,
+}: {
+  preset: Preset
+  onSelect: () => void
+}) {
+  return (
+    <ShowcaseCard
+      label={preset.name}
+      action={<PaletteSwatches preset={preset} />}
+      className="transition hover:border-border-hover hover:shadow-md has-[button:focus-visible]:border-border-hover"
+    >
+      <PresetThumbnail designSystem={preset.designSystem} />
+      {/* Fade the clipped bottom edge into the card chrome. */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-card to-transparent" />
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-label={`Preview ${preset.name}`}
+        className="absolute inset-0 z-10 rounded-2xl focus-visible:focus-ring"
+      />
+    </ShowcaseCard>
+  )
+}

--- a/www/src/modules/presets/preset-modal.tsx
+++ b/www/src/modules/presets/preset-modal.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link as RouterLink } from '@tanstack/react-router'
+import { ExternalLinkIcon, MoonIcon, SunIcon, XIcon } from 'lucide-react'
+import { useTheme } from 'starter-themes'
+
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import { Button, buttonStyles } from '@/registry/ui/button'
+import {
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/registry/ui/dialog'
+import { Modal } from '@/registry/ui/modal'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+import { encodePreset, sendPreviewMode } from '@/modules/create/preset'
+import type { Density, PreviewMode } from '@/modules/create/preset'
+
+import type { Preset } from './presets-data'
+
+const DENSITY_LABEL: Record<Density, string> = {
+  compact: 'Compact',
+  default: 'Default',
+  comfortable: 'Comfortable',
+}
+
+const ALGORITHM_LABEL: Record<string, string> = {
+  oklch: 'OKLCH',
+  tailwind: 'Tailwind',
+  contrast: 'Contrast',
+  material: 'Material',
+}
+
+/** A descriptive word for a `--radius-factor` multiplier (1 = builder default). */
+function radiusLabel(factor: string | undefined): string {
+  const n = factor ? Number(factor) : 1
+  if (Number.isNaN(n) || n === 1) return 'Default'
+  if (n <= 0.5) return 'Sharp'
+  if (n < 1) return 'Tight'
+  if (n >= 2) return 'Pill'
+  return 'Rounded'
+}
+
+interface PresetModalProps {
+  /** The preset to present; retained through the close animation so the panel
+   *  doesn't blank out as it scales away. */
+  preset: Preset | null
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * The preset presentation modal: a large two-pane dialog that shows a design
+ * system the way a designer would walk you through it. The left pane is an
+ * editorial spec sheet (name, palette, the headline axes) with the call to take
+ * it into the editor; the right pane is the live showcase — the exact `/create`
+ * preview iframe, themed by this preset, with a light / dark toggle.
+ */
+export function PresetModal({
+  preset,
+  isOpen,
+  onOpenChange,
+}: PresetModalProps) {
+  // Keep the last preset mounted while the modal animates closed (the overlay
+  // lingers for the exit transition); without this the panel empties mid-close.
+  const [shown, setShown] = useState(preset)
+  useEffect(() => {
+    if (preset) setShown(preset)
+  }, [preset])
+  const active = preset ?? shown
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      className="h-[80vh] w-full sm:max-w-3xl md:max-w-4xl lg:max-w-5xl xl:max-w-6xl"
+    >
+      <DialogContent
+        aria-label={active ? `${active.name} design system` : 'Design system'}
+        className="relative flex h-full min-h-0 flex-col overflow-hidden p-0"
+      >
+        {/* Close sits just outside the panel's top-right corner (kept inside the
+            dialog so focus management still scopes to it). */}
+        <Button
+          variant="quiet"
+          size="sm"
+          isIconOnly
+          aria-label="Close"
+          onPress={() => onOpenChange(false)}
+          className="absolute -top-10 right-0 z-10 text-fg-muted hover:bg-inverse/10 hover:text-fg"
+        >
+          <XIcon />
+        </Button>
+        {active ? <PresetModalBody preset={active} /> : null}
+      </DialogContent>
+    </Modal>
+  )
+}
+
+function PresetModalBody({ preset }: { preset: Preset }) {
+  const { resolvedTheme } = useTheme()
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const [previewMode, setPreviewMode] = useState<PreviewMode>('light')
+
+  const encoded = useMemo(
+    () => encodePreset(preset.designSystem),
+    [preset.designSystem],
+  )
+  const iframeSrc = encoded
+    ? `/preview/cards?preset=${encodeURIComponent(encoded)}`
+    : '/preview/cards'
+
+  // Seed the preview's light / dark from the site theme on open, then it's
+  // independent (mirrors the /create PreviewPanel: the SSR'd server can't know
+  // the client's stored theme, so seed after mount rather than during render).
+  useEffect(() => {
+    setPreviewMode(resolvedTheme === 'dark' ? 'dark' : 'light')
+    // oxlint-disable-next-line react/exhaustive-deps -- seed once at open; preview mode is independent thereafter
+  }, [])
+
+  // Forward the preview mode to the iframe — on change, on load, and when it
+  // signals ready (its listener can mount after the load event fires).
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!iframe) return
+    const send = () => sendPreviewMode(iframe, previewMode)
+    if (iframe.contentWindow) send()
+    iframe.addEventListener('load', send)
+    const onReady = (event: MessageEvent) => {
+      if (event.data?.type === 'preview-ready') send()
+    }
+    window.addEventListener('message', onReady)
+    return () => {
+      iframe.removeEventListener('load', send)
+      window.removeEventListener('message', onReady)
+    }
+  }, [previewMode])
+
+  const seeds = preset.designSystem.color?.seeds ?? DEFAULT_COLOR_CONFIG.seeds
+  const palette = [
+    { label: 'Accent', color: seeds.accent },
+    { label: 'Neutral', color: seeds.neutral },
+    { label: 'Success', color: seeds.success },
+    { label: 'Warning', color: seeds.warning },
+    { label: 'Danger', color: seeds.danger },
+    { label: 'Info', color: seeds.info },
+  ].filter((s): s is { label: string; color: string } => Boolean(s.color))
+
+  const specs = [
+    { label: 'Density', value: DENSITY_LABEL[preset.designSystem.density] },
+    {
+      label: 'Radius',
+      value: radiusLabel(preset.designSystem.tokens['--radius-factor']),
+    },
+    {
+      label: 'Color model',
+      value: ALGORITHM_LABEL[preset.designSystem.color?.algorithm ?? 'oklch'],
+    },
+  ]
+
+  return (
+    <div className="flex h-full min-h-0 flex-col md:flex-row">
+      {/* LEFT: the editorial spec sheet. Capped on mobile (where it stacks above
+          the preview) so the live showcase always keeps a usable share. */}
+      <div className="flex min-h-0 flex-col gap-6 overflow-auto border-b p-6 max-md:max-h-[55%] md:w-[340px] md:shrink-0 md:border-r md:border-b-0 lg:w-[380px]">
+        <div className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium tracking-wide text-fg-muted uppercase">
+            Design system
+          </span>
+          <DialogTitle className="text-2xl font-semibold tracking-tight">
+            {preset.name}
+          </DialogTitle>
+          <DialogDescription className="text-sm text-fg-muted">
+            {preset.description}
+          </DialogDescription>
+        </div>
+
+        <section className="flex flex-col gap-2.5">
+          <h3 className="text-xs font-medium tracking-wide text-fg-muted uppercase">
+            Palette
+          </h3>
+          <div className="grid grid-cols-2 gap-2">
+            {palette.map(({ label, color }) => (
+              <div
+                key={label}
+                className="flex items-center gap-2 rounded-lg border bg-bg p-2"
+              >
+                <span
+                  className="size-6 shrink-0 rounded-md border border-bg shadow-sm"
+                  style={{ backgroundColor: color }}
+                />
+                <div className="min-w-0">
+                  <div className="truncate text-xs font-medium">{label}</div>
+                  <div className="truncate font-mono text-[0.7rem] text-fg-muted uppercase">
+                    {color}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-2.5">
+          <h3 className="text-xs font-medium tracking-wide text-fg-muted uppercase">
+            Details
+          </h3>
+          <dl className="grid grid-cols-3 gap-2">
+            {specs.map(({ label, value }) => (
+              <div key={label} className="rounded-lg border bg-bg p-3">
+                <dt className="text-xs text-fg-muted">{label}</dt>
+                <dd className="mt-1 text-sm font-medium">{value}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <div className="mt-auto pt-2">
+          <RouterLink
+            to="/create"
+            search={encoded ? { preset: encoded } : {}}
+            className={buttonStyles({
+              variant: 'primary',
+              size: 'lg',
+              className: 'w-full',
+            })}
+          >
+            Open in editor
+          </RouterLink>
+        </div>
+      </div>
+
+      {/* RIGHT: the live showcase, themed by this preset. */}
+      <div className="relative flex min-h-0 flex-1 flex-col bg-bg">
+        <div className="flex h-11 shrink-0 items-center justify-end gap-1 border-b px-2">
+          <Tooltip>
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              onPress={() =>
+                setPreviewMode((m) => (m === 'dark' ? 'light' : 'dark'))
+              }
+              aria-label="Toggle preview mode"
+            >
+              {previewMode === 'dark' ? <SunIcon /> : <MoonIcon />}
+            </Button>
+            <TooltipContent>
+              {previewMode === 'dark' ? 'Light mode' : 'Dark mode'}
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              onPress={() =>
+                window.open(iframeSrc, '_blank', 'noopener,noreferrer')
+              }
+              aria-label="Open preview in new tab"
+            >
+              <ExternalLinkIcon />
+            </Button>
+            <TooltipContent>Open in new tab</TooltipContent>
+          </Tooltip>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <iframe
+            ref={iframeRef}
+            src={iframeSrc}
+            title={`${preset.name} preview`}
+            className="size-full border-0 bg-bg"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/presets/preset-thumbnail.tsx
+++ b/www/src/modules/presets/preset-thumbnail.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { DesignSystemProvider } from '@/lib/styles'
+import { CardsGrid } from '@/components/showcase/cards-grid'
+import type { DesignSystem } from '@/modules/create/preset'
+
+/**
+ * Virtual width the showcase renders at before being scaled down into a tile.
+ * Wide enough to lay the cards out in two columns; the tile clips the overflow.
+ */
+const BASE_WIDTH = 720
+
+/**
+ * A live, scaled-down render of the landing-page showcase cards, themed to a
+ * single preset via a *scoped* DesignSystemProvider (so many of these can sit
+ * on one page, each in its own theme). Fills its container and scales the
+ * showcase to match, so it works at any tile width. Purely decorative — inert
+ * and pointer-events-none so the parent tile owns the interaction.
+ *
+ * Note: scoped theming is client-only (it mirrors the live `:root` token
+ * closure), so on first paint a tile shows the page's default theme and
+ * re-themes on hydration.
+ */
+export function PresetThumbnail({
+  designSystem,
+}: {
+  designSystem: DesignSystem
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(0)
+
+  // Measure the tile so the showcase can be scaled to fill it at any width.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const update = () => setWidth(el.clientWidth)
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div ref={containerRef} className="absolute inset-0 overflow-hidden">
+      {width > 0 && (
+        <DesignSystemProvider
+          scoped
+          params={designSystem.componentParams}
+          tokens={designSystem.tokens}
+          density={designSystem.density}
+          color={designSystem.color}
+        >
+          {/* Canvas, themed by the scope so the cards sit on the preset's own bg. */}
+          <div aria-hidden className="absolute inset-0 bg-bg" />
+          <div
+            inert
+            aria-hidden
+            className="pointer-events-none absolute top-0 left-0 origin-top-left select-none"
+            style={{
+              width: BASE_WIDTH,
+              transform: `scale(${width / BASE_WIDTH})`,
+            }}
+          >
+            <div className="p-4">
+              <CardsGrid variant="preview" />
+            </div>
+          </div>
+        </DesignSystemProvider>
+      )}
+    </div>
+  )
+}

--- a/www/src/modules/presets/presets-data.ts
+++ b/www/src/modules/presets/presets-data.ts
@@ -1,0 +1,129 @@
+import { DEFAULT_COLOR_CONFIG, type ColorConfig } from '@/registry/theme'
+import { DEFAULTS, type DesignSystem } from '@/modules/create/preset'
+
+/**
+ * A pre-built design system the gallery can browse and present.
+ *
+ * EXPERIMENT: this hand-authored list stands in for a real preset source so we
+ * can validate the gallery UI. Each entry varies only the high-impact, low-risk
+ * axes (palette seeds, algorithm, density, radius) off the builder defaults —
+ * enough to read as a distinct design system in the scaled-down preview.
+ */
+export type Preset = {
+  id: string
+  name: string
+  description: string
+  designSystem: DesignSystem
+}
+
+function makeDesignSystem(opts: {
+  algorithm?: ColorConfig['algorithm']
+  neutral: string
+  accent: string
+  density?: DesignSystem['density']
+  /** Multiplier on every radius token (1 = builder default). */
+  radiusFactor?: string
+  /** Per-producer tuning (e.g. force a gray accent to stay gray). */
+  knobs?: ColorConfig['knobs']
+}): DesignSystem {
+  const { algorithm = 'oklch', neutral, accent, density = 'compact' } = opts
+  return {
+    ...DEFAULTS,
+    density,
+    tokens: opts.radiusFactor ? { '--radius-factor': opts.radiusFactor } : {},
+    color: {
+      algorithm,
+      seeds: { ...DEFAULT_COLOR_CONFIG.seeds, neutral, accent },
+      ...(opts.knobs ? { knobs: opts.knobs } : {}),
+    },
+  }
+}
+
+export const PRESETS: Preset[] = [
+  {
+    id: 'default',
+    name: 'Default',
+    description: 'dotUI out of the box.',
+    designSystem: { ...DEFAULTS },
+  },
+  {
+    id: 'vercel',
+    name: 'Vercel',
+    description: 'Monochrome, tight radii.',
+    designSystem: makeDesignSystem({
+      neutral: '#737373',
+      accent: '#171717',
+      radiusFactor: '0.5',
+      density: 'compact',
+      // A pure-gray accent: kill chroma so the producer doesn't floor it back
+      // up to a tinted ramp (Geist-style neutral primary).
+      knobs: { chromaMult: 0, minChroma: 0 },
+    }),
+  },
+  {
+    id: 'supabase',
+    name: 'Supabase',
+    description: 'Emerald on cool gray.',
+    designSystem: makeDesignSystem({
+      neutral: '#6b7280',
+      accent: '#3ecf8e',
+      density: 'default',
+    }),
+  },
+  {
+    id: 'material',
+    name: 'Material You',
+    description: 'Soft purple, generous round.',
+    designSystem: makeDesignSystem({
+      algorithm: 'material',
+      neutral: '#79747e',
+      accent: '#6750a4',
+      radiusFactor: '1.75',
+      density: 'comfortable',
+    }),
+  },
+  {
+    id: 'linear',
+    name: 'Linear',
+    description: 'Indigo, crisp and compact.',
+    designSystem: makeDesignSystem({
+      neutral: '#8a8f98',
+      accent: '#5e6ad2',
+      density: 'compact',
+    }),
+  },
+  {
+    id: 'claude',
+    name: 'Claude',
+    description: 'Warm coral on sand.',
+    designSystem: makeDesignSystem({
+      neutral: '#8a8278',
+      accent: '#d97757',
+      radiusFactor: '1.5',
+      density: 'default',
+    }),
+  },
+  {
+    id: 'rose',
+    name: 'Rosé',
+    description: 'Pink, pill-soft radii.',
+    designSystem: makeDesignSystem({
+      neutral: '#7d7d7d',
+      accent: '#e11d48',
+      radiusFactor: '2',
+      density: 'comfortable',
+    }),
+  },
+  {
+    id: 'contrast',
+    name: 'Contrast',
+    description: 'APCA-tuned emerald.',
+    designSystem: makeDesignSystem({
+      algorithm: 'contrast',
+      neutral: '#71717a',
+      accent: '#059669',
+      radiusFactor: '0.75',
+      density: 'default',
+    }),
+  },
+]

--- a/www/src/modules/presets/presets-page.tsx
+++ b/www/src/modules/presets/presets-page.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useState } from 'react'
+
+import { LinkButton } from '@/registry/ui/button'
+import { Footer } from '@/components/layout/footer'
+import { PageHero } from '@/components/page-hero'
+
+import { PresetCard } from './preset-card'
+import { PresetModal } from './preset-modal'
+import { PRESETS, type Preset } from './presets-data'
+
+export function PresetsPage() {
+  // The presented preset, or null when the modal is closed.
+  const [selected, setSelected] = useState<Preset | null>(null)
+
+  return (
+    <div className="min-h-[calc(100vh-var(--header-height))]">
+      {/* The <main> landmark lives in the shared _app layout; use a fragment here
+          so we don't nest a second one. */}
+      <>
+        <PageHero
+          eyebrow="Curated design systems"
+          title={
+            <>
+              Start from a{' '}
+              <span className="font-bold italic">beautiful preset</span>.
+            </>
+          }
+          description={`${PRESETS.length} ready-made design systems. Preview one live, then open it in the editor and make it yours.`}
+        >
+          <LinkButton href="/create" variant="primary" size="lg">
+            Launch the editor
+          </LinkButton>
+          <LinkButton href="/docs/components" variant="default" size="lg">
+            View components
+          </LinkButton>
+        </PageHero>
+
+        {/* Gallery — the same grid rhythm as the /charts showcase. */}
+        <section className="container mt-12 sm:mt-16">
+          <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+            {PRESETS.map((preset) => (
+              <PresetCard
+                key={preset.id}
+                preset={preset}
+                onSelect={() => setSelected(preset)}
+              />
+            ))}
+          </div>
+        </section>
+      </>
+
+      <PresetModal
+        preset={selected}
+        isOpen={selected !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null)
+        }}
+      />
+
+      <Footer />
+    </div>
+  )
+}

--- a/www/src/routeTree.gen.ts
+++ b/www/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as RInitRouteImport } from './routes/r/init'
 import { Route as RNameRouteImport } from './routes/r/$name'
 import { Route as PreviewSlugRouteImport } from './routes/preview/$slug'
 import { Route as DemosSlugRouteImport } from './routes/demos/$slug'
+import { Route as AppPresetsRouteImport } from './routes/_app/presets'
 import { Route as AppCreateRouteImport } from './routes/_app/create'
 import { Route as AppComponentsRouteImport } from './routes/_app/components'
 import { Route as AppChartsRouteImport } from './routes/_app/charts'
@@ -100,6 +101,11 @@ const DemosSlugRoute = DemosSlugRouteImport.update({
   path: '/demos/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AppPresetsRoute = AppPresetsRouteImport.update({
+  id: '/presets',
+  path: '/presets',
+  getParentRoute: () => AppRouteRoute,
+} as any)
 const AppCreateRoute = AppCreateRouteImport.update({
   id: '/create',
   path: '/create',
@@ -150,6 +156,7 @@ export interface FileRoutesByFullPath {
   '/charts': typeof AppChartsRoute
   '/components': typeof AppComponentsRoute
   '/create': typeof AppCreateRoute
+  '/presets': typeof AppPresetsRoute
   '/demos/$slug': typeof DemosSlugRoute
   '/preview/$slug': typeof PreviewSlugRoute
   '/r/$name': typeof RNameRoute
@@ -171,6 +178,7 @@ export interface FileRoutesByTo {
   '/charts': typeof AppChartsRoute
   '/components': typeof AppComponentsRoute
   '/create': typeof AppCreateRoute
+  '/presets': typeof AppPresetsRoute
   '/demos/$slug': typeof DemosSlugRoute
   '/preview/$slug': typeof PreviewSlugRoute
   '/r/$name': typeof RNameRoute
@@ -195,6 +203,7 @@ export interface FileRoutesById {
   '/_app/charts': typeof AppChartsRoute
   '/_app/components': typeof AppComponentsRoute
   '/_app/create': typeof AppCreateRoute
+  '/_app/presets': typeof AppPresetsRoute
   '/demos/$slug': typeof DemosSlugRoute
   '/preview/$slug': typeof PreviewSlugRoute
   '/r/$name': typeof RNameRoute
@@ -220,6 +229,7 @@ export interface FileRouteTypes {
     | '/charts'
     | '/components'
     | '/create'
+    | '/presets'
     | '/demos/$slug'
     | '/preview/$slug'
     | '/r/$name'
@@ -241,6 +251,7 @@ export interface FileRouteTypes {
     | '/charts'
     | '/components'
     | '/create'
+    | '/presets'
     | '/demos/$slug'
     | '/preview/$slug'
     | '/r/$name'
@@ -264,6 +275,7 @@ export interface FileRouteTypes {
     | '/_app/charts'
     | '/_app/components'
     | '/_app/create'
+    | '/_app/presets'
     | '/demos/$slug'
     | '/preview/$slug'
     | '/r/$name'
@@ -392,6 +404,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DemosSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_app/presets': {
+      id: '/_app/presets'
+      path: '/presets'
+      fullPath: '/presets'
+      preLoaderRoute: typeof AppPresetsRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
     '/_app/create': {
       id: '/_app/create'
       path: '/create'
@@ -463,6 +482,7 @@ interface AppRouteRouteChildren {
   AppChartsRoute: typeof AppChartsRoute
   AppComponentsRoute: typeof AppComponentsRoute
   AppCreateRoute: typeof AppCreateRoute
+  AppPresetsRoute: typeof AppPresetsRoute
   AppIndexRoute: typeof AppIndexRoute
 }
 
@@ -471,6 +491,7 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppChartsRoute: AppChartsRoute,
   AppComponentsRoute: AppComponentsRoute,
   AppCreateRoute: AppCreateRoute,
+  AppPresetsRoute: AppPresetsRoute,
   AppIndexRoute: AppIndexRoute,
 }
 

--- a/www/src/routes/_app/presets.tsx
+++ b/www/src/routes/_app/presets.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { siteConfig } from '@/config/site'
+import { PresetsPage } from '@/modules/presets/presets-page'
+
+const TITLE = 'Presets'
+const DESCRIPTION =
+  'Browse ready-made design systems — preview each one live on real components, then open it in the editor and make it yours.'
+
+export const Route = createFileRoute('/_app/presets')({
+  head: () => {
+    const ogImageUrl = `${siteConfig.url}/og?title=${encodeURIComponent(
+      TITLE,
+    )}&description=${encodeURIComponent(DESCRIPTION)}`
+    return {
+      meta: [
+        { title: `${TITLE} - ${siteConfig.name}` },
+        { name: 'description', content: DESCRIPTION },
+        { property: 'og:title', content: TITLE },
+        { property: 'og:description', content: DESCRIPTION },
+        { property: 'og:type', content: 'website' },
+        { property: 'og:url', content: `${siteConfig.url}/presets` },
+        { property: 'og:image', content: ogImageUrl },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: TITLE },
+        { name: 'twitter:description', content: DESCRIPTION },
+        { name: 'twitter:image', content: ogImageUrl },
+        { name: 'twitter:creator', content: siteConfig.twitter.creator },
+      ],
+    }
+  },
+  component: PresetsPage,
+})


### PR DESCRIPTION
## Summary

- Remake `/presets` in the `/charts` + landing style — a centered `PageHero` over a grid of preset cards, then the footer — dropping the `/create`-style right-sliding preview panel.
- Selecting a preset now opens a **presentation modal**: an editorial spec sheet (palette with hex, density / radius / color-model, **Open in editor** deeplinking to `/create?preset=…`) beside the live `/preview/cards` iframe themed by that preset, with a light / dark toggle and open-in-new-tab.
- Extract two shared components used by **both** `/charts` and `/presets`, and refactor `/charts` onto them:
  - `PageHero` (`www/src/components/page-hero.tsx`) — eyebrow + headline + description + actions.
  - `ShowcaseCard` (`www/src/components/showcase-card.tsx`) — the chart-card shell (quiet header row over a framed `h-60 rounded-2xl` box; spreads extra props onto the box, e.g. `inert aria-hidden`).
- Add the `/presets` route (with OG meta, like `/charts`) and the **Presets** nav entry.

## Notes for reviewers

- Self-contained under `www/src/modules/presets/` + `routes/_app/presets.tsx`. The 8 entries in `presets-data.ts` are hand-authored **mock** `DesignSystem`s (ported from #275) varying only seeds / algorithm / density / radius — placeholder data, not a real preset source yet.
- The modal is a controlled `Modal` (one shared instance, not one per card) that retains the last preset through the close animation. Each open mounts a fresh iframe with the preset baked into `src`, so only the light/dark mode rides `postMessage` (`sendPreviewMode`) — no design-system sync needed.
- The preset card can't be a `<button>` (the themed thumbnail renders the showcase's own buttons — nested buttons are invalid), so the thumbnail is `inert` and a transparent button overlays the box to open the modal.
- `routeTree.gen.ts` is regenerated for the new route; no registry / `__generated__` drift.

## Verification

- `pnpm typecheck` and `pnpm check` pass (the 2 lint warnings are pre-existing, in unrelated files).
- Verified in the browser: gallery (8 themed thumbnails), modal (centered, per-preset palette/specs, light/dark toggle), the full **Open in editor → `/create` with the preset applied** flow, `/charts` still rendering after the refactor, and mobile (single-column grid; modal stacks with the live preview kept prominent).

> Alternative to #275, which has the right-sliding preview-panel version on another branch. Pick one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing UI and reuse of existing preset encode/preview paths; mock preset data only, no auth or backend changes.
> 
> **Overview**
> Adds a **`/presets`** marketing gallery aligned with **`/charts`**: shared **`PageHero`** and **`ShowcaseCard`**, a grid of eight mock presets with live themed thumbnails, and a **Presets** nav item plus route/OG meta.
> 
> **`/charts`** drops its inline hero and card chrome in favor of those shared components; chart behavior is unchanged.
> 
> Choosing a preset opens a **presentation modal** (spec sheet + palette/details, **Open in editor** via `/create?preset=…`) beside a **`/preview/cards`** iframe with light/dark **`postMessage`** sync. Cards use an overlay button so nested buttons in the thumbnail stay valid HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 403654f996c3767a0399fbe4f104d40603db0631. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->