### PR TITLE
feat(docs): interactive example cards with code modal

### DIFF
--- a/www/content/docs/components/accordion.mdx
+++ b/www/content/docs/components/accordion.mdx
@@ -41,6 +41,14 @@ import {
 </Accordion>
 ```
 
+## Examples
+
+<Examples className="sm:grid-cols-2 lg:grid-cols-3">
+  <Example name="accordion/demos/basic" title="FAQ" />
+  <Example name="accordion/demos/product-features" title="Product Features" />
+  <Example name="accordion/demos/settings-panel" title="Settings Panel" />
+</Examples>
+
 ## API Reference
 
 ### Accordion

--- a/www/content/docs/components/alert.mdx
+++ b/www/content/docs/components/alert.mdx
@@ -41,13 +41,11 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
 ## Examples
 
-<Examples className="grid-cols-1 lg:grid-cols-2">
+<Examples className="sm:grid-cols-2">
   <Example name="alert/demos/default" title="Default" />
-  <Example name="alert/demos/warning" title="Warning" />
-  <Example name="alert/demos/danger" title="Danger" />
-  <Example name="alert/demos/success" title="Success" />
-  <Example name="alert/demos/custom-icon" title="Custom Icon" />
-  <Example name="alert/demos/action" title="Action" />
+  <Example name="alert/demos/action" title="With Action" />
+  <Example name="alert/demos/dismissible" title="Dismissible" />
+  <Example name="alert/demos/form-error" title="Form Error" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/avatar.mdx
+++ b/www/content/docs/components/avatar.mdx
@@ -50,17 +50,10 @@ import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 
 <Examples className="grid-cols-2 sm:grid-cols-3">
   <Example name="avatar/demos/basic" title="Basic" />
-  <Example name="avatar/demos/fallback-only" title="Fallback-only" />
-  <Example name="avatar/demos/sizes" title="Sizes" />
-  <Example name="avatar/demos/radii" title="Radii" />
-  <Example name="avatar/demos/badge" title="Badge" />
-  <Example name="avatar/demos/badge-with-icon" title="Badge with icon" />
-  <Example name="avatar/demos/badge-top-right" title="Status badge" />
   <Example
     name="avatar/demos/badge-notification"
     title="Badge with notification"
   />
-  <Example name="avatar/demos/icon-fallback" title="Icon fallback" />
   <Example name="avatar/demos/group" title="Group" />
   <Example name="avatar/demos/avatar-group-count" title="Group with count" />
 </Examples>

--- a/www/content/docs/components/badge.mdx
+++ b/www/content/docs/components/badge.mdx
@@ -37,12 +37,7 @@ import { Badge } from '@/components/ui/badge'
 
 <Examples className="grid-cols-2 md:grid-cols-3">
   <Example name="badge/demos/default" title="Default" />
-  <Example name="badge/demos/variants" title="Variants" />
-  <Example name="badge/demos/sizes" title="Sizes" />
-  <Example name="badge/demos/icon" title="Icon" />
   <Example name="badge/demos/pending" title="Pending" />
-  <Example name="badge/demos/loader" title="Loader" />
-  <Example name="badge/demos/count" title="Count" />
   <Example name="badge/demos/link" title="Link" />
 </Examples>
 

--- a/www/content/docs/components/breadcrumbs.mdx
+++ b/www/content/docs/components/breadcrumbs.mdx
@@ -139,9 +139,10 @@ const BreadcrumbLink = ({ className, ...props }: BreadcrumbLinkProps) => {
 
 ## Examples
 
-<Examples className="sm:grid-cols-2">
-  <Example title="With Menu" name="breadcrumbs/demos/menu" />
-  <Example title="Custom Separator" name="breadcrumbs/demos/custom-separator" />
+<Examples className="md:grid-cols-2">
+  <Example name="breadcrumbs/demos/basic" title="Default" />
+  <Example name="breadcrumbs/demos/menu" title="With Menu" />
+  <Example name="breadcrumbs/demos/with-icons" title="With Icons" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/button.mdx
+++ b/www/content/docs/components/button.mdx
@@ -45,12 +45,8 @@ import { Button } from '@dotui/registry/ui/button'
 
 <Examples className="grid-cols-2 md:grid-cols-3">
   <Example name="button/demos/default" title="Default" />
-  <Example name="button/demos/variants" title="Variants" />
-  <Example name="button/demos/sizes" title="Sizes" />
-  <Example name="button/demos/shapes" title="Shapes" />
-  <Example name="button/demos/prefix-and-suffix" title="Prefix and Suffix" />
-  <Example name="button/demos/loading" title="Loading" />
-  <Example name="button/demos/disabled" title="Disabled" />
+  <Example name="button/demos/prefix-and-suffix" title="With Icons" />
+  <Example name="button/demos/loading" title="Loading State" />
   <Example name="button/demos/link-button" title="Link Button" />
 </Examples>
 

--- a/www/content/docs/components/calendar.mdx
+++ b/www/content/docs/components/calendar.mdx
@@ -112,38 +112,17 @@ const [value, setValue] = useState<DateValue>(parseDate('2020-02-03'))
 
 <Examples className="lg:grid-cols-2">
   <Example name="calendar/demos/range" title="Range" />
-  <Example name="calendar/demos/disabled-example" title="Disabled" />
-  <Example
-    name="calendar/demos/range-multiple-months"
-    title="Multiple months"
-    className="lg:col-span-2"
-  />
-  <Example name="calendar/demos/invalid" title="Validation" />
-  <Example name="calendar/demos/min-max" title="Min and max dates" />
-  <Example
-    name="calendar/demos/unavailable-weekends"
-    title="Unavailable dates"
-  />
-  <Example name="calendar/demos/today-indicator" title="Today indicator" />
-  <Example name="calendar/demos/short-weekdays" title="Short weekdays" />
-  <Example
-    name="calendar/demos/international"
-    title="Internationalization (arabic)"
-  />
-  <Example
-    name="calendar/demos/with-dropdowns"
-    title="Month and year dropdowns"
-  />
-  <Example name="calendar/demos/with-presets" title="With presets" />
-  <Example
-    name="calendar/demos/custom-days"
-    title="Custom days"
-    className="lg:col-span-2"
-  />
   <Example
     name="calendar/demos/scheduler"
     title="Scheduler"
-    className="lg:col-span-2"
+    className="col-span-full"
+  />
+  <Example name="calendar/demos/with-time" title="Date and time" />
+  <Example name="calendar/demos/custom-days" title="With pricing" />
+  <Example
+    name="calendar/demos/range-multiple-months"
+    title="Multiple months"
+    className="col-span-full"
   />
 </Examples>
 

--- a/www/content/docs/components/card.mdx
+++ b/www/content/docs/components/card.mdx
@@ -44,12 +44,14 @@ import {
 ## Examples
 
 <Examples className="lg:grid-cols-2">
-  <Example name="card/demos/small" title="Size" />
+  <Example name="card/demos/default" title="Default" />
+  <Example name="card/demos/basic" title="Login Form" />
   <Example
     name="card/demos/with-image"
-    title="With image"
+    title="With Image"
     className="**:data-card:pt-0!"
   />
+  <Example name="card/demos/meeting-notes" title="Meeting Notes" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/chart.mdx
+++ b/www/content/docs/components/chart.mdx
@@ -148,12 +148,36 @@ Second — and unique to dotUI — every family demo renders `ChartDataTable` al
 Each family is a curated set of variants — install one, then copy the variant you need. Browse them all on the [charts page](/charts).
 
 <Examples className="lg:grid-cols-2">
-  <Example name="chart-line/demos/multiple" title="Line" />
-  <Example name="chart-area/demos/stacked" title="Area" />
-  <Example name="chart-pie/demos/donut-text" title="Pie" />
-  <Example name="chart-radar/demos/dots" title="Radar" />
-  <Example name="chart-radial/demos/stacked" title="Radial" />
-  <Example name="chart-bar/demos/horizontal" title="Bar" />
+  <Example
+    name="chart-line/demos/multiple"
+    title="Line"
+    className="col-span-full"
+  />
+  <Example
+    name="chart-area/demos/stacked"
+    title="Area"
+    className="col-span-full"
+  />
+  <Example
+    name="chart-pie/demos/donut-text"
+    title="Pie"
+    className="col-span-full"
+  />
+  <Example
+    name="chart-radar/demos/dots"
+    title="Radar"
+    className="col-span-full"
+  />
+  <Example
+    name="chart-radial/demos/stacked"
+    title="Radial"
+    className="col-span-full"
+  />
+  <Example
+    name="chart-bar/demos/horizontal"
+    title="Bar"
+    className="col-span-full"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/checkbox-group.mdx
+++ b/www/content/docs/components/checkbox-group.mdx
@@ -82,18 +82,14 @@ const [frameworks, setFrameworks] = useState<string[]>(['nextjs'])
 
 ## Examples
 
-<Examples className="lg:grid-cols-3">
+<Examples className="sm:grid-cols-2">
   <Example name="checkbox-group/demos/default" title="Default" />
-  <Example name="checkbox-group/demos/description" title="With Description" />
-  <Example name="checkbox-group/demos/error-message" title="Invalid" />
-  <Example name="checkbox-group/demos/disabled" title="Disabled" />
-  <Example name="checkbox-group/demos/read-only" title="ReadOnly" />
-  <Example name="checkbox-group/demos/required" title="Required" />
+  <Example name="checkbox-group/demos/cards" title="Cards" />
   <Example
-    name="checkbox-group/demos/cards"
-    title="Cards"
-    className="lg:col-span-3"
+    name="checkbox-group/demos/permissions"
+    title="Notification Preferences"
   />
+  <Example name="checkbox-group/demos/form" title="Event RSVP Form" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/checkbox.mdx
+++ b/www/content/docs/components/checkbox.mdx
@@ -75,15 +75,11 @@ const [isSelected, setIsSelected] = useState(false)
 
 ## Examples
 
-<Examples className="lg:grid-cols-2">
-  <Example name="checkbox/demos/standalone" title="Standalone" />
+<Examples className="sm:grid-cols-2">
   <Example name="checkbox/demos/basic" title="Basic" />
-  <Example name="checkbox/demos/description" title="With Description" />
-  <Example name="checkbox/demos/invalid" title="Invalid" />
-  <Example name="checkbox/demos/indeterminate" title="Indeterminate" />
-  <Example name="checkbox/demos/disabled" title="Disabled" />
-  <Example name="checkbox/demos/read-only" title="Read Only" />
-  <Example name="checkbox/demos/card" title="Card" />
+  <Example name="checkbox/demos/card" title="With Indicator" />
+  <Example name="checkbox/demos/terms-acceptance" title="Terms Acceptance" />
+  <Example name="checkbox/demos/preferences-list" title="Preferences List" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/color-area.mdx
+++ b/www/content/docs/components/color-area.mdx
@@ -40,12 +40,14 @@ import { ColorThumb } from '@/components/ui/color-thumb'
 
 ## Examples
 
-<Examples className="lg:grid-cols-2">
+<Examples className="sm:grid-cols-2">
   <Example name="color-area/demos/default" title="Default" />
-  <Example name="color-area/demos/channels" title="Channels" />
-  <Example name="color-area/demos/disabled" title="Disabled" />
-  <Example name="color-area/demos/uncontrolled" title="Uncontrolled" />
-  <Example name="color-area/demos/controlled" title="Controlled" />
+  <Example name="color-area/demos/brand-color" title="Brand Color Picker" />
+  <Example
+    name="color-area/demos/theme-customizer"
+    title="Theme Customizer"
+    className="col-span-full"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/color-field.mdx
+++ b/www/content/docs/components/color-field.mdx
@@ -53,19 +53,13 @@ import { Input } from '@/components/ui/input'
 
 ## Examples
 
-<Examples>
-  <Example name="color-field/demos/basic" />
-  <Example name="color-field/demos/sizes" />
-  <Example name="color-field/demos/label" />
-  <Example name="color-field/demos/description" />
-  <Example name="color-field/demos/invalid" />
-  <Example name="color-field/demos/addons" />
-  <Example name="color-field/demos/color-channel" />
-  <Example name="color-field/demos/disabled" />
-  <Example name="color-field/demos/read-only" />
-  <Example name="color-field/demos/required" />
-  <Example name="color-field/demos/uncontrolled" />
-  <Example name="color-field/demos/controlled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="color-field/demos/basic" title="Basic Color Field" />
+  <Example name="color-field/demos/addons" title="With Icon Addon" />
+  <Example
+    name="color-field/demos/color-channel"
+    title="HSL Channel Controls"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/color-picker.mdx
+++ b/www/content/docs/components/color-picker.mdx
@@ -39,12 +39,13 @@ import {
 
 ## Examples
 
-<Examples>
-  <Example name="color-picker/demos/basic" />
-  <Example name="color-picker/demos/swatches" />
-  <Example name="color-picker/demos/channel-sliders" />
-  <Example name="color-picker/demos/uncontrolled" />
-  <Example name="color-picker/demos/controlled" />
+<Examples className="sm:grid-cols-2 md:grid-cols-3">
+  <Example name="color-picker/demos/basic" title="Basic Color Picker" />
+  <Example name="color-picker/demos/swatches" title="With Preset Swatches" />
+  <Example
+    name="color-picker/demos/channel-sliders"
+    title="Channel Sliders with Color Space Selector"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/color-slider.mdx
+++ b/www/content/docs/components/color-slider.mdx
@@ -54,14 +54,9 @@ import { Label } from '@/components/ui/field'
 
 ## Examples
 
-<Examples>
-  <Example name="color-slider/demos/default" />
-  <Example name="color-slider/demos/label" />
-  <Example name="color-slider/demos/channel" />
-  <Example name="color-slider/demos/vertical" />
-  <Example name="color-slider/demos/disabled" />
-  <Example name="color-slider/demos/uncontrolled" />
-  <Example name="color-slider/demos/controlled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="color-slider/demos/default" title="Default" />
+  <Example name="color-slider/demos/channel" title="With Opacity" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/color-swatch-picker.mdx
+++ b/www/content/docs/components/color-swatch-picker.mdx
@@ -45,10 +45,16 @@ import {
 
 ## Examples
 
-<Examples>
+<Examples className="sm:grid-cols-2 md:grid-cols-3">
   <Example name="color-swatch-picker/demos/basic" title="Basic" />
-  <Example name="color-swatch-picker/demos/disabled" title="Disabled" />
-  <Example name="color-swatch-picker/demos/controlled" title="Controlled" />
+  <Example
+    name="color-swatch-picker/demos/brand-color"
+    title="Brand Color Picker"
+  />
+  <Example
+    name="color-swatch-picker/demos/theme-colors"
+    title="Theme Color Selection"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/color-swatch.mdx
+++ b/www/content/docs/components/color-swatch.mdx
@@ -38,8 +38,10 @@ import { ColorSwatch } from '@/components/ui/color-swatch'
 
 ## Examples
 
-<Examples>
+<Examples className="sm:grid-cols-2 lg:grid-cols-3">
   <Example name="color-swatch/demos/default" title="Default" />
+  <Example name="color-swatch/demos/color-palette" title="Color Palette" />
+  <Example name="color-swatch/demos/in-button" title="In Button" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/combobox.mdx
+++ b/www/content/docs/components/combobox.mdx
@@ -64,19 +64,12 @@ import {
 
 ## Examples
 
-<Examples>
-  <Example name="combobox/demos/basic" />
-  <Example name="combobox/demos/label" />
-  <Example name="combobox/demos/description" />
-  <Example name="combobox/demos/invalid" />
-  <Example name="combobox/demos/custom-value" />
-  <Example name="combobox/demos/disabled" />
-  <Example name="combobox/demos/loading" />
-  <Example name="combobox/demos/sections" />
-  <Example name="combobox/demos/required" />
-  <Example name="combobox/demos/uncontrolled" />
-  <Example name="combobox/demos/controlled" />
-  <Example name="combobox/demos/async-loading" />
+<Examples className="sm:grid-cols-2">
+  <Example name="combobox/demos/basic" title="Basic" />
+  <Example name="combobox/demos/with-form" title="In a Form" />
+  <Example name="combobox/demos/in-dialog" title="In Dialog" />
+  <Example name="combobox/demos/with-custom-items" title="Custom Items" />
+  <Example name="combobox/demos/multi-select" title="Multi-Select" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/command.mdx
+++ b/www/content/docs/components/command.mdx
@@ -61,11 +61,10 @@ Because the input and the list are ordinary primitives, anything they support wo
 
 ## Examples
 
-<Examples>
+<Examples className="sm:grid-cols-2">
   <Example name="command/demos/basic" title="Basic" />
   <Example name="command/demos/in-modal" title="In a modal" />
   <Example name="command/demos/in-select" title="In a select" />
-  <Example name="command/demos/with-tag-group" title="With a tag group" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/context-menu.mdx
+++ b/www/content/docs/components/context-menu.mdx
@@ -41,13 +41,13 @@ import { Popover } from '@/components/ui/popover'
 
 ## Examples
 
-<Examples>
-  <Example name="context-menu/demos/basic" />
-  <Example name="context-menu/demos/with-icons" />
-  <Example name="context-menu/demos/with-submenu" />
-  <Example name="context-menu/demos/controlled" />
-  <Example name="context-menu/demos/nested" />
-  <Example name="context-menu/demos/disabled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="context-menu/demos/basic" title="Basic" />
+  <Example
+    name="context-menu/demos/with-icons"
+    title="With Icons & Shortcuts"
+  />
+  <Example name="context-menu/demos/nested" title="Nested Context Menus" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/date-field.mdx
+++ b/www/content/docs/components/date-field.mdx
@@ -58,23 +58,12 @@ import { Label } from '@/components/ui/field'
 
 ## Examples
 
-<Examples>
-  <Example name="date-field/demos/basic" />
-  <Example name="date-field/demos/sizes" />
-  <Example name="date-field/demos/label" />
-  <Example name="date-field/demos/description" />
-  <Example name="date-field/demos/error-message" />
-  <Example name="date-field/demos/placeholder" />
-  <Example name="date-field/demos/granularity" />
-  <Example name="date-field/demos/hour-cycle" />
-  <Example name="date-field/demos/time-zones" />
-  <Example name="date-field/demos/hide-time-zone" />
-  <Example name="date-field/demos/prefix-and-suffix" />
-  <Example name="date-field/demos/disabled" />
-  <Example name="date-field/demos/read-only" />
-  <Example name="date-field/demos/required" />
-  <Example name="date-field/demos/uncontrolled" />
-  <Example name="date-field/demos/controlled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="date-field/demos/basic" title="Basic Date Field" />
+  <Example name="date-field/demos/prefix-and-suffix" title="With Icon" />
+  <Example name="date-field/demos/event-form" title="Event Date Picker" />
+  <Example name="date-field/demos/appointment" title="Appointment Booking" />
+  <Example name="date-field/demos/trip-dates" title="Trip Date Range" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/date-picker.mdx
+++ b/www/content/docs/components/date-picker.mdx
@@ -52,22 +52,14 @@ import { Popover } from '@/components/ui/popover'
 
 ## Examples
 
-<Examples>
-  <Example name="date-picker/demos/basic" />
-  <Example name="date-picker/demos/label" />
-  <Example name="date-picker/demos/description" />
-  <Example name="date-picker/demos/error-message" />
-  <Example name="date-picker/demos/placeholder" />
-  <Example name="date-picker/demos/granularity" />
-  <Example name="date-picker/demos/hour-cycle" />
-  <Example name="date-picker/demos/time-zones" />
-  <Example name="date-picker/demos/hide-time-zone" />
-  <Example name="date-picker/demos/disabled" />
-  <Example name="date-picker/demos/read-only" />
-  <Example name="date-picker/demos/required" />
-  <Example name="date-picker/demos/composition" />
-  <Example name="date-picker/demos/uncontrolled" />
-  <Example name="date-picker/demos/controlled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="date-picker/demos/basic" title="Basic" />
+  <Example
+    name="date-picker/demos/composition"
+    title="With Label & Description"
+  />
+  <Example name="date-picker/demos/with-modal" title="Modal Variant" />
+  <Example name="date-picker/demos/with-drawer" title="Drawer Variant" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/dialog.mdx
+++ b/www/content/docs/components/dialog.mdx
@@ -73,17 +73,12 @@ import { Modal } from '@/components/ui/modal'
 ## Examples
 
 <Examples>
-  <Example name="dialog/demos/basic" />
-  <Example name="dialog/demos/title" />
-  <Example name="dialog/demos/description" />
-  <Example name="dialog/demos/types" />
-  <Example name="dialog/demos/dismissable" />
-  <Example name="dialog/demos/alert-dialog" />
-  <Example name="dialog/demos/composition" />
-  <Example name="dialog/demos/controlled" />
-  <Example name="dialog/demos/nested" />
-  <Example name="dialog/demos/inset-content" />
-  <Example name="dialog/demos/async-form-submission" />
+  <Example name="dialog/demos/basic" title="Create Issue Form" />
+  <Example name="dialog/demos/alert-dialog" title="Delete Confirmation" />
+  <Example
+    name="dialog/demos/async-form-submission"
+    title="Async Form Submission"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/disclosure.mdx
+++ b/www/content/docs/components/disclosure.mdx
@@ -55,21 +55,14 @@ import { ChevronDownIcon } from 'your-icon-library'
 
 ## Examples
 
-<Examples>
-  <Example name="disclosure/demos/basic" description="Basic disclosure" />
-  <Example
-    name="disclosure/demos/default-expanded"
-    description="Default expanded disclosure"
-  />
-  <Example name="disclosure/demos/disabled" description="Disabled disclosure" />
-  <Example
-    name="disclosure/demos/controlled"
-    description="Controlled disclosure"
-  />
+<Examples className="sm:grid-cols-2">
+  <Example name="disclosure/demos/basic" title="Basic Disclosure" />
   <Example
     name="disclosure/demos/advanced-composition"
-    description="Advanced composition"
+    title="Advanced Composition"
   />
+  <Example name="disclosure/demos/faq-section" title="FAQ Section" />
+  <Example name="disclosure/demos/feature-details" title="Feature Details" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/drawer.mdx
+++ b/www/content/docs/components/drawer.mdx
@@ -46,10 +46,12 @@ import { Drawer } from '@/components/ui/drawer'
 
 ## Examples
 
-<Examples>
-  <Example name="drawer/demos/basic" />
-  <Example name="drawer/demos/dialog-parts" />
-  <Example name="drawer/demos/placement" />
+<Examples className="sm:grid-cols-2">
+  <Example name="drawer/demos/basic" title="Basic Drawer" />
+  <Example name="drawer/demos/dialog-parts" title="Settings Panel" />
+  <Example name="drawer/demos/nested" title="Nested Drawers" />
+  <Example name="drawer/demos/scrollable" title="Scrollable Content" />
+  <Example name="drawer/demos/with-form" title="Form Drawer" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/drop-zone.mdx
+++ b/www/content/docs/components/drop-zone.mdx
@@ -45,13 +45,15 @@ import { DropZone, DropZoneLabel } from '@/components/ui/drop-zone'
 
 ## Examples
 
-<Examples>
-  <Example name="drop-zone/demos/basic" />
-  <Example name="drop-zone/demos/label" />
-  <Example name="drop-zone/demos/visual-feedback" />
-  <Example name="drop-zone/demos/file-trigger" />
-  <Example name="drop-zone/demos/events" />
-  <Example name="drop-zone/demos/disabled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="drop-zone/demos/basic" title="Basic Drop Zone" />
+  <Example name="drop-zone/demos/file-trigger" title="With File Trigger" />
+  <Example
+    name="drop-zone/demos/events"
+    title="Drag and Drop Events"
+    className="col-span-full"
+  />
+  <Example name="drop-zone/demos/visual-feedback" title="Visual Feedback" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/empty.mdx
+++ b/www/content/docs/components/empty.mdx
@@ -35,8 +35,11 @@ import {
 
 ## Examples
 
-<Examples>
-  <Example name="empty/demos/empty-projects" />
+<Examples className="md:grid-cols-2">
+  <Example name="empty/demos/basic" title="Basic Empty State" />
+  <Example name="empty/demos/empty-projects" title="No Projects" />
+  <Example name="empty/demos/in-card" title="In Card" />
+  <Example name="empty/demos/with-border" title="404 Error Page" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/field.mdx
+++ b/www/content/docs/components/field.mdx
@@ -26,8 +26,10 @@ import { Field, Label, Description, FieldError } from '@/components/ui/field'
 
 ## Examples
 
-<Examples>
-  <p className="text-fg-muted col-span-full">No examples yet.</p>
+<Examples className="sm:grid-cols-2">
+  <Example name="field/demos/login-form" title="Login Form" />
+  <Example name="field/demos/registration" title="Registration Form" />
+  <Example name="field/demos/profile-settings" title="Profile Settings" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/file-trigger.mdx
+++ b/www/content/docs/components/file-trigger.mdx
@@ -41,12 +41,17 @@ import { FileTrigger } from '@/components/ui/file-trigger'
 
 ## Examples
 
-<Examples>
-  <Example name="file-trigger/demos/default" />
-  <Example name="file-trigger/demos/multiple-files" />
-  <Example name="file-trigger/demos/file-types" />
-  <Example name="file-trigger/demos/directory-selection" />
-  <Example name="file-trigger/demos/media-capture" />
+<Examples className="sm:grid-cols-2 lg:grid-cols-3">
+  <Example name="file-trigger/demos/default" title="Basic Upload" />
+  <Example
+    name="file-trigger/demos/profile-picture"
+    title="Profile Picture Upload"
+  />
+  <Example name="file-trigger/demos/document-upload" title="Document Upload" />
+  <Example
+    name="file-trigger/demos/image-gallery-upload"
+    title="Multi-Image Upload"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/form.mdx
+++ b/www/content/docs/components/form.mdx
@@ -42,8 +42,8 @@ import { Input } from '@/components/ui/input'
 ## Examples
 
 <Examples>
-  <Example name="form/demos/basic" />
-  <Example name="form/demos/react-aria" />
+  <Example name="form/demos/basic" title="Basic Form" />
+  <Example name="form/demos/react-aria" title="Registration Form" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/group.mdx
+++ b/www/content/docs/components/group.mdx
@@ -27,8 +27,27 @@ import { Group } from '@/components/ui/group'
 
 ## Examples
 
-<Examples>
-  <Example name="group/demos/basic" />
+<Examples className="sm:grid-cols-2 lg:grid-cols-3">
+  <Example name="group/demos/basic" title="Basic Group" />
+  <Example name="group/demos/navigation" title="Navigation Controls" />
+  <Example name="group/demos/nested" title="Chat Interface" />
+  <Example
+    name="group/demos/pagination"
+    title="Pagination"
+    className="col-span-full"
+  />
+  <Example name="group/demos/vertical-nested" title="Design Tools Palette" />
+  <Example
+    name="group/demos/with-dropdown"
+    title="Split Button with Dropdown"
+  />
+  <Example name="group/demos/with-fields" title="Numeric Field with Controls" />
+  <Example name="group/demos/with-like" title="Like Button" />
+  <Example
+    name="group/demos/with-select-and-input"
+    title="Amount Transfer Form"
+  />
+  <Example name="group/demos/with-select" title="Duration Selector" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/input-group.mdx
+++ b/www/content/docs/components/input-group.mdx
@@ -51,9 +51,17 @@ The `size` prop is forwarded to the wrapped input. Available sizes are `sm`, `md
 
 ## Examples
 
-<Examples>
-  <Example name="input-group/demos/input-group" title="Prefix" />
-  <Example name="input-group/demos/vertical-group" title="Vertical" />
+<Examples className="sm:grid-cols-2">
+  <Example name="input-group/demos/input-group" title="With Prefix" />
+  <Example
+    name="input-group/demos/vertical-group"
+    title="Vertical Comment Form"
+  />
+  <Example name="input-group/demos/in-card" title="Form in Card" />
+  <Example
+    name="input-group/demos/tooltip-dropdown-popover"
+    title="Interactive Addons"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/input.mdx
+++ b/www/content/docs/components/input.mdx
@@ -52,11 +52,11 @@ Use the `size` prop to control the input height. Available sizes are `sm`, `md` 
 
 ## Examples
 
-<Examples>
+<Examples className="sm:grid-cols-2 md:grid-cols-3">
   <Example name="input/demos/default" title="Default" />
-  <Example name="input/demos/sizes" title="All sizes" />
-  <Example name="input/demos/disabled" title="Disabled" />
   <Example name="input/demos/textarea" title="Textarea" />
+  <Example name="input/demos/search-bar" title="Search Bar" />
+  <Example name="input/demos/email-field" title="Email Field" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/kbd.mdx
+++ b/www/content/docs/components/kbd.mdx
@@ -22,8 +22,11 @@ import { Kbd } from '@/components/ui/kbd'
 
 ## Examples
 
-<Examples>
-  <p className="text-fg-muted col-span-full">No examples yet.</p>
+<Examples className="sm:grid-cols-2">
+  <Example name="kbd/demos/basic" title="Basic Keys" />
+  <Example name="kbd/demos/group" title="Keyboard Shortcut" />
+  <Example name="kbd/demos/in-tooltip" title="In Tooltip" />
+  <Example name="kbd/demos/in-input-group" title="Input with Keyboard Hint" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/link.mdx
+++ b/www/content/docs/components/link.mdx
@@ -25,8 +25,11 @@ import { Link } from '@/components/ui/link'
 
 ## Examples
 
-<Examples>
-  <p className="text-fg-muted col-span-full">No examples yet.</p>
+<Examples className="grid-cols-2 md:grid-cols-3">
+  <Example name="link/demos/default" title="Default" />
+  <Example name="link/demos/in-text" title="In Text" />
+  <Example name="link/demos/footer-navigation" title="Footer Navigation" />
+  <Example name="link/demos/with-icon" title="With Icon" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/list-box.mdx
+++ b/www/content/docs/components/list-box.mdx
@@ -49,23 +49,12 @@ import { ListBox, ListBoxItem } from '@/components/ui/list-box'
 
 ## Examples
 
-<Examples>
-  <Example name="list-box/demos/basic" />
-  <Example name="list-box/demos/multiple-selection" />
-  <Example name="list-box/demos/with-description" />
-  <Example name="list-box/demos/with-icons" />
-  <Example name="list-box/demos/danger" />
-  <Example name="list-box/demos/sections" />
-  <Example name="list-box/demos/separator" />
-  <Example name="list-box/demos/user-menu" />
-  <Example name="list-box/demos/disabled" />
-  <Example name="list-box/demos/horizontal" />
-  <Example name="list-box/demos/grid" />
-  <Example name="list-box/demos/async" />
-  <Example name="list-box/demos/empty" />
-  <Example name="list-box/demos/in-select" />
-  <Example name="list-box/demos/in-combobox" />
-  <Example name="list-box/demos/in-command" />
+<Examples className="sm:grid-cols-2">
+  <Example name="list-box/demos/basic" title="Basic" />
+  <Example name="list-box/demos/with-icons" title="Action Menu" />
+  <Example name="list-box/demos/user-menu" title="User Menu" />
+  <Example name="list-box/demos/sections" title="Organized Sections" />
+  <Example name="list-box/demos/async" title="Async Loading" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/loader.mdx
+++ b/www/content/docs/components/loader.mdx
@@ -22,8 +22,11 @@ import { Loader } from '@/components/ui/loader'
 
 ## Examples
 
-<Examples>
-  <p className="text-fg-muted col-span-full">No examples yet.</p>
+<Examples className="grid-cols-2 md:grid-cols-3">
+  <Example name="loader/demos/basic" title="Basic" />
+  <Example name="loader/demos/in-button" title="In Button" />
+  <Example name="loader/demos/in-input" title="In Input" />
+  <Example name="loader/demos/overlay" title="Loading Overlay" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/menu.mdx
+++ b/www/content/docs/components/menu.mdx
@@ -50,25 +50,21 @@ import { Popover } from '@/components/ui/popover'
 
 ## Examples
 
-<Examples>
-  <Example name="menu/demos/basic" />
-  <Example name="menu/demos/label-and-description" />
-  <Example name="menu/demos/prefix-and-suffix" />
-  <Example name="menu/demos/shortcut" />
-  <Example name="menu/demos/item-variant" />
-  <Example name="menu/demos/section" />
-  <Example name="menu/demos/separator" />
-  <Example name="menu/demos/submenus" />
-  <Example name="menu/demos/link-items" />
-  <Example name="menu/demos/disabled-items" />
-  <Example name="menu/demos/single-selection" />
-  <Example name="menu/demos/multiple-selection" />
-  <Example name="menu/demos/placement" />
-  <Example name="menu/demos/overlay-type" />
-  <Example name="menu/demos/with-drawer" />
-  <Example name="menu/demos/with-modal" />
-  <Example name="menu/demos/long-press" />
-  <Example name="menu/demos/controlled" />
+<Examples className="md:grid-cols-2">
+  <Example name="menu/demos/basic" title="Basic Menu" />
+  <Example name="menu/demos/with-avatar" title="Account Dropdown" />
+  <Example name="menu/demos/with-destructive" title="Menu with Actions" />
+  <Example name="menu/demos/with-icons" title="Menu with Icons" />
+  <Example name="menu/demos/link-items" title="Social Links Menu" />
+  <Example
+    name="menu/demos/checkboxes-with-icons"
+    title="Notification Preferences"
+  />
+  <Example name="menu/demos/radio-with-icons" title="Payment Method Selector" />
+  <Example name="menu/demos/complex" title="Complex Menu" />
+  <Example name="menu/demos/with-drawer" title="Menu in Drawer" />
+  <Example name="menu/demos/with-modal" title="Menu in Modal" />
+  <Example name="menu/demos/in-dialog" title="Menu in Dialog" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/modal.mdx
+++ b/www/content/docs/components/modal.mdx
@@ -45,8 +45,10 @@ import { Modal } from '@/components/ui/modal'
 
 ## Examples
 
-<Examples>
-  <Example name="modal/demos/basic" />
+<Examples className="md:grid-cols-2">
+  <Example name="modal/demos/basic" title="Basic Modal" />
+  <Example name="modal/demos/with-form" title="Modal with Form" />
+  <Example name="modal/demos/chat-settings" title="Settings Modal" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/number-field.mdx
+++ b/www/content/docs/components/number-field.mdx
@@ -58,18 +58,17 @@ import { Label } from '@/components/ui/field'
 
 ## Examples
 
-<Examples>
-  <Example name="number-field/demos/basic" />
-  <Example name="number-field/demos/sizes" />
-  <Example name="number-field/demos/label" />
-  <Example name="number-field/demos/description" />
-  <Example name="number-field/demos/error-message" />
-  <Example name="number-field/demos/format-options" />
-  <Example name="number-field/demos/disabled" />
-  <Example name="number-field/demos/read-only" />
-  <Example name="number-field/demos/required" />
-  <Example name="number-field/demos/uncontrolled" />
-  <Example name="number-field/demos/controlled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="number-field/demos/basic" title="Basic" />
+  <Example
+    name="number-field/demos/with-input-group"
+    title="With Input Group"
+  />
+  <Example
+    name="number-field/demos/format-options"
+    title="Format Options"
+    className="col-span-full"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/otp-field.mdx
+++ b/www/content/docs/components/otp-field.mdx
@@ -42,15 +42,14 @@ import { Input } from '@/components/ui/input'
 
 ## Examples
 
-<Examples>
-  <Example name="otp-field/demos/basic" />
-  <Example name="otp-field/demos/separator" />
-  <Example name="otp-field/demos/controlled" />
-  <Example name="otp-field/demos/disabled" />
-  <Example name="otp-field/demos/error-message" />
-  <Example name="otp-field/demos/four-digits" />
-  <Example name="otp-field/demos/alphanumeric" />
-  <Example name="otp-field/demos/form" />
+<Examples className="sm:grid-cols-2">
+  <Example name="otp-field/demos/basic" title="Basic OTP Field" />
+  <Example name="otp-field/demos/form" title="Verification Form" />
+  <Example name="otp-field/demos/two-factor-auth" title="2FA Verification" />
+  <Example
+    name="otp-field/demos/email-verification"
+    title="Email Verification"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/pagination.mdx
+++ b/www/content/docs/components/pagination.mdx
@@ -58,10 +58,17 @@ import {
 ## Examples
 
 <Examples className="sm:grid-cols-2">
-  <Example title="Links" name="pagination/demos/links" />
-  <Example title="Controlled" name="pagination/demos/controlled" />
-  <Example title="Sizes" name="pagination/demos/sizes" />
-  <Example title="Compact" name="pagination/demos/compact" />
+  <Example name="pagination/demos/links" title="Links" />
+  <Example
+    name="pagination/demos/default"
+    title="Controlled with Smart Range"
+  />
+  <Example name="pagination/demos/with-results" title="With Results Summary" />
+  <Example
+    name="pagination/demos/table-integration"
+    title="Table with Pagination"
+    className="col-span-full"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/popover.mdx
+++ b/www/content/docs/components/popover.mdx
@@ -49,8 +49,10 @@ import { Popover } from '@/components/ui/popover'
 
 ## Examples
 
-<Examples>
-  <Example name="popover/demos/basic" />
+<Examples className="md:grid-cols-2">
+  <Example name="popover/demos/basic" title="Basic" />
+  <Example name="popover/demos/in-dialog" title="In Dialog" />
+  <Example name="popover/demos/with-form" title="With Form" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/progress-bar.mdx
+++ b/www/content/docs/components/progress-bar.mdx
@@ -52,18 +52,13 @@ import { ProgressBar, ProgressBarControl } from '@/components/ui/progress-bar'
 
 ## Examples
 
-<Examples>
-  <Example name="progress-bar/demos/animated" />
-  <Example name="progress-bar/demos/sizes" />
-  <Example name="progress-bar/demos/variants" />
-  <Example name="progress-bar/demos/shape" />
-  <Example name="progress-bar/demos/label" />
-  <Example name="progress-bar/demos/value-label" />
-  <Example name="progress-bar/demos/custom-value-label" />
-  <Example name="progress-bar/demos/format-options" />
-  <Example name="progress-bar/demos/min-max-values" />
-  <Example name="progress-bar/demos/indeterminate" />
-  <Example name="progress-bar/demos/duration" />
+<Examples className="md:grid-cols-2">
+  <Example name="progress-bar/demos/shape" title="Default" />
+  <Example
+    name="progress-bar/demos/file-upload-list"
+    title="File Upload Progress"
+  />
+  <Example name="progress-bar/demos/value-label" title="With Progress Label" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/radio-group.mdx
+++ b/www/content/docs/components/radio-group.mdx
@@ -72,17 +72,16 @@ import { FieldGroup, Label } from '@/components/ui/field'
 
 ## Examples
 
-<Examples className="lg:grid-cols-3">
+<Examples className="md:grid-cols-2">
   <Example name="radio-group/demos/default" title="Default" />
-  <Example name="radio-group/demos/description" title="With Description" />
-  <Example name="radio-group/demos/error-message" title="Invalid" />
-  <Example name="radio-group/demos/disabled" title="Disabled" />
-  <Example name="radio-group/demos/read-only" title="ReadOnly" />
-  <Example name="radio-group/demos/required" title="Required" />
+  <Example name="radio-group/demos/cards" title="Card Layout" />
   <Example
-    name="radio-group/demos/cards"
-    title="Cards"
-    className="lg:col-span-3"
+    name="radio-group/demos/subscription-plan"
+    title="Subscription Plan"
+  />
+  <Example
+    name="radio-group/demos/notification-preferences"
+    title="Notification Preferences"
   />
 </Examples>
 

--- a/www/content/docs/components/search-field.mdx
+++ b/www/content/docs/components/search-field.mdx
@@ -58,17 +58,18 @@ import { Label } from '@/components/ui/field'
 
 ## Examples
 
-<Examples>
-  <Example name="search-field/demos/default" />
-  <Example name="search-field/demos/sizes" />
-  <Example name="search-field/demos/label" />
-  <Example name="search-field/demos/description" />
-  <Example name="search-field/demos/error-message" />
-  <Example name="search-field/demos/disabled" />
-  <Example name="search-field/demos/read-only" />
-  <Example name="search-field/demos/required" />
-  <Example name="search-field/demos/uncontrolled" />
-  <Example name="search-field/demos/controlled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="search-field/demos/default" title="Basic Search" />
+  <Example
+    name="search-field/demos/with-suggestions"
+    title="Search with Suggestions"
+  />
+  <Example name="search-field/demos/header-search" title="Header Search" />
+  <Example
+    name="search-field/demos/filterable-list"
+    title="Search with Filtered Results"
+    className="col-span-full"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/select.mdx
+++ b/www/content/docs/components/select.mdx
@@ -112,20 +112,10 @@ This approach lets you:
 ## Examples
 
 <Examples>
-  <Example name="select/demos/basic" />
-  <Example name="select/demos/placeholder" />
-  <Example name="select/demos/label" />
-  <Example name="select/demos/description" />
-  <Example name="select/demos/validation" />
-  <Example name="select/demos/sections" />
-  <Example name="select/demos/links" />
-  <Example name="select/demos/disabled" />
-  <Example name="select/demos/loading" />
-  <Example name="select/demos/required" />
-  <Example name="select/demos/uncontrolled" />
-  <Example name="select/demos/controlled" />
-  <Example name="select/demos/composition" />
-  <Example name="select/demos/async-loading" />
+  <Example name="select/demos/basic" title="Basic" />
+  <Example name="select/demos/sections" title="Sectioned List" />
+  <Example name="select/demos/links" title="With Links" />
+  <Example name="select/demos/async-loading" title="Async Loading" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/separator.mdx
+++ b/www/content/docs/components/separator.mdx
@@ -39,9 +39,15 @@ import { Separator } from '@/components/ui/separator'
 
 ## Examples
 
-<Examples>
-  <Example name="separator/demos/orientation" />
-  <Example name="separator/demos/card" />
+<Examples className="grid-cols-2 md:grid-cols-3">
+  <Example
+    name="separator/demos/card"
+    title="In Card"
+    className="col-span-full"
+  />
+  <Example name="separator/demos/default" title="Default" />
+  <Example name="separator/demos/menu-section" title="Menu Section" />
+  <Example name="separator/demos/list-menu" title="List Menu" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/sidebar.mdx
+++ b/www/content/docs/components/sidebar.mdx
@@ -101,19 +101,13 @@ Drive the open state yourself with `isOpen` and `onOpenChange` on `SidebarProvid
 
 ## Examples
 
-<Examples>
-  <Example name="sidebar/demos/collapsible-icon" />
-  <Example name="sidebar/demos/floating" />
-  <Example name="sidebar/demos/inset" />
-  <Example name="sidebar/demos/right" />
-  <Example name="sidebar/demos/groups" />
-  <Example name="sidebar/demos/submenu" />
-  <Example name="sidebar/demos/badges-and-actions" />
-  <Example name="sidebar/demos/search" />
-  <Example name="sidebar/demos/footer-user" />
-  <Example name="sidebar/demos/loading" />
-  <Example name="sidebar/demos/rail" />
-  <Example name="sidebar/demos/controlled" />
+<Examples className="md:grid-cols-2">
+  <Example name="sidebar/demos/basic" title="Basic Sidebar" />
+  <Example name="sidebar/demos/groups" title="Multiple Groups" />
+  <Example name="sidebar/demos/submenu" title="Nested Menu" />
+  <Example name="sidebar/demos/badges-and-actions" title="Badges & Actions" />
+  <Example name="sidebar/demos/search" title="With Search" />
+  <Example name="sidebar/demos/footer-user" title="User Menu" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/skeleton.mdx
+++ b/www/content/docs/components/skeleton.mdx
@@ -41,7 +41,8 @@ import { Skeleton } from '@/components/ui/skeleton'
 ## Examples
 
 <Examples>
-  <Example name="skeleton/demos/card" />
+  <Example name="skeleton/demos/card" title="Card" />
+  <Example name="skeleton/demos/list-items" title="List Items" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/slider.mdx
+++ b/www/content/docs/components/slider.mdx
@@ -51,20 +51,12 @@ import { Slider, SliderControl } from '@/components/ui/slider'
 
 ## Examples
 
-<Examples>
-  <Example name="slider/demos/default" />
-  <Example name="slider/demos/vertical" />
-  <Example name="slider/demos/label" />
-  <Example name="slider/demos/description" />
-  <Example name="slider/demos/value-label" />
-  <Example name="slider/demos/value-scale" />
-  <Example name="slider/demos/step" />
-  <Example name="slider/demos/format-options" />
-  <Example name="slider/demos/range" />
-  <Example name="slider/demos/disabled" />
-  <Example name="slider/demos/composition" />
-  <Example name="slider/demos/uncontrolled" />
-  <Example name="slider/demos/controlled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="slider/demos/default" title="Default" />
+  <Example name="slider/demos/composition" title="Volume Control" />
+  <Example name="slider/demos/range" title="Price Range Selector" />
+  <Example name="slider/demos/value-label" title="Quantity Picker" />
+  <Example name="slider/demos/format-options" title="Currency Price" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/switch.mdx
+++ b/www/content/docs/components/switch.mdx
@@ -45,15 +45,15 @@ import { Switch, SwitchControl } from '@/components/ui/switch'
 
 ## Examples
 
-<Examples className="lg:grid-cols-2">
-  <Example name="switch/demos/standalone" title="Standalone" />
+<Examples className="sm:grid-cols-2">
   <Example name="switch/demos/basic" title="Basic" />
-  <Example name="switch/demos/description" title="With Description" />
-  <Example name="switch/demos/disabled" title="Disabled" />
-  <Example name="switch/demos/read-only" title="Read Only" />
-  <Example name="switch/demos/sizes" title="Sizes" />
-  <Example name="switch/demos/controlled" title="Controlled" />
-  <Example name="switch/demos/card" title="Card" />
+  <Example name="switch/demos/card" title="In a Card" />
+  <Example name="switch/demos/settings-panel" title="Settings Panel" />
+  <Example name="switch/demos/feature-flags" title="Feature Flags" />
+  <Example
+    name="switch/demos/notification-preferences"
+    title="Notification Preferences"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/table.mdx
+++ b/www/content/docs/components/table.mdx
@@ -106,28 +106,33 @@ Use `TableVirtualizer` for large collections. It uses the table layout exported 
 
 ## Examples
 
-<Examples>
-  <Example name="table/demos/basic" />
-  <Example name="table/demos/invoices" />
-  <Example name="table/demos/project-budget" />
-  <Example name="table/demos/tasks" />
-  <Example name="table/demos/large-list-virtualized" />
-  <Example name="table/demos/async-loading" />
-  <Example name="table/demos/controls" />
-  <Example name="table/demos/dynamic-collection" />
-  <Example name="table/demos/expandable-rows" />
-  <Example name="table/demos/selection" />
-  <Example name="table/demos/disallow-empty-selection" />
-  <Example name="table/demos/disabled-rows" />
-  <Example name="table/demos/links" />
-  <Example name="table/demos/sorting" />
-  <Example name="table/demos/column-resizing" />
-  <Example name="table/demos/row-action" />
-  <Example name="table/demos/static-row-action" />
-  <Example name="table/demos/reordable" />
-  <Example name="table/demos/empty-state" />
-  <Example name="table/demos/uncontrolled" />
-  <Example name="table/demos/controlled" />
+<Examples className="md:grid-cols-2">
+  <Example name="table/demos/basic" title="Basic Table" />
+  <Example
+    name="table/demos/invoices"
+    title="Invoices Table"
+    className="col-span-full"
+  />
+  <Example
+    name="table/demos/project-budget"
+    title="Project Budget"
+    className="col-span-full"
+  />
+  <Example
+    name="table/demos/tasks"
+    title="Task Management"
+    className="col-span-full"
+  />
+  <Example
+    name="table/demos/issue-groups"
+    title="Issue Groups"
+    className="col-span-full"
+  />
+  <Example
+    name="table/demos/links"
+    title="Links & Bookmarks"
+    className="col-span-full"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/tabs.mdx
+++ b/www/content/docs/components/tabs.mdx
@@ -53,13 +53,11 @@ import { Tab, TabList, TabPanel, Tabs } from '@/components/ui/tabs'
 
 ## Examples
 
-<Examples>
-  <Example name="tabs/demos/basic" />
-  <Example name="tabs/demos/variant" />
-  <Example name="tabs/demos/vertical" />
-  <Example name="tabs/demos/disabled" />
-  <Example name="tabs/demos/keyboard-activation" />
-  <Example name="tabs/demos/controlled" />
+<Examples className="md:grid-cols-2">
+  <Example name="tabs/demos/basic" title="Basic Tabs" />
+  <Example name="tabs/demos/settings-panel" title="Settings Panel" />
+  <Example name="tabs/demos/documentation" title="Documentation Tabs" />
+  <Example name="tabs/demos/product-details" title="Product Details" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/tag-group.mdx
+++ b/www/content/docs/components/tag-group.mdx
@@ -33,7 +33,11 @@ import { TagGroup, TagList, Tag } from '@/components/ui/tag-group'
 ## Examples
 
 <Examples>
-  <Example name="tag-group/demos/basic" />
+  <Example name="tag-group/demos/basic" title="Basic" />
+  <Example name="tag-group/demos/with-combobox" title="With Combobox" />
+  <Example name="tag-group/demos/removable" title="Removable Tags" />
+  <Example name="tag-group/demos/with-icon" title="With Icons" />
+  <Example name="tag-group/demos/links" title="Clickable Links" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/text-area.mdx
+++ b/www/content/docs/components/text-area.mdx
@@ -73,17 +73,11 @@ import { Label } from '@/components/ui/field'
 
 ## Examples
 
-<Examples>
-  <Example name="text-area/demos/default" />
-  <Example name="text-area/demos/label" />
-  <Example name="text-area/demos/description" />
-  <Example name="text-area/demos/error-message" />
-  <Example name="text-area/demos/prefix-and-suffix" />
-  <Example name="text-area/demos/disabled" />
-  <Example name="text-area/demos/read-only" />
-  <Example name="text-area/demos/required" />
-  <Example name="text-area/demos/uncontrolled" />
-  <Example name="text-area/demos/controlled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="text-area/demos/default" title="Basic" />
+  <Example name="text-area/demos/prefix-and-suffix" title="Comment Composer" />
+  <Example name="text-area/demos/feedback-form" title="Feedback Form" />
+  <Example name="text-area/demos/issue-description" title="Issue Description" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/text-field.mdx
+++ b/www/content/docs/components/text-field.mdx
@@ -70,18 +70,14 @@ import { Label } from '@/components/ui/field'
 
 ## Examples
 
-<Examples className="md:grid-cols-2">
-  <Example name="text-field/demos/basic" />
-  <Example name="text-field/demos/description" />
-  <Example name="text-field/demos/disabled" />
-  <Example name="text-field/demos/error-message" />
-  <Example name="text-field/demos/label" />
-  <Example name="text-field/demos/prefix-and-suffix" />
-  <Example name="text-field/demos/read-only" />
-  <Example name="text-field/demos/required" />
-  <Example name="text-field/demos/sizes" />
-  <Example name="text-field/demos/uncontrolled" />
-  <Example name="text-field/demos/controlled" />
+<Examples className="sm:grid-cols-2">
+  <Example name="text-field/demos/basic" title="Basic" />
+  <Example name="text-field/demos/prefix-and-suffix" title="Prefix & Suffix" />
+  <Example name="text-field/demos/login-form" title="Login Form" />
+  <Example
+    name="text-field/demos/newsletter-signup"
+    title="Newsletter Signup"
+  />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/time-field.mdx
+++ b/www/content/docs/components/time-field.mdx
@@ -58,23 +58,10 @@ import { Label } from '@/components/ui/field'
 
 ## Examples
 
-<Examples className="md:grid-cols-2">
-  <Example name="time-field/demos/basic" />
-  <Example name="time-field/demos/description" />
-  <Example name="time-field/demos/disabled" />
-  <Example name="time-field/demos/error-message" />
-  <Example name="time-field/demos/granularity" />
-  <Example name="time-field/demos/hide-time-zone" />
-  <Example name="time-field/demos/hour-cycle" />
-  <Example name="time-field/demos/label" />
-  <Example name="time-field/demos/placeholder" />
-  <Example name="time-field/demos/prefix-and-suffix" />
-  <Example name="time-field/demos/read-only" />
-  <Example name="time-field/demos/required" />
-  <Example name="time-field/demos/sizes" />
-  <Example name="time-field/demos/time-zones" />
-  <Example name="time-field/demos/uncontrolled" />
-  <Example name="time-field/demos/controlled" />
+<Examples className="sm:grid-cols-2 md:grid-cols-2">
+  <Example name="time-field/demos/basic" title="Basic Time Field" />
+  <Example name="time-field/demos/prefix-and-suffix" title="With Icon" />
+  <Example name="time-field/demos/time-zones" title="Time Zones" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/toggle-button-group.mdx
+++ b/www/content/docs/components/toggle-button-group.mdx
@@ -35,12 +35,9 @@ import { ToggleButtonGroup } from '@/components/ui/toggle-button-group'
 ## Examples
 
 <Examples className="grid-cols-2">
-  <Example name="toggle-button-group/demos/default" title="Default" />
-  <Example name="toggle-button-group/demos/with-text" title="With Text" />
-  <Example name="toggle-button-group/demos/variants" title="Variants" />
-  <Example name="toggle-button-group/demos/sizes" title="Sizes" />
-  <Example name="toggle-button-group/demos/vertical" title="Vertical" />
-  <Example name="toggle-button-group/demos/multiple" title="Multiple" />
+  <Example name="toggle-button-group/demos/default" title="Icon Buttons" />
+  <Example name="toggle-button-group/demos/with-text" title="Text Alignment" />
+  <Example name="toggle-button-group/demos/vertical" title="View Mode" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/toggle-button.mdx
+++ b/www/content/docs/components/toggle-button.mdx
@@ -42,15 +42,14 @@ import { ToggleButton } from '@/components/ui/toggle-button'
 
 ## Examples
 
-<Examples className="grid-cols-2">
+<Examples className="sm:grid-cols-2 md:grid-cols-3">
   <Example name="toggle-button/demos/default" title="Default" />
-  <Example name="toggle-button/demos/variants" title="Variants" />
-  <Example name="toggle-button/demos/prefix-and-suffix" title="With Text" />
-  <Example name="toggle-button/demos/sizes" title="Sizes" />
-  <Example name="toggle-button/demos/shapes" title="Shapes" />
-  <Example name="toggle-button/demos/disabled" title="Disabled" />
-  <Example name="toggle-button/demos/uncontrolled" title="Uncontrolled" />
-  <Example name="toggle-button/demos/controlled" title="Controlled" />
+  <Example name="toggle-button/demos/favorite-button" title="Favorite Toggle" />
+  <Example
+    name="toggle-button/demos/text-formatting-toolbar"
+    title="Text Formatting Toolbar"
+  />
+  <Example name="toggle-button/demos/view-switcher" title="View Switcher" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/tooltip.mdx
+++ b/www/content/docs/components/tooltip.mdx
@@ -53,14 +53,10 @@ import { Tooltip, TooltipContent } from '@/components/ui/tooltip'
 
 ## Examples
 
-<Examples>
-  <Example name="tooltip/demos/basic" />
-  <Example name="tooltip/demos/with-icon" />
-  <Example name="tooltip/demos/with-keyboard" />
-  <Example name="tooltip/demos/on-link" />
-  <Example name="tooltip/demos/long-content" />
-  <Example name="tooltip/demos/formatted" />
-  <Example name="tooltip/demos/placement" />
+<Examples className="grid-cols-2 md:grid-cols-3">
+  <Example name="tooltip/demos/basic" title="Basic Tooltip" />
+  <Example name="tooltip/demos/with-keyboard" title="With Keyboard Shortcut" />
+  <Example name="tooltip/demos/formatted" title="Formatted Content" />
 </Examples>
 
 ## API Reference

--- a/www/content/docs/components/tree.mdx
+++ b/www/content/docs/components/tree.mdx
@@ -80,15 +80,10 @@ import { Collection } from 'react-aria-components'
 
 ## Examples
 
-<Examples className="md:grid-cols-2">
+<Examples className="sm:grid-cols-2">
   <Example name="tree/demos/basic" title="Basic" />
-  <Example name="tree/demos/selection" title="Multiple selection" />
-  <Example name="tree/demos/with-icons" title="With icons" />
-  <Example name="tree/demos/dynamic" title="Dynamic items" />
-  <Example name="tree/demos/default-expanded" title="Default expanded" />
-  <Example name="tree/demos/disabled" title="Disabled items" />
+  <Example name="tree/demos/with-icons" title="File tree with icons" />
   <Example name="tree/demos/drag-and-drop" title="Drag and drop" />
-  <Example name="tree/demos/empty" title="Empty state" />
 </Examples>
 
 ## API Reference

--- a/www/src/modules/docs/example-code-modal.tsx
+++ b/www/src/modules/docs/example-code-modal.tsx
@@ -1,0 +1,122 @@
+import type React from 'react'
+import { CodeIcon, XIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { Dialog, DialogContent, DialogTitle } from '@/registry/ui/dialog'
+import { Modal } from '@/registry/ui/modal'
+
+import { CodeBlock, Pre } from './code-block'
+import {
+  CodeBlockTab,
+  CodeBlockTabs,
+  CodeBlockTabsList,
+  CodeBlockTabsTrigger,
+} from './code-block-tabs'
+import { DemoPreset } from './demo-preset'
+import { buildInstallCommands, PACKAGE_MANAGERS } from './install-commands'
+
+export interface ExampleCodeModalProps {
+  /** Modal title — the example's title. */
+  title: string
+  /** The live demo component, rendered as the preview. */
+  component: React.ComponentType
+  /** Pre-highlighted source (the `DemoCode` slot content built at MDX build time). */
+  code: React.ReactNode
+  /** Registry items to install, e.g. `["button"]`. */
+  install: string[]
+}
+
+/**
+ * The example card's "Show code" action: a quiet trigger that opens a large
+ * modal with the live preview and install command on the left and the example's
+ * source on the right — mirroring the gallery modal on /charts. The source is
+ * already highlighted at build time (passed in as `code`), so nothing here pulls
+ * in the syntax highlighter.
+ */
+export function ExampleCodeModal({
+  title,
+  component: Component,
+  code,
+  install,
+}: ExampleCodeModalProps) {
+  const commands = buildInstallCommands(install)
+
+  return (
+    <Dialog>
+      <Button variant="quiet" size="sm" className="text-fg-muted hover:text-fg">
+        <CodeIcon />
+        Show code
+      </Button>
+      <Modal className="h-[80vh] w-full sm:max-w-3xl md:max-w-4xl lg:max-w-5xl xl:max-w-6xl">
+        <DialogContent
+          aria-label={`${title} code`}
+          className="relative flex h-full min-h-0 flex-col p-0"
+        >
+          {/* Close sits just outside the panel's top-right corner. Kept inside
+              the dialog (so slot="close" works) but escaping the rounded body. */}
+          <Button
+            slot="close"
+            variant="quiet"
+            size="sm"
+            isIconOnly
+            aria-label="Close"
+            className="absolute -top-10 right-0 z-10 text-fg-muted hover:bg-inverse/10 hover:text-fg"
+          >
+            <XIcon />
+          </Button>
+          <div className="flex h-full min-h-0 flex-col md:flex-row">
+            {/* LEFT: title, live preview, install command */}
+            <div className="flex min-h-0 flex-col md:w-2/5 md:border-r lg:w-1/2">
+              <DialogTitle className="shrink-0 px-4 pt-3 text-sm text-fg-muted">
+                {title}
+              </DialogTitle>
+              <div className="flex min-h-56 flex-1 items-center justify-center overflow-auto p-6 sm:p-8">
+                <DemoPreset>
+                  <Component />
+                </DemoPreset>
+              </div>
+              {install.length > 0 ? (
+                <div className="shrink-0 border-t p-4">
+                  <p className="mb-2 text-xs font-medium text-fg-muted">
+                    Install
+                  </p>
+                  <CodeBlockTabs
+                    groupId="package-manager"
+                    defaultValue="pnpm"
+                    className="gap-2"
+                  >
+                    <CodeBlockTabsList>
+                      {PACKAGE_MANAGERS.map((pm) => (
+                        <CodeBlockTabsTrigger key={pm} value={pm}>
+                          {pm}
+                        </CodeBlockTabsTrigger>
+                      ))}
+                    </CodeBlockTabsList>
+                    {PACKAGE_MANAGERS.map((pm) => (
+                      <CodeBlockTab key={pm} value={pm}>
+                        <CodeBlock>
+                          <pre className="overflow-x-auto px-3 py-2.5 font-mono text-[0.8125rem] text-fg">
+                            {commands[pm]}
+                          </pre>
+                        </CodeBlock>
+                      </CodeBlockTab>
+                    ))}
+                  </CodeBlockTabs>
+                </div>
+              ) : null}
+            </div>
+
+            {/* RIGHT: example source, filling the full modal height */}
+            <div className="flex min-h-0 flex-1 flex-col border-t bg-card md:border-t-0">
+              <div className="min-h-0 flex-1 overflow-auto">
+                <CodeBlock className="rounded-none border-0 bg-transparent">
+                  <Pre>{code}</Pre>
+                </CodeBlock>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Modal>
+    </Dialog>
+  )
+}

--- a/www/src/modules/docs/example.tsx
+++ b/www/src/modules/docs/example.tsx
@@ -1,21 +1,23 @@
-import type React from 'react'
+import React from 'react'
 
 import { cn } from '@/registry/lib/utils'
-import { Button } from '@/registry/ui/button'
-import { Dialog, DialogBody, DialogContent } from '@/registry/ui/dialog'
-import { Modal } from '@/registry/ui/modal'
 
+import { DemoCode, getSlotContent } from './demo'
 import { DemoPreset } from './demo-preset'
+import { ExampleCodeModal } from './example-code-modal'
 
 export interface ExampleProps extends React.ComponentProps<'div'> {
   component: React.ComponentType
   title?: string
+  /** Registry items to install, injected by the rehype transform. */
+  install?: string[]
   children?: React.ReactNode
 }
 
 export function Example({
   component: Component,
   title,
+  install,
   children,
   className,
   ...props
@@ -25,41 +27,44 @@ export function Example({
   // render nothing instead.
   if (!Component) return null
 
+  // The rehype transform injects two children: the title `<h3>` (kept in the TOC)
+  // and a `<DemoCode>` slot holding the build-time-highlighted source. The source
+  // is routed to the "Show code" modal, never rendered inline.
+  const code = getSlotContent(children, DemoCode)
+  const heading = React.Children.toArray(children).filter(
+    (child) => !(React.isValidElement(child) && child.type === DemoCode),
+  )
+
   return (
     <div
       className={cn(
-        'flex flex-col gap-1',
-        '[&_h3]:mt-0 [&_h3]:px-1.5 [&_h3]:py-2 [&_h3]:text-sm [&_h3]:font-normal [&_h3]:tracking-normal [&_h3]:text-fg-muted',
+        'flex flex-col gap-2',
+        '[&_h3]:mt-0 [&_h3]:truncate [&_h3]:text-sm [&_h3]:font-normal [&_h3]:tracking-normal [&_h3]:text-fg-muted',
         className,
       )}
       {...props}
     >
-      {children ?? (title ? <h3>{title}</h3> : null)}
+      {/* Header row: title left, "Show code" right — like the gallery cards on /charts. */}
+      <div className="flex min-h-7 items-center justify-between gap-2 pl-1">
+        <div className="min-w-0">{heading}</div>
+        {code ? (
+          <ExampleCodeModal
+            title={title ?? 'Example'}
+            component={Component}
+            code={code}
+            install={install ?? []}
+          />
+        ) : null}
+      </div>
+
+      {/* The demo renders live and interactive in place. Height grows with
+          content so tall demos (tables, forms, sidebars) aren't clipped. */}
       <DemoPreset>
-        <div className="relative flex flex-1 flex-col">
-          <div
-            data-example-preview=""
-            tabIndex={-1}
-            className="pointer-events-none scrollbar-none flex min-h-32 flex-1 flex-col items-center justify-center gap-6 overflow-x-auto p-6 sm:p-10"
-          >
-            <Component />
-          </div>
-          <Dialog>
-            <Button
-              variant="quiet"
-              aria-label={title ? `Expand ${title} example` : 'Expand example'}
-              className="absolute inset-0 z-2 size-auto h-auto! border hover:border-border-hover"
-            />
-            <Modal>
-              <DialogContent
-                aria-label={title ? `${title} example` : 'Example'}
-              >
-                <DialogBody>
-                  <Component />
-                </DialogBody>
-              </DialogContent>
-            </Modal>
-          </Dialog>
+        <div
+          data-example-preview=""
+          className="scrollbar-none flex min-h-32 flex-1 flex-col items-center justify-center gap-6 overflow-x-auto rounded-2xl border bg-card p-6 sm:p-10"
+        >
+          <Component />
         </div>
       </DemoPreset>
     </div>

--- a/www/src/modules/docs/install-commands.ts
+++ b/www/src/modules/docs/install-commands.ts
@@ -1,0 +1,20 @@
+/** Package managers offered in install snippets, in display order. */
+export const PACKAGE_MANAGERS = ['npm', 'pnpm', 'yarn', 'bun'] as const
+
+export type PackageManager = (typeof PACKAGE_MANAGERS)[number]
+
+/**
+ * The shadcn install command per package manager for a set of registry items
+ * (e.g. `["button", "input"]` → `npx shadcn@latest add @dotui/button @dotui/input`).
+ */
+export function buildInstallCommands(
+  items: string[],
+): Record<PackageManager, string> {
+  const arg = `shadcn@latest add ${items.map((item) => `@dotui/${item}`).join(' ')}`
+  return {
+    npm: `npx ${arg}`,
+    pnpm: `pnpm dlx ${arg}`,
+    yarn: `yarn dlx ${arg}`,
+    bun: `bunx ${arg}`,
+  }
+}

--- a/www/src/modules/docs/mdx-plugins/rehype-transform.ts
+++ b/www/src/modules/docs/mdx-plugins/rehype-transform.ts
@@ -69,6 +69,8 @@ interface ProcessedDemo {
   importPath: string
   sourceHast: Root
   previewHast: Root
+  /** Registry items to install for this demo (the page component + extra imports). */
+  install: string[]
 }
 
 interface ReferenceNodeInfo {
@@ -290,6 +292,7 @@ async function processDemoNode(
       importPath,
       sourceHast,
       previewHast,
+      install: computeInstallItems(info.name, rawSource),
     }
   } catch (error) {
     console.error(
@@ -330,6 +333,22 @@ function generateImportName(demoName: string): string {
     .split(/[/-]/)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join('')
+}
+
+/**
+ * Registry items to install for a demo: the page component (the demo key's first
+ * segment) plus any other registry UI components its source imports — so a
+ * composed example (e.g. a login card) lists every `@dotui/*` it needs. Mirrors
+ * the chart gallery's `installItems`.
+ */
+function computeInstallItems(demoName: string, source: string): string[] {
+  const pageItem = demoName.slice(0, demoName.indexOf('/')) || demoName
+  const extras = new Set<string>()
+  for (const match of source.matchAll(/@\/registry\/ui\/([a-z0-9-]+)/g)) {
+    const name = match[1]
+    if (name && name !== pageItem) extras.add(name)
+  }
+  return [pageItem, ...[...extras].sort()]
 }
 
 // ============================================================================
@@ -493,30 +512,6 @@ function transformDemoNode(processed: ProcessedDemo): void {
   }
   node.attributes.push(componentAttr)
 
-  // Example doesn't consume the code slots — only Demo does. Inject a real
-  // <h3 id="{slug}">{title}</h3> from the `title` prop so it shows up in the
-  // TOC, then strip the prop from the JSX.
-  if (processed.nodeInfo.type === 'Example') {
-    const { title, titleId } = processed.nodeInfo
-    const existing = (node.children ?? []) as ElementContent[]
-
-    if (title && titleId) {
-      node.attributes = node.attributes.filter(
-        (attr) => !(attr.type === 'mdxJsxAttribute' && attr.name === 'title'),
-      )
-      const heading: Element = {
-        type: 'element',
-        tagName: 'h3',
-        properties: { id: titleId },
-        children: [{ type: 'text', value: title }],
-      }
-      node.children = [heading, ...existing]
-    } else {
-      node.children = existing
-    }
-    return
-  }
-
   // Create DemoCode wrapper with highlighted code HAST
   // sourceHast.children contains the <pre><code>...</code></pre> structure
   const demoCodeElement: MdxJsxFlowElementHast = {
@@ -524,6 +519,33 @@ function transformDemoNode(processed: ProcessedDemo): void {
     name: 'DemoCode',
     attributes: [],
     children: processed.sourceHast.children as ElementContent[],
+  }
+
+  // The Example card renders the demo live and exposes its source via a "Show
+  // code" modal. Inject a real <h3 id="{slug}">{title}</h3> so the title shows
+  // up in the TOC (the `title` prop is kept too, for the modal heading), the
+  // install items for the modal, and the highlighted source as a DemoCode slot
+  // the card routes into the modal.
+  if (processed.nodeInfo.type === 'Example') {
+    const { title, titleId } = processed.nodeInfo
+    const existing = (node.children ?? []) as ElementContent[]
+
+    node.attributes.push(
+      makeJsonParseAttr('install', JSON.stringify(processed.install)),
+    )
+
+    if (title && titleId) {
+      const heading: Element = {
+        type: 'element',
+        tagName: 'h3',
+        properties: { id: titleId },
+        children: [{ type: 'text', value: title }],
+      }
+      node.children = [heading, ...existing, demoCodeElement]
+    } else {
+      node.children = [...existing, demoCodeElement]
+    }
+    return
   }
 
   // Create DemoCodePreview wrapper with highlighted preview HAST

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -33,6 +33,14 @@ export const DemosIndex: Record<
 		files: ["ui/accordion/demos/disabled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/accordion/demos/disabled")),
 	},
+	"accordion/demos/product-features": {
+		files: ["ui/accordion/demos/product-features.tsx"],
+		component: React.lazy(() => import("@/registry/ui/accordion/demos/product-features")),
+	},
+	"accordion/demos/settings-panel": {
+		files: ["ui/accordion/demos/settings-panel.tsx"],
+		component: React.lazy(() => import("@/registry/ui/accordion/demos/settings-panel")),
+	},
 	"alert/demos/action": {
 		files: ["ui/alert/demos/action.tsx"],
 		component: React.lazy(() => import("@/registry/ui/alert/demos/action")),
@@ -48,6 +56,14 @@ export const DemosIndex: Record<
 	"alert/demos/default": {
 		files: ["ui/alert/demos/default.tsx"],
 		component: React.lazy(() => import("@/registry/ui/alert/demos/default")),
+	},
+	"alert/demos/dismissible": {
+		files: ["ui/alert/demos/dismissible.tsx"],
+		component: React.lazy(() => import("@/registry/ui/alert/demos/dismissible")),
+	},
+	"alert/demos/form-error": {
+		files: ["ui/alert/demos/form-error.tsx"],
+		component: React.lazy(() => import("@/registry/ui/alert/demos/form-error")),
 	},
 	"alert/demos/success": {
 		files: ["ui/alert/demos/success.tsx"],
@@ -156,6 +172,10 @@ export const DemosIndex: Record<
 	"breadcrumbs/demos/menu": {
 		files: ["ui/breadcrumbs/demos/menu.tsx"],
 		component: React.lazy(() => import("@/registry/ui/breadcrumbs/demos/menu")),
+	},
+	"breadcrumbs/demos/with-icons": {
+		files: ["ui/breadcrumbs/demos/with-icons.tsx"],
+		component: React.lazy(() => import("@/registry/ui/breadcrumbs/demos/with-icons")),
 	},
 	"button/demos/default": {
 		files: ["ui/button/demos/default.tsx"],
@@ -565,6 +585,10 @@ export const DemosIndex: Record<
 		files: ["ui/checkbox/demos/invalid.tsx"],
 		component: React.lazy(() => import("@/registry/ui/checkbox/demos/invalid")),
 	},
+	"checkbox/demos/preferences-list": {
+		files: ["ui/checkbox/demos/preferences-list.tsx"],
+		component: React.lazy(() => import("@/registry/ui/checkbox/demos/preferences-list")),
+	},
 	"checkbox/demos/read-only": {
 		files: ["ui/checkbox/demos/read-only.tsx"],
 		component: React.lazy(() => import("@/registry/ui/checkbox/demos/read-only")),
@@ -572,6 +596,10 @@ export const DemosIndex: Record<
 	"checkbox/demos/standalone": {
 		files: ["ui/checkbox/demos/standalone.tsx"],
 		component: React.lazy(() => import("@/registry/ui/checkbox/demos/standalone")),
+	},
+	"checkbox/demos/terms-acceptance": {
+		files: ["ui/checkbox/demos/terms-acceptance.tsx"],
+		component: React.lazy(() => import("@/registry/ui/checkbox/demos/terms-acceptance")),
 	},
 	"checkbox-group/demos/cards": {
 		files: ["ui/checkbox-group/demos/cards.tsx"],
@@ -597,9 +625,17 @@ export const DemosIndex: Record<
 		files: ["ui/checkbox-group/demos/error-message.tsx"],
 		component: React.lazy(() => import("@/registry/ui/checkbox-group/demos/error-message")),
 	},
+	"checkbox-group/demos/form": {
+		files: ["ui/checkbox-group/demos/form.tsx"],
+		component: React.lazy(() => import("@/registry/ui/checkbox-group/demos/form")),
+	},
 	"checkbox-group/demos/label": {
 		files: ["ui/checkbox-group/demos/label.tsx"],
 		component: React.lazy(() => import("@/registry/ui/checkbox-group/demos/label")),
+	},
+	"checkbox-group/demos/permissions": {
+		files: ["ui/checkbox-group/demos/permissions.tsx"],
+		component: React.lazy(() => import("@/registry/ui/checkbox-group/demos/permissions")),
 	},
 	"checkbox-group/demos/read-only": {
 		files: ["ui/checkbox-group/demos/read-only.tsx"],
@@ -612,6 +648,10 @@ export const DemosIndex: Record<
 	"checkbox-group/demos/uncontrolled": {
 		files: ["ui/checkbox-group/demos/uncontrolled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/checkbox-group/demos/uncontrolled")),
+	},
+	"color-area/demos/brand-color": {
+		files: ["ui/color-area/demos/brand-color.tsx"],
+		component: React.lazy(() => import("@/registry/ui/color-area/demos/brand-color")),
 	},
 	"color-area/demos/channels": {
 		files: ["ui/color-area/demos/channels.tsx"],
@@ -628,6 +668,10 @@ export const DemosIndex: Record<
 	"color-area/demos/disabled": {
 		files: ["ui/color-area/demos/disabled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/color-area/demos/disabled")),
+	},
+	"color-area/demos/theme-customizer": {
+		files: ["ui/color-area/demos/theme-customizer.tsx"],
+		component: React.lazy(() => import("@/registry/ui/color-area/demos/theme-customizer")),
 	},
 	"color-area/demos/uncontrolled": {
 		files: ["ui/color-area/demos/uncontrolled.tsx"],
@@ -733,13 +777,25 @@ export const DemosIndex: Record<
 		files: ["ui/color-slider/demos/vertical.tsx"],
 		component: React.lazy(() => import("@/registry/ui/color-slider/demos/vertical")),
 	},
+	"color-swatch/demos/color-palette": {
+		files: ["ui/color-swatch/demos/color-palette.tsx"],
+		component: React.lazy(() => import("@/registry/ui/color-swatch/demos/color-palette")),
+	},
 	"color-swatch/demos/default": {
 		files: ["ui/color-swatch/demos/default.tsx"],
 		component: React.lazy(() => import("@/registry/ui/color-swatch/demos/default")),
 	},
+	"color-swatch/demos/in-button": {
+		files: ["ui/color-swatch/demos/in-button.tsx"],
+		component: React.lazy(() => import("@/registry/ui/color-swatch/demos/in-button")),
+	},
 	"color-swatch-picker/demos/basic": {
 		files: ["ui/color-swatch-picker/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/color-swatch-picker/demos/basic")),
+	},
+	"color-swatch-picker/demos/brand-color": {
+		files: ["ui/color-swatch-picker/demos/brand-color.tsx"],
+		component: React.lazy(() => import("@/registry/ui/color-swatch-picker/demos/brand-color")),
 	},
 	"color-swatch-picker/demos/controlled": {
 		files: ["ui/color-swatch-picker/demos/controlled.tsx"],
@@ -748,6 +804,10 @@ export const DemosIndex: Record<
 	"color-swatch-picker/demos/disabled": {
 		files: ["ui/color-swatch-picker/demos/disabled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/color-swatch-picker/demos/disabled")),
+	},
+	"color-swatch-picker/demos/theme-colors": {
+		files: ["ui/color-swatch-picker/demos/theme-colors.tsx"],
+		component: React.lazy(() => import("@/registry/ui/color-swatch-picker/demos/theme-colors")),
 	},
 	"combobox/demos/async-loading": {
 		files: ["ui/combobox/demos/async-loading.tsx"],
@@ -889,6 +949,10 @@ export const DemosIndex: Record<
 		files: ["ui/context-menu/demos/with-submenu.tsx"],
 		component: React.lazy(() => import("@/registry/ui/context-menu/demos/with-submenu")),
 	},
+	"date-field/demos/appointment": {
+		files: ["ui/date-field/demos/appointment.tsx"],
+		component: React.lazy(() => import("@/registry/ui/date-field/demos/appointment")),
+	},
 	"date-field/demos/basic": {
 		files: ["ui/date-field/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/date-field/demos/basic")),
@@ -908,6 +972,10 @@ export const DemosIndex: Record<
 	"date-field/demos/error-message": {
 		files: ["ui/date-field/demos/error-message.tsx"],
 		component: React.lazy(() => import("@/registry/ui/date-field/demos/error-message")),
+	},
+	"date-field/demos/event-form": {
+		files: ["ui/date-field/demos/event-form.tsx"],
+		component: React.lazy(() => import("@/registry/ui/date-field/demos/event-form")),
 	},
 	"date-field/demos/granularity": {
 		files: ["ui/date-field/demos/granularity.tsx"],
@@ -948,6 +1016,10 @@ export const DemosIndex: Record<
 	"date-field/demos/time-zones": {
 		files: ["ui/date-field/demos/time-zones.tsx"],
 		component: React.lazy(() => import("@/registry/ui/date-field/demos/time-zones")),
+	},
+	"date-field/demos/trip-dates": {
+		files: ["ui/date-field/demos/trip-dates.tsx"],
+		component: React.lazy(() => import("@/registry/ui/date-field/demos/trip-dates")),
 	},
 	"date-field/demos/uncontrolled": {
 		files: ["ui/date-field/demos/uncontrolled.tsx"],
@@ -1161,6 +1233,14 @@ export const DemosIndex: Record<
 		files: ["ui/disclosure/demos/disabled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/disclosure/demos/disabled")),
 	},
+	"disclosure/demos/faq-section": {
+		files: ["ui/disclosure/demos/faq-section.tsx"],
+		component: React.lazy(() => import("@/registry/ui/disclosure/demos/faq-section")),
+	},
+	"disclosure/demos/feature-details": {
+		files: ["ui/disclosure/demos/feature-details.tsx"],
+		component: React.lazy(() => import("@/registry/ui/disclosure/demos/feature-details")),
+	},
 	"drawer/demos/basic": {
 		files: ["ui/drawer/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/drawer/demos/basic")),
@@ -1253,6 +1333,18 @@ export const DemosIndex: Record<
 		files: ["ui/empty/demos/with-muted-background.tsx"],
 		component: React.lazy(() => import("@/registry/ui/empty/demos/with-muted-background")),
 	},
+	"field/demos/login-form": {
+		files: ["ui/field/demos/login-form.tsx"],
+		component: React.lazy(() => import("@/registry/ui/field/demos/login-form")),
+	},
+	"field/demos/profile-settings": {
+		files: ["ui/field/demos/profile-settings.tsx"],
+		component: React.lazy(() => import("@/registry/ui/field/demos/profile-settings")),
+	},
+	"field/demos/registration": {
+		files: ["ui/field/demos/registration.tsx"],
+		component: React.lazy(() => import("@/registry/ui/field/demos/registration")),
+	},
 	"file-trigger/demos/default": {
 		files: ["ui/file-trigger/demos/default.tsx"],
 		component: React.lazy(() => import("@/registry/ui/file-trigger/demos/default")),
@@ -1261,9 +1353,17 @@ export const DemosIndex: Record<
 		files: ["ui/file-trigger/demos/directory-selection.tsx"],
 		component: React.lazy(() => import("@/registry/ui/file-trigger/demos/directory-selection")),
 	},
+	"file-trigger/demos/document-upload": {
+		files: ["ui/file-trigger/demos/document-upload.tsx"],
+		component: React.lazy(() => import("@/registry/ui/file-trigger/demos/document-upload")),
+	},
 	"file-trigger/demos/file-types": {
 		files: ["ui/file-trigger/demos/file-types.tsx"],
 		component: React.lazy(() => import("@/registry/ui/file-trigger/demos/file-types")),
+	},
+	"file-trigger/demos/image-gallery-upload": {
+		files: ["ui/file-trigger/demos/image-gallery-upload.tsx"],
+		component: React.lazy(() => import("@/registry/ui/file-trigger/demos/image-gallery-upload")),
 	},
 	"file-trigger/demos/media-capture": {
 		files: ["ui/file-trigger/demos/media-capture.tsx"],
@@ -1272,6 +1372,10 @@ export const DemosIndex: Record<
 	"file-trigger/demos/multiple-files": {
 		files: ["ui/file-trigger/demos/multiple-files.tsx"],
 		component: React.lazy(() => import("@/registry/ui/file-trigger/demos/multiple-files")),
+	},
+	"file-trigger/demos/profile-picture": {
+		files: ["ui/file-trigger/demos/profile-picture.tsx"],
+		component: React.lazy(() => import("@/registry/ui/file-trigger/demos/profile-picture")),
 	},
 	"form/demos/basic": {
 		files: ["ui/form/demos/basic.tsx"],
@@ -1353,9 +1457,17 @@ export const DemosIndex: Record<
 		files: ["ui/input/demos/disabled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/input/demos/disabled")),
 	},
+	"input/demos/email-field": {
+		files: ["ui/input/demos/email-field.tsx"],
+		component: React.lazy(() => import("@/registry/ui/input/demos/email-field")),
+	},
 	"input/demos/invalid": {
 		files: ["ui/input/demos/invalid.tsx"],
 		component: React.lazy(() => import("@/registry/ui/input/demos/invalid")),
+	},
+	"input/demos/search-bar": {
+		files: ["ui/input/demos/search-bar.tsx"],
+		component: React.lazy(() => import("@/registry/ui/input/demos/search-bar")),
 	},
 	"input/demos/sizes": {
 		files: ["ui/input/demos/sizes.tsx"],
@@ -1445,6 +1557,22 @@ export const DemosIndex: Record<
 		files: ["ui/kbd/demos/with-samp.tsx"],
 		component: React.lazy(() => import("@/registry/ui/kbd/demos/with-samp")),
 	},
+	"link/demos/default": {
+		files: ["ui/link/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/link/demos/default")),
+	},
+	"link/demos/footer-navigation": {
+		files: ["ui/link/demos/footer-navigation.tsx"],
+		component: React.lazy(() => import("@/registry/ui/link/demos/footer-navigation")),
+	},
+	"link/demos/in-text": {
+		files: ["ui/link/demos/in-text.tsx"],
+		component: React.lazy(() => import("@/registry/ui/link/demos/in-text")),
+	},
+	"link/demos/with-icon": {
+		files: ["ui/link/demos/with-icon.tsx"],
+		component: React.lazy(() => import("@/registry/ui/link/demos/with-icon")),
+	},
 	"list-box/demos/async": {
 		files: ["ui/list-box/demos/async.tsx"],
 		component: React.lazy(() => import("@/registry/ui/list-box/demos/async")),
@@ -1516,6 +1644,18 @@ export const DemosIndex: Record<
 	"loader/demos/basic": {
 		files: ["ui/loader/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/loader/demos/basic")),
+	},
+	"loader/demos/in-button": {
+		files: ["ui/loader/demos/in-button.tsx"],
+		component: React.lazy(() => import("@/registry/ui/loader/demos/in-button")),
+	},
+	"loader/demos/in-input": {
+		files: ["ui/loader/demos/in-input.tsx"],
+		component: React.lazy(() => import("@/registry/ui/loader/demos/in-input")),
+	},
+	"loader/demos/overlay": {
+		files: ["ui/loader/demos/overlay.tsx"],
+		component: React.lazy(() => import("@/registry/ui/loader/demos/overlay")),
 	},
 	"menu/demos/account": {
 		files: ["ui/menu/demos/account.tsx"],
@@ -1717,6 +1857,10 @@ export const DemosIndex: Record<
 		files: ["ui/otp-field/demos/disabled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/otp-field/demos/disabled")),
 	},
+	"otp-field/demos/email-verification": {
+		files: ["ui/otp-field/demos/email-verification.tsx"],
+		component: React.lazy(() => import("@/registry/ui/otp-field/demos/email-verification")),
+	},
 	"otp-field/demos/error-message": {
 		files: ["ui/otp-field/demos/error-message.tsx"],
 		component: React.lazy(() => import("@/registry/ui/otp-field/demos/error-message")),
@@ -1732,6 +1876,10 @@ export const DemosIndex: Record<
 	"otp-field/demos/separator": {
 		files: ["ui/otp-field/demos/separator.tsx"],
 		component: React.lazy(() => import("@/registry/ui/otp-field/demos/separator")),
+	},
+	"otp-field/demos/two-factor-auth": {
+		files: ["ui/otp-field/demos/two-factor-auth.tsx"],
+		component: React.lazy(() => import("@/registry/ui/otp-field/demos/two-factor-auth")),
 	},
 	"pagination/demos/compact": {
 		files: ["ui/pagination/demos/compact.tsx"],
@@ -1752,6 +1900,14 @@ export const DemosIndex: Record<
 	"pagination/demos/sizes": {
 		files: ["ui/pagination/demos/sizes.tsx"],
 		component: React.lazy(() => import("@/registry/ui/pagination/demos/sizes")),
+	},
+	"pagination/demos/table-integration": {
+		files: ["ui/pagination/demos/table-integration.tsx"],
+		component: React.lazy(() => import("@/registry/ui/pagination/demos/table-integration")),
+	},
+	"pagination/demos/with-results": {
+		files: ["ui/pagination/demos/with-results.tsx"],
+		component: React.lazy(() => import("@/registry/ui/pagination/demos/with-results")),
 	},
 	"popover/demos/basic": {
 		files: ["ui/popover/demos/basic.tsx"],
@@ -1857,6 +2013,10 @@ export const DemosIndex: Record<
 		files: ["ui/radio-group/demos/label.tsx"],
 		component: React.lazy(() => import("@/registry/ui/radio-group/demos/label")),
 	},
+	"radio-group/demos/notification-preferences": {
+		files: ["ui/radio-group/demos/notification-preferences.tsx"],
+		component: React.lazy(() => import("@/registry/ui/radio-group/demos/notification-preferences")),
+	},
 	"radio-group/demos/read-only": {
 		files: ["ui/radio-group/demos/read-only.tsx"],
 		component: React.lazy(() => import("@/registry/ui/radio-group/demos/read-only")),
@@ -1864,6 +2024,10 @@ export const DemosIndex: Record<
 	"radio-group/demos/required": {
 		files: ["ui/radio-group/demos/required.tsx"],
 		component: React.lazy(() => import("@/registry/ui/radio-group/demos/required")),
+	},
+	"radio-group/demos/subscription-plan": {
+		files: ["ui/radio-group/demos/subscription-plan.tsx"],
+		component: React.lazy(() => import("@/registry/ui/radio-group/demos/subscription-plan")),
 	},
 	"radio-group/demos/uncontrolled": {
 		files: ["ui/radio-group/demos/uncontrolled.tsx"],
@@ -1893,6 +2057,14 @@ export const DemosIndex: Record<
 		files: ["ui/search-field/demos/error-message.tsx"],
 		component: React.lazy(() => import("@/registry/ui/search-field/demos/error-message")),
 	},
+	"search-field/demos/filterable-list": {
+		files: ["ui/search-field/demos/filterable-list.tsx"],
+		component: React.lazy(() => import("@/registry/ui/search-field/demos/filterable-list")),
+	},
+	"search-field/demos/header-search": {
+		files: ["ui/search-field/demos/header-search.tsx"],
+		component: React.lazy(() => import("@/registry/ui/search-field/demos/header-search")),
+	},
 	"search-field/demos/label": {
 		files: ["ui/search-field/demos/label.tsx"],
 		component: React.lazy(() => import("@/registry/ui/search-field/demos/label")),
@@ -1912,6 +2084,10 @@ export const DemosIndex: Record<
 	"search-field/demos/uncontrolled": {
 		files: ["ui/search-field/demos/uncontrolled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/search-field/demos/uncontrolled")),
+	},
+	"search-field/demos/with-suggestions": {
+		files: ["ui/search-field/demos/with-suggestions.tsx"],
+		component: React.lazy(() => import("@/registry/ui/search-field/demos/with-suggestions")),
 	},
 	"select/demos/async-loading": {
 		files: ["ui/select/demos/async-loading.tsx"],
@@ -1973,6 +2149,18 @@ export const DemosIndex: Record<
 		files: ["ui/separator/demos/card.tsx"],
 		component: React.lazy(() => import("@/registry/ui/separator/demos/card")),
 	},
+	"separator/demos/default": {
+		files: ["ui/separator/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/separator/demos/default")),
+	},
+	"separator/demos/list-menu": {
+		files: ["ui/separator/demos/list-menu.tsx"],
+		component: React.lazy(() => import("@/registry/ui/separator/demos/list-menu")),
+	},
+	"separator/demos/menu-section": {
+		files: ["ui/separator/demos/menu-section.tsx"],
+		component: React.lazy(() => import("@/registry/ui/separator/demos/menu-section")),
+	},
 	"separator/demos/orientation": {
 		files: ["ui/separator/demos/orientation.tsx"],
 		component: React.lazy(() => import("@/registry/ui/separator/demos/orientation")),
@@ -2032,6 +2220,10 @@ export const DemosIndex: Record<
 	"skeleton/demos/card": {
 		files: ["ui/skeleton/demos/card.tsx"],
 		component: React.lazy(() => import("@/registry/ui/skeleton/demos/card")),
+	},
+	"skeleton/demos/list-items": {
+		files: ["ui/skeleton/demos/list-items.tsx"],
+		component: React.lazy(() => import("@/registry/ui/skeleton/demos/list-items")),
 	},
 	"slider/demos/composition": {
 		files: ["ui/slider/demos/composition.tsx"],
@@ -2113,13 +2305,25 @@ export const DemosIndex: Record<
 		files: ["ui/switch/demos/disabled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/switch/demos/disabled")),
 	},
+	"switch/demos/feature-flags": {
+		files: ["ui/switch/demos/feature-flags.tsx"],
+		component: React.lazy(() => import("@/registry/ui/switch/demos/feature-flags")),
+	},
 	"switch/demos/label": {
 		files: ["ui/switch/demos/label.tsx"],
 		component: React.lazy(() => import("@/registry/ui/switch/demos/label")),
 	},
+	"switch/demos/notification-preferences": {
+		files: ["ui/switch/demos/notification-preferences.tsx"],
+		component: React.lazy(() => import("@/registry/ui/switch/demos/notification-preferences")),
+	},
 	"switch/demos/read-only": {
 		files: ["ui/switch/demos/read-only.tsx"],
 		component: React.lazy(() => import("@/registry/ui/switch/demos/read-only")),
+	},
+	"switch/demos/settings-panel": {
+		files: ["ui/switch/demos/settings-panel.tsx"],
+		component: React.lazy(() => import("@/registry/ui/switch/demos/settings-panel")),
 	},
 	"switch/demos/sizes": {
 		files: ["ui/switch/demos/sizes.tsx"],
@@ -2233,9 +2437,21 @@ export const DemosIndex: Record<
 		files: ["ui/tabs/demos/disabled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/tabs/demos/disabled")),
 	},
+	"tabs/demos/documentation": {
+		files: ["ui/tabs/demos/documentation.tsx"],
+		component: React.lazy(() => import("@/registry/ui/tabs/demos/documentation")),
+	},
 	"tabs/demos/keyboard-activation": {
 		files: ["ui/tabs/demos/keyboard-activation.tsx"],
 		component: React.lazy(() => import("@/registry/ui/tabs/demos/keyboard-activation")),
+	},
+	"tabs/demos/product-details": {
+		files: ["ui/tabs/demos/product-details.tsx"],
+		component: React.lazy(() => import("@/registry/ui/tabs/demos/product-details")),
+	},
+	"tabs/demos/settings-panel": {
+		files: ["ui/tabs/demos/settings-panel.tsx"],
+		component: React.lazy(() => import("@/registry/ui/tabs/demos/settings-panel")),
 	},
 	"tabs/demos/variant": {
 		files: ["ui/tabs/demos/variant.tsx"],
@@ -2309,6 +2525,14 @@ export const DemosIndex: Record<
 		files: ["ui/text-area/demos/error-message.tsx"],
 		component: React.lazy(() => import("@/registry/ui/text-area/demos/error-message")),
 	},
+	"text-area/demos/feedback-form": {
+		files: ["ui/text-area/demos/feedback-form.tsx"],
+		component: React.lazy(() => import("@/registry/ui/text-area/demos/feedback-form")),
+	},
+	"text-area/demos/issue-description": {
+		files: ["ui/text-area/demos/issue-description.tsx"],
+		component: React.lazy(() => import("@/registry/ui/text-area/demos/issue-description")),
+	},
 	"text-area/demos/label": {
 		files: ["ui/text-area/demos/label.tsx"],
 		component: React.lazy(() => import("@/registry/ui/text-area/demos/label")),
@@ -2356,6 +2580,14 @@ export const DemosIndex: Record<
 	"text-field/demos/label": {
 		files: ["ui/text-field/demos/label.tsx"],
 		component: React.lazy(() => import("@/registry/ui/text-field/demos/label")),
+	},
+	"text-field/demos/login-form": {
+		files: ["ui/text-field/demos/login-form.tsx"],
+		component: React.lazy(() => import("@/registry/ui/text-field/demos/login-form")),
+	},
+	"text-field/demos/newsletter-signup": {
+		files: ["ui/text-field/demos/newsletter-signup.tsx"],
+		component: React.lazy(() => import("@/registry/ui/text-field/demos/newsletter-signup")),
 	},
 	"text-field/demos/prefix-and-suffix": {
 		files: ["ui/text-field/demos/prefix-and-suffix.tsx"],
@@ -2457,6 +2689,10 @@ export const DemosIndex: Record<
 		files: ["ui/toggle-button/demos/disabled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/toggle-button/demos/disabled")),
 	},
+	"toggle-button/demos/favorite-button": {
+		files: ["ui/toggle-button/demos/favorite-button.tsx"],
+		component: React.lazy(() => import("@/registry/ui/toggle-button/demos/favorite-button")),
+	},
 	"toggle-button/demos/prefix-and-suffix": {
 		files: ["ui/toggle-button/demos/prefix-and-suffix.tsx"],
 		component: React.lazy(() => import("@/registry/ui/toggle-button/demos/prefix-and-suffix")),
@@ -2469,6 +2705,10 @@ export const DemosIndex: Record<
 		files: ["ui/toggle-button/demos/sizes.tsx"],
 		component: React.lazy(() => import("@/registry/ui/toggle-button/demos/sizes")),
 	},
+	"toggle-button/demos/text-formatting-toolbar": {
+		files: ["ui/toggle-button/demos/text-formatting-toolbar.tsx"],
+		component: React.lazy(() => import("@/registry/ui/toggle-button/demos/text-formatting-toolbar")),
+	},
 	"toggle-button/demos/uncontrolled": {
 		files: ["ui/toggle-button/demos/uncontrolled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/toggle-button/demos/uncontrolled")),
@@ -2476,6 +2716,10 @@ export const DemosIndex: Record<
 	"toggle-button/demos/variants": {
 		files: ["ui/toggle-button/demos/variants.tsx"],
 		component: React.lazy(() => import("@/registry/ui/toggle-button/demos/variants")),
+	},
+	"toggle-button/demos/view-switcher": {
+		files: ["ui/toggle-button/demos/view-switcher.tsx"],
+		component: React.lazy(() => import("@/registry/ui/toggle-button/demos/view-switcher")),
 	},
 	"toggle-button-group/demos/default": {
 		files: ["ui/toggle-button-group/demos/default.tsx"],

--- a/www/src/registry/ui/accordion/demos/product-features.tsx
+++ b/www/src/registry/ui/accordion/demos/product-features.tsx
@@ -1,0 +1,52 @@
+import { Accordion } from '@/registry/ui/accordion'
+import {
+  Disclosure,
+  DisclosurePanel,
+  DisclosureTrigger,
+} from '@/registry/ui/disclosure'
+
+const categories = [
+  {
+    name: 'Collaboration',
+    features: [
+      'Real-time multiplayer editing',
+      'Inline comments and mentions',
+      'Shared workspaces with roles',
+    ],
+  },
+  {
+    name: 'Automation',
+    features: [
+      'Custom workflow triggers',
+      'Scheduled tasks and reminders',
+      'Webhooks for any event',
+    ],
+  },
+  {
+    name: 'Security',
+    features: [
+      'SSO and SCIM provisioning',
+      'Granular access controls',
+      'Audit logs and data export',
+    ],
+  },
+]
+
+export default function Demo() {
+  return (
+    <Accordion className="w-full max-w-sm">
+      {categories.map((category) => (
+        <Disclosure key={category.name} id={category.name}>
+          <DisclosureTrigger>{category.name}</DisclosureTrigger>
+          <DisclosurePanel>
+            <ul className="list-disc space-y-1 pl-4 text-sm text-fg-muted">
+              {category.features.map((feature) => (
+                <li key={feature}>{feature}</li>
+              ))}
+            </ul>
+          </DisclosurePanel>
+        </Disclosure>
+      ))}
+    </Accordion>
+  )
+}

--- a/www/src/registry/ui/accordion/demos/settings-panel.tsx
+++ b/www/src/registry/ui/accordion/demos/settings-panel.tsx
@@ -1,0 +1,72 @@
+import { Accordion } from '@/registry/ui/accordion'
+import {
+  Disclosure,
+  DisclosurePanel,
+  DisclosureTrigger,
+} from '@/registry/ui/disclosure'
+import { Description, FieldContent, Label } from '@/registry/ui/field'
+import { Switch, SwitchControl, SwitchIndicator } from '@/registry/ui/switch'
+
+const sections = [
+  {
+    name: 'Notifications',
+    settings: [
+      {
+        label: 'Email digests',
+        description: 'A weekly summary of your activity.',
+        defaultSelected: true,
+      },
+      {
+        label: 'Push notifications',
+        description: 'Alerts on your devices in real time.',
+        defaultSelected: false,
+      },
+    ],
+  },
+  {
+    name: 'Privacy',
+    settings: [
+      {
+        label: 'Public profile',
+        description: 'Let anyone view your profile page.',
+        defaultSelected: false,
+      },
+      {
+        label: 'Show activity status',
+        description: 'Display when you were last online.',
+        defaultSelected: true,
+      },
+    ],
+  },
+]
+
+export default function Demo() {
+  return (
+    <Accordion className="w-full max-w-sm">
+      {sections.map((section) => (
+        <Disclosure key={section.name} id={section.name}>
+          <DisclosureTrigger>{section.name}</DisclosureTrigger>
+          <DisclosurePanel>
+            <div className="flex flex-col gap-4">
+              {section.settings.map((setting) => (
+                <Switch
+                  key={setting.label}
+                  className="w-full"
+                  defaultSelected={setting.defaultSelected}
+                >
+                  <SwitchControl>
+                    <FieldContent>
+                      <Label>{setting.label}</Label>
+                      <Description>{setting.description}</Description>
+                    </FieldContent>
+                    <SwitchIndicator />
+                  </SwitchControl>
+                </Switch>
+              ))}
+            </div>
+          </DisclosurePanel>
+        </Disclosure>
+      ))}
+    </Accordion>
+  )
+}

--- a/www/src/registry/ui/alert/demos/dismissible.tsx
+++ b/www/src/registry/ui/alert/demos/dismissible.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState } from 'react'
+import { CheckCircle2Icon, XIcon } from 'lucide-react'
+
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
+} from '@/registry/ui/alert'
+import { Button } from '@/registry/ui/button'
+
+export default function Demo() {
+  const [isVisible, setIsVisible] = useState(true)
+
+  if (!isVisible) {
+    return (
+      <Button variant="quiet" size="sm" onPress={() => setIsVisible(true)}>
+        Show alert
+      </Button>
+    )
+  }
+
+  return (
+    <Alert variant="success">
+      <CheckCircle2Icon />
+      <AlertTitle>Changes saved</AlertTitle>
+      <AlertDescription>
+        Your profile has been updated successfully.
+      </AlertDescription>
+      <AlertAction>
+        <Button
+          variant="quiet"
+          size="sm"
+          isIconOnly
+          aria-label="Dismiss"
+          onPress={() => setIsVisible(false)}
+        >
+          <XIcon />
+        </Button>
+      </AlertAction>
+    </Alert>
+  )
+}

--- a/www/src/registry/ui/alert/demos/form-error.tsx
+++ b/www/src/registry/ui/alert/demos/form-error.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState } from 'react'
+import { AlertCircleIcon } from 'lucide-react'
+
+import { Alert, AlertDescription, AlertTitle } from '@/registry/ui/alert'
+import { Button } from '@/registry/ui/button'
+import { Label } from '@/registry/ui/field'
+import { Input } from '@/registry/ui/input'
+import { TextField } from '@/registry/ui/text-field'
+
+export default function Demo() {
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState(true)
+
+  return (
+    <form
+      className="flex w-full max-w-xs flex-col gap-3"
+      onSubmit={(e) => {
+        e.preventDefault()
+        setError(!email.includes('@'))
+      }}
+    >
+      {error && (
+        <Alert variant="danger">
+          <AlertCircleIcon />
+          <AlertTitle>Invalid email</AlertTitle>
+          <AlertDescription>
+            Enter a valid email address to continue.
+          </AlertDescription>
+        </Alert>
+      )}
+      <TextField value={email} onChange={setEmail} isInvalid={error}>
+        <Label>Email</Label>
+        <Input type="email" placeholder="you@example.com" />
+      </TextField>
+      <Button type="submit" variant="primary" size="sm">
+        Sign in
+      </Button>
+    </form>
+  )
+}

--- a/www/src/registry/ui/breadcrumbs/demos/with-icons.tsx
+++ b/www/src/registry/ui/breadcrumbs/demos/with-icons.tsx
@@ -1,0 +1,46 @@
+import {
+  FileTextIcon,
+  FolderIcon,
+  FolderOpenIcon,
+  HomeIcon,
+} from '@/registry/__generated__/icons'
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  Breadcrumbs,
+} from '@/registry/ui/breadcrumbs'
+
+export default function Demo() {
+  return (
+    <Breadcrumbs>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="#">
+          <HomeIcon />
+          My Drive
+        </BreadcrumbLink>
+        <BreadcrumbSeparator />
+      </BreadcrumbItem>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="#">
+          <FolderIcon />
+          Projects
+        </BreadcrumbLink>
+        <BreadcrumbSeparator />
+      </BreadcrumbItem>
+      <BreadcrumbItem>
+        <BreadcrumbLink href="#">
+          <FolderOpenIcon />
+          Q3 Report
+        </BreadcrumbLink>
+        <BreadcrumbSeparator />
+      </BreadcrumbItem>
+      <BreadcrumbItem>
+        <BreadcrumbLink>
+          <FileTextIcon />
+          Summary.pdf
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+    </Breadcrumbs>
+  )
+}

--- a/www/src/registry/ui/checkbox-group/demos/form.tsx
+++ b/www/src/registry/ui/checkbox-group/demos/form.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import * as FormPrimitives from 'react-aria-components/Form'
+
+import { Button } from '@/registry/ui/button'
+import { Checkbox, CheckboxControl } from '@/registry/ui/checkbox'
+import { CheckboxGroup } from '@/registry/ui/checkbox-group'
+import { Description, FieldGroup, Label } from '@/registry/ui/field'
+
+export default function Demo() {
+  return (
+    <FormPrimitives.Form
+      onSubmit={(e) => {
+        e.preventDefault()
+        const data = Object.fromEntries(new FormData(e.currentTarget))
+        alert(JSON.stringify(data, null, 2))
+      }}
+      className="w-full max-w-xs space-y-6"
+    >
+      <CheckboxGroup name="dietary">
+        <Label>Dietary restrictions</Label>
+        <FieldGroup>
+          <Checkbox value="vegetarian">
+            <CheckboxControl />
+            <Label>Vegetarian</Label>
+          </Checkbox>
+          <Checkbox value="vegan">
+            <CheckboxControl />
+            <Label>Vegan</Label>
+          </Checkbox>
+          <Checkbox value="gluten-free">
+            <CheckboxControl />
+            <Label>Gluten-free</Label>
+          </Checkbox>
+        </FieldGroup>
+      </CheckboxGroup>
+      <CheckboxGroup name="activities" defaultValue={['workshop']}>
+        <Label>Activities</Label>
+        <FieldGroup>
+          <Checkbox value="workshop">
+            <CheckboxControl />
+            <Label>Workshop</Label>
+          </Checkbox>
+          <Checkbox value="networking">
+            <CheckboxControl />
+            <Label>Networking</Label>
+          </Checkbox>
+          <Checkbox value="dinner">
+            <CheckboxControl />
+            <Label>Dinner</Label>
+          </Checkbox>
+        </FieldGroup>
+      </CheckboxGroup>
+      <CheckboxGroup name="consent" isRequired>
+        <Label>Consent</Label>
+        <Description>Required to complete your RSVP.</Description>
+        <FieldGroup>
+          <Checkbox value="terms">
+            <CheckboxControl />
+            <Label>I accept the event terms</Label>
+          </Checkbox>
+          <Checkbox value="photos">
+            <CheckboxControl />
+            <Label>I consent to event photos</Label>
+          </Checkbox>
+        </FieldGroup>
+      </CheckboxGroup>
+      <Button type="submit" variant="primary" className="w-full">
+        Confirm RSVP
+      </Button>
+    </FormPrimitives.Form>
+  )
+}

--- a/www/src/registry/ui/checkbox-group/demos/permissions.tsx
+++ b/www/src/registry/ui/checkbox-group/demos/permissions.tsx
@@ -1,0 +1,46 @@
+import { Checkbox, CheckboxControl } from '@/registry/ui/checkbox'
+import { CheckboxGroup } from '@/registry/ui/checkbox-group'
+import { Description, FieldGroup, Label } from '@/registry/ui/field'
+
+export default function Demo() {
+  return (
+    <div className="w-full max-w-xs space-y-6">
+      <CheckboxGroup defaultValue={['email', 'push']}>
+        <Label>Channels</Label>
+        <Description>Where we reach you.</Description>
+        <FieldGroup>
+          <Checkbox value="email">
+            <CheckboxControl />
+            <Label>Email</Label>
+          </Checkbox>
+          <Checkbox value="sms">
+            <CheckboxControl />
+            <Label>SMS</Label>
+          </Checkbox>
+          <Checkbox value="push">
+            <CheckboxControl />
+            <Label>Push</Label>
+          </Checkbox>
+        </FieldGroup>
+      </CheckboxGroup>
+      <CheckboxGroup defaultValue={['updates', 'security']}>
+        <Label>Notification types</Label>
+        <Description>What we notify you about.</Description>
+        <FieldGroup>
+          <Checkbox value="marketing">
+            <CheckboxControl />
+            <Label>Marketing</Label>
+          </Checkbox>
+          <Checkbox value="updates">
+            <CheckboxControl />
+            <Label>Product updates</Label>
+          </Checkbox>
+          <Checkbox value="security">
+            <CheckboxControl />
+            <Label>Security alerts</Label>
+          </Checkbox>
+        </FieldGroup>
+      </CheckboxGroup>
+    </div>
+  )
+}

--- a/www/src/registry/ui/checkbox/demos/preferences-list.tsx
+++ b/www/src/registry/ui/checkbox/demos/preferences-list.tsx
@@ -1,0 +1,49 @@
+import {
+  Checkbox,
+  CheckboxControl,
+  CheckboxIndicator,
+} from '@/registry/ui/checkbox'
+import { Description, FieldContent, Label } from '@/registry/ui/field'
+
+const preferences = [
+  {
+    id: 'updates',
+    label: 'Product updates',
+    description: 'Get notified about new features.',
+    defaultSelected: true,
+  },
+  {
+    id: 'security',
+    label: 'Security alerts',
+    description: 'Important account activity.',
+    defaultSelected: true,
+  },
+  {
+    id: 'newsletter',
+    label: 'Weekly newsletter',
+    description: 'A digest of tips and news.',
+    defaultSelected: false,
+  },
+]
+
+export default function Demo() {
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-1">
+      {preferences.map((pref) => (
+        <Checkbox
+          key={pref.id}
+          defaultSelected={pref.defaultSelected}
+          className="w-full rounded-md p-2 hover:bg-muted"
+        >
+          <CheckboxControl>
+            <CheckboxIndicator />
+            <FieldContent>
+              <Label>{pref.label}</Label>
+              <Description>{pref.description}</Description>
+            </FieldContent>
+          </CheckboxControl>
+        </Checkbox>
+      ))}
+    </div>
+  )
+}

--- a/www/src/registry/ui/checkbox/demos/terms-acceptance.tsx
+++ b/www/src/registry/ui/checkbox/demos/terms-acceptance.tsx
@@ -1,0 +1,47 @@
+import {
+  Checkbox,
+  CheckboxControl,
+  CheckboxIndicator,
+} from '@/registry/ui/checkbox'
+import {
+  Description,
+  FieldContent,
+  Fieldset,
+  Label,
+  Legend,
+} from '@/registry/ui/field'
+
+export default function Demo() {
+  return (
+    <Fieldset className="w-full max-w-sm">
+      <Legend>Before you continue</Legend>
+      <Checkbox className="w-full">
+        <CheckboxControl>
+          <CheckboxIndicator />
+          <FieldContent>
+            <Label>Terms of Service</Label>
+            <Description>I have read and agree to the terms.</Description>
+          </FieldContent>
+        </CheckboxControl>
+      </Checkbox>
+      <Checkbox className="w-full">
+        <CheckboxControl>
+          <CheckboxIndicator />
+          <FieldContent>
+            <Label>Privacy Policy</Label>
+            <Description>I consent to how my data is handled.</Description>
+          </FieldContent>
+        </CheckboxControl>
+      </Checkbox>
+      <Checkbox className="w-full" defaultSelected>
+        <CheckboxControl>
+          <CheckboxIndicator />
+          <FieldContent>
+            <Label>Marketing emails</Label>
+            <Description>Send me product updates and offers.</Description>
+          </FieldContent>
+        </CheckboxControl>
+      </Checkbox>
+    </Fieldset>
+  )
+}

--- a/www/src/registry/ui/color-area/demos/brand-color.tsx
+++ b/www/src/registry/ui/color-area/demos/brand-color.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import React from 'react'
+import * as ColorAreaPrimitives from 'react-aria-components/ColorArea'
+
+import { ColorArea } from '@/registry/ui/color-area'
+
+export default function Demo() {
+  const [value, setValue] = React.useState(
+    ColorAreaPrimitives.parseColor('hsl(217, 91%, 60%)'),
+  )
+  return (
+    <div className="flex w-full max-w-xs flex-col items-center gap-3">
+      <ColorArea
+        value={value}
+        onChange={setValue}
+        xChannel="saturation"
+        yChannel="lightness"
+        aria-label="Brand color"
+      />
+      <div className="flex w-full items-center gap-2 rounded-md border border-border p-2">
+        <div
+          className="size-8 shrink-0 rounded-sm border border-border"
+          style={{ backgroundColor: value.toString('hex') }}
+        />
+        <div className="flex flex-col">
+          <span className="text-xs font-medium">Brand color</span>
+          <span className="text-xs text-fg-muted uppercase">
+            {value.toString('hex')}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/www/src/registry/ui/color-area/demos/theme-customizer.tsx
+++ b/www/src/registry/ui/color-area/demos/theme-customizer.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import React from 'react'
+import * as ColorAreaPrimitives from 'react-aria-components/ColorArea'
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/registry/ui/card'
+import { ColorArea } from '@/registry/ui/color-area'
+import { Label } from '@/registry/ui/field'
+
+export default function Demo() {
+  const [primary, setPrimary] = React.useState(
+    ColorAreaPrimitives.parseColor('hsl(217, 91%, 60%)'),
+  )
+  const [secondary, setSecondary] = React.useState(
+    ColorAreaPrimitives.parseColor('hsl(280, 70%, 60%)'),
+  )
+  return (
+    <div className="flex w-full flex-col gap-6 sm:flex-row">
+      <div className="flex flex-1 gap-6">
+        <div className="flex flex-col gap-2">
+          <Label>Primary</Label>
+          <ColorArea
+            value={primary}
+            onChange={setPrimary}
+            xChannel="saturation"
+            yChannel="lightness"
+            aria-label="Primary color"
+          />
+          <span className="text-xs text-fg-muted uppercase">
+            {primary.toString('hex')}
+          </span>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label>Secondary</Label>
+          <ColorArea
+            value={secondary}
+            onChange={setSecondary}
+            xChannel="saturation"
+            yChannel="lightness"
+            aria-label="Secondary color"
+          />
+          <span className="text-xs text-fg-muted uppercase">
+            {secondary.toString('hex')}
+          </span>
+        </div>
+      </div>
+      <Card className="flex-1">
+        <CardHeader>
+          <CardTitle>Preview</CardTitle>
+          <CardDescription>Live theme colors</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-2">
+          <button
+            type="button"
+            className="rounded-md px-3 py-2 text-sm font-medium text-white"
+            style={{ backgroundColor: primary.toString('hex') }}
+          >
+            Primary button
+          </button>
+          <button
+            type="button"
+            className="rounded-md px-3 py-2 text-sm font-medium text-white"
+            style={{ backgroundColor: secondary.toString('hex') }}
+          >
+            Secondary button
+          </button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/www/src/registry/ui/color-swatch-picker/demos/brand-color.tsx
+++ b/www/src/registry/ui/color-swatch-picker/demos/brand-color.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react'
+import * as ColorAreaPrimitives from 'react-aria-components/ColorArea'
+
+import { Button } from '@/registry/ui/button'
+import {
+  ColorSwatchPicker,
+  ColorSwatchPickerItem,
+} from '@/registry/ui/color-swatch-picker'
+import { Description, Label } from '@/registry/ui/field'
+
+const brandColors = ['#635bff', '#0070f3', '#16a34a', '#ea580c', '#db2777']
+
+export default function Demo() {
+  const [value, setValue] = useState<ColorAreaPrimitives.Color>(
+    ColorAreaPrimitives.parseColor('#635bff'),
+  )
+
+  return (
+    <div className="flex w-full max-w-xs flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <Label id="brand-color-label">Brand color</Label>
+        <Description>Used for buttons, links, and accents.</Description>
+      </div>
+      <ColorSwatchPicker
+        aria-labelledby="brand-color-label"
+        value={value}
+        onChange={setValue}
+      >
+        {brandColors.map((color) => (
+          <ColorSwatchPickerItem key={color} color={color} />
+        ))}
+      </ColorSwatchPicker>
+      <Button variant="primary" size="sm" className="self-start">
+        Save changes
+      </Button>
+    </div>
+  )
+}

--- a/www/src/registry/ui/color-swatch-picker/demos/theme-colors.tsx
+++ b/www/src/registry/ui/color-swatch-picker/demos/theme-colors.tsx
@@ -1,0 +1,37 @@
+import {
+  ColorSwatchPicker,
+  ColorSwatchPickerItem,
+} from '@/registry/ui/color-swatch-picker'
+import { Description, Label } from '@/registry/ui/field'
+
+const accents = [
+  '#18181b',
+  '#dc2626',
+  '#ea580c',
+  '#ca8a04',
+  '#16a34a',
+  '#0d9488',
+  '#2563eb',
+  '#7c3aed',
+  '#db2777',
+]
+
+export default function Demo() {
+  return (
+    <div className="flex w-full max-w-xs flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <Label id="accent-label">Accent</Label>
+        <Description>Pick a preset color scheme.</Description>
+      </div>
+      <ColorSwatchPicker
+        aria-labelledby="accent-label"
+        defaultValue="#2563eb"
+        className="grid grid-cols-5"
+      >
+        {accents.map((color) => (
+          <ColorSwatchPickerItem key={color} color={color} />
+        ))}
+      </ColorSwatchPicker>
+    </div>
+  )
+}

--- a/www/src/registry/ui/color-swatch/demos/color-palette.tsx
+++ b/www/src/registry/ui/color-swatch/demos/color-palette.tsx
@@ -1,0 +1,23 @@
+import { ColorSwatch } from '@/registry/ui/color-swatch'
+
+const palette = [
+  { name: 'Sky', color: '#0ea5e9' },
+  { name: 'Emerald', color: '#10b981' },
+  { name: 'Amber', color: '#f59e0b' },
+  { name: 'Rose', color: '#f43f5e' },
+  { name: 'Violet', color: '#8b5cf6' },
+  { name: 'Slate', color: '#64748b' },
+]
+
+export default function Demo() {
+  return (
+    <div className="grid w-full max-w-xs grid-cols-3 gap-3">
+      {palette.map((swatch) => (
+        <div key={swatch.name} className="flex flex-col items-center gap-1.5">
+          <ColorSwatch color={swatch.color} className="size-10" />
+          <span className="text-xs text-fg-muted">{swatch.name}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/www/src/registry/ui/color-swatch/demos/in-button.tsx
+++ b/www/src/registry/ui/color-swatch/demos/in-button.tsx
@@ -1,0 +1,16 @@
+import { ChevronDown } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { ColorSwatch } from '@/registry/ui/color-swatch'
+
+export default function Demo() {
+  return (
+    <Button variant="default" className="w-full max-w-xs justify-between">
+      <span className="flex items-center gap-2">
+        <ColorSwatch color="#8b5cf6" className="size-4" />
+        Violet
+      </span>
+      <ChevronDown className="text-fg-muted" />
+    </Button>
+  )
+}

--- a/www/src/registry/ui/date-field/demos/appointment.tsx
+++ b/www/src/registry/ui/date-field/demos/appointment.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Button } from '@/registry/ui/button'
+import { DateField } from '@/registry/ui/date-field'
+import { Description, FieldError, Label } from '@/registry/ui/field'
+import { DateInput } from '@/registry/ui/input'
+
+export default function Demo() {
+  const [submitted, setSubmitted] = useState(false)
+
+  return (
+    <form
+      noValidate
+      className="flex w-full max-w-xs flex-col gap-4"
+      onSubmit={(event) => {
+        event.preventDefault()
+        setSubmitted(true)
+      }}
+    >
+      <DateField
+        name="appointment"
+        granularity="minute"
+        isRequired
+        isInvalid={submitted}
+      >
+        <Label>Appointment</Label>
+        <DateInput />
+        <Description>We will confirm your slot by email.</Description>
+        <FieldError>Please choose a date and time.</FieldError>
+      </DateField>
+      <Button type="submit" className="w-full">
+        Schedule
+      </Button>
+    </form>
+  )
+}

--- a/www/src/registry/ui/date-field/demos/event-form.tsx
+++ b/www/src/registry/ui/date-field/demos/event-form.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { Button } from '@/registry/ui/button'
+import { DateField } from '@/registry/ui/date-field'
+import { Description, Label } from '@/registry/ui/field'
+import { DateInput } from '@/registry/ui/input'
+
+export default function Demo() {
+  return (
+    <form
+      className="flex w-full max-w-xs flex-col gap-4"
+      onSubmit={(event) => event.preventDefault()}
+    >
+      <DateField name="event-date" granularity="day" isRequired>
+        <Label>Event date</Label>
+        <DateInput />
+      </DateField>
+      <DateField name="event-time" granularity="minute">
+        <Label>Start time (optional)</Label>
+        <DateInput />
+        <Description>Leave empty for an all-day event.</Description>
+      </DateField>
+      <Button type="submit" className="w-full">
+        Book event
+      </Button>
+    </form>
+  )
+}

--- a/www/src/registry/ui/date-field/demos/trip-dates.tsx
+++ b/www/src/registry/ui/date-field/demos/trip-dates.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { DateField } from '@/registry/ui/date-field'
+import { Description, Label } from '@/registry/ui/field'
+import { DateInput } from '@/registry/ui/input'
+
+export default function Demo() {
+  return (
+    <div className="flex w-full max-w-xs flex-col gap-4">
+      <DateField name="check-in" granularity="day">
+        <Label>Check-in</Label>
+        <DateInput />
+        <Description>The day your trip starts.</Description>
+      </DateField>
+      <DateField name="check-out" granularity="day">
+        <Label>Check-out</Label>
+        <DateInput />
+        <Description>The day you head back home.</Description>
+      </DateField>
+    </div>
+  )
+}

--- a/www/src/registry/ui/disclosure/demos/faq-section.tsx
+++ b/www/src/registry/ui/disclosure/demos/faq-section.tsx
@@ -1,0 +1,41 @@
+import {
+  Disclosure,
+  DisclosurePanel,
+  DisclosureTrigger,
+} from '@/registry/ui/disclosure'
+
+const faqs = [
+  {
+    question: 'How do I reset my password?',
+    answer:
+      'Go to Settings, then Security, and select "Reset password". We will email you a secure link that stays valid for 30 minutes.',
+  },
+  {
+    question: 'Can I change my plan later?',
+    answer:
+      'Yes. You can upgrade or downgrade at any time from the Billing page. Changes are prorated and take effect immediately.',
+  },
+  {
+    question: 'Do you offer refunds?',
+    answer:
+      'We offer a full refund within 14 days of purchase, no questions asked. Reach out to support and we will process it right away.',
+  },
+]
+
+export default function Demo() {
+  return (
+    <div className="w-full max-w-sm">
+      <h3 className="mb-2 text-sm font-medium text-fg-muted">
+        Frequently asked questions
+      </h3>
+      <div className="divide-y divide-border">
+        {faqs.map((faq) => (
+          <Disclosure key={faq.question}>
+            <DisclosureTrigger>{faq.question}</DisclosureTrigger>
+            <DisclosurePanel>{faq.answer}</DisclosurePanel>
+          </Disclosure>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/www/src/registry/ui/disclosure/demos/feature-details.tsx
+++ b/www/src/registry/ui/disclosure/demos/feature-details.tsx
@@ -1,0 +1,37 @@
+import { ZapIcon } from 'lucide-react'
+
+import {
+  Disclosure,
+  DisclosurePanel,
+  DisclosureTrigger,
+} from '@/registry/ui/disclosure'
+
+export default function Demo() {
+  return (
+    <div className="w-full max-w-sm rounded-lg border bg-bg p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <ZapIcon className="size-4" />
+        </div>
+        <div className="min-w-0">
+          <h3 className="text-sm font-medium">Edge Functions</h3>
+          <p className="text-sm text-fg-muted">
+            Run code closer to your users with zero cold starts.
+          </p>
+        </div>
+        <span className="ml-auto shrink-0 text-sm font-medium">$20/mo</span>
+      </div>
+      <Disclosure className="mt-2">
+        <DisclosureTrigger>What's included</DisclosureTrigger>
+        <DisclosurePanel>
+          <ul className="list-inside list-disc space-y-1 text-sm text-fg-muted">
+            <li>1M invocations per month</li>
+            <li>Deploy to 30+ regions worldwide</li>
+            <li>Automatic failover and scaling</li>
+            <li>Logs and metrics retained for 7 days</li>
+          </ul>
+        </DisclosurePanel>
+      </Disclosure>
+    </div>
+  )
+}

--- a/www/src/registry/ui/field/demos/login-form.tsx
+++ b/www/src/registry/ui/field/demos/login-form.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { Button } from '@/registry/ui/button'
+import { Description, FieldError, FieldGroup, Label } from '@/registry/ui/field'
+import { Input } from '@/registry/ui/input'
+import { TextField } from '@/registry/ui/text-field'
+
+export default function Demo() {
+  return (
+    <form className="w-full max-w-xs">
+      <FieldGroup>
+        <TextField type="email" defaultValue="ada@example" isInvalid>
+          <Label>Email</Label>
+          <Input placeholder="you@example.com" />
+          <FieldError>Enter a valid email address.</FieldError>
+        </TextField>
+        <TextField type="password" isRequired>
+          <Label>Password</Label>
+          <Input placeholder="••••••••" />
+          <Description>At least 8 characters.</Description>
+        </TextField>
+        <Button type="submit" variant="primary" className="w-full">
+          Sign in
+        </Button>
+      </FieldGroup>
+    </form>
+  )
+}

--- a/www/src/registry/ui/field/demos/profile-settings.tsx
+++ b/www/src/registry/ui/field/demos/profile-settings.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Button } from '@/registry/ui/button'
+import { Description, FieldGroup, Label } from '@/registry/ui/field'
+import { Input } from '@/registry/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from '@/registry/ui/select'
+import { TextField } from '@/registry/ui/text-field'
+
+export default function Demo() {
+  return (
+    <form className="w-full max-w-xs">
+      <FieldGroup>
+        <TextField defaultValue="Ada Lovelace">
+          <Label>Display name</Label>
+          <Input placeholder="Your name" />
+        </TextField>
+        <TextField type="email" defaultValue="ada@example.com">
+          <Label>Email</Label>
+          <Input placeholder="you@example.com" />
+          <Description>Used for sign-in and notifications.</Description>
+        </TextField>
+        <Select defaultSelectedKey="utc" placeholder="Select timezone">
+          <Label>Timezone</Label>
+          <SelectTrigger />
+          <SelectContent>
+            <SelectItem id="utc">UTC</SelectItem>
+            <SelectItem id="est">Eastern Time</SelectItem>
+            <SelectItem id="pst">Pacific Time</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button type="submit" variant="primary" className="w-full">
+          Save changes
+        </Button>
+      </FieldGroup>
+    </form>
+  )
+}

--- a/www/src/registry/ui/field/demos/registration.tsx
+++ b/www/src/registry/ui/field/demos/registration.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { Button } from '@/registry/ui/button'
+import { Checkbox, CheckboxControl } from '@/registry/ui/checkbox'
+import {
+  Description,
+  FieldContent,
+  FieldGroup,
+  Label,
+} from '@/registry/ui/field'
+import { Input } from '@/registry/ui/input'
+import { TextField } from '@/registry/ui/text-field'
+
+export default function Demo() {
+  return (
+    <form className="w-full max-w-xs">
+      <FieldGroup>
+        <TextField>
+          <Label>Username</Label>
+          <Input placeholder="ada_lovelace" />
+          <Description>This will be your public handle.</Description>
+        </TextField>
+        <TextField type="email">
+          <Label>Email</Label>
+          <Input placeholder="you@example.com" />
+        </TextField>
+        <TextField type="password">
+          <Label>Password</Label>
+          <Input placeholder="••••••••" />
+          <Description>At least 8 characters.</Description>
+        </TextField>
+        <Checkbox>
+          <CheckboxControl />
+          <FieldContent>
+            <Label>Email me product updates</Label>
+            <Description>You can unsubscribe anytime.</Description>
+          </FieldContent>
+        </Checkbox>
+        <Button type="submit" variant="primary" className="w-full">
+          Create account
+        </Button>
+      </FieldGroup>
+    </form>
+  )
+}

--- a/www/src/registry/ui/file-trigger/demos/document-upload.tsx
+++ b/www/src/registry/ui/file-trigger/demos/document-upload.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import React from 'react'
+
+import {
+  FileTextIcon,
+  TrashIcon,
+  UploadIcon,
+} from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { FileTrigger } from '@/registry/ui/file-trigger'
+
+export default function Demo() {
+  const [docs, setDocs] = React.useState<string[]>([])
+  return (
+    <div className="flex w-full max-w-xs flex-col gap-3">
+      <FileTrigger
+        acceptedFileTypes={[
+          'application/pdf',
+          'application/msword',
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        ]}
+        allowsMultiple
+        onSelect={(e) => {
+          if (e) {
+            const names = Array.from(e).map((file) => file.name)
+            setDocs((prev) => [...prev, ...names])
+          }
+        }}
+      >
+        <Button variant="default" className="w-full">
+          <UploadIcon /> Upload documents
+        </Button>
+      </FileTrigger>
+      {docs.length > 0 && (
+        <ul className="flex flex-col gap-1">
+          {docs.map((name, i) => (
+            <li
+              key={`${name}-${i}`}
+              className="flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm"
+            >
+              <FileTextIcon className="size-4 shrink-0 text-fg-muted" />
+              <span className="flex-1 truncate">{name}</span>
+              <Button
+                variant="quiet"
+                size="xs"
+                isIconOnly
+                aria-label={`Remove ${name}`}
+                onPress={() =>
+                  setDocs((prev) => prev.filter((_, idx) => idx !== i))
+                }
+              >
+                <TrashIcon />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/www/src/registry/ui/file-trigger/demos/image-gallery-upload.tsx
+++ b/www/src/registry/ui/file-trigger/demos/image-gallery-upload.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import React from 'react'
+
+import { ImageIcon, UploadIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { FileTrigger } from '@/registry/ui/file-trigger'
+
+export default function Demo() {
+  const [images, setImages] = React.useState<string[]>([])
+  return (
+    <div className="flex w-full max-w-xs flex-col gap-3">
+      <div className="grid grid-cols-3 gap-2">
+        {images.map((src, i) => (
+          <img
+            key={`${src}-${i}`}
+            src={src}
+            alt={`Upload ${i + 1}`}
+            className="aspect-square w-full rounded-md border object-cover"
+          />
+        ))}
+        <FileTrigger
+          acceptedFileTypes={['image/*']}
+          allowsMultiple
+          onSelect={(e) => {
+            if (e) {
+              const urls = Array.from(e).map((file) =>
+                URL.createObjectURL(file),
+              )
+              setImages((prev) => [...prev, ...urls])
+            }
+          }}
+        >
+          <Button
+            variant="quiet"
+            aria-label="Add images"
+            className="flex aspect-square size-full flex-col gap-1 border border-dashed text-fg-muted"
+          >
+            <ImageIcon className="size-5" />
+          </Button>
+        </FileTrigger>
+      </div>
+      <FileTrigger
+        acceptedFileTypes={['image/*']}
+        allowsMultiple
+        onSelect={(e) => {
+          if (e) {
+            const urls = Array.from(e).map((file) => URL.createObjectURL(file))
+            setImages((prev) => [...prev, ...urls])
+          }
+        }}
+      >
+        <Button variant="default" size="sm" className="w-full">
+          <UploadIcon /> Upload images
+        </Button>
+      </FileTrigger>
+    </div>
+  )
+}

--- a/www/src/registry/ui/file-trigger/demos/profile-picture.tsx
+++ b/www/src/registry/ui/file-trigger/demos/profile-picture.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import React from 'react'
+
+import { UploadIcon } from '@/registry/__generated__/icons'
+import { Avatar, AvatarFallback, AvatarImage } from '@/registry/ui/avatar'
+import { Button } from '@/registry/ui/button'
+import { FileTrigger } from '@/registry/ui/file-trigger'
+
+export default function Demo() {
+  const [src, setSrc] = React.useState<string | null>(null)
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <Avatar size="lg">
+        {src && <AvatarImage src={src} alt="Profile picture" />}
+        <AvatarFallback>M</AvatarFallback>
+      </Avatar>
+      <FileTrigger
+        acceptedFileTypes={['image/*']}
+        onSelect={(e) => {
+          if (e) {
+            const file = Array.from(e)[0]
+            if (file) setSrc(URL.createObjectURL(file))
+          }
+        }}
+      >
+        <Button variant="default" size="sm">
+          <UploadIcon /> {src ? 'Change photo' : 'Upload photo'}
+        </Button>
+      </FileTrigger>
+    </div>
+  )
+}

--- a/www/src/registry/ui/input/demos/email-field.tsx
+++ b/www/src/registry/ui/input/demos/email-field.tsx
@@ -1,0 +1,13 @@
+import { Description, Label } from '@/registry/ui/field'
+import { Input } from '@/registry/ui/input'
+import { TextField } from '@/registry/ui/text-field'
+
+export default function Demo() {
+  return (
+    <TextField className="w-full max-w-xs" type="email" name="email">
+      <Label>Email address</Label>
+      <Input placeholder="you@example.com" />
+      <Description>We'll never share your email with anyone.</Description>
+    </TextField>
+  )
+}

--- a/www/src/registry/ui/input/demos/search-bar.tsx
+++ b/www/src/registry/ui/input/demos/search-bar.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useState } from 'react'
+import { SearchIcon, XIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { TextField } from '@/registry/ui/text-field'
+
+export default function Demo() {
+  const [value, setValue] = useState('')
+  return (
+    <TextField
+      aria-label="Search members"
+      className="w-full max-w-xs"
+      value={value}
+      onChange={setValue}
+    >
+      <InputGroup>
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <Input placeholder="Search members..." />
+        {value && (
+          <InputGroupAddon>
+            <Button
+              variant="quiet"
+              isIconOnly
+              aria-label="Clear search"
+              onPress={() => setValue('')}
+            >
+              <XIcon />
+            </Button>
+          </InputGroupAddon>
+        )}
+      </InputGroup>
+    </TextField>
+  )
+}

--- a/www/src/registry/ui/link/demos/default.tsx
+++ b/www/src/registry/ui/link/demos/default.tsx
@@ -1,0 +1,5 @@
+import { Link } from '@/registry/ui/link'
+
+export default function Demo() {
+  return <Link href="#">View documentation</Link>
+}

--- a/www/src/registry/ui/link/demos/footer-navigation.tsx
+++ b/www/src/registry/ui/link/demos/footer-navigation.tsx
@@ -1,0 +1,25 @@
+import { Link } from '@/registry/ui/link'
+
+const sections = [
+  { title: 'Product', links: ['Features', 'Pricing', 'Changelog'] },
+  { title: 'Company', links: ['About', 'Blog', 'Careers'] },
+]
+
+export default function Demo() {
+  return (
+    <div className="grid w-full max-w-xs grid-cols-2 gap-6">
+      {sections.map((section) => (
+        <div key={section.title} className="flex flex-col gap-2">
+          <span className="text-xs font-medium text-fg-muted">
+            {section.title}
+          </span>
+          {section.links.map((label) => (
+            <Link key={label} href="#" variant="quiet" className="text-sm">
+              {label}
+            </Link>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/www/src/registry/ui/link/demos/in-text.tsx
+++ b/www/src/registry/ui/link/demos/in-text.tsx
@@ -1,0 +1,11 @@
+import { Link } from '@/registry/ui/link'
+
+export default function Demo() {
+  return (
+    <p className="max-w-xs text-sm text-fg-muted">
+      Built on <Link href="#">React Aria Components</Link> for accessibility and
+      styled with <Link href="#">Tailwind CSS</Link>. Read the{' '}
+      <Link href="#">getting started guide</Link> to learn more.
+    </p>
+  )
+}

--- a/www/src/registry/ui/link/demos/with-icon.tsx
+++ b/www/src/registry/ui/link/demos/with-icon.tsx
@@ -1,0 +1,22 @@
+import { ArrowRight, BookOpen, ExternalLink } from 'lucide-react'
+
+import { Link } from '@/registry/ui/link'
+
+export default function Demo() {
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <Link href="#">
+        <BookOpen className="size-4" />
+        Read the docs
+      </Link>
+      <Link href="#">
+        Read the changelog
+        <ArrowRight className="size-4" />
+      </Link>
+      <Link href="#" variant="quiet">
+        Open in v0
+        <ExternalLink className="size-3.5" />
+      </Link>
+    </div>
+  )
+}

--- a/www/src/registry/ui/loader/demos/in-button.tsx
+++ b/www/src/registry/ui/loader/demos/in-button.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Button } from '@/registry/ui/button'
+import { Loader } from '@/registry/ui/loader'
+
+export default function Demo() {
+  const [isSaving, setIsSaving] = useState(false)
+  return (
+    <Button
+      isDisabled={isSaving}
+      onPress={() => {
+        setIsSaving(true)
+        setTimeout(() => setIsSaving(false), 2000)
+      }}
+    >
+      {isSaving ? (
+        <>
+          <Loader />
+          Saving...
+        </>
+      ) : (
+        'Save changes'
+      )}
+    </Button>
+  )
+}

--- a/www/src/registry/ui/loader/demos/in-input.tsx
+++ b/www/src/registry/ui/loader/demos/in-input.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useState } from 'react'
+import { SearchIcon } from 'lucide-react'
+
+import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Loader } from '@/registry/ui/loader'
+import { TextField } from '@/registry/ui/text-field'
+
+export default function Demo() {
+  const [value, setValue] = useState('')
+  const [isSearching, setIsSearching] = useState(false)
+  return (
+    <TextField
+      aria-label="Search"
+      className="w-full max-w-xs"
+      value={value}
+      onChange={(next) => {
+        setValue(next)
+        setIsSearching(next.length > 0)
+        setTimeout(() => setIsSearching(false), 1500)
+      }}
+    >
+      <InputGroup>
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <Input placeholder="Search..." />
+        {isSearching && (
+          <InputGroupAddon>
+            <Loader aria-label="Searching" />
+          </InputGroupAddon>
+        )}
+      </InputGroup>
+    </TextField>
+  )
+}

--- a/www/src/registry/ui/loader/demos/overlay.tsx
+++ b/www/src/registry/ui/loader/demos/overlay.tsx
@@ -1,0 +1,12 @@
+import { Loader } from '@/registry/ui/loader'
+
+export default function Demo() {
+  return (
+    <div className="flex w-full max-w-xs items-center justify-center rounded-md border border-dashed py-12">
+      <div className="flex flex-col items-center gap-3 text-fg-muted">
+        <Loader aria-label="Loading" className="size-6" />
+        <p className="text-sm">Loading content...</p>
+      </div>
+    </div>
+  )
+}

--- a/www/src/registry/ui/otp-field/demos/email-verification.tsx
+++ b/www/src/registry/ui/otp-field/demos/email-verification.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import React from 'react'
+import { Mail } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { Description, FieldError, Label } from '@/registry/ui/field'
+import { Group } from '@/registry/ui/group'
+import { Input } from '@/registry/ui/input'
+import { OTPField } from '@/registry/ui/otp-field'
+
+const CORRECT_CODE = '123456'
+
+export default function Demo() {
+  const [value, setValue] = React.useState('')
+  const [isPending, setIsPending] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    if (value.length !== 6) {
+      setError('Enter all six digits.')
+      return
+    }
+    setError(null)
+    setIsPending(true)
+    setTimeout(() => {
+      setIsPending(false)
+      if (value !== CORRECT_CODE) {
+        setError('That code is incorrect or expired.')
+      }
+    }, 1200)
+  }
+
+  return (
+    <form
+      noValidate
+      className="flex w-full max-w-xs flex-col gap-4 rounded-lg border bg-bg p-5"
+      onSubmit={handleSubmit}
+    >
+      <div className="flex size-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <Mail className="size-5" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <h3 className="text-base font-semibold">Verify your email</h3>
+        <p className="text-sm text-fg-muted">We sent a code to jane@acme.com</p>
+      </div>
+      <OTPField
+        length={6}
+        name="code"
+        value={value}
+        onChange={(next) => {
+          setValue(next)
+          if (error) setError(null)
+        }}
+        isInvalid={Boolean(error)}
+        isDisabled={isPending}
+      >
+        <Label className="sr-only">Email verification code</Label>
+        <Group>
+          <Input />
+          <Input aria-label="Digit 2" />
+          <Input aria-label="Digit 3" />
+          <Input aria-label="Digit 4" />
+          <Input aria-label="Digit 5" />
+          <Input aria-label="Digit 6" />
+        </Group>
+        {error ? (
+          <FieldError>{error}</FieldError>
+        ) : (
+          <Description>The code expires in 10 minutes.</Description>
+        )}
+      </OTPField>
+      <Button type="submit" className="w-full" isPending={isPending}>
+        Continue
+      </Button>
+    </form>
+  )
+}

--- a/www/src/registry/ui/otp-field/demos/two-factor-auth.tsx
+++ b/www/src/registry/ui/otp-field/demos/two-factor-auth.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import React from 'react'
+import { ShieldCheck } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { FieldError, Label } from '@/registry/ui/field'
+import { Group } from '@/registry/ui/group'
+import { Input } from '@/registry/ui/input'
+import { OTPField } from '@/registry/ui/otp-field'
+
+export default function Demo() {
+  const [value, setValue] = React.useState('')
+  const [submitted, setSubmitted] = React.useState(false)
+  const [seconds, setSeconds] = React.useState(30)
+  const isInvalid = submitted && value.length !== 6
+
+  React.useEffect(() => {
+    if (seconds === 0) return
+    const id = setTimeout(() => setSeconds((s) => s - 1), 1000)
+    return () => clearTimeout(id)
+  }, [seconds])
+
+  return (
+    <form
+      noValidate
+      className="flex w-full max-w-xs flex-col gap-4 rounded-lg border bg-bg p-5"
+      onSubmit={(event) => {
+        event.preventDefault()
+        setSubmitted(true)
+      }}
+    >
+      <div className="flex size-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <ShieldCheck className="size-5" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <h3 className="text-base font-semibold">Two-factor authentication</h3>
+        <p className="text-sm text-fg-muted">
+          Enter the code from your authenticator app.
+        </p>
+      </div>
+      <OTPField
+        length={6}
+        name="code"
+        value={value}
+        onChange={setValue}
+        isInvalid={isInvalid}
+      >
+        <Label className="sr-only">Authentication code</Label>
+        <Group>
+          <Input />
+          <Input aria-label="Digit 2" />
+          <Input aria-label="Digit 3" />
+          <Input aria-label="Digit 4" />
+          <Input aria-label="Digit 5" />
+          <Input aria-label="Digit 6" />
+        </Group>
+        <FieldError>Enter all six digits.</FieldError>
+      </OTPField>
+      <Button type="submit" className="w-full">
+        Verify
+      </Button>
+      <Button
+        type="button"
+        variant="quiet"
+        size="sm"
+        className="w-full"
+        isDisabled={seconds > 0}
+        onPress={() => {
+          setSeconds(30)
+          setValue('')
+          setSubmitted(false)
+        }}
+      >
+        {seconds > 0 ? `Resend code in ${seconds}s` : 'Resend code'}
+      </Button>
+    </form>
+  )
+}

--- a/www/src/registry/ui/pagination/demos/table-integration.tsx
+++ b/www/src/registry/ui/pagination/demos/table-integration.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import * as React from 'react'
+
+import {
+  Pagination,
+  PaginationItem,
+  PaginationList,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/registry/ui/pagination'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContainer,
+  TableHeader,
+  TableRow,
+} from '@/registry/ui/table'
+
+interface Invoice {
+  id: string
+  customer: string
+  amount: string
+}
+
+const INVOICES: Invoice[] = [
+  { id: 'INV-001', customer: 'Acme Corp', amount: '$1,240.00' },
+  { id: 'INV-002', customer: 'Globex', amount: '$820.50' },
+  { id: 'INV-003', customer: 'Initech', amount: '$3,100.00' },
+  { id: 'INV-004', customer: 'Umbrella', amount: '$540.00' },
+  { id: 'INV-005', customer: 'Soylent', amount: '$2,015.75' },
+  { id: 'INV-006', customer: 'Hooli', amount: '$1,890.00' },
+  { id: 'INV-007', customer: 'Stark Inc', amount: '$4,320.00' },
+  { id: 'INV-008', customer: 'Wayne Co', amount: '$960.25' },
+]
+
+const PAGE_SIZE = 3
+const TOTAL_PAGES = Math.ceil(INVOICES.length / PAGE_SIZE)
+
+export default function Demo() {
+  const [page, setPage] = React.useState(1)
+
+  const rows = INVOICES.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <TableContainer>
+        <Table aria-label="Invoices">
+          <TableHeader>
+            <TableColumn isRowHeader>Invoice</TableColumn>
+            <TableColumn>Customer</TableColumn>
+            <TableColumn>Amount</TableColumn>
+          </TableHeader>
+          <TableBody items={rows}>
+            {(invoice) => (
+              <TableRow id={invoice.id}>
+                <TableCell>{invoice.id}</TableCell>
+                <TableCell>{invoice.customer}</TableCell>
+                <TableCell className="tabular-nums">{invoice.amount}</TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-fg-muted tabular-nums">
+          Page {page} of {TOTAL_PAGES}
+        </p>
+        <Pagination>
+          <PaginationList>
+            <PaginationItem>
+              <PaginationPrevious
+                isIconOnly
+                isDisabled={page === 1}
+                onPress={() => setPage((p) => Math.max(1, p - 1))}
+              />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext
+                isIconOnly
+                isDisabled={page === TOTAL_PAGES}
+                onPress={() => setPage((p) => Math.min(TOTAL_PAGES, p + 1))}
+              />
+            </PaginationItem>
+          </PaginationList>
+        </Pagination>
+      </div>
+    </div>
+  )
+}

--- a/www/src/registry/ui/pagination/demos/with-results.tsx
+++ b/www/src/registry/ui/pagination/demos/with-results.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import * as React from 'react'
+
+import {
+  Pagination,
+  PaginationItem,
+  PaginationList,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/registry/ui/pagination'
+
+const PAGE_SIZE = 10
+const TOTAL_RESULTS = 42
+const TOTAL_PAGES = Math.ceil(TOTAL_RESULTS / PAGE_SIZE)
+
+export default function Demo() {
+  const [page, setPage] = React.useState(1)
+
+  const from = (page - 1) * PAGE_SIZE + 1
+  const to = Math.min(page * PAGE_SIZE, TOTAL_RESULTS)
+
+  return (
+    <div className="flex w-full max-w-sm flex-col items-center gap-3">
+      <p className="text-sm text-fg-muted tabular-nums">
+        Showing {from}–{to} of {TOTAL_RESULTS} results
+      </p>
+      <Pagination>
+        <PaginationList>
+          <PaginationItem>
+            <PaginationPrevious
+              isDisabled={page === 1}
+              onPress={() => setPage((p) => Math.max(1, p - 1))}
+            />
+          </PaginationItem>
+          <PaginationItem>
+            <span className="px-2 text-sm text-fg-muted tabular-nums">
+              Page {page} of {TOTAL_PAGES}
+            </span>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext
+              isDisabled={page === TOTAL_PAGES}
+              onPress={() => setPage((p) => Math.min(TOTAL_PAGES, p + 1))}
+            />
+          </PaginationItem>
+        </PaginationList>
+      </Pagination>
+    </div>
+  )
+}

--- a/www/src/registry/ui/radio-group/demos/notification-preferences.tsx
+++ b/www/src/registry/ui/radio-group/demos/notification-preferences.tsx
@@ -1,0 +1,59 @@
+import {
+  Description,
+  FieldContent,
+  FieldGroup,
+  Label,
+} from '@/registry/ui/field'
+import {
+  Radio,
+  RadioControl,
+  RadioGroup,
+  RadioIndicator,
+} from '@/registry/ui/radio-group'
+
+export default function Demo() {
+  return (
+    <RadioGroup defaultValue="weekly" className="w-full max-w-xs">
+      <Label>Email updates</Label>
+      <Description>Choose how often we email you.</Description>
+      <FieldGroup>
+        <Radio value="realtime">
+          <RadioControl>
+            <RadioIndicator />
+            <FieldContent>
+              <Label>Real-time</Label>
+              <Description>Notify me as activity happens</Description>
+            </FieldContent>
+          </RadioControl>
+        </Radio>
+        <Radio value="daily">
+          <RadioControl>
+            <RadioIndicator />
+            <FieldContent>
+              <Label>Daily digest</Label>
+              <Description>One summary every morning</Description>
+            </FieldContent>
+          </RadioControl>
+        </Radio>
+        <Radio value="weekly">
+          <RadioControl>
+            <RadioIndicator />
+            <FieldContent>
+              <Label>Weekly digest</Label>
+              <Description>A recap every Monday</Description>
+            </FieldContent>
+          </RadioControl>
+        </Radio>
+        <Radio value="off">
+          <RadioControl>
+            <RadioIndicator />
+            <FieldContent>
+              <Label>Off</Label>
+              <Description>Don't send me any emails</Description>
+            </FieldContent>
+          </RadioControl>
+        </Radio>
+      </FieldGroup>
+    </RadioGroup>
+  )
+}

--- a/www/src/registry/ui/radio-group/demos/subscription-plan.tsx
+++ b/www/src/registry/ui/radio-group/demos/subscription-plan.tsx
@@ -1,0 +1,49 @@
+import {
+  Description,
+  FieldContent,
+  FieldGroup,
+  Label,
+} from '@/registry/ui/field'
+import {
+  Radio,
+  RadioControl,
+  RadioGroup,
+  RadioIndicator,
+} from '@/registry/ui/radio-group'
+
+export default function Demo() {
+  return (
+    <RadioGroup defaultValue="pro" className="w-full max-w-xs">
+      <Label>Subscription plan</Label>
+      <FieldGroup>
+        <Radio value="starter">
+          <RadioControl>
+            <RadioIndicator />
+            <FieldContent>
+              <Label>Starter · $0/mo</Label>
+              <Description>1 project, community support</Description>
+            </FieldContent>
+          </RadioControl>
+        </Radio>
+        <Radio value="pro">
+          <RadioControl>
+            <RadioIndicator />
+            <FieldContent>
+              <Label>Pro · $12/mo</Label>
+              <Description>Unlimited projects, priority support</Description>
+            </FieldContent>
+          </RadioControl>
+        </Radio>
+        <Radio value="team">
+          <RadioControl>
+            <RadioIndicator />
+            <FieldContent>
+              <Label>Team · $49/mo</Label>
+              <Description>Everything in Pro, plus SSO and roles</Description>
+            </FieldContent>
+          </RadioControl>
+        </Radio>
+      </FieldGroup>
+    </RadioGroup>
+  )
+}

--- a/www/src/registry/ui/search-field/demos/filterable-list.tsx
+++ b/www/src/registry/ui/search-field/demos/filterable-list.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Input } from '@/registry/ui/input'
+import { SearchField } from '@/registry/ui/search-field'
+
+const members = [
+  { name: 'Olivia Martin', email: 'olivia.martin@email.com', role: 'Owner' },
+  { name: 'Jackson Lee', email: 'jackson.lee@email.com', role: 'Member' },
+  { name: 'Isabella Nguyen', email: 'isabella.n@email.com', role: 'Member' },
+  { name: 'William Kim', email: 'will.kim@email.com', role: 'Admin' },
+  { name: 'Sofia Davis', email: 'sofia.davis@email.com', role: 'Member' },
+]
+
+export default function Demo() {
+  const [query, setQuery] = useState('')
+
+  const results = members.filter((member) =>
+    `${member.name} ${member.email}`
+      .toLowerCase()
+      .includes(query.toLowerCase()),
+  )
+
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-3 rounded-lg border bg-bg p-4">
+      <SearchField
+        aria-label="Search members"
+        value={query}
+        onChange={setQuery}
+      >
+        <Input placeholder="Filter members…" />
+      </SearchField>
+      <ul className="flex flex-col gap-1">
+        {results.length === 0 ? (
+          <li className="px-2 py-6 text-center text-sm text-fg-muted">
+            No members found.
+          </li>
+        ) : (
+          results.map((member) => (
+            <li
+              key={member.email}
+              className="flex items-center justify-between gap-3 rounded-md px-2 py-2 hover:bg-muted"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{member.name}</p>
+                <p className="truncate text-xs text-fg-muted">{member.email}</p>
+              </div>
+              <span className="shrink-0 text-xs text-fg-muted">
+                {member.role}
+              </span>
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  )
+}

--- a/www/src/registry/ui/search-field/demos/header-search.tsx
+++ b/www/src/registry/ui/search-field/demos/header-search.tsx
@@ -1,0 +1,21 @@
+import { Bell, LayoutGrid } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { Input } from '@/registry/ui/input'
+import { SearchField } from '@/registry/ui/search-field'
+
+export default function Demo() {
+  return (
+    <div className="flex w-full max-w-sm items-center gap-3 rounded-lg border bg-bg px-3 py-2">
+      <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-primary text-fg-on-primary">
+        <LayoutGrid className="size-4" />
+      </div>
+      <SearchField aria-label="Search the app" className="flex-1">
+        <Input placeholder="Search…" size="sm" />
+      </SearchField>
+      <Button variant="quiet" size="sm" isIconOnly aria-label="Notifications">
+        <Bell />
+      </Button>
+    </div>
+  )
+}

--- a/www/src/registry/ui/search-field/demos/with-suggestions.tsx
+++ b/www/src/registry/ui/search-field/demos/with-suggestions.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Input } from '@/registry/ui/input'
+import { SearchField } from '@/registry/ui/search-field'
+
+const cities = [
+  'San Francisco',
+  'San Diego',
+  'San Jose',
+  'Sacramento',
+  'Seattle',
+  'Austin',
+  'Boston',
+  'Denver',
+]
+
+export default function Demo() {
+  const [query, setQuery] = useState('')
+
+  const suggestions = query
+    ? cities.filter((city) => city.toLowerCase().includes(query.toLowerCase()))
+    : []
+
+  return (
+    <div className="w-full max-w-xs">
+      <SearchField aria-label="Search cities" value={query} onChange={setQuery}>
+        <Input placeholder="Search cities…" />
+      </SearchField>
+      {suggestions.length > 0 && (
+        <ul className="mt-2 overflow-hidden rounded-md border bg-bg shadow-md">
+          {suggestions.map((city) => (
+            <li key={city}>
+              <button
+                type="button"
+                onClick={() => setQuery(city)}
+                className="w-full px-3 py-2 text-left text-sm hover:bg-muted"
+              >
+                {city}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/www/src/registry/ui/separator/demos/default.tsx
+++ b/www/src/registry/ui/separator/demos/default.tsx
@@ -1,0 +1,11 @@
+import { Separator } from '@/registry/ui/separator'
+
+export default function Demo() {
+  return (
+    <div className="w-full max-w-xs text-sm">
+      <p>Above the separator</p>
+      <Separator className="my-3" />
+      <p>Below the separator</p>
+    </div>
+  )
+}

--- a/www/src/registry/ui/separator/demos/list-menu.tsx
+++ b/www/src/registry/ui/separator/demos/list-menu.tsx
@@ -1,0 +1,47 @@
+import {
+  BellIcon,
+  CreditCardIcon,
+  LogOutIcon,
+  SettingsIcon,
+} from 'lucide-react'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/registry/ui/avatar'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+import { Separator } from '@/registry/ui/separator'
+
+export default function Demo() {
+  return (
+    <div className="w-full max-w-xs rounded-md border bg-card shadow-sm">
+      <div className="flex items-center gap-2 p-2">
+        <Avatar size="sm">
+          <AvatarImage src="https://github.com/mehdibha.png" alt="@mehdibha" />
+          <AvatarFallback>MB</AvatarFallback>
+        </Avatar>
+        <div className="flex flex-col text-sm">
+          <p>Mehdi Ben Hadj Ali</p>
+          <p className="text-xs text-fg-muted">mehdi@example.com</p>
+        </div>
+      </div>
+      <Separator />
+      <ListBox aria-label="User menu">
+        <ListBoxItem id="settings" textValue="Settings">
+          <SettingsIcon />
+          Settings
+        </ListBoxItem>
+        <ListBoxItem id="billing" textValue="Billing">
+          <CreditCardIcon />
+          Billing
+        </ListBoxItem>
+        <ListBoxItem id="notifications" textValue="Notifications">
+          <BellIcon />
+          Notifications
+        </ListBoxItem>
+        <Separator />
+        <ListBoxItem id="logout" variant="danger" textValue="Log out">
+          <LogOutIcon />
+          Log out
+        </ListBoxItem>
+      </ListBox>
+    </div>
+  )
+}

--- a/www/src/registry/ui/separator/demos/menu-section.tsx
+++ b/www/src/registry/ui/separator/demos/menu-section.tsx
@@ -1,0 +1,53 @@
+import {
+  CreditCardIcon,
+  LifeBuoyIcon,
+  LogOutIcon,
+  MessageSquareIcon,
+  SettingsIcon,
+  UserIcon,
+} from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { Menu, MenuContent, MenuItem } from '@/registry/ui/menu'
+import { Popover } from '@/registry/ui/popover'
+import { Separator } from '@/registry/ui/separator'
+
+export default function Demo() {
+  return (
+    <Menu>
+      <Button variant="default" className="w-fit">
+        Account
+      </Button>
+      <Popover>
+        <MenuContent>
+          <MenuItem textValue="Profile">
+            <UserIcon />
+            Profile
+          </MenuItem>
+          <MenuItem textValue="Billing">
+            <CreditCardIcon />
+            Billing
+          </MenuItem>
+          <MenuItem textValue="Settings">
+            <SettingsIcon />
+            Settings
+          </MenuItem>
+          <Separator />
+          <MenuItem textValue="Support">
+            <LifeBuoyIcon />
+            Support
+          </MenuItem>
+          <MenuItem textValue="Feedback">
+            <MessageSquareIcon />
+            Feedback
+          </MenuItem>
+          <Separator />
+          <MenuItem variant="danger" textValue="Log out">
+            <LogOutIcon />
+            Log out
+          </MenuItem>
+        </MenuContent>
+      </Popover>
+    </Menu>
+  )
+}

--- a/www/src/registry/ui/skeleton/demos/list-items.tsx
+++ b/www/src/registry/ui/skeleton/demos/list-items.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { Skeleton } from '@/registry/ui/skeleton'
+
+export default function Demo() {
+  return (
+    <Skeleton isLoading className="w-full max-w-xs space-y-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div key={index} className="flex items-center gap-3">
+          <Skeleton className="size-9 shrink-0 rounded-full" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-3.5 w-2/3" />
+            <Skeleton className="h-3 w-1/3" />
+          </div>
+          <Skeleton className="size-4 shrink-0 rounded" />
+        </div>
+      ))}
+    </Skeleton>
+  )
+}

--- a/www/src/registry/ui/switch/demos/feature-flags.tsx
+++ b/www/src/registry/ui/switch/demos/feature-flags.tsx
@@ -1,0 +1,54 @@
+import { Badge } from '@/registry/ui/badge'
+import { Description, FieldContent, Label } from '@/registry/ui/field'
+import { Switch, SwitchControl, SwitchIndicator } from '@/registry/ui/switch'
+
+const flags = [
+  {
+    key: 'new-dashboard',
+    description: 'Redesigned analytics overview.',
+    status: 'Stable',
+    variant: 'success' as const,
+    defaultSelected: true,
+  },
+  {
+    key: 'ai-suggestions',
+    description: 'Inline AI completions in the editor.',
+    status: 'Beta',
+    variant: 'info' as const,
+    defaultSelected: true,
+  },
+  {
+    key: 'edge-cache',
+    description: 'Serve responses from the edge.',
+    status: 'Experimental',
+    variant: 'warning' as const,
+    defaultSelected: false,
+  },
+]
+
+export default function Demo() {
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-3">
+      {flags.map((flag) => (
+        <Switch
+          key={flag.key}
+          className="w-full"
+          defaultSelected={flag.defaultSelected}
+        >
+          <SwitchControl>
+            <FieldContent>
+              <div className="flex items-center gap-2">
+                <Label className="font-mono">{flag.key}</Label>
+                <Badge appearance="subtle" variant={flag.variant} size="sm">
+                  {flag.status}
+                </Badge>
+              </div>
+              <Description>{flag.description}</Description>
+            </FieldContent>
+            <SwitchIndicator />
+          </SwitchControl>
+        </Switch>
+      ))}
+    </div>
+  )
+}

--- a/www/src/registry/ui/switch/demos/notification-preferences.tsx
+++ b/www/src/registry/ui/switch/demos/notification-preferences.tsx
@@ -1,0 +1,51 @@
+import {
+  Description,
+  FieldContent,
+  Fieldset,
+  Label,
+  Legend,
+} from '@/registry/ui/field'
+import { Switch, SwitchControl, SwitchIndicator } from '@/registry/ui/switch'
+
+const channels = [
+  {
+    label: 'Email',
+    description: 'Updates sent to your inbox.',
+    defaultSelected: true,
+  },
+  {
+    label: 'Push',
+    description: 'Alerts on your devices.',
+    defaultSelected: true,
+  },
+  {
+    label: 'SMS',
+    description: 'Text messages for urgent items.',
+    defaultSelected: false,
+  },
+]
+
+export default function Demo() {
+  return (
+    <Fieldset className="w-full max-w-sm">
+      <Legend>Notifications</Legend>
+      <div className="flex flex-col gap-3">
+        {channels.map((channel) => (
+          <Switch
+            key={channel.label}
+            className="w-full"
+            defaultSelected={channel.defaultSelected}
+          >
+            <SwitchControl>
+              <FieldContent>
+                <Label>{channel.label}</Label>
+                <Description>{channel.description}</Description>
+              </FieldContent>
+              <SwitchIndicator />
+            </SwitchControl>
+          </Switch>
+        ))}
+      </div>
+    </Fieldset>
+  )
+}

--- a/www/src/registry/ui/switch/demos/settings-panel.tsx
+++ b/www/src/registry/ui/switch/demos/settings-panel.tsx
@@ -1,0 +1,48 @@
+import { Button } from '@/registry/ui/button'
+import { Description, FieldContent, Label } from '@/registry/ui/field'
+import { Switch, SwitchControl, SwitchIndicator } from '@/registry/ui/switch'
+
+const settings = [
+  {
+    label: 'Email digest',
+    description: 'Receive a weekly summary of your activity.',
+    defaultSelected: true,
+  },
+  {
+    label: 'Two-factor auth',
+    description: 'Require a code at sign-in for extra security.',
+    defaultSelected: true,
+  },
+  {
+    label: 'Public profile',
+    description: 'Let anyone view your profile and activity.',
+    defaultSelected: false,
+  },
+]
+
+export default function Demo() {
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-4">
+      <div className="flex flex-col gap-3">
+        {settings.map((setting) => (
+          <Switch
+            key={setting.label}
+            className="w-full"
+            defaultSelected={setting.defaultSelected}
+          >
+            <SwitchControl>
+              <FieldContent>
+                <Label>{setting.label}</Label>
+                <Description>{setting.description}</Description>
+              </FieldContent>
+              <SwitchIndicator />
+            </SwitchControl>
+          </Switch>
+        ))}
+      </div>
+      <Button variant="primary" size="sm" className="w-full">
+        Save preferences
+      </Button>
+    </div>
+  )
+}

--- a/www/src/registry/ui/tabs/demos/documentation.tsx
+++ b/www/src/registry/ui/tabs/demos/documentation.tsx
@@ -1,0 +1,50 @@
+import { Copy } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { Tab, TabList, TabPanel, Tabs } from '@/registry/ui/tabs'
+
+export default function Demo() {
+  return (
+    <Tabs className="w-full max-w-sm">
+      <TabList variant="line">
+        <Tab id="overview">Overview</Tab>
+        <Tab id="examples">Code</Tab>
+        <Tab id="api">API</Tab>
+      </TabList>
+      <TabPanel id="overview">
+        <p className="text-sm text-fg-muted">
+          The <span className="font-medium text-fg">useToggle</span> hook
+          manages a boolean state and returns a setter to flip it.
+        </p>
+      </TabPanel>
+      <TabPanel id="examples">
+        <div className="relative rounded-lg bg-muted p-3 font-mono text-xs text-fg">
+          <Button
+            variant="quiet"
+            size="sm"
+            isIconOnly
+            aria-label="Copy code"
+            className="absolute top-1.5 right-1.5"
+          >
+            <Copy />
+          </Button>
+          <pre className="overflow-x-auto pr-7">
+            {`const [on, toggle] = useToggle()`}
+          </pre>
+        </div>
+      </TabPanel>
+      <TabPanel id="api">
+        <dl className="flex flex-col gap-2 text-sm">
+          <div className="flex items-baseline justify-between gap-2">
+            <dt className="font-mono text-fg">on</dt>
+            <dd className="text-fg-muted">boolean</dd>
+          </div>
+          <div className="flex items-baseline justify-between gap-2">
+            <dt className="font-mono text-fg">toggle</dt>
+            <dd className="text-fg-muted">() =&gt; void</dd>
+          </div>
+        </dl>
+      </TabPanel>
+    </Tabs>
+  )
+}

--- a/www/src/registry/ui/tabs/demos/product-details.tsx
+++ b/www/src/registry/ui/tabs/demos/product-details.tsx
@@ -1,0 +1,64 @@
+import { Star } from 'lucide-react'
+
+import { Badge } from '@/registry/ui/badge'
+import { Button } from '@/registry/ui/button'
+import { Tab, TabList, TabPanel, Tabs } from '@/registry/ui/tabs'
+
+export default function Demo() {
+  return (
+    <div className="w-full max-w-sm rounded-lg border bg-bg p-4">
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-fg">Aero Runner</h3>
+          <p className="text-sm text-fg-muted">$129.00</p>
+        </div>
+        <Badge variant="success" appearance="subtle">
+          In stock
+        </Badge>
+      </div>
+      <Tabs>
+        <TabList variant="line">
+          <Tab id="description">Description</Tab>
+          <Tab id="specs">Specs</Tab>
+          <Tab id="reviews">Reviews</Tab>
+        </TabList>
+        <TabPanel id="description">
+          <p className="text-sm text-fg-muted">
+            Lightweight trainers built for daily mileage, with a breathable knit
+            upper and responsive foam midsole.
+          </p>
+        </TabPanel>
+        <TabPanel id="specs">
+          <dl className="flex flex-col gap-2 text-sm">
+            <div className="flex justify-between gap-2">
+              <dt className="text-fg-muted">Weight</dt>
+              <dd className="text-fg">238 g</dd>
+            </div>
+            <div className="flex justify-between gap-2">
+              <dt className="text-fg-muted">Drop</dt>
+              <dd className="text-fg">8 mm</dd>
+            </div>
+            <div className="flex justify-between gap-2">
+              <dt className="text-fg-muted">Material</dt>
+              <dd className="text-fg">Recycled knit</dd>
+            </div>
+          </dl>
+        </TabPanel>
+        <TabPanel id="reviews">
+          <div className="flex items-center gap-1.5 text-sm">
+            <div className="flex text-warning">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Star key={i} className="size-3.5 fill-current" />
+              ))}
+              <Star className="size-3.5" />
+            </div>
+            <span className="text-fg-muted">4.0 (128 reviews)</span>
+          </div>
+        </TabPanel>
+      </Tabs>
+      <Button variant="primary" className="mt-4 w-full">
+        Add to cart
+      </Button>
+    </div>
+  )
+}

--- a/www/src/registry/ui/tabs/demos/settings-panel.tsx
+++ b/www/src/registry/ui/tabs/demos/settings-panel.tsx
@@ -1,0 +1,83 @@
+import { Checkbox, CheckboxControl } from '@/registry/ui/checkbox'
+import { Description, FieldContent, Label } from '@/registry/ui/field'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from '@/registry/ui/select'
+import { Switch, SwitchControl, SwitchIndicator } from '@/registry/ui/switch'
+import { Tab, TabList, TabPanel, Tabs } from '@/registry/ui/tabs'
+
+export default function Demo() {
+  return (
+    <Tabs className="w-full max-w-sm">
+      <TabList>
+        <Tab id="general">General</Tab>
+        <Tab id="notifications">Notifications</Tab>
+        <Tab id="personalization">Personalization</Tab>
+      </TabList>
+      <TabPanel id="general">
+        <div className="flex flex-col gap-4">
+          <Select defaultSelectedKey="utc" placeholder="Select a timezone">
+            <Label>Timezone</Label>
+            <SelectTrigger />
+            <SelectContent>
+              <SelectItem id="utc">UTC</SelectItem>
+              <SelectItem id="cet">Central European Time</SelectItem>
+              <SelectItem id="pst">Pacific Standard Time</SelectItem>
+            </SelectContent>
+          </Select>
+          <Switch className="w-full" defaultSelected>
+            <SwitchControl>
+              <FieldContent>
+                <Label>Auto-save</Label>
+                <Description>Save changes as you type.</Description>
+              </FieldContent>
+              <SwitchIndicator />
+            </SwitchControl>
+          </Switch>
+        </div>
+      </TabPanel>
+      <TabPanel id="notifications">
+        <div className="flex flex-col gap-4">
+          <Switch className="w-full" defaultSelected>
+            <SwitchControl>
+              <FieldContent>
+                <Label>Email digests</Label>
+                <Description>A weekly summary of activity.</Description>
+              </FieldContent>
+              <SwitchIndicator />
+            </SwitchControl>
+          </Switch>
+          <Switch className="w-full">
+            <SwitchControl>
+              <FieldContent>
+                <Label>Push notifications</Label>
+                <Description>Real-time alerts on your devices.</Description>
+              </FieldContent>
+              <SwitchIndicator />
+            </SwitchControl>
+          </Switch>
+        </div>
+      </TabPanel>
+      <TabPanel id="personalization">
+        <div className="flex flex-col gap-4">
+          <Select defaultSelectedKey="system" placeholder="Select a theme">
+            <Label>Theme</Label>
+            <SelectTrigger />
+            <SelectContent>
+              <SelectItem id="system">System</SelectItem>
+              <SelectItem id="light">Light</SelectItem>
+              <SelectItem id="dark">Dark</SelectItem>
+            </SelectContent>
+          </Select>
+          <Checkbox defaultSelected>
+            <CheckboxControl />
+            <Label>Reduce motion</Label>
+          </Checkbox>
+        </div>
+      </TabPanel>
+    </Tabs>
+  )
+}

--- a/www/src/registry/ui/text-area/demos/feedback-form.tsx
+++ b/www/src/registry/ui/text-area/demos/feedback-form.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Button } from '@/registry/ui/button'
+import { Description, FieldError, Label } from '@/registry/ui/field'
+import { TextArea } from '@/registry/ui/input'
+import { TextField } from '@/registry/ui/text-field'
+
+const MAX_LENGTH = 240
+
+export default function Demo() {
+  const [feedback, setFeedback] = useState('')
+  const isTooLong = feedback.length > MAX_LENGTH
+
+  return (
+    <form
+      className="flex w-full max-w-sm flex-col gap-4"
+      onSubmit={(e) => e.preventDefault()}
+    >
+      <TextField
+        value={feedback}
+        onChange={setFeedback}
+        isInvalid={isTooLong}
+        className="w-full"
+      >
+        <div className="flex items-center justify-between">
+          <Label>Your feedback</Label>
+          <span className="text-xs text-fg-muted tabular-nums">
+            {feedback.length}/{MAX_LENGTH}
+          </span>
+        </div>
+        <TextArea placeholder="Tell us what you think…" rows={4} />
+        {isTooLong ? (
+          <FieldError>Please keep it under {MAX_LENGTH} characters.</FieldError>
+        ) : (
+          <Description>Share what we could improve.</Description>
+        )}
+      </TextField>
+      <Button type="submit" isDisabled={isTooLong || feedback.length === 0}>
+        Send feedback
+      </Button>
+    </form>
+  )
+}

--- a/www/src/registry/ui/text-area/demos/issue-description.tsx
+++ b/www/src/registry/ui/text-area/demos/issue-description.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Button } from '@/registry/ui/button'
+import { Description, FieldError, Label } from '@/registry/ui/field'
+import { TextArea } from '@/registry/ui/input'
+import { TextField } from '@/registry/ui/text-field'
+
+const MIN_LENGTH = 20
+
+export default function Demo() {
+  const [description, setDescription] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+  const isTooShort = description.trim().length < MIN_LENGTH
+
+  return (
+    <form
+      className="flex w-full max-w-sm flex-col gap-4"
+      onSubmit={(e) => {
+        e.preventDefault()
+        setSubmitted(true)
+      }}
+    >
+      <TextField
+        value={description}
+        onChange={(value) => {
+          setDescription(value)
+          setSubmitted(false)
+        }}
+        isInvalid={submitted && isTooShort}
+        className="w-full"
+      >
+        <div className="flex items-center justify-between">
+          <Label>Describe the issue</Label>
+          <span className="text-xs text-fg-muted tabular-nums">
+            {description.length}
+          </span>
+        </div>
+        <TextArea
+          placeholder="Steps to reproduce, expected vs. actual behavior…"
+          rows={5}
+        />
+        {submitted && isTooShort ? (
+          <FieldError>
+            Add at least {MIN_LENGTH} characters so we can investigate.
+          </FieldError>
+        ) : (
+          <Description>
+            Include steps to reproduce and what you expected.
+          </Description>
+        )}
+      </TextField>
+      <Button type="submit">Submit report</Button>
+    </form>
+  )
+}

--- a/www/src/registry/ui/text-field/demos/login-form.tsx
+++ b/www/src/registry/ui/text-field/demos/login-form.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { Button } from '@/registry/ui/button'
+import { Label } from '@/registry/ui/field'
+import { Input } from '@/registry/ui/input'
+import { TextField } from '@/registry/ui/text-field'
+
+export default function Demo() {
+  return (
+    <form
+      className="flex w-full max-w-xs flex-col gap-4"
+      onSubmit={(e) => e.preventDefault()}
+    >
+      <TextField type="email" autoComplete="email" isRequired>
+        <Label>Email</Label>
+        <Input placeholder="you@example.com" />
+      </TextField>
+      <TextField type="password" autoComplete="current-password" isRequired>
+        <Label>Password</Label>
+        <Input placeholder="••••••••" />
+      </TextField>
+      <Button type="submit" className="w-full">
+        Sign in
+      </Button>
+    </form>
+  )
+}

--- a/www/src/registry/ui/text-field/demos/newsletter-signup.tsx
+++ b/www/src/registry/ui/text-field/demos/newsletter-signup.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { Button } from '@/registry/ui/button'
+import { Description, Label } from '@/registry/ui/field'
+import { Input } from '@/registry/ui/input'
+import { TextField } from '@/registry/ui/text-field'
+
+export default function Demo() {
+  return (
+    <form
+      className="flex w-full max-w-xs flex-col gap-3"
+      onSubmit={(e) => e.preventDefault()}
+    >
+      <TextField type="email" autoComplete="email" isRequired>
+        <Label>Subscribe to our newsletter</Label>
+        <Input placeholder="you@example.com" />
+        <Description>
+          Get product updates. No spam, unsubscribe anytime.
+        </Description>
+      </TextField>
+      <Button type="submit" className="w-full">
+        Subscribe
+      </Button>
+    </form>
+  )
+}

--- a/www/src/registry/ui/toggle-button/demos/favorite-button.tsx
+++ b/www/src/registry/ui/toggle-button/demos/favorite-button.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState } from 'react'
+import { HeartIcon } from 'lucide-react'
+
+import { ToggleButton } from '@/registry/ui/toggle-button'
+
+export default function Demo() {
+  const [isFavorite, setFavorite] = useState(false)
+  return (
+    <div className="w-full max-w-xs overflow-hidden rounded-lg border">
+      <div className="bg-bg-muted flex aspect-video items-center justify-center">
+        <span className="text-sm text-fg-muted">Wireless Headphones</span>
+      </div>
+      <div className="flex items-center justify-between gap-2 p-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">Wireless Headphones</p>
+          <p className="text-sm text-fg-muted">$129.00</p>
+        </div>
+        <ToggleButton
+          variant="quiet"
+          isIconOnly
+          isSelected={isFavorite}
+          onChange={setFavorite}
+          aria-label="Add to favorites"
+        >
+          <HeartIcon
+            className={isFavorite ? 'fill-current text-danger' : undefined}
+          />
+        </ToggleButton>
+      </div>
+    </div>
+  )
+}

--- a/www/src/registry/ui/toggle-button/demos/text-formatting-toolbar.tsx
+++ b/www/src/registry/ui/toggle-button/demos/text-formatting-toolbar.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useState } from 'react'
+import { BoldIcon, ItalicIcon, UnderlineIcon } from 'lucide-react'
+
+import { ToggleButton } from '@/registry/ui/toggle-button'
+
+export default function Demo() {
+  const [formats, setFormats] = useState<string[]>(['bold'])
+
+  const toggle = (format: string) => (isSelected: boolean) =>
+    setFormats((prev) =>
+      isSelected ? [...prev, format] : prev.filter((f) => f !== format),
+    )
+
+  return (
+    <div className="flex w-fit items-center gap-1 rounded-lg border p-1">
+      <ToggleButton
+        variant="quiet"
+        isIconOnly
+        isSelected={formats.includes('bold')}
+        onChange={toggle('bold')}
+        aria-label="Bold"
+      >
+        <BoldIcon />
+      </ToggleButton>
+      <ToggleButton
+        variant="quiet"
+        isIconOnly
+        isSelected={formats.includes('italic')}
+        onChange={toggle('italic')}
+        aria-label="Italic"
+      >
+        <ItalicIcon />
+      </ToggleButton>
+      <ToggleButton
+        variant="quiet"
+        isIconOnly
+        isSelected={formats.includes('underline')}
+        onChange={toggle('underline')}
+        aria-label="Underline"
+      >
+        <UnderlineIcon />
+      </ToggleButton>
+    </div>
+  )
+}

--- a/www/src/registry/ui/toggle-button/demos/view-switcher.tsx
+++ b/www/src/registry/ui/toggle-button/demos/view-switcher.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState } from 'react'
+import { LayoutGridIcon, ListIcon } from 'lucide-react'
+
+import { ToggleButton } from '@/registry/ui/toggle-button'
+
+type View = 'list' | 'grid'
+
+export default function Demo() {
+  const [view, setView] = useState<View>('grid')
+  return (
+    <div className="flex items-center gap-1 rounded-lg border p-1">
+      <ToggleButton
+        variant="quiet"
+        isIconOnly
+        isSelected={view === 'list'}
+        onChange={() => setView('list')}
+        aria-label="List view"
+      >
+        <ListIcon />
+      </ToggleButton>
+      <ToggleButton
+        variant="quiet"
+        isIconOnly
+        isSelected={view === 'grid'}
+        onChange={() => setView('grid')}
+        aria-label="Grid view"
+      >
+        <LayoutGridIcon />
+      </ToggleButton>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Reworks the **Examples** section of every component docs page (63 pages).

- **Interactive in place.** Each example used to render a read-only preview that opened a modal to become usable. Now the demo renders **live and interactive directly in a framed card**, mirroring the gallery cards on `/charts`.
- **Title + "Show code".** Every card has a title (kept in the page TOC) and a "Show code" action that opens a modal with the **live preview + install command (npm/pnpm/yarn/bun) + highlighted source** — same layout as the charts modal.
- **Curated to real-world examples.** The grid now shows only real-world use cases plus one canonical *Default* per component. Prop/state mechanics (controlled, disabled, required, error-message, …) and option showcases (sizes, variants, shapes, …) are removed from the grid. **Their demo files are kept on disk** for a future dedicated section — nothing is deleted.
- **New real-world demos.** 61 new demos were authored for 26 pages that would otherwise be sparse (login/registration forms, settings panels, OTP 2FA, file uploads, search-with-suggestions, formatting toolbars, FAQ sections, …). `field` and `link` go from "No examples yet" to full galleries.
- **No overflow.** Grid columns and full-width spans are tuned per page so cards don't overflow.

## How

- `Example` renders the demo once (interactive), framed like the shared `ShowcaseCard`.
- New `ExampleCodeModal` + `install-commands` helper (`@dotui/<item>` across the four package managers).
- `rehype-transform` now injects the already-computed highlighted source as a `DemoCode` slot for `Example` (previously only `Demo` consumed it) and auto-derives install items from the demo's `@/registry/ui/*` imports — so a composed demo lists every package it needs (e.g. `add @dotui/select @dotui/field`). The example title is still injected as a TOC heading.

## Verification

- `pnpm typecheck`, `pnpm check`, `pnpm build:registry` all pass; regenerated `__generated__/demos.tsx` is committed (registry-drift job).
- All 253 `<Example>` refs resolve to real demo files; no malformed markup; no runtime console errors.
- Swept all 63 pages in-browser for overflow and fixed every real case.

## Reviewer notes

- **toast** is `wip: true` with no demo files, so it's left as a "No examples yet" placeholder (deferred).
- **button** — the Loading demo overflows ~12px at 3 columns (imperceptible, scrollbar hidden); flagship 3-col layout kept. Trivial to drop to 2 columns if preferred.
- **group (10) / menu (11)** keep a lot of real-world demos — all legitimate, trimmable if leaner pages are wanted.
- The 61 new demos are AI-authored; they typecheck and render, but are worth a skim for taste.