### PR TITLE
feat(create): add AI-assisted builder redesign behind ?next

### DIFF
--- a/www/src/modules/create/next/ai.ts
+++ b/www/src/modules/create/next/ai.ts
@@ -1,0 +1,469 @@
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import {
+  DEFAULT_RADIUS_FACTOR,
+  RADIUS_FACTOR_VAR,
+} from '@/modules/create/layout'
+import type { Density, DesignSystem } from '@/modules/create/preset'
+
+/* ----------------------------------------------------------------------------
+ * The builder's AI layer is UI-only: no model is called here. Every assistant
+ * action — compose a system from a prompt, refine it, extract from an image, or
+ * audit it — is expressed as the SAME reviewable primitive: a `DesignSystemDiff`,
+ * a list of typed per-axis operations the user can toggle row by row, apply, and
+ * undo. Wiring a real model later means replacing the canned builders below with
+ * a server function that returns this exact shape — the UI doesn't change.
+ * -------------------------------------------------------------------------- */
+
+/** Namespaced tokens for the new axes. Visual-only today (no component reads them
+ *  yet), but they round-trip through the preset so the builder UI is complete. */
+export const NEXT_TOKENS = {
+  headingFont: '--next-heading-font',
+  typeScale: '--next-type-scale',
+  headingWeight: '--next-heading-weight',
+  tracking: '--next-tracking',
+  spacingUnit: '--next-spacing-unit',
+  spacingScale: '--next-spacing-scale',
+  elevation: '--next-elevation',
+  elevationTint: '--next-elevation-tint',
+  motion: '--next-motion',
+  easing: '--next-easing',
+  borders: '--next-borders',
+  focus: '--next-focus',
+  surfaces: '--next-surfaces',
+} as const
+
+export const NEXT_DEFAULTS = {
+  headingFont: 'Geist',
+  typeScale: '1.25',
+  headingWeight: '600',
+  tracking: '0',
+  spacingUnit: '4',
+  spacingScale: 'geometric',
+  elevation: 'subtle',
+  elevationTint: 'neutral',
+  motion: 'smooth',
+  easing: 'standard',
+  borders: 'default',
+  focus: 'default',
+  surfaces: 'opaque',
+} as const
+
+const ACCENT_DEFAULT = DEFAULT_COLOR_CONFIG.seeds.accent ?? '#6366f1'
+const NEUTRAL_DEFAULT = DEFAULT_COLOR_CONFIG.seeds.neutral ?? '#737373'
+
+/* ------------------------------ Axis read/write ------------------------------ */
+
+export function readAccent(ds: DesignSystem): string {
+  return (ds.color ?? DEFAULT_COLOR_CONFIG).seeds.accent ?? ACCENT_DEFAULT
+}
+export function readNeutral(ds: DesignSystem): string {
+  return (ds.color ?? DEFAULT_COLOR_CONFIG).seeds.neutral ?? NEUTRAL_DEFAULT
+}
+function writeSeed(
+  ds: DesignSystem,
+  seed: 'accent' | 'neutral',
+  value: string,
+): DesignSystem {
+  const base = ds.color ?? DEFAULT_COLOR_CONFIG
+  return { ...ds, color: { ...base, seeds: { ...base.seeds, [seed]: value } } }
+}
+export function readToken(
+  ds: DesignSystem,
+  name: string,
+  fallback: string,
+): string {
+  return ds.tokens[name] ?? fallback
+}
+export function writeToken(
+  ds: DesignSystem,
+  name: string,
+  value: string,
+): DesignSystem {
+  return { ...ds, tokens: { ...ds.tokens, [name]: value } }
+}
+
+/* --------------------------------- Diff types -------------------------------- */
+
+export type DiffKind = 'color' | 'text' | 'value'
+
+export interface DiffRow {
+  id: string
+  /** Axis label, e.g. "Accent", "Radius", "Elevation". */
+  axis: string
+  kind: DiffKind
+  fromLabel: string
+  toLabel: string
+  fromColor?: string
+  toColor?: string
+  included: boolean
+  /** Pure op — the only thing Apply runs. */
+  apply: (ds: DesignSystem) => DesignSystem
+}
+
+/** What the assistant is allowed to change in one turn. */
+export interface ThemeTarget {
+  accent?: string
+  neutral?: string
+  headingFont?: string
+  typeScale?: string
+  radius?: string
+  density?: Density
+  elevation?: string
+  motion?: string
+  borders?: string
+}
+
+const radiusLabel = (v: string) => `${Number.parseFloat(v).toFixed(2)}×`
+const titleCase = (v: string) => v.charAt(0).toUpperCase() + v.slice(1)
+
+/** Diff the current system against a target, emitting one row per changed axis. */
+export function diffFromTarget(
+  ds: DesignSystem,
+  target: ThemeTarget,
+): DiffRow[] {
+  const rows: DiffRow[] = []
+  let n = 0
+  const id = () => `r${n++}`
+
+  if (target.accent && !sameColor(target.accent, readAccent(ds))) {
+    const to = target.accent
+    rows.push({
+      id: id(),
+      axis: 'Accent',
+      kind: 'color',
+      fromColor: readAccent(ds),
+      toColor: to,
+      fromLabel: readAccent(ds).toUpperCase(),
+      toLabel: to.toUpperCase(),
+      included: true,
+      apply: (d) => writeSeed(d, 'accent', to),
+    })
+  }
+  if (target.neutral && !sameColor(target.neutral, readNeutral(ds))) {
+    const to = target.neutral
+    rows.push({
+      id: id(),
+      axis: 'Neutral',
+      kind: 'color',
+      fromColor: readNeutral(ds),
+      toColor: to,
+      fromLabel: readNeutral(ds).toUpperCase(),
+      toLabel: to.toUpperCase(),
+      included: true,
+      apply: (d) => writeSeed(d, 'neutral', to),
+    })
+  }
+  pushToken(
+    rows,
+    id,
+    target.headingFont,
+    ds,
+    NEXT_TOKENS.headingFont,
+    NEXT_DEFAULTS.headingFont,
+    'Heading',
+    'text',
+  )
+  pushToken(
+    rows,
+    id,
+    target.typeScale,
+    ds,
+    NEXT_TOKENS.typeScale,
+    NEXT_DEFAULTS.typeScale,
+    'Type scale',
+    'value',
+  )
+  if (target.radius) {
+    const from = readToken(ds, RADIUS_FACTOR_VAR, DEFAULT_RADIUS_FACTOR)
+    if (Number.parseFloat(from) !== Number.parseFloat(target.radius)) {
+      const to = target.radius
+      rows.push({
+        id: id(),
+        axis: 'Radius',
+        kind: 'value',
+        fromLabel: radiusLabel(from),
+        toLabel: radiusLabel(to),
+        included: true,
+        apply: (d) => writeToken(d, RADIUS_FACTOR_VAR, to),
+      })
+    }
+  }
+  if (target.density && target.density !== ds.density) {
+    const to = target.density
+    rows.push({
+      id: id(),
+      axis: 'Density',
+      kind: 'text',
+      fromLabel: titleCase(ds.density),
+      toLabel: titleCase(to),
+      included: true,
+      apply: (d) => ({ ...d, density: to }),
+    })
+  }
+  pushToken(
+    rows,
+    id,
+    target.elevation,
+    ds,
+    NEXT_TOKENS.elevation,
+    NEXT_DEFAULTS.elevation,
+    'Elevation',
+    'text',
+    titleCase,
+  )
+  pushToken(
+    rows,
+    id,
+    target.motion,
+    ds,
+    NEXT_TOKENS.motion,
+    NEXT_DEFAULTS.motion,
+    'Motion',
+    'text',
+    titleCase,
+  )
+  pushToken(
+    rows,
+    id,
+    target.borders,
+    ds,
+    NEXT_TOKENS.borders,
+    NEXT_DEFAULTS.borders,
+    'Borders',
+    'text',
+    titleCase,
+  )
+  return rows
+}
+
+function pushToken(
+  rows: DiffRow[],
+  id: () => string,
+  target: string | undefined,
+  ds: DesignSystem,
+  token: string,
+  fallback: string,
+  axis: string,
+  kind: DiffKind,
+  format: (v: string) => string = (v) => v,
+) {
+  if (!target) return
+  const from = readToken(ds, token, fallback)
+  if (from === target) return
+  rows.push({
+    id: id(),
+    axis,
+    kind,
+    fromLabel: format(from),
+    toLabel: format(target),
+    included: true,
+    apply: (d) => writeToken(d, token, target),
+  })
+}
+
+function sameColor(a: string, b: string) {
+  return a.toLowerCase() === b.toLowerCase()
+}
+
+/** Apply only the rows the user kept selected. */
+export function applyRows(ds: DesignSystem, rows: DiffRow[]): DesignSystem {
+  return rows.filter((r) => r.included).reduce((acc, r) => r.apply(acc), ds)
+}
+
+/* --------------------------------- Compose ----------------------------------- */
+
+export interface ComposePreset {
+  prompt: string
+  intro: string
+  target: ThemeTarget
+}
+
+export const COMPOSE_PRESETS = {
+  linear: {
+    prompt: 'Make it feel like Linear, but a touch warmer',
+    intro:
+      'A calm, dense system — indigo accent, flat surfaces, hairline borders, snappy motion.',
+    target: {
+      accent: '#5e6ad2',
+      headingFont: 'Inter',
+      typeScale: '1.2',
+      radius: '0.45',
+      density: 'compact',
+      elevation: 'flat',
+      borders: 'hairline',
+      motion: 'snappy',
+    },
+  },
+  editorial: {
+    prompt: 'A warm editorial system with a serif display',
+    intro:
+      'Generous, calm, and literary — a teal accent, a serif heading, and roomy spacing.',
+    target: {
+      accent: '#0f766e',
+      headingFont: 'Source Serif 4',
+      typeScale: '1.333',
+      radius: '0.25',
+      density: 'comfortable',
+      elevation: 'flat',
+      motion: 'smooth',
+    },
+  },
+  playful: {
+    prompt: 'More playful and rounder',
+    intro:
+      'Friendly and bouncy — a coral accent, big radii, and expressive motion.',
+    target: {
+      accent: '#f43f5e',
+      headingFont: 'Geist',
+      typeScale: '1.25',
+      radius: '1.6',
+      density: 'comfortable',
+      elevation: 'lifted',
+      motion: 'expressive',
+    },
+  },
+  stripe: {
+    prompt: 'Match the look of stripe.com',
+    intro:
+      'Crisp and trustworthy — an indigo-violet accent with soft, lifted surfaces.',
+    target: {
+      accent: '#635bff',
+      headingFont: 'Inter',
+      typeScale: '1.25',
+      radius: '0.8',
+      density: 'default',
+      elevation: 'lifted',
+      motion: 'smooth',
+    },
+  },
+  minimal: {
+    prompt: 'Minimal and monochrome',
+    intro:
+      'Quiet and precise — near-black accent, tight corners, flat surfaces.',
+    target: {
+      accent: '#171717',
+      headingFont: 'Geist',
+      typeScale: '1.2',
+      radius: '0.4',
+      density: 'compact',
+      elevation: 'flat',
+      borders: 'default',
+      motion: 'snappy',
+    },
+  },
+} satisfies Record<string, ComposePreset>
+
+/** Map a free-text prompt to a compose preset (keyword match — a stand-in for a model). */
+export function matchPrompt(prompt: string): ComposePreset {
+  const p = prompt.toLowerCase()
+  if (/linear|calm|dense/.test(p)) return COMPOSE_PRESETS.linear
+  if (/editorial|serif|warm|magazine/.test(p)) return COMPOSE_PRESETS.editorial
+  if (/playful|round|fun|bouncy/.test(p)) return COMPOSE_PRESETS.playful
+  if (/stripe|trust|fintech/.test(p)) return COMPOSE_PRESETS.stripe
+  if (/minimal|mono|quiet/.test(p)) return COMPOSE_PRESETS.minimal
+  return COMPOSE_PRESETS.linear
+}
+
+/* ---------------------------------- Refine ----------------------------------- */
+
+export interface RefineAction {
+  id: string
+  label: string
+  prompt: string
+  intro: string
+  target: ThemeTarget
+}
+
+export const REFINE_ACTIONS: RefineAction[] = [
+  {
+    id: 'rounder',
+    label: 'Rounder',
+    prompt: 'Rounder',
+    intro: 'Softening the corners and letting surfaces lift a little.',
+    target: { radius: '1.1', elevation: 'lifted' },
+  },
+  {
+    id: 'contrast',
+    label: 'More contrast',
+    prompt: 'More contrast',
+    intro: 'Deepening neutrals and firming up the borders for legibility.',
+    target: { neutral: '#171717', borders: 'default' },
+  },
+  {
+    id: 'calm',
+    label: 'Calmer motion',
+    prompt: 'Calmer motion',
+    intro: 'Easing the transition speed across the system.',
+    target: { motion: 'smooth' },
+  },
+]
+
+/* ----------------------------------- Audit ----------------------------------- */
+
+export interface AuditIssue {
+  id: string
+  severity: 'high' | 'med'
+  title: string
+  detail: string
+  fix: { label: string; apply: (ds: DesignSystem) => DesignSystem }
+}
+
+export function auditSystem(): AuditIssue[] {
+  return [
+    {
+      id: 'a1',
+      severity: 'high',
+      title: 'Danger text fails AA on solid',
+      detail:
+        'Contrast is ~3.1:1 on the danger button. Darken the danger seed to pass AA.',
+      fix: {
+        label: 'Darken seed',
+        apply: (d) => writeSeed(d, 'accent', readAccent(d)),
+      },
+    },
+    {
+      id: 'a2',
+      severity: 'med',
+      title: 'Heading scale jumps two steps',
+      detail: 'h1 is 2.4× h2 — tighten the type scale for smoother rhythm.',
+      fix: {
+        label: 'Set 1.2',
+        apply: (d) => writeToken(d, NEXT_TOKENS.typeScale, '1.2'),
+      },
+    },
+    {
+      id: 'a3',
+      severity: 'med',
+      title: 'Focus ring blends into accent',
+      detail:
+        'The focus ring sits on the accent fill with no offset. Add a bolder ring.',
+      fix: {
+        label: 'Bolder ring',
+        apply: (d) => writeToken(d, NEXT_TOKENS.focus, 'bold'),
+      },
+    },
+  ]
+}
+
+/* ---------------------------------- Extract ---------------------------------- */
+
+export interface ExtractResult {
+  fileName: string
+  palette: string[]
+  intro: string
+  rows: DiffRow[]
+}
+
+export function extractFromImage(ds: DesignSystem): ExtractResult {
+  return {
+    fileName: 'brand-screenshot.png',
+    palette: ['#0a2540', '#635bff', '#00d4ff', '#f6f9fc'],
+    intro:
+      'Pulled a dominant palette and a likely heading font from the image.',
+    rows: diffFromTarget(ds, {
+      accent: '#635bff',
+      headingFont: 'Inter',
+      radius: '0.8',
+    }),
+  }
+}

--- a/www/src/modules/create/next/assistant.tsx
+++ b/www/src/modules/create/next/assistant.tsx
@@ -1,0 +1,601 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  ArrowRightIcon,
+  ArrowUpIcon,
+  CheckIcon,
+  GitCompareIcon,
+  ImageIcon,
+  PaperclipIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+  Undo2Icon,
+  XIcon,
+} from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+
+import { useDesignSystem } from '../preset'
+import type { DesignSystem } from '../preset'
+import {
+  type AuditIssue,
+  type DiffRow,
+  REFINE_ACTIONS,
+  type RefineAction,
+  applyRows,
+  auditSystem,
+  diffFromTarget,
+  extractFromImage,
+  matchPrompt,
+} from './ai'
+
+type DiffStatus = 'pending' | 'applied' | 'discarded' | 'reverted'
+
+type Turn =
+  | { id: number; kind: 'user'; text: string; attachment?: string }
+  | { id: number; kind: 'text'; text: string }
+  | { id: number; kind: 'thinking' }
+  | {
+      id: number
+      kind: 'diff'
+      intro: string
+      palette?: string[]
+      rows: DiffRow[]
+      status: DiffStatus
+      appliedCount: number
+      snapshot: DesignSystem | null
+    }
+  | {
+      id: number
+      kind: 'audit'
+      intro: string
+      issues: (AuditIssue & { fixed?: boolean })[]
+    }
+
+export function Assistant({ onClose }: { onClose: () => void }) {
+  const { designSystem, setDesignSystem } = useDesignSystem()
+  const idRef = useRef(2)
+  const nextId = () => idRef.current++
+  const [turns, setTurns] = useState<Turn[]>(() => {
+    const preset = matchPrompt('linear')
+    return [
+      { id: 0, kind: 'user', text: preset.prompt },
+      {
+        id: 1,
+        kind: 'diff',
+        intro: preset.intro,
+        rows: diffFromTarget(designSystem, preset.target),
+        status: 'pending',
+        appliedCount: 0,
+        snapshot: null,
+      },
+    ]
+  })
+  const [input, setInput] = useState('')
+  const threadRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = threadRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [turns])
+
+  function withThinking(userTurn: Turn, produce: () => Turn[]) {
+    const thinkingId = nextId()
+    setTurns((t) => [...t, userTurn, { id: thinkingId, kind: 'thinking' }])
+    window.setTimeout(() => {
+      setTurns((t) => [...t.filter((x) => x.id !== thinkingId), ...produce()])
+    }, 720)
+  }
+
+  function compose(prompt: string) {
+    const preset = matchPrompt(prompt)
+    withThinking({ id: nextId(), kind: 'user', text: prompt }, () => [
+      {
+        id: nextId(),
+        kind: 'diff',
+        intro: preset.intro,
+        rows: diffFromTarget(designSystem, preset.target),
+        status: 'pending',
+        appliedCount: 0,
+        snapshot: null,
+      },
+    ])
+  }
+
+  function refine(action: RefineAction) {
+    withThinking({ id: nextId(), kind: 'user', text: action.prompt }, () => {
+      const rows = diffFromTarget(designSystem, action.target)
+      return [
+        {
+          id: nextId(),
+          kind: 'diff',
+          intro: action.intro,
+          rows,
+          status: 'pending',
+          appliedCount: 0,
+          snapshot: null,
+        },
+      ]
+    })
+  }
+
+  function audit() {
+    withThinking(
+      { id: nextId(), kind: 'user', text: 'Audit my system' },
+      () => [
+        {
+          id: nextId(),
+          kind: 'audit',
+          intro:
+            'Scanned color, type, and components — three things to tighten:',
+          issues: auditSystem(),
+        },
+      ],
+    )
+  }
+
+  function extract() {
+    const result = extractFromImage(designSystem)
+    withThinking(
+      { id: nextId(), kind: 'user', text: '', attachment: result.fileName },
+      () => [
+        {
+          id: nextId(),
+          kind: 'diff',
+          intro: result.intro,
+          palette: result.palette,
+          rows: result.rows,
+          status: 'pending',
+          appliedCount: 0,
+          snapshot: null,
+        },
+      ],
+    )
+  }
+
+  function toggleRow(turnId: number, rowId: string) {
+    setTurns((t) =>
+      t.map((turn) =>
+        turn.id === turnId && turn.kind === 'diff'
+          ? {
+              ...turn,
+              rows: turn.rows.map((r) =>
+                r.id === rowId ? { ...r, included: !r.included } : r,
+              ),
+            }
+          : turn,
+      ),
+    )
+  }
+
+  function applyDiff(turnId: number) {
+    const turn = turns.find((t) => t.id === turnId)
+    if (!turn || turn.kind !== 'diff') return
+    const snapshot = designSystem
+    setDesignSystem(applyRows(snapshot, turn.rows))
+    const count = turn.rows.filter((r) => r.included).length
+    setTurns((t) =>
+      t.map((x) =>
+        x.id === turnId && x.kind === 'diff'
+          ? { ...x, status: 'applied', appliedCount: count, snapshot }
+          : x,
+      ),
+    )
+  }
+
+  function undoDiff(turnId: number) {
+    const turn = turns.find((t) => t.id === turnId)
+    if (!turn || turn.kind !== 'diff' || !turn.snapshot) return
+    setDesignSystem(turn.snapshot)
+    setTurns((t) =>
+      t.map((x) =>
+        x.id === turnId && x.kind === 'diff' ? { ...x, status: 'reverted' } : x,
+      ),
+    )
+  }
+
+  function discardDiff(turnId: number) {
+    setTurns((t) =>
+      t.map((x) =>
+        x.id === turnId && x.kind === 'diff'
+          ? { ...x, status: 'discarded' }
+          : x,
+      ),
+    )
+  }
+
+  function fixIssue(turnId: number, issue: AuditIssue) {
+    setDesignSystem(issue.fix.apply(designSystem))
+    setTurns((t) =>
+      t.map((turn) =>
+        turn.id === turnId && turn.kind === 'audit'
+          ? {
+              ...turn,
+              issues: turn.issues.map((i) =>
+                i.id === issue.id ? { ...i, fixed: true } : i,
+              ),
+            }
+          : turn,
+      ),
+    )
+  }
+
+  function submit() {
+    const value = input.trim()
+    if (!value) return
+    setInput('')
+    compose(value)
+  }
+
+  return (
+    <div className="flex w-80 shrink-0 flex-col border-l bg-card max-lg:hidden">
+      {/* Header */}
+      <div className="flex items-center gap-2.5 border-b px-3 py-2.5">
+        <div className="flex size-6 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <SparklesIcon className="size-4" />
+        </div>
+        <div className="flex-1">
+          <div className="text-sm font-medium">Assistant</div>
+          <div className="text-[11px] text-fg-muted">
+            Composes, refines, and audits
+          </div>
+        </div>
+        <Quiet onPress={onClose} label="Close assistant">
+          <XIcon className="size-4" />
+        </Quiet>
+      </div>
+
+      {/* Thread */}
+      <div
+        ref={threadRef}
+        className="scrollbar-none flex flex-1 flex-col gap-4 overflow-y-auto p-3"
+      >
+        {turns.map((turn) => (
+          <TurnView
+            key={turn.id}
+            turn={turn}
+            onToggle={toggleRow}
+            onApply={applyDiff}
+            onUndo={undoDiff}
+            onDiscard={discardDiff}
+            onFix={fixIssue}
+          />
+        ))}
+      </div>
+
+      {/* Quick actions */}
+      <div className="flex flex-wrap gap-1.5 border-t px-3 pt-2.5">
+        {REFINE_ACTIONS.map((a) => (
+          <Chip key={a.id} onPress={() => refine(a)}>
+            {a.label}
+          </Chip>
+        ))}
+        <Chip onPress={audit}>
+          <ShieldCheckIcon className="size-3" />
+          Audit
+        </Chip>
+        <Chip onPress={extract}>
+          <ImageIcon className="size-3" />
+          Extract
+        </Chip>
+      </div>
+
+      {/* Input */}
+      <div className="flex items-center gap-2 p-3">
+        <Quiet onPress={extract} label="Attach image">
+          <PaperclipIcon className="size-4" />
+        </Quiet>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') submit()
+          }}
+          placeholder="Describe a change, or paste a URL…"
+          className="h-9 min-w-0 flex-1 rounded-md border bg-neutral px-3 text-sm outline-none placeholder:text-fg-muted focus-visible:focus-ring"
+        />
+        <ButtonPrimitives.Button
+          onPress={submit}
+          aria-label="Send"
+          className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary text-fg-on-primary focus-reset transition-opacity hover:opacity-90 focus-visible:focus-ring"
+        >
+          <ArrowUpIcon className="size-4" />
+        </ButtonPrimitives.Button>
+      </div>
+    </div>
+  )
+}
+
+/* --------------------------------- Turns --------------------------------- */
+
+function TurnView({
+  turn,
+  onToggle,
+  onApply,
+  onUndo,
+  onDiscard,
+  onFix,
+}: {
+  turn: Turn
+  onToggle: (turnId: number, rowId: string) => void
+  onApply: (turnId: number) => void
+  onUndo: (turnId: number) => void
+  onDiscard: (turnId: number) => void
+  onFix: (turnId: number, issue: AuditIssue) => void
+}) {
+  if (turn.kind === 'user') {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[85%] rounded-xl rounded-br-sm bg-primary px-3 py-1.5 text-xs leading-relaxed text-fg-on-primary">
+          {turn.attachment ? (
+            <span className="flex items-center gap-1.5 font-mono">
+              <ImageIcon className="size-3.5" />
+              {turn.attachment}
+            </span>
+          ) : (
+            turn.text
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  if (turn.kind === 'thinking') {
+    return (
+      <AssistantRow>
+        <span className="flex items-center gap-1.5 text-xs text-primary">
+          <span className="size-1.5 animate-pulse rounded-full bg-primary" />
+          Thinking…
+        </span>
+      </AssistantRow>
+    )
+  }
+
+  if (turn.kind === 'text') {
+    return (
+      <AssistantRow>
+        <p className="text-sm leading-relaxed">{turn.text}</p>
+      </AssistantRow>
+    )
+  }
+
+  if (turn.kind === 'audit') {
+    return (
+      <AssistantRow>
+        <p className="text-sm leading-relaxed">{turn.intro}</p>
+        <div className="mt-2 flex flex-col rounded-lg border bg-bg">
+          {turn.issues.map((issue) => (
+            <div
+              key={issue.id}
+              className="flex items-start gap-2.5 border-b p-2.5 last:border-b-0"
+            >
+              <span
+                className={cn(
+                  'mt-1 size-2 shrink-0 rounded-full',
+                  issue.severity === 'high' ? 'bg-danger' : 'bg-warning',
+                )}
+              />
+              <div className="flex-1">
+                <div className="text-xs font-medium">{issue.title}</div>
+                <div className="text-xs text-fg-muted">{issue.detail}</div>
+              </div>
+              <ButtonPrimitives.Button
+                onPress={() => onFix(turn.id, issue)}
+                isDisabled={issue.fixed}
+                className={cn(
+                  'shrink-0 rounded-md border px-2 py-1 text-[11px] focus-reset transition-colors focus-visible:focus-ring',
+                  issue.fixed
+                    ? 'border-transparent text-success'
+                    : 'hover:bg-neutral',
+                )}
+              >
+                {issue.fixed ? (
+                  <span className="flex items-center gap-1">
+                    <CheckIcon className="size-3" />
+                    Fixed
+                  </span>
+                ) : (
+                  issue.fix.label
+                )}
+              </ButtonPrimitives.Button>
+            </div>
+          ))}
+        </div>
+      </AssistantRow>
+    )
+  }
+
+  // diff
+  return (
+    <AssistantRow>
+      <p className="text-sm leading-relaxed">{turn.intro}</p>
+      {turn.palette && (
+        <div className="mt-2 flex gap-1.5">
+          {turn.palette.map((c) => (
+            <span
+              key={c}
+              className="size-6 rounded-md border"
+              style={{ backgroundColor: c }}
+            />
+          ))}
+        </div>
+      )}
+      <DiffCard
+        turn={turn}
+        onToggle={onToggle}
+        onApply={onApply}
+        onUndo={onUndo}
+        onDiscard={onDiscard}
+      />
+    </AssistantRow>
+  )
+}
+
+function DiffCard({
+  turn,
+  onToggle,
+  onApply,
+  onUndo,
+  onDiscard,
+}: {
+  turn: Extract<Turn, { kind: 'diff' }>
+  onToggle: (turnId: number, rowId: string) => void
+  onApply: (turnId: number) => void
+  onUndo: (turnId: number) => void
+  onDiscard: (turnId: number) => void
+}) {
+  if (turn.rows.length === 0) {
+    return (
+      <div className="mt-2 rounded-lg border bg-bg px-3 py-2 text-xs text-fg-muted">
+        Already matches — nothing to change.
+      </div>
+    )
+  }
+
+  if (turn.status === 'applied') {
+    return (
+      <div className="mt-2 flex items-center gap-2 rounded-lg border bg-bg px-3 py-2 text-xs text-success">
+        <CheckIcon className="size-4" />
+        Applied {turn.appliedCount}{' '}
+        {turn.appliedCount === 1 ? 'change' : 'changes'}
+        <ButtonPrimitives.Button
+          onPress={() => onUndo(turn.id)}
+          className="ml-auto flex items-center gap-1 text-fg-muted underline-offset-2 focus-reset hover:underline focus-visible:focus-ring"
+        >
+          <Undo2Icon className="size-3" />
+          Undo
+        </ButtonPrimitives.Button>
+      </div>
+    )
+  }
+
+  if (turn.status === 'discarded' || turn.status === 'reverted') {
+    return (
+      <div className="mt-2 flex items-center gap-2 rounded-lg border bg-bg px-3 py-2 text-xs text-fg-muted">
+        <XIcon className="size-3.5" />
+        {turn.status === 'discarded' ? 'Discarded' : 'Reverted'}
+      </div>
+    )
+  }
+
+  const selected = turn.rows.filter((r) => r.included).length
+
+  return (
+    <div className="mt-2 overflow-hidden rounded-lg border bg-bg">
+      <div className="flex items-center justify-between border-b px-3 py-2 text-[11px] font-medium text-fg-muted">
+        <span className="flex items-center gap-1.5">
+          <GitCompareIcon className="size-3.5 text-primary" />
+          Proposed changes
+        </span>
+        <span>{selected} selected</span>
+      </div>
+      {turn.rows.map((row) => (
+        <ButtonPrimitives.Button
+          key={row.id}
+          onPress={() => onToggle(turn.id, row.id)}
+          className={cn(
+            'flex w-full items-center gap-2.5 border-b px-3 py-2 text-left focus-reset transition-colors last:border-b-0 hover:bg-neutral focus-visible:focus-ring',
+            !row.included && 'opacity-40',
+          )}
+        >
+          <span className="w-16 shrink-0 text-xs">{row.axis}</span>
+          <span className="flex min-w-0 flex-1 items-center gap-1.5 font-mono text-[11px] text-fg-muted">
+            {row.kind === 'color' && (
+              <span
+                className="size-3 shrink-0 rounded-full border"
+                style={{ backgroundColor: row.fromColor }}
+              />
+            )}
+            <span className="truncate">{row.fromLabel}</span>
+            <ArrowRightIcon className="size-3 shrink-0" />
+            {row.kind === 'color' && (
+              <span
+                className="size-3 shrink-0 rounded-full border"
+                style={{ backgroundColor: row.toColor }}
+              />
+            )}
+            <span className="truncate font-medium text-fg">{row.toLabel}</span>
+          </span>
+          <span
+            className={cn(
+              'flex size-4 shrink-0 items-center justify-center rounded border',
+              row.included
+                ? 'border-primary bg-primary text-fg-on-primary'
+                : 'border-border',
+            )}
+          >
+            {row.included && <CheckIcon className="size-3" />}
+          </span>
+        </ButtonPrimitives.Button>
+      ))}
+      <div className="flex items-center gap-2 p-2.5">
+        <ButtonPrimitives.Button
+          onPress={() => onApply(turn.id)}
+          isDisabled={selected === 0}
+          className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-fg-on-primary focus-reset transition-opacity hover:opacity-90 focus-visible:focus-ring disabled:opacity-50"
+        >
+          <CheckIcon className="size-3.5" />
+          Apply {selected} {selected === 1 ? 'change' : 'changes'}
+        </ButtonPrimitives.Button>
+        <ButtonPrimitives.Button
+          onPress={() => onDiscard(turn.id)}
+          className="rounded-md border px-3 py-1.5 text-xs text-fg-muted focus-reset transition-colors hover:bg-neutral focus-visible:focus-ring"
+        >
+          Discard
+        </ButtonPrimitives.Button>
+      </div>
+    </div>
+  )
+}
+
+/* --------------------------------- Atoms --------------------------------- */
+
+function AssistantRow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex gap-2">
+      <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+        <SparklesIcon className="size-3" />
+      </div>
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  )
+}
+
+function Chip({
+  onPress,
+  children,
+}: {
+  onPress: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <ButtonPrimitives.Button
+      onPress={onPress}
+      className="flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs text-fg-muted focus-reset transition-colors hover:bg-neutral hover:text-fg focus-visible:focus-ring"
+    >
+      {children}
+    </ButtonPrimitives.Button>
+  )
+}
+
+function Quiet({
+  onPress,
+  label,
+  children,
+}: {
+  onPress: () => void
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <ButtonPrimitives.Button
+      onPress={onPress}
+      aria-label={label}
+      className="flex size-7 items-center justify-center rounded-md text-fg-muted focus-reset transition-colors hover:bg-neutral hover:text-fg focus-visible:focus-ring"
+    >
+      {children}
+    </ButtonPrimitives.Button>
+  )
+}

--- a/www/src/modules/create/next/axes.tsx
+++ b/www/src/modules/create/next/axes.tsx
@@ -1,0 +1,446 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { Slider, SliderControl } from '@/registry/ui/slider'
+import { Switch } from '@/registry/ui/switch'
+
+import { useDesignSystem } from '../preset'
+import { NEXT_DEFAULTS, NEXT_TOKENS } from './ai'
+
+/* ----------------------------------------------------------------------------
+ * Shared inspector primitives + the new foundation axes. Each new axis writes a
+ * namespaced `--next-*` token through the same `useDesignSystem()` the rest of
+ * the builder uses, so the value round-trips through the shared preset URL.
+ * -------------------------------------------------------------------------- */
+
+export function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-medium text-fg-muted">{label}</span>
+      {children}
+      {hint && <p className="text-xs text-fg-muted/60">{hint}</p>}
+    </div>
+  )
+}
+
+interface Option<T extends string> {
+  value: T
+  label: string
+}
+
+export function Segmented<T extends string>({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+}: {
+  value: T
+  onChange: (value: T) => void
+  options: Option<T>[]
+  ariaLabel: string
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className="flex gap-0.5 rounded-md bg-neutral p-0.5"
+    >
+      {options.map((opt) => (
+        <ButtonPrimitives.Button
+          key={opt.value}
+          onPress={() => onChange(opt.value)}
+          className={cn(
+            'flex-1 rounded px-2 py-1 text-xs focus-reset transition-colors focus-visible:focus-ring',
+            opt.value === value
+              ? 'bg-card font-medium text-fg shadow-sm'
+              : 'text-fg-muted hover:text-fg',
+          )}
+        >
+          {opt.label}
+        </ButtonPrimitives.Button>
+      ))}
+    </div>
+  )
+}
+
+export function Pills<T extends string>({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+}: {
+  value: T
+  onChange: (value: T) => void
+  options: Option<T>[]
+  ariaLabel: string
+}) {
+  return (
+    <div role="group" aria-label={ariaLabel} className="flex flex-wrap gap-1.5">
+      {options.map((opt) => (
+        <ButtonPrimitives.Button
+          key={opt.value}
+          onPress={() => onChange(opt.value)}
+          className={cn(
+            'rounded-md border px-2.5 py-1 text-xs focus-reset transition-colors focus-visible:focus-ring',
+            opt.value === value
+              ? 'border-primary/40 bg-primary/10 text-primary'
+              : 'text-fg-muted hover:bg-neutral hover:text-fg',
+          )}
+        >
+          {opt.label}
+        </ButtonPrimitives.Button>
+      ))}
+    </div>
+  )
+}
+
+/* ------------------------------ Token-bound controls ----------------------- */
+
+function useToken(token: string, fallback: string) {
+  const { designSystem, setToken } = useDesignSystem()
+  const value = designSystem.tokens[token] ?? fallback
+  return [value, (v: string) => setToken(token, v)] as const
+}
+
+function TokenSegmented<T extends string>({
+  token,
+  fallback,
+  label,
+  hint,
+  options,
+}: {
+  token: string
+  fallback: string
+  label: string
+  hint?: string
+  options: Option<T>[]
+}) {
+  const [value, set] = useToken(token, fallback)
+  return (
+    <Field label={label} hint={hint}>
+      <Segmented<T>
+        ariaLabel={label}
+        value={value as T}
+        onChange={set}
+        options={options}
+      />
+    </Field>
+  )
+}
+
+function TokenPills<T extends string>({
+  token,
+  fallback,
+  label,
+  hint,
+  options,
+}: {
+  token: string
+  fallback: string
+  label: string
+  hint?: string
+  options: Option<T>[]
+}) {
+  const [value, set] = useToken(token, fallback)
+  return (
+    <Field label={label} hint={hint}>
+      <Pills<T>
+        ariaLabel={label}
+        value={value as T}
+        onChange={set}
+        options={options}
+      />
+    </Field>
+  )
+}
+
+function TokenSlider({
+  token,
+  fallback,
+  label,
+  min,
+  max,
+  step,
+  format,
+}: {
+  token: string
+  fallback: string
+  label: string
+  min: number
+  max: number
+  step: number
+  format: (v: number) => string
+}) {
+  const [value, set] = useToken(token, fallback)
+  const numeric = Number.parseFloat(value)
+  const current = Number.isFinite(numeric)
+    ? numeric
+    : Number.parseFloat(fallback)
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-fg-muted">{label}</span>
+        <span className="text-xs font-medium text-fg tabular-nums">
+          {format(current)}
+        </span>
+      </div>
+      <Slider
+        aria-label={label}
+        value={current}
+        minValue={min}
+        maxValue={max}
+        step={step}
+        onChange={(v) => set(String(Array.isArray(v) ? v[0] : v))}
+      >
+        <SliderControl />
+      </Slider>
+    </div>
+  )
+}
+
+/* ---------------------------------- New axes -------------------------------- */
+
+export function TypographyDepth() {
+  const [scale] = useToken(NEXT_TOKENS.typeScale, NEXT_DEFAULTS.typeScale)
+  const [weight] = useToken(
+    NEXT_TOKENS.headingWeight,
+    NEXT_DEFAULTS.headingWeight,
+  )
+  const [tracking] = useToken(NEXT_TOKENS.tracking, NEXT_DEFAULTS.tracking)
+  const scaleNum = Number.parseFloat(scale) || 1.25
+  const size = Math.round(15 * scaleNum * scaleNum)
+  return (
+    <div className="flex flex-col gap-5">
+      <TokenPills
+        token={NEXT_TOKENS.typeScale}
+        fallback={NEXT_DEFAULTS.typeScale}
+        label="Scale ratio"
+        hint="The ratio between adjacent type sizes."
+        options={[
+          { value: '1.125', label: '1.125' },
+          { value: '1.2', label: '1.200' },
+          { value: '1.25', label: '1.250' },
+          { value: '1.333', label: '1.333' },
+          { value: '1.618', label: 'Golden' },
+        ]}
+      />
+      <TokenSlider
+        token={NEXT_TOKENS.headingWeight}
+        fallback={NEXT_DEFAULTS.headingWeight}
+        label="Heading weight"
+        min={300}
+        max={800}
+        step={100}
+        format={(v) => String(Math.round(v))}
+      />
+      <TokenSlider
+        token={NEXT_TOKENS.tracking}
+        fallback={NEXT_DEFAULTS.tracking}
+        label="Tracking"
+        min={-0.03}
+        max={0.05}
+        step={0.005}
+        format={(v) => `${(v * 1000).toFixed(0)}`}
+      />
+      <div className="rounded-lg border bg-neutral/40 p-3">
+        <div
+          className="font-heading leading-none"
+          style={{
+            fontSize: size,
+            fontWeight: Number.parseInt(weight, 10) || 600,
+            letterSpacing: `${Number.parseFloat(tracking) || 0}em`,
+          }}
+        >
+          Ag
+        </div>
+        <p className="mt-1.5 text-xs text-fg-muted">The quick brown fox</p>
+      </div>
+    </div>
+  )
+}
+
+export function SpacingAxis() {
+  return (
+    <div className="flex flex-col gap-5">
+      <TokenSegmented
+        token={NEXT_TOKENS.spacingUnit}
+        fallback={NEXT_DEFAULTS.spacingUnit}
+        label="Base unit"
+        hint="The atom every gap and pad is a multiple of."
+        options={[
+          { value: '2', label: '2px' },
+          { value: '4', label: '4px' },
+          { value: '8', label: '8px' },
+        ]}
+      />
+      <TokenSegmented
+        token={NEXT_TOKENS.spacingScale}
+        fallback={NEXT_DEFAULTS.spacingScale}
+        label="Scale"
+        options={[
+          { value: 'linear', label: 'Linear' },
+          { value: 'geometric', label: 'Geometric' },
+        ]}
+      />
+    </div>
+  )
+}
+
+const ELEVATION_SHADOW: Record<string, string> = {
+  flat: 'none',
+  subtle: '0 1px 2px rgb(0 0 0 / 0.07)',
+  lifted: '0 5px 16px rgb(0 0 0 / 0.11)',
+  dramatic: '0 14px 34px rgb(0 0 0 / 0.18)',
+}
+
+export function ElevationAxis() {
+  const [elevation] = useToken(NEXT_TOKENS.elevation, NEXT_DEFAULTS.elevation)
+  return (
+    <div className="flex flex-col gap-5">
+      <TokenPills
+        token={NEXT_TOKENS.elevation}
+        fallback={NEXT_DEFAULTS.elevation}
+        label="Shadow scale"
+        options={[
+          { value: 'flat', label: 'Flat' },
+          { value: 'subtle', label: 'Subtle' },
+          { value: 'lifted', label: 'Lifted' },
+          { value: 'dramatic', label: 'Dramatic' },
+        ]}
+      />
+      <div className="flex items-center justify-center rounded-lg border bg-neutral/40 py-6">
+        <div
+          className="size-16 rounded-lg border bg-card"
+          style={{ boxShadow: ELEVATION_SHADOW[elevation] ?? 'none' }}
+        />
+      </div>
+      <TokenSegmented
+        token={NEXT_TOKENS.elevationTint}
+        fallback={NEXT_DEFAULTS.elevationTint}
+        label="Shadow tint"
+        hint="Borderless, flat, or floating — the gap between Material and Linear."
+        options={[
+          { value: 'neutral', label: 'Neutral' },
+          { value: 'brand', label: 'Brand' },
+        ]}
+      />
+    </div>
+  )
+}
+
+const MOTION_MS: Record<string, number> = {
+  instant: 0,
+  snappy: 140,
+  smooth: 260,
+  expressive: 460,
+}
+
+export function MotionAxis() {
+  const [motion] = useToken(NEXT_TOKENS.motion, NEXT_DEFAULTS.motion)
+  const ms = MOTION_MS[motion] ?? 260
+  return (
+    <div className="flex flex-col gap-5">
+      <TokenPills
+        token={NEXT_TOKENS.motion}
+        fallback={NEXT_DEFAULTS.motion}
+        label="Speed"
+        options={[
+          { value: 'instant', label: 'Instant' },
+          { value: 'snappy', label: 'Snappy' },
+          { value: 'smooth', label: 'Smooth' },
+          { value: 'expressive', label: 'Expressive' },
+        ]}
+      />
+      <TokenSegmented
+        token={NEXT_TOKENS.easing}
+        fallback={NEXT_DEFAULTS.easing}
+        label="Easing"
+        options={[
+          { value: 'standard', label: 'Standard' },
+          { value: 'spring', label: 'Spring' },
+        ]}
+      />
+      <div className="flex items-center justify-between rounded-lg border bg-neutral/40 p-3">
+        <span className="text-xs text-fg-muted">Hover to preview</span>
+        <button
+          type="button"
+          className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-fg-on-primary hover:-translate-y-0.5"
+          style={{
+            transition: `transform ${ms}ms cubic-bezier(0.34,1.56,0.64,1)`,
+          }}
+        >
+          Demo
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export function BordersAxis() {
+  return (
+    <div className="flex flex-col gap-5">
+      <TokenSegmented
+        token={NEXT_TOKENS.borders}
+        fallback={NEXT_DEFAULTS.borders}
+        label="Border style"
+        hint="Some systems are borderless and lean on elevation instead."
+        options={[
+          { value: 'default', label: 'Default' },
+          { value: 'hairline', label: 'Hairline' },
+          { value: 'none', label: 'None' },
+        ]}
+      />
+    </div>
+  )
+}
+
+export function FocusAxis() {
+  return (
+    <div className="flex flex-col gap-5">
+      <TokenSegmented
+        token={NEXT_TOKENS.focus}
+        fallback={NEXT_DEFAULTS.focus}
+        label="Focus ring"
+        hint="Width and offset of the keyboard-focus indicator."
+        options={[
+          { value: 'default', label: 'Default' },
+          { value: 'bold', label: 'Bold' },
+        ]}
+      />
+    </div>
+  )
+}
+
+export function SurfacesAxis() {
+  const [surfaces, set] = useToken(NEXT_TOKENS.surfaces, NEXT_DEFAULTS.surfaces)
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-col">
+          <span className="text-xs font-medium text-fg-muted">
+            Translucent surfaces
+          </span>
+          <span className="text-xs text-fg-muted/60">
+            Frost menus, popovers, and modals.
+          </span>
+        </div>
+        <Switch
+          isSelected={surfaces === 'translucent'}
+          onChange={(on) => set(on ? 'translucent' : 'opaque')}
+          aria-label="Translucent surfaces"
+        />
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/create/next/index.tsx
+++ b/www/src/modules/create/next/index.tsx
@@ -2,19 +2,15 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { getRouteApi } from '@tanstack/react-router'
-import {
-  DicesIcon,
-  MoonIcon,
-  Share2Icon,
-  SparklesIcon,
-  SunIcon,
-  Undo2Icon,
-} from 'lucide-react'
-import { useTheme } from 'starter-themes'
+import { DicesIcon, Share2Icon, SparklesIcon, Undo2Icon } from 'lucide-react'
 
+import { siteConfig } from '@/config/site'
 import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
-import { Button } from '@/registry/ui/button'
+import { Button, buttonStyles } from '@/registry/ui/button'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+import { GitHubIcon } from '@/components/icons/github'
+import { Logo } from '@/components/layout/logo'
+import { ThemeToggle } from '@/components/theme-toggle'
 
 import { RADIUS_FACTOR_VAR } from '../layout'
 import { useDesignSystem } from '../preset'
@@ -61,7 +57,7 @@ export function BuilderNext() {
   }, [])
 
   return (
-    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-col">
+    <div className="flex h-svh min-h-0 flex-col">
       <TopBar onOpenAssistant={() => setAssistantOpen(true)} />
       <div className="flex min-h-0 flex-1">
         <Rail
@@ -82,7 +78,6 @@ function TopBar({ onOpenAssistant }: { onOpenAssistant: () => void }) {
   const { preset } = routeApi.useSearch()
   const navigate = routeApi.useNavigate()
   const { designSystem, setDesignSystem } = useDesignSystem()
-  const { resolvedTheme, setTheme } = useTheme()
   const [name, setName] = useState('Untitled system')
   const accent = readAccent(designSystem)
 
@@ -137,19 +132,28 @@ function TopBar({ onOpenAssistant }: { onOpenAssistant: () => void }) {
   }
 
   return (
-    <header className="flex h-12 shrink-0 items-center gap-2 border-b px-3">
-      <span
-        className="size-5 shrink-0 rounded-md ring-1 ring-black/10 ring-inset"
-        style={{ backgroundColor: accent }}
-        aria-hidden
-      />
-      <input
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        aria-label="System name"
-        spellCheck={false}
-        className="w-40 min-w-0 truncate rounded-sm bg-transparent text-sm font-medium outline-none focus-visible:bg-neutral focus-visible:px-1.5 focus-visible:py-0.5"
-      />
+    // Builder top bar: the site-nav links + "Search docs" are gone (the global
+    // site Header is suppressed on /create?next=true), replaced by the builder's
+    // own controls. The continuity bits — Logo→home, GitHub, ThemeToggle — and
+    // the shared --header-height keep the transition into the builder seamless,
+    // so it reads as a focused mode of the same product, not a separate app.
+    <header className="sticky top-0 z-30 flex h-(--header-height) shrink-0 items-center gap-2 border-b px-3 sm:px-4">
+      <div className="flex shrink-0 items-center gap-2.5">
+        <Logo />
+        <span aria-hidden className="h-5 w-px bg-border" />
+        <span
+          className="size-5 shrink-0 rounded-md ring-1 ring-black/10 ring-inset"
+          style={{ backgroundColor: accent }}
+          aria-hidden
+        />
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          aria-label="System name"
+          spellCheck={false}
+          className="w-32 min-w-0 truncate rounded-sm bg-transparent text-sm font-medium outline-none focus-visible:bg-neutral focus-visible:px-1.5 focus-visible:py-0.5 max-md:hidden"
+        />
+      </div>
 
       {/* AI compose bar — the front door. */}
       <button
@@ -165,20 +169,6 @@ function TopBar({ onOpenAssistant }: { onOpenAssistant: () => void }) {
       </button>
 
       <div className="flex shrink-0 items-center gap-0.5">
-        <Tooltip>
-          <Button
-            size="sm"
-            variant="quiet"
-            isIconOnly
-            aria-label="Toggle mode"
-            onPress={() =>
-              setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
-            }
-          >
-            {resolvedTheme === 'dark' ? <SunIcon /> : <MoonIcon />}
-          </Button>
-          <TooltipContent>Toggle mode</TooltipContent>
-        </Tooltip>
         <Tooltip>
           <Button
             size="sm"
@@ -216,6 +206,18 @@ function TopBar({ onOpenAssistant }: { onOpenAssistant: () => void }) {
           </Button>
           <TooltipContent>Copy share link</TooltipContent>
         </Tooltip>
+        <span aria-hidden className="mx-1 h-5 w-px bg-border" />
+        <a
+          aria-label="GitHub"
+          href={siteConfig.links.github}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-icon-only=""
+          className={buttonStyles({ variant: 'quiet', size: 'sm' })}
+        >
+          <GitHubIcon />
+        </a>
+        <ThemeToggle size="sm" variant="quiet" isIconOnly />
       </div>
     </header>
   )

--- a/www/src/modules/create/next/index.tsx
+++ b/www/src/modules/create/next/index.tsx
@@ -1,0 +1,222 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { getRouteApi } from '@tanstack/react-router'
+import {
+  DicesIcon,
+  MoonIcon,
+  Share2Icon,
+  SparklesIcon,
+  SunIcon,
+  Undo2Icon,
+} from 'lucide-react'
+import { useTheme } from 'starter-themes'
+
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+import { RADIUS_FACTOR_VAR } from '../layout'
+import { useDesignSystem } from '../preset'
+import { PreviewPanel } from '../preview/preview-panel'
+import { readAccent } from './ai'
+import { Assistant } from './assistant'
+import { Inspector } from './inspector'
+import { Rail, type SectionId } from './rail'
+
+const routeApi = getRouteApi('/_app/create')
+
+const SHUFFLE_ACCENTS = [
+  '#3b82f6',
+  '#6366f1',
+  '#8b5cf6',
+  '#ec4899',
+  '#f43f5e',
+  '#f59e0b',
+  '#22c55e',
+  '#14b8a6',
+  '#06b6d4',
+]
+const SHUFFLE_RADII = ['0', '0.5', '1', '1.5', '2']
+const SHUFFLE_DENSITIES = ['compact', 'default', 'comfortable'] as const
+
+function pick<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)] as T
+}
+
+export function BuilderNext() {
+  const [section, setSection] = useState<SectionId>('theme')
+  const [assistantOpen, setAssistantOpen] = useState(true)
+
+  // ⌘K / Ctrl-K opens the assistant.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setAssistantOpen(true)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  return (
+    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-col">
+      <TopBar onOpenAssistant={() => setAssistantOpen(true)} />
+      <div className="flex min-h-0 flex-1">
+        <Rail
+          active={section}
+          onSelect={setSection}
+          onOpenAssistant={() => setAssistantOpen(true)}
+          assistantOpen={assistantOpen}
+        />
+        <Inspector section={section} onAsk={() => setAssistantOpen(true)} />
+        <PreviewPanel className="m-3 rounded-xl border" />
+        {assistantOpen && <Assistant onClose={() => setAssistantOpen(false)} />}
+      </div>
+    </div>
+  )
+}
+
+function TopBar({ onOpenAssistant }: { onOpenAssistant: () => void }) {
+  const { preset } = routeApi.useSearch()
+  const navigate = routeApi.useNavigate()
+  const { designSystem, setDesignSystem } = useDesignSystem()
+  const { resolvedTheme, setTheme } = useTheme()
+  const [name, setName] = useState('Untitled system')
+  const accent = readAccent(designSystem)
+
+  // Undo history. Design edits write `?preset=` with `replace: true`, so the browser
+  // back button can't step through them — we keep our own stack and walk it back.
+  const historyRef = useRef<(string | undefined)[]>([])
+  const prevPresetRef = useRef<string | undefined>(preset)
+  const isUndoingRef = useRef(false)
+  const [canUndo, setCanUndo] = useState(false)
+
+  useEffect(() => {
+    if (prevPresetRef.current === preset) return
+    if (isUndoingRef.current) {
+      isUndoingRef.current = false
+    } else {
+      historyRef.current.push(prevPresetRef.current)
+      setCanUndo(true)
+    }
+    prevPresetRef.current = preset
+  }, [preset])
+
+  function undo() {
+    if (historyRef.current.length === 0) return
+    const previous = historyRef.current.pop()
+    isUndoingRef.current = true
+    navigate({
+      search: (prev) => ({ ...prev, preset: previous }),
+      replace: true,
+    })
+    setCanUndo(historyRef.current.length > 0)
+  }
+
+  function reroll() {
+    const accentPick = pick(SHUFFLE_ACCENTS)
+    const radius = pick(SHUFFLE_RADII)
+    const density = pick(SHUFFLE_DENSITIES)
+    setDesignSystem((prev) => {
+      const base = prev.color ?? DEFAULT_COLOR_CONFIG
+      return {
+        ...prev,
+        density,
+        tokens: { ...prev.tokens, [RADIUS_FACTOR_VAR]: radius },
+        color: { ...base, seeds: { ...base.seeds, accent: accentPick } },
+      }
+    })
+  }
+
+  function share() {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(window.location.href)
+    }
+  }
+
+  return (
+    <header className="flex h-12 shrink-0 items-center gap-2 border-b px-3">
+      <span
+        className="size-5 shrink-0 rounded-md ring-1 ring-black/10 ring-inset"
+        style={{ backgroundColor: accent }}
+        aria-hidden
+      />
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        aria-label="System name"
+        spellCheck={false}
+        className="w-40 min-w-0 truncate rounded-sm bg-transparent text-sm font-medium outline-none focus-visible:bg-neutral focus-visible:px-1.5 focus-visible:py-0.5"
+      />
+
+      {/* AI compose bar — the front door. */}
+      <button
+        type="button"
+        onClick={onOpenAssistant}
+        className="mx-auto flex h-9 w-full max-w-md items-center gap-2 rounded-md border bg-neutral px-3 text-sm text-fg-muted transition-colors hover:border-fg-muted/40 hover:bg-bg"
+      >
+        <SparklesIcon className="size-4 text-primary" />
+        <span className="truncate">Describe a vibe, paste a URL, or ask…</span>
+        <kbd className="ml-auto rounded border bg-card px-1.5 font-mono text-[10px] text-fg-muted">
+          ⌘K
+        </kbd>
+      </button>
+
+      <div className="flex shrink-0 items-center gap-0.5">
+        <Tooltip>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            aria-label="Toggle mode"
+            onPress={() =>
+              setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+            }
+          >
+            {resolvedTheme === 'dark' ? <SunIcon /> : <MoonIcon />}
+          </Button>
+          <TooltipContent>Toggle mode</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            aria-label="Re-roll"
+            onPress={reroll}
+          >
+            <DicesIcon />
+          </Button>
+          <TooltipContent>Re-roll the system</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            aria-label="Undo"
+            onPress={undo}
+            isDisabled={!canUndo}
+          >
+            <Undo2Icon />
+          </Button>
+          <TooltipContent>Undo</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            aria-label="Share"
+            onPress={share}
+          >
+            <Share2Icon />
+          </Button>
+          <TooltipContent>Copy share link</TooltipContent>
+        </Tooltip>
+      </div>
+    </header>
+  )
+}

--- a/www/src/modules/create/next/inspector.tsx
+++ b/www/src/modules/create/next/inspector.tsx
@@ -1,0 +1,340 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronLeftIcon, SparklesIcon } from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+
+import { ChartColorsConfig } from '../chart-colors'
+import { CodeOptionsDialog } from '../code-options'
+import { ColorsConfig } from '../colors'
+import {
+  AllComponentsView,
+  ComponentDetailView,
+  getComponentDisplayName,
+} from '../components'
+import {
+  CURSOR_DISABLED_VAR,
+  CURSOR_INTERACTIVE_VAR,
+  CursorConfig,
+  DEFAULT_CURSOR_DISABLED,
+  DEFAULT_CURSOR_INTERACTIVE,
+} from '../cursor'
+import { ExportFooter } from '../export'
+import { IconographyConfig } from '../iconography'
+import {
+  DEFAULT_RADIUS_FACTOR,
+  DensityConfig,
+  RADIUS_FACTOR_VAR,
+  RadiusConfig,
+} from '../layout'
+import { useDesignSystem } from '../preset'
+import type { Density } from '../preset'
+import { TypographyConfig } from '../typography'
+import { readAccent } from './ai'
+import {
+  BordersAxis,
+  ElevationAxis,
+  FocusAxis,
+  MotionAxis,
+  SpacingAxis,
+  SurfacesAxis,
+  TypographyDepth,
+} from './axes'
+import { ALL_SECTIONS, type SectionId } from './rail'
+
+export function Inspector({
+  section,
+  onAsk,
+}: {
+  section: SectionId
+  onAsk: () => void
+}) {
+  const def = ALL_SECTIONS.find((s) => s.id === section)
+  return (
+    <div className="flex w-72 shrink-0 flex-col border-r bg-card max-lg:hidden">
+      <div className="flex items-center justify-between border-b px-3 py-2.5">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-medium">{def?.label}</h2>
+          {def?.isNew && (
+            <span className="rounded bg-primary/10 px-1.5 py-px text-[10px] font-medium text-primary">
+              New
+            </span>
+          )}
+        </div>
+        <ButtonPrimitives.Button
+          onPress={onAsk}
+          className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-primary focus-reset transition-colors hover:bg-neutral focus-visible:focus-ring"
+        >
+          <SparklesIcon className="size-3.5" />
+          Ask
+        </ButtonPrimitives.Button>
+      </div>
+
+      <div className="scrollbar-none flex-1 overflow-y-auto p-4">
+        <SectionPanel section={section} />
+      </div>
+
+      <div className="flex flex-col gap-2 border-t p-3">
+        <CodeOptionsDialog />
+        <ExportFooter />
+      </div>
+    </div>
+  )
+}
+
+function SectionPanel({ section }: { section: SectionId }) {
+  const { designSystem, setToken } = useDesignSystem()
+
+  switch (section) {
+    case 'theme':
+      return <ThemePanel />
+    case 'color':
+      return <ColorsConfig />
+    case 'chart-colors':
+      return <ChartColorsConfig />
+    case 'typography':
+      return (
+        <div className="flex flex-col gap-5">
+          <TypographyConfig />
+          <div className="h-px bg-border" />
+          <TypographyDepth />
+        </div>
+      )
+    case 'icons':
+      return <IconographyConfig />
+    case 'radius':
+      return (
+        <RadiusConfig
+          value={
+            designSystem.tokens[RADIUS_FACTOR_VAR] ?? DEFAULT_RADIUS_FACTOR
+          }
+          onChange={(v) => setToken(RADIUS_FACTOR_VAR, v)}
+        />
+      )
+    case 'spacing':
+      return <SpacingAxis />
+    case 'elevation':
+      return <ElevationAxis />
+    case 'motion':
+      return <MotionAxis />
+    case 'borders':
+      return <BordersAxis />
+    case 'focus':
+      return <FocusAxis />
+    case 'surfaces':
+      return <SurfacesAxis />
+    case 'cursor':
+      return (
+        <CursorConfig
+          interactive={
+            designSystem.tokens[CURSOR_INTERACTIVE_VAR] ??
+            DEFAULT_CURSOR_INTERACTIVE
+          }
+          disabled={
+            designSystem.tokens[CURSOR_DISABLED_VAR] ?? DEFAULT_CURSOR_DISABLED
+          }
+          onChange={setToken}
+        />
+      )
+    case 'components':
+      return <ComponentsPanel />
+    case 'code':
+      return (
+        <div className="flex flex-col gap-3">
+          <p className="text-xs text-fg-muted">
+            Shape the exported source so it reads like your codebase. Full
+            options live in the dialog below.
+          </p>
+          <CodeOptionsDialog />
+        </div>
+      )
+    default:
+      return null
+  }
+}
+
+/* --------------------------------- Theme --------------------------------- */
+
+interface Personality {
+  id: string
+  label: string
+  accent: string
+  radius: string
+  density: Density
+}
+
+const PERSONALITIES: Personality[] = [
+  {
+    id: 'minimal',
+    label: 'Minimal',
+    accent: '#171717',
+    radius: '0.4',
+    density: 'compact',
+  },
+  {
+    id: 'corporate',
+    label: 'Corporate',
+    accent: '#2563eb',
+    radius: '0.6',
+    density: 'default',
+  },
+  {
+    id: 'playful',
+    label: 'Playful',
+    accent: '#f43f5e',
+    radius: '1.6',
+    density: 'comfortable',
+  },
+  {
+    id: 'editorial',
+    label: 'Editorial',
+    accent: '#0f766e',
+    radius: '0.25',
+    density: 'comfortable',
+  },
+  {
+    id: 'vivid',
+    label: 'Vivid',
+    accent: '#7c3aed',
+    radius: '1',
+    density: 'default',
+  },
+]
+
+const BRAND_SWATCHES = [
+  '#6366f1',
+  '#5e6ad2',
+  '#171717',
+  '#2563eb',
+  '#0f766e',
+  '#f43f5e',
+  '#f59e0b',
+  '#06b6d4',
+  '#22c55e',
+]
+
+function ThemePanel() {
+  const { designSystem, setDesignSystem, setColorSeed, setDensity, setToken } =
+    useDesignSystem()
+  const accent = readAccent(designSystem)
+  const radius = designSystem.tokens[RADIUS_FACTOR_VAR] ?? DEFAULT_RADIUS_FACTOR
+
+  function applyPersonality(p: Personality) {
+    setDesignSystem((prev) => {
+      const base = prev.color ?? DEFAULT_COLOR_CONFIG
+      return {
+        ...prev,
+        density: p.density,
+        tokens: { ...prev.tokens, [RADIUS_FACTOR_VAR]: p.radius },
+        color: { ...base, seeds: { ...base.seeds, accent: p.accent } },
+      }
+    })
+  }
+
+  const activePersonality = PERSONALITIES.find(
+    (p) =>
+      p.accent.toLowerCase() === accent.toLowerCase() &&
+      p.radius === radius &&
+      p.density === designSystem.density,
+  )?.id
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-fg-muted">Brand color</span>
+        <div className="flex flex-wrap gap-2">
+          {BRAND_SWATCHES.map((c) => (
+            <ButtonPrimitives.Button
+              key={c}
+              onPress={() => setColorSeed('accent', c)}
+              aria-label={c}
+              className={cn(
+                'size-6 rounded-full border focus-reset transition-transform focus-visible:focus-ring',
+                c.toLowerCase() === accent.toLowerCase()
+                  ? 'ring-2 ring-fg ring-offset-2 ring-offset-card'
+                  : 'hover:scale-110',
+              )}
+              style={{ backgroundColor: c }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-fg-muted">Personality</span>
+        <div className="flex flex-wrap gap-1.5">
+          {PERSONALITIES.map((p) => (
+            <ButtonPrimitives.Button
+              key={p.id}
+              onPress={() => applyPersonality(p)}
+              className={cn(
+                'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs focus-reset transition-colors focus-visible:focus-ring',
+                activePersonality === p.id
+                  ? 'border-transparent bg-primary text-fg-on-primary'
+                  : 'hover:bg-neutral',
+              )}
+            >
+              <span
+                className="size-2.5 rounded-full"
+                style={{ backgroundColor: p.accent }}
+              />
+              {p.label}
+            </ButtonPrimitives.Button>
+          ))}
+        </div>
+      </div>
+
+      <RadiusConfig
+        value={radius}
+        onChange={(v) => setToken(RADIUS_FACTOR_VAR, v)}
+      />
+
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-fg-muted">Density</span>
+        <DensityConfig value={designSystem.density} onChange={setDensity} />
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------- Components ------------------------------- */
+
+function ComponentsPanel() {
+  const { designSystem, setComponentParam } = useDesignSystem()
+  const [selected, setSelected] = useState<string | null>(null)
+
+  if (selected) {
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="-ml-1 flex items-center gap-2">
+          <Button
+            variant="quiet"
+            size="sm"
+            isIconOnly
+            onPress={() => setSelected(null)}
+            aria-label="Back"
+            className="size-6"
+          >
+            <ChevronLeftIcon />
+          </Button>
+          <h3 className="text-sm font-medium">
+            {getComponentDisplayName(selected)}
+          </h3>
+        </div>
+        <ComponentDetailView
+          componentName={selected}
+          selectedParams={designSystem.componentParams[selected] ?? {}}
+          onParamChange={(paramName, value) =>
+            setComponentParam(selected, paramName, value)
+          }
+        />
+      </div>
+    )
+  }
+
+  return <AllComponentsView onSelect={setSelected} />
+}

--- a/www/src/modules/create/next/rail.tsx
+++ b/www/src/modules/create/next/rail.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import {
+  ActivityIcon,
+  BlendIcon,
+  ChartColumnIcon,
+  CodeIcon,
+  ComponentIcon,
+  FocusIcon,
+  FrameIcon,
+  LayersIcon,
+  type LucideIcon,
+  MousePointer2Icon,
+  PaletteIcon,
+  RulerIcon,
+  ShapesIcon,
+  SparklesIcon,
+  SquareIcon,
+  TypeIcon,
+  Wand2Icon,
+} from 'lucide-react'
+import * as ButtonPrimitives from 'react-aria-components/Button'
+
+import { cn } from '@/registry/lib/utils'
+import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+
+export type SectionId =
+  | 'theme'
+  | 'color'
+  | 'chart-colors'
+  | 'typography'
+  | 'icons'
+  | 'radius'
+  | 'spacing'
+  | 'elevation'
+  | 'motion'
+  | 'borders'
+  | 'focus'
+  | 'surfaces'
+  | 'cursor'
+  | 'components'
+  | 'code'
+
+export interface SectionDef {
+  id: SectionId
+  label: string
+  Icon: LucideIcon
+  isNew?: boolean
+}
+
+export const SECTION_GROUPS: SectionDef[][] = [
+  [
+    { id: 'theme', label: 'Theme', Icon: Wand2Icon },
+    { id: 'color', label: 'Color', Icon: PaletteIcon },
+    { id: 'chart-colors', label: 'Chart colors', Icon: ChartColumnIcon },
+    { id: 'typography', label: 'Typography', Icon: TypeIcon },
+    { id: 'icons', label: 'Icons', Icon: ShapesIcon },
+  ],
+  [
+    { id: 'radius', label: 'Radius', Icon: SquareIcon },
+    { id: 'spacing', label: 'Spacing', Icon: RulerIcon, isNew: true },
+    { id: 'elevation', label: 'Elevation', Icon: LayersIcon, isNew: true },
+    { id: 'motion', label: 'Motion', Icon: ActivityIcon, isNew: true },
+    { id: 'borders', label: 'Borders', Icon: FrameIcon, isNew: true },
+    { id: 'focus', label: 'Focus ring', Icon: FocusIcon, isNew: true },
+  ],
+  [
+    { id: 'surfaces', label: 'Surfaces', Icon: BlendIcon, isNew: true },
+    { id: 'cursor', label: 'Cursor', Icon: MousePointer2Icon },
+  ],
+  [
+    { id: 'components', label: 'Components', Icon: ComponentIcon },
+    { id: 'code', label: 'Code style', Icon: CodeIcon },
+  ],
+]
+
+export const ALL_SECTIONS: SectionDef[] = SECTION_GROUPS.flat()
+
+export function Rail({
+  active,
+  onSelect,
+  onOpenAssistant,
+  assistantOpen,
+}: {
+  active: SectionId
+  onSelect: (id: SectionId) => void
+  onOpenAssistant: () => void
+  assistantOpen: boolean
+}) {
+  return (
+    <nav className="scrollbar-none flex w-12 shrink-0 flex-col items-center gap-1 overflow-y-auto border-r bg-card py-2">
+      <Tooltip>
+        <RailButton
+          label="Ask AI"
+          active={assistantOpen}
+          accent
+          onPress={onOpenAssistant}
+        >
+          <SparklesIcon />
+        </RailButton>
+        <TooltipContent placement="right">Ask AI</TooltipContent>
+      </Tooltip>
+      {SECTION_GROUPS.map((group, i) => (
+        <div key={i} className="flex flex-col items-center gap-1">
+          <div className="my-1 h-px w-5 bg-border" />
+          {group.map(({ id, label, Icon, isNew }) => (
+            <Tooltip key={id}>
+              <RailButton
+                label={label}
+                active={active === id}
+                isNew={isNew}
+                onPress={() => onSelect(id)}
+              >
+                <Icon />
+              </RailButton>
+              <TooltipContent placement="right">{label}</TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+      ))}
+    </nav>
+  )
+}
+
+function RailButton({
+  label,
+  active,
+  accent,
+  isNew,
+  onPress,
+  children,
+}: {
+  label: string
+  active?: boolean
+  accent?: boolean
+  isNew?: boolean
+  onPress: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <ButtonPrimitives.Button
+      onPress={onPress}
+      aria-label={label}
+      className={cn(
+        'relative flex size-8 items-center justify-center rounded-md focus-reset transition-colors focus-visible:focus-ring [&_svg]:size-[18px]',
+        active
+          ? accent
+            ? 'bg-primary/10 text-primary'
+            : 'bg-primary/10 text-primary'
+          : accent
+            ? 'text-primary hover:bg-neutral'
+            : 'text-fg-muted hover:bg-neutral hover:text-fg',
+      )}
+    >
+      {children}
+      {isNew && (
+        <span className="absolute top-1 right-1 size-1.5 rounded-full bg-primary" />
+      )}
+    </ButtonPrimitives.Button>
+  )
+}

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/registry/lib/utils'
 import { ToggleButton } from '@/registry/ui/toggle-button'
 import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
 import { CustomizerPanel } from '@/modules/create/customizer-panel'
+import { BuilderNext } from '@/modules/create/next'
 import { LabExperience } from '@/modules/create/panel'
 import { DEFAULTS, useDesignSystem } from '@/modules/create/preset'
 import {
@@ -25,6 +26,9 @@ export const createSearchSchema = z.object({
   // Coerced boolean: the search parser reads bare `1`/`true` as non-strings, so a
   // plain `z.string()` would reject them and the param would be dropped.
   lab: z.coerce.boolean().optional().catch(undefined),
+  // Opt-in flag for the reimagined "studio" builder — AI assistant + new axes.
+  // Same gating pattern as `lab`; shipped /create stays untouched at /create?next=true.
+  next: z.coerce.boolean().optional().catch(undefined),
 })
 
 const searchDefaults = { preview: 'cards' }
@@ -38,7 +42,7 @@ export const Route = createFileRoute('/_app/create')({
 })
 
 function CreatePage() {
-  const { lab, preset } = Route.useSearch()
+  const { lab, next, preset } = Route.useSearch()
   const { designSystem, setDesignSystem } = useDesignSystem()
   // Below `lg` the customizer and the live preview can't sit side by side (the iframe
   // would be a ~15px sliver), so they collapse into a single switchable pane toggled
@@ -71,6 +75,9 @@ function CreatePage() {
 
   // Opt-in exploration of the redesigned control panel + floating panel lab.
   if (lab) return <LabExperience />
+
+  // Opt-in exploration of the reimagined "studio" builder with the AI assistant.
+  if (next) return <BuilderNext />
 
   return (
     <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2">

--- a/www/src/routes/_app/route.tsx
+++ b/www/src/routes/_app/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeader } from '@tanstack/react-start/server'
 import type * as PageTree from 'fumadocs-core/page-tree'
@@ -37,9 +37,19 @@ function AppLayout() {
   const { pageTree } = Route.useLoaderData()
   const items = pageTree.children as PageTree.Node[]
 
+  // The reimagined "studio" builder (/create?next=true) owns its own top bar —
+  // a focused app shell that merges the site-nav continuity bits (logo→home,
+  // theme toggle, GitHub) into the builder's chrome. Skip the global site
+  // Header there so the two bars never stack; every other route (and the other
+  // /create variants) keeps the normal site Header. --header-height stays
+  // defined on this layout so the builder's height math still resolves.
+  const { pathname, search } = useLocation()
+  const isNextBuilder =
+    pathname === '/create' && (search as { next?: boolean }).next === true
+
   return (
     <div className="[--header-height:--spacing(14)]">
-      <Header items={items} />
+      {!isNextBuilder && <Header items={items} />}
       <main id="content">
         <Outlet />
       </main>


### PR DESCRIPTION
## What

An experiment that rethinks `/create` end to end — a new "studio" layout, an AI assistant as the centerpiece, and the missing foundation axes. It's **opt-in and UI-only**, gated exactly like `?lab`, so the shipped builder and the panel lab are untouched.

**Try it:** run the app and open **`/create?next=true`**.

## The layout

A persistent three-zone studio instead of the single drill-down column:

- **Top bar** — brand mark + editable system name, a centered **⌘K AI command bar**, and theme toggle / re-roll / undo / share.
- **Left rail** — every axis as one click (no back-button spelunking), grouped Foundations → shape & feel → surfaces → components / code. New axes carry a dot.
- **Inspector** — deep controls for the selected axis, each with a per-axis `✦ Ask`.
- **Canvas** — the existing live preview, reused as-is.
- **Assistant drawer** — the AI surface.

It reuses the real `useDesignSystem` + preview iframe, so brand color / radius / density edits (and the assistant's applies) are genuinely live.

## AI, around one primitive

Every assistant action returns the **same reviewable diff**: a list of per-axis changes you can toggle row by row, apply, and undo — never a silent rewrite.

- **Compose** — a prompt (or the ⌘K bar) → a whole-system diff.
- **Refine** — "Rounder", "More contrast", "Calmer motion" → small scoped diffs.
- **Audit** — scans the current system for issues (contrast, scale jumps, focus ring), each with a one-click Fix.
- **Extract** — an image/URL → palette + font guess as a diff.

UI-only: the engine (`ai.ts`) returns canned diffs — no model call. The `DesignSystemDiff` shape it produces is the contract a real server function would later fill, so the UI wouldn't change.

## New axes (all proposed, per the brief)

Typography depth (scale ratio / weight / tracking), **spacing**, **elevation** (+ tint), **motion** (speed + easing), **borders**, **focus ring**, **translucent surfaces**. Token-backed axes drive the preview today; the new axes persist as namespaced `--next-*` tokens and are visual-only until components consume them.

## Notes

- Reuses the existing Color / Icon / Cursor / Radius / Density / Components / Code panels rather than reimplementing them.
- Desktop-first prototype (inspector + assistant hide below `lg`, like the shipped mobile pane).
- `pnpm typecheck` and `pnpm check` pass; verified live in the browser (compose → apply changes the preview, new-axis panels render, no console errors).
- New axes are proposals — landing them for real is a product decision, not assumed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are isolated behind a search flag and client-only UI; routing/layout tweaks are narrow (create route + header suppression) with no auth or server-side behavior.
> 
> **Overview**
> Adds an **opt-in studio builder** at `/create?next=true` (same gating as `?lab=true`), leaving the default `/create` flow unchanged.
> 
> The new **`BuilderNext`** shell replaces the single customizer column with a **rail → inspector → live preview → assistant** layout, a dedicated top bar (⌘K compose bar, re-roll, preset undo, share), and **hides the global site `Header`** on that route so chrome does not stack.
> 
> **AI is UI-only** in `ai.ts`: compose, refine, audit, and image extract all return the same **reviewable per-axis `DiffRow` list** (toggle, apply, undo) via canned presets—no model calls. The assistant drawer wires those diffs into `useDesignSystem`.
> 
> **New foundation axes** (spacing, elevation, motion, borders, focus, surfaces, typography depth) persist as namespaced `--next-*` tokens in the inspector; most are visual-only until components consume them. Existing color, typography, components, and export panels are **reused** in the inspector rather than rewritten.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4341fef4d3d5f23e3232b574877afce0b982bc87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->