### PR TITLE
feat: animate scoped preset changes, cycle home showcase

### DIFF
--- a/www/src/lib/styles.tsx
+++ b/www/src/lib/styles.tsx
@@ -215,6 +215,15 @@ function buildScopedThemeCss(
   return blocks.join('\n')
 }
 
+/* ----------------------- Preset-change transition ----------------------- */
+
+// How long the subtree stays flagged for tweening after a scoped design-system
+// change, in ms. Must stay >= the CSS transition duration in styles.css
+// (`--dotui-transition-duration`, default 500ms) so the flag outlives the tween;
+// the small buffer covers timer/paint jitter.
+const PRESET_TRANSITION_MS = 500
+const PRESET_TRANSITION_BUFFER_MS = 80
+
 interface DesignSystemProviderProps {
   params?: ParamSelections
   tokens?: GlobalTokenSelections
@@ -284,6 +293,48 @@ function DesignSystemProvider({
   // constant across renders, so the injected <style> and the wrapper element always agree.
   const scopeId = React.useId()
   const scopeSelector = `[data-dotui-scope="${scopeId}"]`
+
+  // --- Smooth preset transitions (scoped mode only) --------------------------
+  // When the design system changes (a preset swap, or any density / color /
+  // radius edit), tween the whole subtree from the old theme to the new instead
+  // of snapping. A signature of the live inputs distinguishes a real change from
+  // an unrelated re-render; on a change we flag the scope with
+  // `data-dotui-transition` *in the same commit* as the new tokens/classes (so the
+  // global CSS transition in styles.css catches the old→new value change), then a
+  // timer clears the flag once the tween is done. Off for global (`:root`) mode —
+  // its sole consumer is the live /create preview, where slider drags should track
+  // the cursor, not lag behind a half-second tween.
+  const signature = React.useMemo(
+    () => (scoped ? JSON.stringify({ params, tokens, density, color }) : ''),
+    [scoped, params, tokens, density, color],
+  )
+  const prevSignatureRef = React.useRef<string | null>(null)
+  const [transitioning, setTransitioning] = React.useState(false)
+
+  if (scoped) {
+    if (prevSignatureRef.current === null) {
+      // First render: record the baseline; never animate the initial paint.
+      prevSignatureRef.current = signature
+    } else if (prevSignatureRef.current !== signature) {
+      // A real change. Record the new baseline and flag the tween for THIS commit:
+      // setting state during render re-runs the component before paint, so the flag
+      // and the new tokens land together — required for the transition to fire.
+      prevSignatureRef.current = signature
+      if (!transitioning) setTransitioning(true)
+    }
+  }
+
+  // Clear the flag once the tween finishes. `signature` in the deps re-arms the
+  // timer on every change, so a swap mid-tween extends the window instead of
+  // cutting the previous one short.
+  React.useEffect(() => {
+    if (!transitioning) return
+    const timer = setTimeout(
+      () => setTransitioning(false),
+      PRESET_TRANSITION_MS + PRESET_TRANSITION_BUFFER_MS,
+    )
+    return () => clearTimeout(timer)
+  }, [transitioning, signature])
 
   // Apply the global token vars to :root so values that reference each other via calc() +
   // var() (e.g. --radius-sm = calc(.25rem * var(--radius-factor))) recompute correctly —
@@ -371,6 +422,7 @@ function DesignSystemProvider({
   return (
     <div
       data-dotui-scope={scopeId}
+      data-dotui-transition={transitioning ? '' : undefined}
       style={{ display: 'contents', ...scopeStyle }}
     >
       {themeStyle}
@@ -385,6 +437,7 @@ function DesignSystemProvider({
             <div
               id={portalDomId}
               data-dotui-scope={scopeId}
+              data-dotui-transition={transitioning ? '' : undefined}
               style={scopeStyle}
             />,
             document.body,

--- a/www/src/modules/marketing/cards.tsx
+++ b/www/src/modules/marketing/cards.tsx
@@ -1,9 +1,40 @@
+import { useEffect, useState } from 'react'
+
+import { DesignSystemProvider } from '@/lib/styles'
 import { CardsGrid } from '@/components/showcase/cards-grid'
 import { SkeletonRail } from '@/components/showcase/skeleton-cards'
+import { DEFAULTS } from '@/modules/create/preset'
+import { PRESETS } from '@/modules/presets/presets-data'
+
+// How long each preset is shown before the showcase morphs to the next one.
+const PRESET_CYCLE_MS = 3000
 
 // The landing showcase: the shared `CardsGrid` centered and capped, flanked by
-// skeleton rails and faded into the next section at the bottom.
+// skeleton rails and faded into the next section at the bottom. The real grid is
+// wrapped in a *scoped* DesignSystemProvider that cycles through the preset
+// gallery on a timer — so the showcase keeps re-theming itself (color, radius,
+// density), and the provider tweens each swap smoothly (see lib/styles.tsx). The
+// skeleton rails stay on the site theme on purpose: they read as neutral chrome
+// framing the live, shape-shifting grid.
 export function Cards() {
+  // Index 0 is the "Default" preset (no color override, page baseline), so SSR /
+  // first paint matches the rest of the page; cycling begins after hydration.
+  const [presetIndex, setPresetIndex] = useState(0)
+
+  useEffect(() => {
+    // Reduced-motion: the rapid re-theming is motion, and styles.css disables the
+    // tween anyway (so swaps would snap). Stay on the baseline and don't cycle.
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    const timer = setInterval(() => {
+      setPresetIndex((i) => (i + 1) % PRESETS.length)
+    }, PRESET_CYCLE_MS)
+    return () => clearInterval(timer)
+  }, [])
+
+  // `?? DEFAULTS` never triggers (index is always `% PRESETS.length`); it just
+  // satisfies noUncheckedIndexedAccess without a non-null assertion.
+  const preset = PRESETS[presetIndex]?.designSystem ?? DEFAULTS
+
   return (
     <div className="flex flex-col [--grid-max:1500px] [--rail-gap:--spacing(4)] [--rail-peek:2.5rem] sm:[--rail-peek:3.5rem] md:[--rail-peek:5rem] lg:[--rail-peek:7rem]">
       {/* Flex row: [left rail | gap | capped real grid | gap | right rail]. The rails
@@ -25,8 +56,18 @@ export function Cards() {
         {/* The centered, capped real grid (shared with the /create preview), sized as
 				    a flex item that bleeds past the rails on small screens, caps at
 				    `--grid-max` on large ones, and bumps to 4-up at xl. Kept interactive on purpose: the
-				    showcase is a live playground, so visitors can poke the cards. */}
-        <CardsGrid className="relative z-20 w-[max(52rem,120vw)] max-w-none shrink-0 lg:w-full lg:max-w-(--grid-max) lg:min-w-0 lg:shrink" />
+				    showcase is a live playground, so visitors can poke the cards. The scoped
+				    provider re-themes only this grid (it renders `display: contents`, so the
+				    grid stays the flex item and the layout is unchanged). */}
+        <DesignSystemProvider
+          scoped
+          params={preset.componentParams}
+          tokens={preset.tokens}
+          density={preset.density}
+          color={preset.color}
+        >
+          <CardsGrid className="relative z-20 w-[max(52rem,120vw)] max-w-none shrink-0 lg:w-full lg:max-w-(--grid-max) lg:min-w-0 lg:shrink" />
+        </DesignSystemProvider>
         <SkeletonRail side="right" />
         {/* Below `lg` (no rails) the real grid bleeds off both edges; this overlay
 				    fades those bleeding columns into the page background so they read as

--- a/www/src/styles.css
+++ b/www/src/styles.css
@@ -167,6 +167,30 @@
   --scroll-fade-size: --value([length], [percentage]);
 }
 
+/* dotUI preset morph — when a *scoped* DesignSystemProvider's design system
+   changes (a preset swap on the landing showcase, or any density / color / radius
+   edit), the provider flags its subtree with `data-dotui-transition` for one beat
+   (see lib/styles.tsx). This rule tweens the affected properties from the old
+   theme to the new one so the change glides instead of snapping: colors and
+   radius, plus the box-model / type sizes that density drives. The flag is
+   time-boxed by the provider, so it never slows the components' own hover/press
+   transitions outside the swap. Tune via `--dotui-transition-duration` /
+   `--dotui-transition-ease`; skipped entirely under reduced-motion. */
+@media (prefers-reduced-motion: no-preference) {
+  [data-dotui-transition],
+  [data-dotui-transition] * {
+    transition-property:
+      color, background-color, border-color, border-radius, outline-color,
+      text-decoration-color, fill, stroke, box-shadow, padding, gap, width,
+      height, min-height, font-size, line-height;
+    transition-duration: var(--dotui-transition-duration, 500ms);
+    transition-timing-function: var(
+      --dotui-transition-ease,
+      cubic-bezier(0.4, 0, 0.2, 1)
+    );
+  }
+}
+
 /* Click ripple for the docs component-gallery cursor (components-list/autoplay).
    Expands and fades from the pointer hotspot; mounts only during the press beat
    so it replays on each loop. */


### PR DESCRIPTION
Experiment: the scoped design-system provider now tweens its subtree when the design system changes, and the landing showcase auto-cycles presets to show it off.

## Scoped provider morphs on change

`DesignSystemProvider` in scoped mode flags its subtree with `data-dotui-transition` the instant its inputs (`params` / `tokens` / `density` / `color`) change — in the same commit as the new tokens, so the global CSS rule catches the old→new value change — then clears the flag ~500ms later. The rule tweens colors, `border-radius`, `box-shadow`, and the box-model / type sizes density drives (`padding`, `gap`, `height`, `font-size`, …).

Global (`:root`) mode is deliberately left untouched, so the `/create` live preview keeps tracking slider drags instantly rather than lagging behind a tween. Honors `prefers-reduced-motion`; tunable via `--dotui-transition-duration` / `--dotui-transition-ease`.

## Landing showcase auto-cycles presets

The home `CardsGrid` is wrapped in a scoped provider that steps through the preset gallery every 3s, so each swap rides the morph above. The provider renders `display: contents`, so the grid stays the same flex item and the layout is unchanged. It starts on Default (the page baseline) for clean SSR; reduced-motion visitors don't cycle.

## Files

- `www/src/lib/styles.tsx` — change detection + subtree flag (scoped mode only)
- `www/src/styles.css` — the `[data-dotui-transition]` transition rule
- `www/src/modules/marketing/cards.tsx` — 3s preset cycle around the grid

## Verification

- `pnpm typecheck` and `oxfmt` are clean for these files.
- A live browser check wasn't possible in this worktree: the dev server 500s on every route (the known `@/registry/__generated__/publishables` module-resolution issue), so the effect was validated statically and via a standalone demo of the morph.
