### PR TITLE
feat(create): add opt-in studio builder redesign

### DIFF
--- a/www/src/modules/create/create-top-bar.tsx
+++ b/www/src/modules/create/create-top-bar.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { siteConfig } from '@/config/site'
+import { buttonStyles } from '@/registry/ui/button'
+import { GitHubIcon } from '@/components/icons/github'
+import { Logo } from '@/components/layout/logo'
+import { ThemeToggle } from '@/components/theme-toggle'
+
+/**
+ * Minimal builder top bar for the shipped `/create` (and `?lab`) variants. The
+ * global site Header is suppressed on `/create` (see routes/_app/route.tsx), so
+ * these variants own this bar instead — same `--header-height`, Logo (→ home),
+ * GitHub, and ThemeToggle as the site header, minus the nav links + search that
+ * don't belong inside the builder. The studio variant ships its own richer bar.
+ */
+export function CreateTopBar() {
+  return (
+    <header className="sticky top-0 z-30 flex h-(--header-height) w-full shrink-0 items-center justify-between gap-3 border-b bg-bg/80 px-4 backdrop-blur md:px-6">
+      <Logo />
+      <div className="flex items-center gap-2">
+        <a
+          aria-label="GitHub"
+          href={siteConfig.links.github}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-icon-only=""
+          className={buttonStyles({ variant: 'quiet', size: 'sm' })}
+        >
+          <GitHubIcon />
+        </a>
+        <ThemeToggle isIconOnly variant="quiet" size="sm" />
+      </div>
+    </header>
+  )
+}

--- a/www/src/modules/create/studio/ai-bar.tsx
+++ b/www/src/modules/create/studio/ai-bar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ArrowUpIcon, SparklesIcon } from 'lucide-react'
 import * as ButtonPrimitives from 'react-aria-components/Button'
 
@@ -8,6 +8,7 @@ import { cn } from '@/registry/lib/utils'
 import { Button } from '@/registry/ui/button'
 
 import { useDesignSystem } from '../preset'
+import { registerAiFocuser } from './ai-focus'
 import { applyDelta } from './vibes'
 
 const REFINE_CHIPS = [
@@ -27,6 +28,10 @@ export function AiBar({ className }: { className?: string }) {
   const ds = useDesignSystem()
   const [text, setText] = useState('')
   const [log, setLog] = useState<Message[]>([])
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Let the top bar's "Ask dotUI" command (and ⌘K) jump focus straight here.
+  useEffect(() => registerAiFocuser(() => inputRef.current?.focus()), [])
 
   function run(input: string) {
     if (!input.trim()) return
@@ -60,6 +65,7 @@ export function AiBar({ className }: { className?: string }) {
       <div className="flex items-center gap-2 rounded-full border bg-card/95 p-1.5 pl-3 shadow-lg backdrop-blur">
         <SparklesIcon className="size-4 shrink-0 text-primary" />
         <input
+          ref={inputRef}
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={(e) => {

--- a/www/src/modules/create/studio/ai-bar.tsx
+++ b/www/src/modules/create/studio/ai-bar.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useState } from 'react'
+import { ArrowUpIcon, SparklesIcon } from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+
+import { useDesignSystem } from '../preset'
+import { applyDelta } from './vibes'
+
+const REFINE_CHIPS = [
+  'More contrast',
+  'Softer corners',
+  'Tighter density',
+  'More playful',
+  'Surprise me',
+]
+
+interface Message {
+  role: 'you' | 'dotui'
+  text: string
+}
+
+export function AiBar({ className }: { className?: string }) {
+  const ds = useDesignSystem()
+  const [text, setText] = useState('')
+  const [log, setLog] = useState<Message[]>([])
+
+  function run(input: string) {
+    if (!input.trim()) return
+    const reply = applyDelta(ds, input)
+    setLog((prev) => [
+      ...prev.slice(-2),
+      { role: 'you', text: input },
+      { role: 'dotui', text: reply },
+    ])
+    setText('')
+  }
+
+  return (
+    <div className={cn('flex w-full max-w-xl flex-col gap-2', className)}>
+      {log.length > 0 && (
+        <div className="flex flex-col gap-1 rounded-xl border bg-card/95 p-2.5 text-xs shadow-lg backdrop-blur">
+          {log.map((m, i) => (
+            <div
+              key={i}
+              className={m.role === 'you' ? 'text-fg' : 'text-fg-muted'}
+            >
+              <span className="font-medium">
+                {m.role === 'you' ? 'You' : 'dotUI'}:
+              </span>{' '}
+              {m.text}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 rounded-full border bg-card/95 p-1.5 pl-3 shadow-lg backdrop-blur">
+        <SparklesIcon className="size-4 shrink-0 text-primary" />
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') run(text)
+          }}
+          placeholder="Tell dotUI what to change…"
+          aria-label="Refine the design system"
+          className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-fg-muted"
+        />
+        <Button
+          size="sm"
+          isIconOnly
+          aria-label="Send"
+          onPress={() => run(text)}
+        >
+          <ArrowUpIcon />
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap justify-center gap-1.5">
+        {REFINE_CHIPS.map((chip) => (
+          <ButtonPrimitives.Button
+            key={chip}
+            onPress={() => run(chip)}
+            className="rounded-full border bg-card/95 px-2.5 py-1 text-xs text-fg-muted shadow-sm focus-reset backdrop-blur transition-colors hover:text-fg focus-visible:focus-ring"
+          >
+            {chip}
+          </ButtonPrimitives.Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/ai-focus.ts
+++ b/www/src/modules/create/studio/ai-focus.ts
@@ -1,0 +1,21 @@
+/**
+ * Tiny decoupled bridge between the top bar's "Ask dotUI" command (and its ⌘K
+ * shortcut) and the docked AI bar input. The bar registers a focuser on mount;
+ * the command fires it. Keeps the two zones independent — no prop-drilling a ref
+ * up through the studio shell.
+ */
+
+type Focuser = () => void
+
+let focuser: Focuser | null = null
+
+export function registerAiFocuser(fn: Focuser): () => void {
+  focuser = fn
+  return () => {
+    if (focuser === fn) focuser = null
+  }
+}
+
+export function focusAiBar(): void {
+  focuser?.()
+}

--- a/www/src/modules/create/studio/axis-panels.tsx
+++ b/www/src/modules/create/studio/axis-panels.tsx
@@ -1,0 +1,530 @@
+'use client'
+
+import { type ReactNode, useState } from 'react'
+import { PlayIcon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+import { Label } from '@/registry/ui/field'
+import { Slider, SliderControl, SliderOutput } from '@/registry/ui/slider'
+import { Switch } from '@/registry/ui/switch'
+import { ToggleButton } from '@/registry/ui/toggle-button'
+import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
+
+/* ----------------------------------------------------------------------------
+ * The new design axes. These are UI-only in this experiment: each control is
+ * fully interactive (local state) so the panel feels real, but the values are
+ * not yet wired to live preview tokens — that's a follow-up. The dashed note
+ * keeps that honest, mirroring the lab's live/stub distinction.
+ * -------------------------------------------------------------------------- */
+
+function ProposalNote() {
+  return (
+    <p className="rounded-md border border-dashed bg-neutral/40 px-2 py-1.5 text-[11px] leading-snug text-fg-muted">
+      New axis — interactive here, wired to live tokens in a follow-up.
+    </p>
+  )
+}
+
+/* ------------------------------ Shared rows ------------------------------ */
+
+export function SegmentedRow<T extends string>({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string
+  value: T
+  onChange: (value: T) => void
+  options: ReadonlyArray<{ value: T; label: string }>
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-medium text-fg-muted">{label}</span>
+      <ToggleButtonGroup
+        aria-label={label}
+        selectionMode="single"
+        disallowEmptySelection
+        size="sm"
+        selectedKeys={[value]}
+        onSelectionChange={(keys) => {
+          const next = keys.values().next().value
+          if (next) onChange(next as T)
+        }}
+        className="*:flex-1"
+      >
+        {options.map((opt) => (
+          <ToggleButton key={opt.value} id={opt.value}>
+            {opt.label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+    </div>
+  )
+}
+
+export function SliderRow({
+  label,
+  value,
+  minValue,
+  maxValue,
+  step = 1,
+  format,
+  onChange,
+}: {
+  label: string
+  value: number
+  minValue: number
+  maxValue: number
+  step?: number
+  format?: (value: number) => string
+  onChange: (value: number) => void
+}) {
+  return (
+    <Slider
+      aria-label={label}
+      value={value}
+      minValue={minValue}
+      maxValue={maxValue}
+      step={step}
+      onChange={(v) => onChange(typeof v === 'number' ? v : (v[0] ?? minValue))}
+    >
+      <div className="flex items-center justify-between text-xs">
+        <Label>{label}</Label>
+        {format ? (
+          <SliderOutput className="text-fg-muted tabular-nums">
+            {format(value)}
+          </SliderOutput>
+        ) : (
+          <SliderOutput className="text-fg-muted tabular-nums" />
+        )}
+      </div>
+      <SliderControl />
+    </Slider>
+  )
+}
+
+export function SwitchRow({
+  label,
+  description,
+  value,
+  onChange,
+}: {
+  label: string
+  description?: string
+  value: boolean
+  onChange: (value: boolean) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col">
+        <span className="text-xs font-medium text-fg-muted">{label}</span>
+        {description && (
+          <span className="text-[11px] text-fg-muted/60">{description}</span>
+        )}
+      </div>
+      <Switch isSelected={value} onChange={onChange} aria-label={label} />
+    </div>
+  )
+}
+
+function SwatchRow({
+  label,
+  colors,
+  value,
+  onChange,
+}: {
+  label: string
+  colors: readonly string[]
+  value: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-medium text-fg-muted">{label}</span>
+      <div className="flex flex-wrap gap-2">
+        {colors.map((c) => (
+          <button
+            key={c}
+            type="button"
+            aria-label={c}
+            onClick={() => onChange(c)}
+            style={{ backgroundColor: c }}
+            className={cn(
+              'size-6 rounded-md border focus-reset focus-visible:focus-ring',
+              value === c && 'ring-2 ring-fg ring-offset-2 ring-offset-card',
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function PanelShell({ children }: { children: ReactNode }) {
+  return <div className="flex flex-col gap-5">{children}</div>
+}
+
+/* ------------------------------ Elevation ------------------------------ */
+
+type ElevationPreset = 'none' | 'subtle' | 'floating' | 'dramatic'
+
+const ELEVATION_SHADOWS: Record<ElevationPreset, { y: number; blur: number }> =
+  {
+    none: { y: 0, blur: 0 },
+    subtle: { y: 1, blur: 2 },
+    floating: { y: 8, blur: 24 },
+    dramatic: { y: 24, blur: 48 },
+  }
+
+export function ElevationPanel() {
+  const [preset, setPreset] = useState<ElevationPreset>('subtle')
+  const [intensity, setIntensity] = useState(40)
+  const [tint, setTint] = useState('#000000')
+  const { y, blur } = ELEVATION_SHADOWS[preset]
+  const alpha = (intensity / 100) * 0.32
+  const shadow =
+    preset === 'none' ? 'none' : `0 ${y}px ${blur}px rgba(0,0,0,${alpha})`
+
+  return (
+    <PanelShell>
+      <ProposalNote />
+      <SegmentedRow
+        label="Shadow preset"
+        value={preset}
+        onChange={setPreset}
+        options={[
+          { value: 'none', label: 'None' },
+          { value: 'subtle', label: 'Subtle' },
+          { value: 'floating', label: 'Float' },
+          { value: 'dramatic', label: 'Drama' },
+        ]}
+      />
+      <SliderRow
+        label="Intensity"
+        value={intensity}
+        minValue={0}
+        maxValue={100}
+        format={(v) => `${Math.round(v)}%`}
+        onChange={setIntensity}
+      />
+      <SwatchRow
+        label="Tint"
+        colors={['#000000', '#1e293b', '#3b1d60', '#5b3a1d']}
+        value={tint}
+        onChange={setTint}
+      />
+      <div className="flex h-24 items-center justify-center rounded-lg border bg-bg">
+        <div
+          className="size-16 rounded-lg border bg-card"
+          style={{ boxShadow: shadow }}
+        />
+      </div>
+    </PanelShell>
+  )
+}
+
+/* -------------------------------- Motion -------------------------------- */
+
+type EasingId = 'ease' | 'spring' | 'linear'
+
+const EASINGS: Record<EasingId, string> = {
+  ease: 'cubic-bezier(0.32, 0.72, 0, 1)',
+  spring: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+  linear: 'linear',
+}
+
+export function MotionPanel() {
+  const [duration, setDuration] = useState(1)
+  const [easing, setEasing] = useState<EasingId>('spring')
+  const [hoverLift, setHoverLift] = useState(true)
+  const [reduce, setReduce] = useState(true)
+  const [run, setRun] = useState(false)
+
+  return (
+    <PanelShell>
+      <ProposalNote />
+      <SliderRow
+        label="Duration scale"
+        value={duration}
+        minValue={0.5}
+        maxValue={2}
+        step={0.05}
+        format={(v) => `${v.toFixed(2)}×`}
+        onChange={setDuration}
+      />
+      <SegmentedRow
+        label="Easing"
+        value={easing}
+        onChange={setEasing}
+        options={[
+          { value: 'ease', label: 'Ease' },
+          { value: 'spring', label: 'Spring' },
+          { value: 'linear', label: 'Linear' },
+        ]}
+      />
+      <div className="flex items-center gap-3">
+        <div className="relative h-9 flex-1 overflow-hidden rounded-lg border bg-bg">
+          <div
+            className="absolute top-1/2 size-3.5 -translate-y-1/2 rounded-full bg-primary"
+            style={{
+              left: run ? 'calc(100% - 22px)' : '8px',
+              transitionProperty: 'left',
+              transitionDuration: `${0.7 * duration}s`,
+              transitionTimingFunction: EASINGS[easing],
+            }}
+          />
+        </div>
+        <Button size="sm" onPress={() => setRun((r) => !r)}>
+          <PlayIcon />
+          Play
+        </Button>
+      </div>
+      <SwitchRow label="Hover lift" value={hoverLift} onChange={setHoverLift} />
+      <SwitchRow
+        label="Respect reduced motion"
+        description="Honor prefers-reduced-motion"
+        value={reduce}
+        onChange={setReduce}
+      />
+    </PanelShell>
+  )
+}
+
+/* -------------------------------- Surface -------------------------------- */
+
+export function SurfacePanel() {
+  const [glass, setGlass] = useState(true)
+  const [blur, setBlur] = useState(8)
+  const [tint, setTint] = useState(0)
+  const [background, setBackground] = useState('solid')
+  const [noise, setNoise] = useState(false)
+
+  return (
+    <PanelShell>
+      <ProposalNote />
+      <SwitchRow
+        label="Translucent overlays"
+        description="Glassy menus and popovers"
+        value={glass}
+        onChange={setGlass}
+      />
+      <SliderRow
+        label="Backdrop blur"
+        value={blur}
+        minValue={0}
+        maxValue={24}
+        format={(v) => `${Math.round(v)}px`}
+        onChange={setBlur}
+      />
+      <SliderRow
+        label="Surface tint"
+        value={tint}
+        minValue={0}
+        maxValue={20}
+        format={(v) => `${Math.round(v)}%`}
+        onChange={setTint}
+      />
+      <SegmentedRow
+        label="Background"
+        value={background}
+        onChange={setBackground}
+        options={[
+          { value: 'solid', label: 'Solid' },
+          { value: 'dots', label: 'Dots' },
+          { value: 'lines', label: 'Lines' },
+          { value: 'mesh', label: 'Mesh' },
+        ]}
+      />
+      <SwitchRow label="Noise texture" value={noise} onChange={setNoise} />
+    </PanelShell>
+  )
+}
+
+/* --------------------------------- Focus --------------------------------- */
+
+export function FocusPanel() {
+  const [style, setStyle] = useState('ring')
+  const [width, setWidth] = useState(2)
+  const [offset, setOffset] = useState(2)
+  const [color, setColor] = useState('accent')
+
+  const ringColor =
+    color === 'accent' ? 'var(--color-accent)' : 'var(--color-fg)'
+  const ring =
+    style === 'glow'
+      ? `0 0 0 ${width + 2}px color-mix(in oklab, ${ringColor} 40%, transparent)`
+      : `0 0 0 ${offset}px var(--color-card), 0 0 0 ${offset + width}px ${ringColor}`
+
+  return (
+    <PanelShell>
+      <ProposalNote />
+      <SegmentedRow
+        label="Ring style"
+        value={style}
+        onChange={setStyle}
+        options={[
+          { value: 'ring', label: 'Ring' },
+          { value: 'outline', label: 'Outline' },
+          { value: 'glow', label: 'Glow' },
+        ]}
+      />
+      <SliderRow
+        label="Width"
+        value={width}
+        minValue={1}
+        maxValue={4}
+        format={(v) => `${Math.round(v)}px`}
+        onChange={setWidth}
+      />
+      <SliderRow
+        label="Offset"
+        value={offset}
+        minValue={0}
+        maxValue={4}
+        format={(v) => `${Math.round(v)}px`}
+        onChange={setOffset}
+      />
+      <SegmentedRow
+        label="Color"
+        value={color}
+        onChange={setColor}
+        options={[
+          { value: 'accent', label: 'Accent' },
+          { value: 'neutral', label: 'Neutral' },
+        ]}
+      />
+      <div className="flex h-20 items-center justify-center rounded-lg border bg-bg">
+        <Button size="sm" style={{ boxShadow: ring }}>
+          Focused
+        </Button>
+      </div>
+    </PanelShell>
+  )
+}
+
+/* -------------------------------- States -------------------------------- */
+
+export function StatesPanel() {
+  const [hover, setHover] = useState('tint')
+  const [press, setPress] = useState(98)
+  const [transition, setTransition] = useState('snappy')
+  const [dim, setDim] = useState(true)
+
+  return (
+    <PanelShell>
+      <ProposalNote />
+      <SegmentedRow
+        label="Hover effect"
+        value={hover}
+        onChange={setHover}
+        options={[
+          { value: 'lift', label: 'Lift' },
+          { value: 'tint', label: 'Tint' },
+          { value: 'underline', label: 'Line' },
+          { value: 'none', label: 'None' },
+        ]}
+      />
+      <SliderRow
+        label="Press scale"
+        value={press}
+        minValue={92}
+        maxValue={100}
+        format={(v) => `${Math.round(v)}%`}
+        onChange={setPress}
+      />
+      <SegmentedRow
+        label="Transition"
+        value={transition}
+        onChange={setTransition}
+        options={[
+          { value: 'instant', label: 'Instant' },
+          { value: 'snappy', label: 'Snappy' },
+          { value: 'smooth', label: 'Smooth' },
+        ]}
+      />
+      <SwitchRow label="Disabled dims controls" value={dim} onChange={setDim} />
+    </PanelShell>
+  )
+}
+
+/* ----------------------- Extras for existing axes ----------------------- */
+
+export function ShapeExtras() {
+  const [corner, setCorner] = useState('rounded')
+  const [borderWidth, setBorderWidth] = useState(1)
+  const [hairlines, setHairlines] = useState('solid')
+
+  return (
+    <>
+      <SegmentedRow
+        label="Corner style"
+        value={corner}
+        onChange={setCorner}
+        options={[
+          { value: 'sharp', label: 'Sharp' },
+          { value: 'rounded', label: 'Rounded' },
+          { value: 'pill', label: 'Pill' },
+        ]}
+      />
+      <SliderRow
+        label="Border width"
+        value={borderWidth}
+        minValue={0}
+        maxValue={3}
+        step={0.5}
+        format={(v) => `${v}px`}
+        onChange={setBorderWidth}
+      />
+      <SegmentedRow
+        label="Hairlines"
+        value={hairlines}
+        onChange={setHairlines}
+        options={[
+          { value: 'solid', label: 'Solid' },
+          { value: 'hairline', label: 'Hairline' },
+          { value: 'none', label: 'None' },
+        ]}
+      />
+      <ProposalNote />
+    </>
+  )
+}
+
+export function SpacingExtras() {
+  const [unit, setUnit] = useState(4)
+  const [rhythm, setRhythm] = useState(1)
+  const [controlHeight, setControlHeight] = useState(36)
+
+  return (
+    <>
+      <SliderRow
+        label="Base unit"
+        value={unit}
+        minValue={2}
+        maxValue={8}
+        format={(v) => `${Math.round(v)}px`}
+        onChange={setUnit}
+      />
+      <SliderRow
+        label="Gap rhythm"
+        value={rhythm}
+        minValue={0.75}
+        maxValue={1.5}
+        step={0.05}
+        format={(v) => `${v.toFixed(2)}×`}
+        onChange={setRhythm}
+      />
+      <SliderRow
+        label="Control height"
+        value={controlHeight}
+        minValue={28}
+        maxValue={44}
+        format={(v) => `${Math.round(v)}px`}
+        onChange={setControlHeight}
+      />
+      <ProposalNote />
+    </>
+  )
+}

--- a/www/src/modules/create/studio/index.tsx
+++ b/www/src/modules/create/studio/index.tsx
@@ -8,6 +8,7 @@ import { PreviewPanel } from '../preview/preview-panel'
 import { AiBar } from './ai-bar'
 import { Inspector } from './inspector'
 import { Rail, type DomainId } from './rail'
+import { StudioTopBar } from './top-bar'
 
 const routeApi = getRouteApi('/_app/create')
 
@@ -54,6 +55,10 @@ export function StudioExperience() {
 
   return (
     <>
+      {/* The builder's own top bar — replaces the global site nav on /create,
+          staying visually continuous with it (same height, Logo, ThemeToggle). */}
+      <StudioTopBar canUndo={canUndo} onUndo={undo} />
+
       {/* Desktop-only: the three-zone studio needs width the shipped /create
           doesn't, so below `lg` it points to a wider screen rather than cramming. */}
       <div className="flex h-[calc(100svh-var(--header-height))] flex-col items-center justify-center gap-2 p-8 text-center lg:hidden">
@@ -66,9 +71,9 @@ export function StudioExperience() {
         </p>
       </div>
 
-      <div className="hidden h-[calc(100svh-var(--header-height))] min-h-0 flex-1 gap-3 p-4 pt-2 lg:flex lg:gap-4 lg:p-6 lg:pt-2">
+      <div className="hidden h-[calc(100svh-var(--header-height))] min-h-0 flex-1 gap-3 p-4 pt-4 lg:flex lg:gap-4 lg:p-6 lg:pt-4">
         <Rail domain={domain} onSelect={setDomain} />
-        <Inspector domain={domain} canUndo={canUndo} onUndo={undo} />
+        <Inspector domain={domain} />
         <div className="relative flex min-w-0 flex-1 flex-col">
           <PreviewPanel className="flex-1" />
           <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex justify-center p-4">

--- a/www/src/modules/create/studio/index.tsx
+++ b/www/src/modules/create/studio/index.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+import { SparklesIcon } from 'lucide-react'
+
+import { PreviewPanel } from '../preview/preview-panel'
+import { AiBar } from './ai-bar'
+import { Inspector } from './inspector'
+import { Rail, type DomainId } from './rail'
+
+const routeApi = getRouteApi('/_app/create')
+
+/**
+ * The `/create?studio` experience: a canvas-first builder shell — a persistent
+ * axis rail, a wider inspector on a macro→micro spine, the live preview, and a
+ * docked AI bar — composed from the existing config panels and preview iframe.
+ */
+export function StudioExperience() {
+  const [domain, setDomain] = useState<DomainId>('style')
+
+  // Undo history. Every design change is encoded into `?preset=` with
+  // `replace: true`, so the browser back button can't step through edits — we
+  // keep our own stack and walk back through it (same approach as the shipped
+  // customizer panel).
+  const { preset } = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+  const historyRef = useRef<(string | undefined)[]>([])
+  const prevPresetRef = useRef<string | undefined>(preset)
+  const isUndoingRef = useRef(false)
+  const [canUndo, setCanUndo] = useState(false)
+
+  useEffect(() => {
+    if (prevPresetRef.current === preset) return
+    if (isUndoingRef.current) {
+      isUndoingRef.current = false
+    } else {
+      historyRef.current.push(prevPresetRef.current)
+      setCanUndo(true)
+    }
+    prevPresetRef.current = preset
+  }, [preset])
+
+  function undo() {
+    if (historyRef.current.length === 0) return
+    const previous = historyRef.current.pop()
+    isUndoingRef.current = true
+    navigate({
+      search: (prev) => ({ ...prev, preset: previous }),
+      replace: true,
+    })
+    setCanUndo(historyRef.current.length > 0)
+  }
+
+  return (
+    <>
+      {/* Desktop-only: the three-zone studio needs width the shipped /create
+          doesn't, so below `lg` it points to a wider screen rather than cramming. */}
+      <div className="flex h-[calc(100svh-var(--header-height))] flex-col items-center justify-center gap-2 p-8 text-center lg:hidden">
+        <SparklesIcon className="size-6 text-primary" />
+        <p className="text-sm font-medium">
+          Studio is built for a wider screen
+        </p>
+        <p className="max-w-xs text-sm text-fg-muted">
+          Open this experiment on a desktop, or use the standard editor for now.
+        </p>
+      </div>
+
+      <div className="hidden h-[calc(100svh-var(--header-height))] min-h-0 flex-1 gap-3 p-4 pt-2 lg:flex lg:gap-4 lg:p-6 lg:pt-2">
+        <Rail domain={domain} onSelect={setDomain} />
+        <Inspector domain={domain} canUndo={canUndo} onUndo={undo} />
+        <div className="relative flex min-w-0 flex-1 flex-col">
+          <PreviewPanel className="flex-1" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex justify-center p-4">
+            <AiBar className="pointer-events-auto" />
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/www/src/modules/create/studio/inspector.tsx
+++ b/www/src/modules/create/studio/inspector.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronLeftIcon, ShuffleIcon, Undo2Icon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+
+import { ChartColorsConfig } from '../chart-colors'
+import { CodeOptionsDialog } from '../code-options'
+import { ColorsConfig } from '../colors'
+import {
+  AllComponentsView,
+  ComponentDetailView,
+  GroupDetailView,
+  getComponentDisplayName,
+  getGroupDisplayName,
+  isGroupId,
+} from '../components'
+import {
+  CURSOR_DISABLED_VAR,
+  CURSOR_INTERACTIVE_VAR,
+  CursorConfig,
+  DEFAULT_CURSOR_DISABLED,
+  DEFAULT_CURSOR_INTERACTIVE,
+} from '../cursor'
+import { ExportFooter } from '../export'
+import { IconographyConfig } from '../iconography'
+import {
+  DEFAULT_RADIUS_FACTOR,
+  DensityConfig,
+  RADIUS_FACTOR_VAR,
+  RadiusConfig,
+} from '../layout'
+import { useDesignSystem } from '../preset'
+import { TypographyConfig } from '../typography'
+import {
+  ElevationPanel,
+  FocusPanel,
+  MotionPanel,
+  ShapeExtras,
+  SpacingExtras,
+  StatesPanel,
+  SurfacePanel,
+} from './axis-panels'
+import { DOMAIN_LABELS, type DomainId } from './rail'
+import { StylePanel } from './style-panel'
+import { shuffleSystem } from './vibes'
+
+export function Inspector({
+  domain,
+  canUndo,
+  onUndo,
+  className,
+}: {
+  domain: DomainId
+  canUndo: boolean
+  onUndo: () => void
+  className?: string
+}) {
+  const { setDesignSystem } = useDesignSystem()
+
+  return (
+    <div
+      className={cn(
+        'flex w-[320px] shrink-0 flex-col rounded-xl border bg-card max-lg:w-[280px]',
+        className,
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2 border-b p-2 pl-3">
+        <span className="text-sm font-medium">{DOMAIN_LABELS[domain]}</span>
+        <div className="flex items-center gap-1">
+          <Button
+            size="sm"
+            isIconOnly
+            aria-label="Shuffle"
+            onPress={() => shuffleSystem(setDesignSystem)}
+          >
+            <ShuffleIcon />
+          </Button>
+          <Button
+            size="sm"
+            isIconOnly
+            aria-label="Undo"
+            onPress={onUndo}
+            isDisabled={!canUndo}
+          >
+            <Undo2Icon />
+          </Button>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="scrollbar-none flex-1 overflow-y-auto px-3 pt-4 pb-4">
+        <InspectorBody domain={domain} />
+      </div>
+
+      {/* Footer */}
+      <div className="flex flex-col gap-2 border-t p-3">
+        <CodeOptionsDialog />
+        <ExportFooter />
+      </div>
+    </div>
+  )
+}
+
+function InspectorBody({ domain }: { domain: DomainId }) {
+  const { designSystem, setDensity, setToken } = useDesignSystem()
+
+  const radiusFactor =
+    designSystem.tokens[RADIUS_FACTOR_VAR] ?? DEFAULT_RADIUS_FACTOR
+  const cursorInteractive =
+    designSystem.tokens[CURSOR_INTERACTIVE_VAR] ?? DEFAULT_CURSOR_INTERACTIVE
+  const cursorDisabled =
+    designSystem.tokens[CURSOR_DISABLED_VAR] ?? DEFAULT_CURSOR_DISABLED
+
+  switch (domain) {
+    case 'style':
+      return <StylePanel />
+    case 'color':
+      return <ColorsConfig />
+    case 'typography':
+      return <TypographyConfig />
+    case 'icons':
+      return <IconographyConfig />
+    case 'shape':
+      return (
+        <div className="flex flex-col gap-5">
+          <RadiusConfig
+            value={radiusFactor}
+            onChange={(v) => setToken(RADIUS_FACTOR_VAR, v)}
+          />
+          <ShapeExtras />
+        </div>
+      )
+    case 'spacing':
+      return (
+        <div className="flex flex-col gap-5">
+          <DensityConfig value={designSystem.density} onChange={setDensity} />
+          <SpacingExtras />
+        </div>
+      )
+    case 'elevation':
+      return <ElevationPanel />
+    case 'motion':
+      return <MotionPanel />
+    case 'surface':
+      return <SurfacePanel />
+    case 'focus':
+      return <FocusPanel />
+    case 'states':
+      return <StatesPanel />
+    case 'cursor':
+      return (
+        <CursorConfig
+          interactive={cursorInteractive}
+          disabled={cursorDisabled}
+          onChange={setToken}
+        />
+      )
+    case 'components':
+      return <ComponentsPanel />
+    case 'charts':
+      return <ChartColorsConfig />
+    default:
+      return null
+  }
+}
+
+function ComponentsPanel() {
+  const { designSystem, setComponentParam } = useDesignSystem()
+  const [stack, setStack] = useState<string[]>([])
+  const top = stack[stack.length - 1]
+
+  if (!top) {
+    return <AllComponentsView onSelect={(comp) => setStack([comp])} />
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="mb-1 -ml-1 flex items-center gap-2">
+        <Button
+          variant="quiet"
+          size="sm"
+          isIconOnly
+          aria-label="Back"
+          onPress={() => setStack((s) => s.slice(0, -1))}
+          className="size-6"
+        >
+          <ChevronLeftIcon />
+        </Button>
+        <h3 className="text-sm font-medium">
+          {isGroupId(top)
+            ? getGroupDisplayName(top)
+            : getComponentDisplayName(top)}
+        </h3>
+      </div>
+      {isGroupId(top) ? (
+        <GroupDetailView
+          groupName={top}
+          onSelectComponent={(comp) => setStack((s) => [...s, comp])}
+        />
+      ) : (
+        <ComponentDetailView
+          componentName={top}
+          selectedParams={designSystem.componentParams[top] ?? {}}
+          onParamChange={(paramName, value) =>
+            setComponentParam(top, paramName, value)
+          }
+        />
+      )}
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/inspector.tsx
+++ b/www/src/modules/create/studio/inspector.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { ChevronLeftIcon, ShuffleIcon, Undo2Icon } from 'lucide-react'
+import { ChevronLeftIcon } from 'lucide-react'
 
 import { cn } from '@/registry/lib/utils'
 import { Button } from '@/registry/ui/button'
@@ -45,21 +45,14 @@ import {
 } from './axis-panels'
 import { DOMAIN_LABELS, type DomainId } from './rail'
 import { StylePanel } from './style-panel'
-import { shuffleSystem } from './vibes'
 
 export function Inspector({
   domain,
-  canUndo,
-  onUndo,
   className,
 }: {
   domain: DomainId
-  canUndo: boolean
-  onUndo: () => void
   className?: string
 }) {
-  const { setDesignSystem } = useDesignSystem()
-
   return (
     <div
       className={cn(
@@ -67,28 +60,10 @@ export function Inspector({
         className,
       )}
     >
-      {/* Header */}
-      <div className="flex items-center justify-between gap-2 border-b p-2 pl-3">
+      {/* Header — re-roll + undo live in the top bar so they act on the whole
+          system, not per-axis; this just labels the active axis. */}
+      <div className="flex items-center gap-2 border-b p-2.5 pl-3">
         <span className="text-sm font-medium">{DOMAIN_LABELS[domain]}</span>
-        <div className="flex items-center gap-1">
-          <Button
-            size="sm"
-            isIconOnly
-            aria-label="Shuffle"
-            onPress={() => shuffleSystem(setDesignSystem)}
-          >
-            <ShuffleIcon />
-          </Button>
-          <Button
-            size="sm"
-            isIconOnly
-            aria-label="Undo"
-            onPress={onUndo}
-            isDisabled={!canUndo}
-          >
-            <Undo2Icon />
-          </Button>
-        </div>
       </div>
 
       {/* Body */}

--- a/www/src/modules/create/studio/rail.tsx
+++ b/www/src/modules/create/studio/rail.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import {
+  ActivityIcon,
+  BarChart3Icon,
+  BlendIcon,
+  ComponentIcon,
+  FocusIcon,
+  FrameIcon,
+  LayersIcon,
+  type LucideIcon,
+  MousePointer2Icon,
+  MousePointerClickIcon,
+  PaletteIcon,
+  RulerIcon,
+  ShapesIcon,
+  SparklesIcon,
+  TypeIcon,
+} from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+
+export type DomainId =
+  | 'style'
+  | 'color'
+  | 'typography'
+  | 'icons'
+  | 'shape'
+  | 'spacing'
+  | 'elevation'
+  | 'motion'
+  | 'surface'
+  | 'focus'
+  | 'states'
+  | 'cursor'
+  | 'components'
+  | 'charts'
+
+export const DOMAINS: { id: DomainId; label: string; icon: LucideIcon }[] = [
+  { id: 'style', label: 'Style', icon: SparklesIcon },
+  { id: 'color', label: 'Color', icon: PaletteIcon },
+  { id: 'typography', label: 'Type', icon: TypeIcon },
+  { id: 'icons', label: 'Icons', icon: ShapesIcon },
+  { id: 'shape', label: 'Shape', icon: FrameIcon },
+  { id: 'spacing', label: 'Spacing', icon: RulerIcon },
+  { id: 'elevation', label: 'Elevation', icon: LayersIcon },
+  { id: 'motion', label: 'Motion', icon: ActivityIcon },
+  { id: 'surface', label: 'Surface', icon: BlendIcon },
+  { id: 'focus', label: 'Focus', icon: FocusIcon },
+  { id: 'states', label: 'States', icon: MousePointerClickIcon },
+  { id: 'cursor', label: 'Cursor', icon: MousePointer2Icon },
+  { id: 'components', label: 'Parts', icon: ComponentIcon },
+  { id: 'charts', label: 'Charts', icon: BarChart3Icon },
+]
+
+export const DOMAIN_LABELS = Object.fromEntries(
+  DOMAINS.map((d) => [d.id, d.label]),
+) as Record<DomainId, string>
+
+export function Rail({
+  domain,
+  onSelect,
+}: {
+  domain: DomainId
+  onSelect: (domain: DomainId) => void
+}) {
+  return (
+    <nav
+      aria-label="Design axes"
+      className="scrollbar-none flex w-16 shrink-0 flex-col gap-1 overflow-y-auto rounded-xl border bg-card p-1.5"
+    >
+      {DOMAINS.map((d) => {
+        const active = d.id === domain
+        return (
+          <ButtonPrimitives.Button
+            key={d.id}
+            onPress={() => onSelect(d.id)}
+            className={cn(
+              'flex flex-col items-center gap-1 rounded-lg px-1 py-2 text-[10px] focus-reset transition-colors focus-visible:focus-ring',
+              active
+                ? 'bg-primary text-fg-on-primary'
+                : 'text-fg-muted hover:bg-neutral hover:text-fg',
+            )}
+          >
+            <d.icon className="size-4" />
+            <span className="w-full truncate text-center">{d.label}</span>
+          </ButtonPrimitives.Button>
+        )
+      })}
+    </nav>
+  )
+}

--- a/www/src/modules/create/studio/style-panel.tsx
+++ b/www/src/modules/create/studio/style-panel.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { useState } from 'react'
+import { ArrowUpIcon, ShuffleIcon } from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+
+import {
+  DEFAULT_RADIUS_FACTOR,
+  RADIUS_FACTOR_VAR,
+  RadiusConfig,
+} from '../layout'
+import { useDesignSystem } from '../preset'
+import type { Density } from '../preset'
+import { SegmentedRow } from './axis-panels'
+import {
+  type Vibe,
+  VIBES,
+  applyVibe,
+  shuffleSystem,
+  vibeFromPrompt,
+} from './vibes'
+
+const PROMPT_CHIPS = [
+  'Warm editorial fintech',
+  'Linear-style minimal',
+  'Playful and rounded',
+  'Calm wellness app',
+  'High-contrast dashboard',
+  'Bold and vivid',
+]
+
+const QUICK_ACCENTS = [
+  '#6366f1',
+  '#2563eb',
+  '#0ea5e9',
+  '#14b8a6',
+  '#22c55e',
+  '#f59e0b',
+  '#ef4444',
+  '#ec4899',
+  '#8b5cf6',
+  '#171717',
+]
+
+const DENSITY_OPTIONS = [
+  { value: 'compact' as Density, label: 'Compact' },
+  { value: 'default' as Density, label: 'Default' },
+  { value: 'comfortable' as Density, label: 'Comfortable' },
+]
+
+export function StylePanel() {
+  const { designSystem, setDesignSystem, setDensity, setToken, setColorSeed } =
+    useDesignSystem()
+  const [prompt, setPrompt] = useState('')
+  const [changelog, setChangelog] = useState<string[] | null>(null)
+
+  const radiusFactor =
+    designSystem.tokens[RADIUS_FACTOR_VAR] ?? DEFAULT_RADIUS_FACTOR
+  const accent =
+    designSystem.color?.seeds.accent ?? DEFAULT_COLOR_CONFIG.seeds.accent
+
+  function generate(text: string) {
+    if (!text.trim()) return
+    apply(vibeFromPrompt(text))
+  }
+
+  function apply(vibe: Vibe) {
+    applyVibe(setDesignSystem, vibe)
+    setChangelog(['Accent', 'Radius', 'Density'])
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-xs text-fg-muted">
+        Set the whole system at once, then refine any axis from the rail.
+      </p>
+
+      {/* Prompt → system */}
+      <div className="flex flex-col gap-2">
+        <div className="relative">
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                generate(prompt)
+              }
+            }}
+            rows={2}
+            placeholder="Describe a brand, paste a URL, or drop a screenshot…"
+            className="w-full resize-none rounded-lg border bg-field p-2.5 pr-10 text-sm outline-none placeholder:text-fg-muted focus-visible:focus-ring"
+          />
+          <Button
+            size="sm"
+            isIconOnly
+            aria-label="Generate system"
+            variant="primary"
+            onPress={() => generate(prompt)}
+            className="absolute right-1.5 bottom-1.5"
+          >
+            <ArrowUpIcon />
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {PROMPT_CHIPS.map((chip) => (
+            <ButtonPrimitives.Button
+              key={chip}
+              onPress={() => {
+                setPrompt(chip)
+                generate(chip)
+              }}
+              className="rounded-full border bg-card px-2.5 py-1 text-xs text-fg-muted focus-reset transition-colors hover:text-fg focus-visible:focus-ring"
+            >
+              {chip}
+            </ButtonPrimitives.Button>
+          ))}
+        </div>
+        {changelog && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-[11px] text-fg-muted">AI set</span>
+            {changelog.map((axis) => (
+              <span
+                key={axis}
+                className="rounded-md bg-success-muted px-1.5 py-0.5 text-[11px] text-fg-success"
+              >
+                {axis}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Vibe presets */}
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-fg-muted">Vibe</span>
+        <div className="grid grid-cols-2 gap-2">
+          {VIBES.map((vibe) => {
+            const active = accent.toLowerCase() === vibe.accent.toLowerCase()
+            return (
+              <ButtonPrimitives.Button
+                key={vibe.id}
+                onPress={() => apply(vibe)}
+                className={cn(
+                  'flex items-center gap-2 rounded-lg border p-2 text-left focus-reset transition-colors hover:bg-neutral focus-visible:focus-ring',
+                  active && 'border-border-focus bg-accent-muted',
+                )}
+              >
+                <span
+                  className="size-4 shrink-0 rounded-md border"
+                  style={{ backgroundColor: vibe.accent }}
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block text-xs font-medium">
+                    {vibe.label}
+                  </span>
+                  <span className="block truncate text-[10px] text-fg-muted">
+                    {vibe.description}
+                  </span>
+                </span>
+              </ButtonPrimitives.Button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Quick accent */}
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-fg-muted">Accent</span>
+        <div className="flex flex-wrap gap-2">
+          {QUICK_ACCENTS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              aria-label={c}
+              onClick={() => setColorSeed('accent', c)}
+              style={{ backgroundColor: c }}
+              className={cn(
+                'size-6 rounded-md border focus-reset focus-visible:focus-ring',
+                accent.toLowerCase() === c.toLowerCase() &&
+                  'ring-2 ring-fg ring-offset-2 ring-offset-card',
+              )}
+            />
+          ))}
+        </div>
+      </div>
+
+      <RadiusConfig
+        value={radiusFactor}
+        onChange={(v) => setToken(RADIUS_FACTOR_VAR, v)}
+      />
+
+      <SegmentedRow
+        label="Density"
+        value={designSystem.density}
+        onChange={setDensity}
+        options={DENSITY_OPTIONS}
+      />
+
+      <Button onPress={() => shuffleSystem(setDesignSystem)}>
+        <ShuffleIcon />
+        Surprise me
+      </Button>
+    </div>
+  )
+}

--- a/www/src/modules/create/studio/top-bar.tsx
+++ b/www/src/modules/create/studio/top-bar.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useEffect } from 'react'
+import { ShuffleIcon, SparklesIcon, Undo2Icon } from 'lucide-react'
+
+import { siteConfig } from '@/config/site'
+import { Button, buttonStyles } from '@/registry/ui/button'
+import { Kbd } from '@/registry/ui/kbd'
+import { GitHubIcon } from '@/components/icons/github'
+import { Logo } from '@/components/layout/logo'
+import { ThemeToggle } from '@/components/theme-toggle'
+
+import { useDesignSystem } from '../preset'
+import { focusAiBar } from './ai-focus'
+import { shuffleSystem } from './vibes'
+
+/**
+ * The studio's own top bar, in place of the global site nav on `/create`. It
+ * sits at the shared `--header-height` and reuses the site Logo + ThemeToggle +
+ * GitHub link so stepping into the builder reads as the same product in a
+ * focused mode — not a separate app. The Logo links home for a two-way exit.
+ *
+ * The site nav links + "Search docs" are dropped (irrelevant inside the
+ * builder) and replaced by this builder's genuinely-primary actions: undo,
+ * re-roll, and the "Ask dotUI" command that focuses the docked AI bar (⌘K).
+ */
+export function StudioTopBar({
+  canUndo,
+  onUndo,
+}: {
+  canUndo: boolean
+  onUndo: () => void
+}) {
+  const { setDesignSystem } = useDesignSystem()
+
+  // ⌘K / Ctrl+K jumps focus to the docked AI bar — the builder's command surface.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        focusAiBar()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  return (
+    <header className="sticky top-0 z-30 flex h-(--header-height) w-full shrink-0 items-center justify-between gap-3 border-b bg-bg/80 px-4 backdrop-blur md:px-6">
+      <div className="flex items-center gap-3">
+        <Logo />
+        <span className="rounded-md border bg-card px-1.5 py-0.5 text-[11px] font-medium text-fg-muted max-sm:hidden">
+          Studio
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
+          <Button
+            size="sm"
+            isIconOnly
+            variant="quiet"
+            aria-label="Re-roll the system"
+            onPress={() => shuffleSystem(setDesignSystem)}
+          >
+            <ShuffleIcon />
+          </Button>
+          <Button
+            size="sm"
+            isIconOnly
+            variant="quiet"
+            aria-label="Undo"
+            onPress={onUndo}
+            isDisabled={!canUndo}
+          >
+            <Undo2Icon />
+          </Button>
+        </div>
+
+        <Button
+          size="sm"
+          variant="default"
+          onPress={focusAiBar}
+          className="md:text-fg-muted"
+        >
+          <SparklesIcon data-icon-start="" className="text-primary" />
+          <span className="max-sm:hidden">Ask dotUI</span>
+          <Kbd className="max-sm:hidden">⌘ K</Kbd>
+        </Button>
+
+        <div className="mx-0.5 h-5 w-px bg-border max-sm:hidden" />
+
+        <a
+          aria-label="GitHub"
+          href={siteConfig.links.github}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-icon-only=""
+          className={buttonStyles({ variant: 'quiet', size: 'sm' })}
+        >
+          <GitHubIcon />
+        </a>
+        <ThemeToggle isIconOnly variant="quiet" size="sm" />
+      </div>
+    </header>
+  )
+}

--- a/www/src/modules/create/studio/vibes.ts
+++ b/www/src/modules/create/studio/vibes.ts
@@ -1,0 +1,196 @@
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+
+import { DEFAULT_RADIUS_FACTOR, RADIUS_FACTOR_VAR } from '../layout'
+import type { Density, DesignSystem, useDesignSystem } from '../preset'
+
+/* ----------------------------------------------------------------------------
+ * Vibes + the AI engine that powers the Style front door and the docked
+ * refine bar. A "vibe" sets the high-leverage, always-legible axes (accent /
+ * radius / density) in one move so a prompt or a preset re-skins the whole
+ * system live. UI-only: every change flows through the existing design-system
+ * setters, so the real preview genuinely updates.
+ * -------------------------------------------------------------------------- */
+
+export interface Vibe {
+  id: string
+  label: string
+  description: string
+  accent: string
+  /** Radius factor (0–2×), same unit as the Shape axis. */
+  radius: string
+  density: Density
+}
+
+const MINIMAL: Vibe = {
+  id: 'minimal',
+  label: 'Minimal',
+  description: 'Tight, monochrome, restrained',
+  accent: '#171717',
+  radius: '0.4',
+  density: 'compact',
+}
+const LINEAR: Vibe = {
+  id: 'linear',
+  label: 'Linear',
+  description: 'Cool, crisp, product-grade',
+  accent: '#5b5bd6',
+  radius: '0.6',
+  density: 'compact',
+}
+const CORPORATE: Vibe = {
+  id: 'corporate',
+  label: 'Corporate',
+  description: 'Trustworthy SaaS blue',
+  accent: '#2563eb',
+  radius: '0.75',
+  density: 'default',
+}
+const EDITORIAL: Vibe = {
+  id: 'editorial',
+  label: 'Editorial',
+  description: 'Warm, calm, generous',
+  accent: '#0f766e',
+  radius: '0.3',
+  density: 'comfortable',
+}
+const PLAYFUL: Vibe = {
+  id: 'playful',
+  label: 'Playful',
+  description: 'Round, bright, friendly',
+  accent: '#f43f5e',
+  radius: '1.7',
+  density: 'comfortable',
+}
+const VIVID: Vibe = {
+  id: 'vivid',
+  label: 'Vivid',
+  description: 'Saturated and bold',
+  accent: '#7c3aed',
+  radius: '1',
+  density: 'default',
+}
+
+export const VIBES: Vibe[] = [
+  MINIMAL,
+  LINEAR,
+  CORPORATE,
+  EDITORIAL,
+  PLAYFUL,
+  VIVID,
+]
+
+type SetDesignSystem = ReturnType<typeof useDesignSystem>['setDesignSystem']
+
+/** Apply a vibe's accent / radius / density in one update (a single undo step). */
+export function applyVibe(setDesignSystem: SetDesignSystem, vibe: Vibe) {
+  setDesignSystem((prev: DesignSystem) => {
+    const base = prev.color ?? DEFAULT_COLOR_CONFIG
+    return {
+      ...prev,
+      density: vibe.density,
+      tokens: { ...prev.tokens, [RADIUS_FACTOR_VAR]: vibe.radius },
+      color: { ...base, seeds: { ...base.seeds, accent: vibe.accent } },
+    }
+  })
+}
+
+const SHUFFLE_ACCENTS = [
+  '#3b82f6',
+  '#6366f1',
+  '#8b5cf6',
+  '#ec4899',
+  '#f43f5e',
+  '#f59e0b',
+  '#22c55e',
+  '#14b8a6',
+  '#06b6d4',
+]
+const SHUFFLE_RADII = ['0', '0.5', '1', '1.5', '2']
+const SHUFFLE_DENSITIES: Density[] = ['compact', 'default', 'comfortable']
+
+function pickRandom<T>(arr: readonly T[], fallback: T): T {
+  return arr[Math.floor(Math.random() * arr.length)] ?? fallback
+}
+
+/** Roll a fresh accent / radius / density combination as a single undo step. */
+export function shuffleSystem(setDesignSystem: SetDesignSystem) {
+  const accent = pickRandom(SHUFFLE_ACCENTS, '#6366f1')
+  const radius = pickRandom(SHUFFLE_RADII, '1')
+  const density = pickRandom(SHUFFLE_DENSITIES, 'default')
+  setDesignSystem((prev: DesignSystem) => {
+    const base = prev.color ?? DEFAULT_COLOR_CONFIG
+    return {
+      ...prev,
+      density,
+      tokens: { ...prev.tokens, [RADIUS_FACTOR_VAR]: radius },
+      color: { ...base, seeds: { ...base.seeds, accent } },
+    }
+  })
+}
+
+/** Map a free-text brief to the closest vibe (the prompt-to-system shortcut). */
+export function vibeFromPrompt(text: string): Vibe {
+  const t = text.toLowerCase()
+  if (/warm|editor|fintech|serif|magazine|calm|wellness|spa/.test(t))
+    return EDITORIAL
+  if (/minimal|mono|stark|restrained|premium|luxur|elegant/.test(t))
+    return MINIMAL
+  if (/play|round|fun|bright|friendly|consumer|cute/.test(t)) return PLAYFUL
+  if (/vivid|bold|saturat|vibrant|energetic/.test(t)) return VIVID
+  if (/corp|dash|saas|enterprise|business|trust|finance/.test(t))
+    return CORPORATE
+  return LINEAR
+}
+
+/**
+ * Apply a natural-language refinement as a delta on the current system, and
+ * return a short confirmation line for the chat log.
+ */
+export function applyDelta(
+  ds: ReturnType<typeof useDesignSystem>,
+  input: string,
+): string {
+  const t = input.toLowerCase()
+  const { setDesignSystem, setDensity, setToken, setColorAlgorithm } = ds
+  const radius =
+    Number.parseFloat(ds.designSystem.tokens[RADIUS_FACTOR_VAR] ?? '') ||
+    Number.parseFloat(DEFAULT_RADIUS_FACTOR)
+
+  if (/contrast|legib|accessib|wcag|aa/.test(t)) {
+    setColorAlgorithm('contrast')
+    return 'Switched to contrast-locked color generation.'
+  }
+  if (/tight|dens|compact|cramp/.test(t)) {
+    setDensity('compact')
+    return 'Tightened density to compact.'
+  }
+  if (/spac|roomy|comfortable|breath|airy/.test(t)) {
+    setDensity('comfortable')
+    return 'Opened up spacing to comfortable.'
+  }
+  if (/playful|fun|cheer/.test(t)) {
+    applyVibe(setDesignSystem, PLAYFUL)
+    return 'Made it more playful.'
+  }
+  if (/premium|minimal|elegant|lux|refined/.test(t)) {
+    applyVibe(setDesignSystem, MINIMAL)
+    return 'Refined toward a minimal, premium look.'
+  }
+  if (/surprise|random|shuffle|roll/.test(t)) {
+    shuffleSystem(setDesignSystem)
+    return 'Rolled a fresh combination.'
+  }
+  if (/sharp|less round|squar/.test(t)) {
+    const r = Math.max(0, radius - 0.3)
+    setToken(RADIUS_FACTOR_VAR, r.toFixed(2))
+    return `Sharpened corners to ${r.toFixed(2)}×.`
+  }
+  if (/soft|round|corner/.test(t)) {
+    const r = Math.min(2, radius + 0.3)
+    setToken(RADIUS_FACTOR_VAR, r.toFixed(2))
+    return `Softened corners to ${r.toFixed(2)}×.`
+  }
+  const vibe = vibeFromPrompt(t)
+  applyVibe(setDesignSystem, vibe)
+  return `Applied a ${vibe.label.toLowerCase()} direction.`
+}

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -13,6 +13,7 @@ import {
   saveStoredPreset,
 } from '@/modules/create/preset/storage'
 import { PreviewPanel } from '@/modules/create/preview/preview-panel'
+import { StudioExperience } from '@/modules/create/studio'
 
 type MobilePane = 'customize' | 'preview'
 
@@ -25,6 +26,9 @@ export const createSearchSchema = z.object({
   // Coerced boolean: the search parser reads bare `1`/`true` as non-strings, so a
   // plain `z.string()` would reject them and the param would be dropped.
   lab: z.coerce.boolean().optional().catch(undefined),
+  // Opt-in flag for the canvas-first "studio" redesign (rail + inspector + AI bar)
+  // explored at /create?studio=true. Same coercion rationale as `lab`.
+  studio: z.coerce.boolean().optional().catch(undefined),
 })
 
 const searchDefaults = { preview: 'cards' }
@@ -38,7 +42,7 @@ export const Route = createFileRoute('/_app/create')({
 })
 
 function CreatePage() {
-  const { lab, preset } = Route.useSearch()
+  const { lab, studio, preset } = Route.useSearch()
   const { designSystem, setDesignSystem } = useDesignSystem()
   // Below `lg` the customizer and the live preview can't sit side by side (the iframe
   // would be a ~15px sliver), so they collapse into a single switchable pane toggled
@@ -71,6 +75,9 @@ function CreatePage() {
 
   // Opt-in exploration of the redesigned control panel + floating panel lab.
   if (lab) return <LabExperience />
+
+  // Opt-in exploration of the canvas-first studio redesign.
+  if (studio) return <StudioExperience />
 
   return (
     <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2">

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { cn } from '@/registry/lib/utils'
 import { ToggleButton } from '@/registry/ui/toggle-button'
 import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
+import { CreateTopBar } from '@/modules/create/create-top-bar'
 import { CustomizerPanel } from '@/modules/create/customizer-panel'
 import { LabExperience } from '@/modules/create/panel'
 import { DEFAULTS, useDesignSystem } from '@/modules/create/preset'
@@ -73,36 +74,48 @@ function CreatePage() {
     saveStoredPreset(designSystem)
   }, [designSystem])
 
-  // Opt-in exploration of the redesigned control panel + floating panel lab.
-  if (lab) return <LabExperience />
+  // The global site Header is suppressed on /create (routes/_app/route.tsx), so
+  // the studio owns its own top bar; the other variants get the minimal one.
 
   // Opt-in exploration of the canvas-first studio redesign.
   if (studio) return <StudioExperience />
 
+  // Opt-in exploration of the redesigned control panel + floating panel lab.
+  if (lab)
+    return (
+      <>
+        <CreateTopBar />
+        <LabExperience />
+      </>
+    )
+
   return (
-    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2">
-      {/* Mobile-only view switcher — hidden once the two panes fit side by side. */}
-      <ToggleButtonGroup
-        aria-label="Editor view"
-        selectionMode="single"
-        disallowEmptySelection
-        size="sm"
-        selectedKeys={[mobilePane]}
-        onSelectionChange={(keys) => {
-          const next = keys.values().next().value
-          if (next === 'customize' || next === 'preview') setMobilePane(next)
-        }}
-        className="w-full shrink-0 *:flex-1 lg:hidden"
-      >
-        <ToggleButton id="customize">Customize</ToggleButton>
-        <ToggleButton id="preview">Preview</ToggleButton>
-      </ToggleButtonGroup>
-      <CustomizerPanel
-        className={cn(mobilePane === 'preview' && 'max-lg:hidden')}
-      />
-      <PreviewPanel
-        className={cn(mobilePane === 'customize' && 'max-lg:hidden')}
-      />
-    </div>
+    <>
+      <CreateTopBar />
+      <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2">
+        {/* Mobile-only view switcher — hidden once the two panes fit side by side. */}
+        <ToggleButtonGroup
+          aria-label="Editor view"
+          selectionMode="single"
+          disallowEmptySelection
+          size="sm"
+          selectedKeys={[mobilePane]}
+          onSelectionChange={(keys) => {
+            const next = keys.values().next().value
+            if (next === 'customize' || next === 'preview') setMobilePane(next)
+          }}
+          className="w-full shrink-0 *:flex-1 lg:hidden"
+        >
+          <ToggleButton id="customize">Customize</ToggleButton>
+          <ToggleButton id="preview">Preview</ToggleButton>
+        </ToggleButtonGroup>
+        <CustomizerPanel
+          className={cn(mobilePane === 'preview' && 'max-lg:hidden')}
+        />
+        <PreviewPanel
+          className={cn(mobilePane === 'customize' && 'max-lg:hidden')}
+        />
+      </div>
+    </>
   )
 }

--- a/www/src/routes/_app/route.tsx
+++ b/www/src/routes/_app/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeader } from '@tanstack/react-start/server'
 import type * as PageTree from 'fumadocs-core/page-tree'
@@ -37,9 +37,16 @@ function AppLayout() {
   const { pageTree } = Route.useLoaderData()
   const items = pageTree.children as PageTree.Node[]
 
+  // The /create builder is a focused mode of dotUI: it owns its own top bar
+  // (see modules/create) in place of the site nav — Docs/Components links and
+  // "Search docs" are irrelevant inside it. Skip the global Header there so the
+  // builder never stacks two bars; every other route keeps the site nav.
+  const { pathname } = useLocation()
+  const isCreate = pathname === '/create'
+
   return (
     <div className="[--header-height:--spacing(14)]">
-      <Header items={items} />
+      {!isCreate && <Header items={items} />}
       <main id="content">
         <Outlet />
       </main>


### PR DESCRIPTION
## What

An experimental, **opt-in** rethink of the `/create` builder at `/create?studio=true`. The shipped editor and the `?lab` experience are untouched — this adds a third, parallel experience behind its own flag (same pattern as `lab`).

> This is a UI/UX exploration ("do only the UI"). It reuses the real design-system state and preview, but the brand-new axes are interactive controls only — not yet wired to live tokens.

## Why

Today's panel is a 288px slide-stack: every axis is buried behind a back button, controls are cramped, undo is invisible, there's no front door for "just make it look like X", and ~half the axes a real design system needs (elevation, motion, surfaces, focus, spacing) are missing. This explores a canvas-first direction that scales to far more tweaks while staying navigable.

## The direction

A canvas-first design tool on a **macro → micro spine**:

- **Persistent axis rail** replaces the slide-stack — every axis is one click away (the rail *is* the IA).
- **Wider inspector (320px)** so sliders, swatches, and segmented controls breathe.
- **Style front door** (the macro layer): an AI prompt, vibe presets, and the highest-leverage knobs (accent / radius / density). Each rail icon drops to the micro layer.
- **Docked AI bar** under the canvas for always-on, conversational refinement.
- **Visible undo** carried over from the shipped panel.

## New axes (the "do anything" breadth)

Beyond the existing color / type / icons / radius / density / cursor / charts (all reused as-is): **elevation**, **motion** (duration, easing/spring with a play demo, reduced-motion), **surfaces** (translucency, blur, background style), **focus** (ring/outline/glow), **states** (hover/press/transition), plus **shape** (corner style, border width, hairlines) and **spacing** (base unit, rhythm, control height) depth.

## AI, woven in (there's none in the product today)

- **Prompt → system**: describe a brand / paste a URL / drop a screenshot → sets accent, radius, and density at once, with an "AI set" changelog. *(This one is live — it really restyles the preview.)*
- **Conversational refine** (docked bar): "more contrast", "softer corners", "tighter density", "surprise me" → live deltas.
- Per-axis "suggest", health/critique, and image→tokens are stubbed in the UI as the next layer.

## Reuse / safety

- Composes the existing `ColorsConfig`, `TypographyConfig`, `ChartColorsConfig`, component editors, `ExportFooter`, `CodeOptionsDialog`, and the preview iframe — no duplication of working axes.
- **No `www/src/registry/` changes** → no registry/reference drift. New code is www-side only (`modules/create/studio/` + one route guard).
- Desktop-first: below `lg` it shows a "use a wider screen" notice rather than cramming the 3-zone layout.

## Verification

- `pnpm typecheck` ✅ · `pnpm check` ✅ (0 errors, 0 new warnings, formatting clean)
- SSR returns `200` at `/create?studio=true` with no server errors; all panels render.
- Smoke-tested in a headless browser at 1440×900: the rail switches panels, vibe/prompt clicks restyle the live preview, and the "AI set" changelog appears.

## Follow-ups (not in this PR)

- Wire the new axes to live tokens / new semantic vars (each is a product decision per CLAUDE.md).
- Replace the keyword-matched "AI" with a real model call (prompt→system, refine, suggest, critique).
- A mobile layout; ⌘K command palette; named checkpoints / history.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in behind `?studio=true`, www-only with no registry changes; default `/create` behavior is preserved aside from the intentional header swap for a builder-specific top bar.
> 
> **Overview**
> Adds an **opt-in** canvas-first builder at `/create?studio=true` (alongside unchanged default and `?lab`), plus layout tweaks so `/create` no longer shows the global site header.
> 
> **Studio shell** is a three-zone desktop layout: persistent **axis rail**, **320px inspector** (reuses existing color/type/components/export panels; new elevation/motion/surface/focus/states panels are interactive UI stubs with dashed “not wired yet” notes), and **live preview** with a docked **AI refine bar**. **Studio top bar** adds undo (preset history stack), re-roll, and “Ask dotUI” (⌘K focuses the AI input via a small `ai-focus` bridge). Below `lg`, studio shows a “use a wider screen” message instead of cramming the layout.
> 
> **Style / “AI” layer** (keyword-driven, not a real model): vibes and prompts map to accent/radius/density through existing `setDesignSystem`; the docked bar’s `applyDelta` tweaks density, radius, contrast algorithm, shuffle, etc., with a short chat log.
> 
> **Default and lab** now render **`CreateTopBar`** (logo, GitHub, theme) because `_app/route.tsx` hides the global **`Header`** on `/create` so builder variants don’t stack two bars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7bc8e4b5ccfa2a205a6b5ed67a94a8e4cb1023d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->