### PR TITLE
docs: cap input/field demos at max-w-xs, pickers at w-52

### DIFF
--- a/www/src/registry/ui/color-field/demos/addons.tsx
+++ b/www/src/registry/ui/color-field/demos/addons.tsx
@@ -5,7 +5,7 @@ import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <div className="flex w-full flex-col items-center gap-4">
+    <div className="flex w-full max-w-xs flex-col items-center gap-4">
       <ColorField aria-label="Color field with prefix">
         <InputGroup>
           <Input />

--- a/www/src/registry/ui/color-field/demos/basic.tsx
+++ b/www/src/registry/ui/color-field/demos/basic.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <ColorField>
+    <ColorField className="max-w-xs">
       <Label>Color</Label>
       <Input />
     </ColorField>

--- a/www/src/registry/ui/color-field/demos/controlled.tsx
+++ b/www/src/registry/ui/color-field/demos/controlled.tsx
@@ -11,7 +11,7 @@ export default function Demo() {
   const [color, setColor] = React.useState<Color | null>(parseColor('#7f007f'))
 
   return (
-    <div className="flex w-full flex-col items-center gap-4">
+    <div className="flex w-full max-w-xs flex-col items-center gap-4">
       <ColorField value={color} onChange={setColor}>
         <Label>Color</Label>
         <Input />

--- a/www/src/registry/ui/color-field/demos/description.tsx
+++ b/www/src/registry/ui/color-field/demos/description.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <ColorField>
+    <ColorField className="max-w-xs">
       <Label>Color</Label>
       <Input />
       <Description>Enter a background color.</Description>

--- a/www/src/registry/ui/color-field/demos/disabled.tsx
+++ b/www/src/registry/ui/color-field/demos/disabled.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/registry/ui/input'
 export default function Demo() {
   return (
     <ColorField
+      className="max-w-xs"
       aria-label="Disabled color"
       value={parseColor('rgb(222,70,58)')}
       isDisabled

--- a/www/src/registry/ui/color-field/demos/invalid.tsx
+++ b/www/src/registry/ui/color-field/demos/invalid.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <ColorField isInvalid>
+    <ColorField className="max-w-xs" isInvalid>
       <Label>Color</Label>
       <Input />
       <FieldError>Please fill out this field.</FieldError>

--- a/www/src/registry/ui/color-field/demos/label.tsx
+++ b/www/src/registry/ui/color-field/demos/label.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <ColorField>
+    <ColorField className="max-w-xs">
       <Label>Background</Label>
       <Input />
     </ColorField>

--- a/www/src/registry/ui/color-field/demos/playground.tsx
+++ b/www/src/registry/ui/color-field/demos/playground.tsx
@@ -11,6 +11,7 @@ export default function Demo({
 } = {}) {
   return (
     <ColorField
+      className="max-w-xs"
       defaultValue="#ff0000"
       isDisabled={isDisabled}
       isReadOnly={isReadOnly}

--- a/www/src/registry/ui/color-field/demos/read-only.tsx
+++ b/www/src/registry/ui/color-field/demos/read-only.tsx
@@ -4,7 +4,12 @@ import { Input } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <ColorField aria-label="Color" isReadOnly value="#121212">
+    <ColorField
+      className="max-w-xs"
+      aria-label="Color"
+      isReadOnly
+      value="#121212"
+    >
       <Label>Read only</Label>
       <Input />
     </ColorField>

--- a/www/src/registry/ui/color-field/demos/required.tsx
+++ b/www/src/registry/ui/color-field/demos/required.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <ColorField aria-label="Color" isRequired>
+    <ColorField className="max-w-xs" aria-label="Color" isRequired>
       <Label>Required</Label>
       <Input />
     </ColorField>

--- a/www/src/registry/ui/color-field/demos/sizes.tsx
+++ b/www/src/registry/ui/color-field/demos/sizes.tsx
@@ -3,7 +3,7 @@ import { Label } from '@/registry/ui/field'
 import { Input } from '@/registry/ui/input'
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <ColorField>
         <Label>small</Label>
         <Input size="sm" />
@@ -16,6 +16,6 @@ export default function Demo() {
         <Label>large</Label>
         <Input size="lg" />
       </ColorField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/color-field/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/color-field/demos/uncontrolled.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <ColorField defaultValue="#7f007f">
+    <ColorField className="max-w-xs" defaultValue="#7f007f">
       <Label>Color</Label>
       <Input />
     </ColorField>

--- a/www/src/registry/ui/combobox/demos/async-loading.tsx
+++ b/www/src/registry/ui/combobox/demos/async-loading.tsx
@@ -26,7 +26,7 @@ export default function Demo() {
   })
 
   return (
-    <Combobox className="max-w-xs">
+    <Combobox className="w-52">
       <Label>Pokemon</Label>
       <InputGroup>
         <Input />

--- a/www/src/registry/ui/combobox/demos/async-loading.tsx
+++ b/www/src/registry/ui/combobox/demos/async-loading.tsx
@@ -26,7 +26,7 @@ export default function Demo() {
   })
 
   return (
-    <Combobox>
+    <Combobox className="max-w-xs">
       <Label>Pokemon</Label>
       <InputGroup>
         <Input />

--- a/www/src/registry/ui/combobox/demos/basic.tsx
+++ b/www/src/registry/ui/combobox/demos/basic.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" aria-label="country">
+    <Combobox className="w-52" aria-label="country">
       <InputGroup>
         <Input placeholder="Select a country..." />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/basic.tsx
+++ b/www/src/registry/ui/combobox/demos/basic.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox aria-label="country">
+    <Combobox className="max-w-xs" aria-label="country">
       <InputGroup>
         <Input placeholder="Select a country..." />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/controlled.tsx
+++ b/www/src/registry/ui/combobox/demos/controlled.tsx
@@ -13,7 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   const [country, setCountry] = React.useState<MenuPrimitives.Key | null>('tn')
   return (
-    <div className="flex max-w-xs flex-col items-center gap-6">
+    <div className="flex w-52 flex-col items-center gap-6">
       <Combobox
         aria-label="country"
         selectedKey={country}

--- a/www/src/registry/ui/combobox/demos/controlled.tsx
+++ b/www/src/registry/ui/combobox/demos/controlled.tsx
@@ -13,7 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   const [country, setCountry] = React.useState<MenuPrimitives.Key | null>('tn')
   return (
-    <div className="flex flex-col items-center gap-6">
+    <div className="flex max-w-xs flex-col items-center gap-6">
       <Combobox
         aria-label="country"
         selectedKey={country}

--- a/www/src/registry/ui/combobox/demos/custom-value.tsx
+++ b/www/src/registry/ui/combobox/demos/custom-value.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" aria-label="country" allowsCustomValue>
+    <Combobox className="w-52" aria-label="country" allowsCustomValue>
       <InputGroup>
         <Input />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/custom-value.tsx
+++ b/www/src/registry/ui/combobox/demos/custom-value.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox aria-label="country" allowsCustomValue>
+    <Combobox className="max-w-xs" aria-label="country" allowsCustomValue>
       <InputGroup>
         <Input />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/description.tsx
+++ b/www/src/registry/ui/combobox/demos/description.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox>
+    <Combobox className="max-w-xs">
       <Label>Country</Label>
       <InputGroup>
         <Input />

--- a/www/src/registry/ui/combobox/demos/description.tsx
+++ b/www/src/registry/ui/combobox/demos/description.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs">
+    <Combobox className="w-52">
       <Label>Country</Label>
       <InputGroup>
         <Input />

--- a/www/src/registry/ui/combobox/demos/disabled-items.tsx
+++ b/www/src/registry/ui/combobox/demos/disabled-items.tsx
@@ -18,7 +18,11 @@ const disabledKeys = ['nuxt', 'remix']
 
 export default function Demo() {
   return (
-    <Combobox aria-label="framework" disabledKeys={disabledKeys}>
+    <Combobox
+      className="max-w-xs"
+      aria-label="framework"
+      disabledKeys={disabledKeys}
+    >
       <InputGroup>
         <Input placeholder="Select a framework" />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/disabled-items.tsx
+++ b/www/src/registry/ui/combobox/demos/disabled-items.tsx
@@ -19,7 +19,7 @@ const disabledKeys = ['nuxt', 'remix']
 export default function Demo() {
   return (
     <Combobox
-      className="max-w-xs"
+      className="w-52"
       aria-label="framework"
       disabledKeys={disabledKeys}
     >

--- a/www/src/registry/ui/combobox/demos/disabled.tsx
+++ b/www/src/registry/ui/combobox/demos/disabled.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox isDisabled aria-label="Animal">
+    <Combobox className="max-w-xs" isDisabled aria-label="Animal">
       <InputGroup>
         <Input placeholder="Select a country..." />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/disabled.tsx
+++ b/www/src/registry/ui/combobox/demos/disabled.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" isDisabled aria-label="Animal">
+    <Combobox className="w-52" isDisabled aria-label="Animal">
       <InputGroup>
         <Input placeholder="Select a country..." />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/invalid.tsx
+++ b/www/src/registry/ui/combobox/demos/invalid.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <Combobox aria-label="Country" isInvalid>
         <InputGroup>
           <Input placeholder="Select a country..." />
@@ -54,6 +54,6 @@ export default function Demo() {
           </ListBox>
         </Popover>
       </Combobox>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/combobox/demos/invalid.tsx
+++ b/www/src/registry/ui/combobox/demos/invalid.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
+    <div className="flex w-52 flex-col gap-6">
       <Combobox aria-label="Country" isInvalid>
         <InputGroup>
           <Input placeholder="Select a country..." />

--- a/www/src/registry/ui/combobox/demos/label.tsx
+++ b/www/src/registry/ui/combobox/demos/label.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox>
+    <Combobox className="max-w-xs">
       <Label>Country</Label>
       <InputGroup>
         <Input />

--- a/www/src/registry/ui/combobox/demos/label.tsx
+++ b/www/src/registry/ui/combobox/demos/label.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs">
+    <Combobox className="w-52">
       <Label>Country</Label>
       <InputGroup>
         <Input />

--- a/www/src/registry/ui/combobox/demos/large-list.tsx
+++ b/www/src/registry/ui/combobox/demos/large-list.tsx
@@ -17,7 +17,7 @@ const items = Array.from({ length: 1000 }, (_, i) => ({
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" aria-label="item">
+    <Combobox className="w-52" aria-label="item">
       <InputGroup>
         <Input placeholder="Search from 1000 items" />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/large-list.tsx
+++ b/www/src/registry/ui/combobox/demos/large-list.tsx
@@ -17,7 +17,7 @@ const items = Array.from({ length: 1000 }, (_, i) => ({
 
 export default function Demo() {
   return (
-    <Combobox aria-label="item">
+    <Combobox className="max-w-xs" aria-label="item">
       <InputGroup>
         <Input placeholder="Search from 1000 items" />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/loading.tsx
+++ b/www/src/registry/ui/combobox/demos/loading.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox aria-label="Animal">
+    <Combobox className="max-w-xs" aria-label="Animal">
       <InputGroup>
         <Input />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/loading.tsx
+++ b/www/src/registry/ui/combobox/demos/loading.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" aria-label="Animal">
+    <Combobox className="w-52" aria-label="Animal">
       <InputGroup>
         <Input />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/multi-select.tsx
+++ b/www/src/registry/ui/combobox/demos/multi-select.tsx
@@ -20,7 +20,7 @@ type Framework = (typeof frameworks)[number]
 export default function Demo() {
   return (
     <Combobox<Framework, 'multiple'>
-      className="max-w-xs"
+      className="w-52"
       selectionMode="multiple"
       defaultValue={['next']}
     >

--- a/www/src/registry/ui/combobox/demos/multi-select.tsx
+++ b/www/src/registry/ui/combobox/demos/multi-select.tsx
@@ -20,6 +20,7 @@ type Framework = (typeof frameworks)[number]
 export default function Demo() {
   return (
     <Combobox<Framework, 'multiple'>
+      className="max-w-xs"
       selectionMode="multiple"
       defaultValue={['next']}
     >

--- a/www/src/registry/ui/combobox/demos/multiple-disabled.tsx
+++ b/www/src/registry/ui/combobox/demos/multiple-disabled.tsx
@@ -19,7 +19,7 @@ type Framework = (typeof frameworks)[number]
 export default function Demo() {
   return (
     <Combobox<Framework, 'multiple'>
-      className="max-w-xs"
+      className="w-52"
       aria-label="frameworks"
       selectionMode="multiple"
       defaultValue={['next', 'sveltekit']}

--- a/www/src/registry/ui/combobox/demos/multiple-disabled.tsx
+++ b/www/src/registry/ui/combobox/demos/multiple-disabled.tsx
@@ -19,6 +19,7 @@ type Framework = (typeof frameworks)[number]
 export default function Demo() {
   return (
     <Combobox<Framework, 'multiple'>
+      className="max-w-xs"
       aria-label="frameworks"
       selectionMode="multiple"
       defaultValue={['next', 'sveltekit']}

--- a/www/src/registry/ui/combobox/demos/multiple-invalid.tsx
+++ b/www/src/registry/ui/combobox/demos/multiple-invalid.tsx
@@ -19,7 +19,7 @@ type Framework = (typeof frameworks)[number]
 
 export default function Demo() {
   return (
-    <div className="flex max-w-xs flex-col gap-4">
+    <div className="flex w-52 flex-col gap-4">
       <Combobox<Framework, 'multiple'>
         aria-label="frameworks"
         selectionMode="multiple"

--- a/www/src/registry/ui/combobox/demos/multiple-invalid.tsx
+++ b/www/src/registry/ui/combobox/demos/multiple-invalid.tsx
@@ -19,7 +19,7 @@ type Framework = (typeof frameworks)[number]
 
 export default function Demo() {
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex max-w-xs flex-col gap-4">
       <Combobox<Framework, 'multiple'>
         aria-label="frameworks"
         selectionMode="multiple"

--- a/www/src/registry/ui/combobox/demos/multiple.tsx
+++ b/www/src/registry/ui/combobox/demos/multiple.tsx
@@ -19,7 +19,7 @@ type Framework = (typeof frameworks)[number]
 export default function Demo() {
   return (
     <Combobox<Framework, 'multiple'>
-      className="max-w-xs"
+      className="w-52"
       aria-label="frameworks"
       selectionMode="multiple"
       defaultValue={['next']}

--- a/www/src/registry/ui/combobox/demos/multiple.tsx
+++ b/www/src/registry/ui/combobox/demos/multiple.tsx
@@ -19,6 +19,7 @@ type Framework = (typeof frameworks)[number]
 export default function Demo() {
   return (
     <Combobox<Framework, 'multiple'>
+      className="max-w-xs"
       aria-label="frameworks"
       selectionMode="multiple"
       defaultValue={['next']}

--- a/www/src/registry/ui/combobox/demos/playground.tsx
+++ b/www/src/registry/ui/combobox/demos/playground.tsx
@@ -16,7 +16,11 @@ export default function Demo({
   isInvalid = false,
 } = {}) {
   return (
-    <Combobox isDisabled={isDisabled} isInvalid={isInvalid}>
+    <Combobox
+      className="max-w-xs"
+      isDisabled={isDisabled}
+      isInvalid={isInvalid}
+    >
       {label && <Label>{label}</Label>}
       <InputGroup>
         <Input data-control-target placeholder={placeholder} />

--- a/www/src/registry/ui/combobox/demos/playground.tsx
+++ b/www/src/registry/ui/combobox/demos/playground.tsx
@@ -16,11 +16,7 @@ export default function Demo({
   isInvalid = false,
 } = {}) {
   return (
-    <Combobox
-      className="max-w-xs"
-      isDisabled={isDisabled}
-      isInvalid={isInvalid}
-    >
+    <Combobox className="w-52" isDisabled={isDisabled} isInvalid={isInvalid}>
       {label && <Label>{label}</Label>}
       <InputGroup>
         <Input data-control-target placeholder={placeholder} />

--- a/www/src/registry/ui/combobox/demos/required.tsx
+++ b/www/src/registry/ui/combobox/demos/required.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" isRequired aria-label="Country">
+    <Combobox className="w-52" isRequired aria-label="Country">
       <InputGroup>
         <Input />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/required.tsx
+++ b/www/src/registry/ui/combobox/demos/required.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox isRequired aria-label="Country">
+    <Combobox className="max-w-xs" isRequired aria-label="Country">
       <InputGroup>
         <Input />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/sections.tsx
+++ b/www/src/registry/ui/combobox/demos/sections.tsx
@@ -13,7 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" aria-label="Country">
+    <Combobox className="w-52" aria-label="Country">
       <InputGroup>
         <Input placeholder="Select a country..." />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/sections.tsx
+++ b/www/src/registry/ui/combobox/demos/sections.tsx
@@ -13,7 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox aria-label="Country">
+    <Combobox className="max-w-xs" aria-label="Country">
       <InputGroup>
         <Input placeholder="Select a country..." />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/combobox/demos/uncontrolled.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" aria-label="country" defaultSelectedKey="tn">
+    <Combobox className="w-52" aria-label="country" defaultSelectedKey="tn">
       <InputGroup>
         <Input />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/combobox/demos/uncontrolled.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox aria-label="country" defaultSelectedKey="tn">
+    <Combobox className="max-w-xs" aria-label="country" defaultSelectedKey="tn">
       <InputGroup>
         <Input />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/with-custom-items.tsx
+++ b/www/src/registry/ui/combobox/demos/with-custom-items.tsx
@@ -43,7 +43,7 @@ const countries = [
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" aria-label="country">
+    <Combobox className="w-52" aria-label="country">
       <InputGroup>
         <Input placeholder="Search countries..." />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/with-custom-items.tsx
+++ b/www/src/registry/ui/combobox/demos/with-custom-items.tsx
@@ -43,7 +43,7 @@ const countries = [
 
 export default function Demo() {
   return (
-    <Combobox aria-label="country">
+    <Combobox className="max-w-xs" aria-label="country">
       <InputGroup>
         <Input placeholder="Search countries..." />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/with-form.tsx
+++ b/www/src/registry/ui/combobox/demos/with-form.tsx
@@ -15,7 +15,7 @@ const frameworks = ['Next.js', 'SvelteKit', 'Nuxt.js', 'Remix', 'Astro']
 
 export default function Demo() {
   return (
-    <Card className="w-full max-w-xs">
+    <Card className="w-52">
       <CardContent>
         <FormPrimitives.Form
           id="form-with-combobox"

--- a/www/src/registry/ui/combobox/demos/with-form.tsx
+++ b/www/src/registry/ui/combobox/demos/with-form.tsx
@@ -15,7 +15,7 @@ const frameworks = ['Next.js', 'SvelteKit', 'Nuxt.js', 'Remix', 'Astro']
 
 export default function Demo() {
   return (
-    <Card className="w-full max-w-sm">
+    <Card className="w-full max-w-xs">
       <CardContent>
         <FormPrimitives.Form
           id="form-with-combobox"

--- a/www/src/registry/ui/combobox/demos/with-groups-and-separator.tsx
+++ b/www/src/registry/ui/combobox/demos/with-groups-and-separator.tsx
@@ -39,7 +39,7 @@ const timezones = [
 
 export default function Demo() {
   return (
-    <Combobox aria-label="timezone">
+    <Combobox className="max-w-xs" aria-label="timezone">
       <InputGroup>
         <Input placeholder="Select a timezone" />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/with-groups-and-separator.tsx
+++ b/www/src/registry/ui/combobox/demos/with-groups-and-separator.tsx
@@ -39,7 +39,7 @@ const timezones = [
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" aria-label="timezone">
+    <Combobox className="w-52" aria-label="timezone">
       <InputGroup>
         <Input placeholder="Select a timezone" />
         <InputGroupAddon>

--- a/www/src/registry/ui/combobox/demos/with-icon.tsx
+++ b/www/src/registry/ui/combobox/demos/with-icon.tsx
@@ -12,7 +12,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox className="max-w-xs" aria-label="Timezone">
+    <Combobox className="w-52" aria-label="Timezone">
       <InputGroup>
         <InputGroupAddon>
           <GlobeIcon />

--- a/www/src/registry/ui/combobox/demos/with-icon.tsx
+++ b/www/src/registry/ui/combobox/demos/with-icon.tsx
@@ -12,7 +12,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <Combobox aria-label="Timezone">
+    <Combobox className="max-w-xs" aria-label="Timezone">
       <InputGroup>
         <InputGroupAddon>
           <GlobeIcon />

--- a/www/src/registry/ui/combobox/demos/with-other-inputs.tsx
+++ b/www/src/registry/ui/combobox/demos/with-other-inputs.tsx
@@ -16,7 +16,7 @@ const frameworks = ['Next.js', 'SvelteKit', 'Nuxt.js', 'Remix', 'Astro']
 
 export default function Demo() {
   return (
-    <div className="flex max-w-xs flex-col items-start gap-2">
+    <div className="flex w-52 flex-col items-start gap-2">
       <Combobox aria-label="framework">
         <InputGroup className="w-52">
           <Input placeholder="Select a framework" />

--- a/www/src/registry/ui/combobox/demos/with-other-inputs.tsx
+++ b/www/src/registry/ui/combobox/demos/with-other-inputs.tsx
@@ -16,7 +16,7 @@ const frameworks = ['Next.js', 'SvelteKit', 'Nuxt.js', 'Remix', 'Astro']
 
 export default function Demo() {
   return (
-    <div className="flex flex-col items-start gap-2">
+    <div className="flex max-w-xs flex-col items-start gap-2">
       <Combobox aria-label="framework">
         <InputGroup className="w-52">
           <Input placeholder="Select a framework" />

--- a/www/src/registry/ui/date-field/demos/basic.tsx
+++ b/www/src/registry/ui/date-field/demos/basic.tsx
@@ -3,7 +3,7 @@ import { DateInput } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DateField aria-label="Meeting date">
+    <DateField className="max-w-xs" aria-label="Meeting date">
       <DateInput />
     </DateField>
   )

--- a/www/src/registry/ui/date-field/demos/controlled.tsx
+++ b/www/src/registry/ui/date-field/demos/controlled.tsx
@@ -13,13 +13,13 @@ export default function Demo() {
   )
 
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DateField aria-label="Event date" value={value} onChange={setValue}>
         <DateInput />
       </DateField>
       <p className="text-sm text-fg-muted">
         selected date: {value ? value.toString() : 'none'}
       </p>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-field/demos/description.tsx
+++ b/www/src/registry/ui/date-field/demos/description.tsx
@@ -6,7 +6,7 @@ import { DateInput } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DateField aria-label="Appointment date">
+    <DateField className="max-w-xs" aria-label="Appointment date">
       <Label>Appointment date</Label>
       <DateInput />
       <Description>Please select a date.</Description>

--- a/www/src/registry/ui/date-field/demos/disabled.tsx
+++ b/www/src/registry/ui/date-field/demos/disabled.tsx
@@ -4,7 +4,7 @@ import { DateInput } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DateField isDisabled>
+    <DateField className="max-w-xs" isDisabled>
       <Label>Event date</Label>
       <DateInput />
     </DateField>

--- a/www/src/registry/ui/date-field/demos/error-message.tsx
+++ b/www/src/registry/ui/date-field/demos/error-message.tsx
@@ -4,7 +4,7 @@ import { DateInput } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DateField isInvalid>
+    <DateField className="max-w-xs" isInvalid>
       <Label>Event date</Label>
       <DateInput />
       <FieldError>Please select a date.</FieldError>

--- a/www/src/registry/ui/date-field/demos/granularity.tsx
+++ b/www/src/registry/ui/date-field/demos/granularity.tsx
@@ -8,7 +8,7 @@ import { DateInput } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DateField
         granularity="hour"
         defaultValue={parseAbsoluteToLocal('2021-04-07T18:45:22Z')}
@@ -30,6 +30,6 @@ export default function Demo() {
         <Label>Second</Label>
         <DateInput />
       </DateField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-field/demos/hide-time-zone.tsx
+++ b/www/src/registry/ui/date-field/demos/hide-time-zone.tsx
@@ -9,6 +9,7 @@ import { DateInput } from '@/registry/ui/input'
 export default function Demo() {
   return (
     <DateField
+      className="max-w-xs"
       granularity="minute"
       defaultValue={parseZonedDateTime('2022-11-07T10:45[America/Los_Angeles]')}
       hideTimeZone

--- a/www/src/registry/ui/date-field/demos/hour-cycle.tsx
+++ b/www/src/registry/ui/date-field/demos/hour-cycle.tsx
@@ -9,7 +9,7 @@ export default function Demo() {
       aria-label="Appointment date"
       granularity="minute"
       hourCycle={24}
-      className="w-auto"
+      className="w-auto max-w-xs"
     >
       <DateInput />
     </DateField>

--- a/www/src/registry/ui/date-field/demos/label.tsx
+++ b/www/src/registry/ui/date-field/demos/label.tsx
@@ -4,12 +4,12 @@ import { DateInput } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DateField aria-label="Meeting date">
         <Label>Meeting date</Label>
         <DateInput />
       </DateField>
       <DateField aria-label="Meeting date" />
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-field/demos/placeholder.tsx
+++ b/www/src/registry/ui/date-field/demos/placeholder.tsx
@@ -8,7 +8,10 @@ import { DateInput } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DateField placeholderValue={new CalendarDate(1980, 1, 1)}>
+    <DateField
+      className="max-w-xs"
+      placeholderValue={new CalendarDate(1980, 1, 1)}
+    >
       <Label>Meeting date</Label>
       <DateInput />
     </DateField>

--- a/www/src/registry/ui/date-field/demos/playground.tsx
+++ b/www/src/registry/ui/date-field/demos/playground.tsx
@@ -12,6 +12,7 @@ export default function Demo({
 } = {}) {
   return (
     <DateField
+      className="max-w-xs"
       isDisabled={isDisabled}
       isReadOnly={isReadOnly}
       isInvalid={isInvalid}

--- a/www/src/registry/ui/date-field/demos/prefix-and-suffix.tsx
+++ b/www/src/registry/ui/date-field/demos/prefix-and-suffix.tsx
@@ -4,7 +4,7 @@ import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DateField aria-label="Meeting date">
         <InputGroup>
           <InputGroupAddon>
@@ -21,6 +21,6 @@ export default function Demo() {
           </InputGroupAddon>
         </InputGroup>
       </DateField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-field/demos/read-only.tsx
+++ b/www/src/registry/ui/date-field/demos/read-only.tsx
@@ -8,6 +8,7 @@ import { DateInput } from '@/registry/ui/input'
 export default function Demo() {
   return (
     <DateField
+      className="max-w-xs"
       aria-label="Event date"
       value={new CalendarDate(1980, 1, 1)}
       isReadOnly

--- a/www/src/registry/ui/date-field/demos/required.tsx
+++ b/www/src/registry/ui/date-field/demos/required.tsx
@@ -5,7 +5,7 @@ import { DateInput } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DateField aria-label="Event date" isRequired>
+    <DateField className="max-w-xs" aria-label="Event date" isRequired>
       <DateInput />
     </DateField>
   )

--- a/www/src/registry/ui/date-field/demos/sizes.tsx
+++ b/www/src/registry/ui/date-field/demos/sizes.tsx
@@ -4,7 +4,7 @@ import { DateInput } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DateField>
         <Label>small (sm)</Label>
         <DateInput />
@@ -17,6 +17,6 @@ export default function Demo() {
         <Label>large (lg)</Label>
         <DateInput />
       </DateField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-field/demos/time-zones.tsx
+++ b/www/src/registry/ui/date-field/demos/time-zones.tsx
@@ -8,6 +8,7 @@ import { DateInput } from '@/registry/ui/input'
 export default function Demo() {
   return (
     <DateField
+      className="max-w-xs"
       aria-label="Meeting time"
       defaultValue={parseZonedDateTime('2022-11-07T00:45[America/Los_Angeles]')}
     >

--- a/www/src/registry/ui/date-field/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/date-field/demos/uncontrolled.tsx
@@ -7,7 +7,11 @@ import { DateInput } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DateField aria-label="Event date" defaultValue={parseDate('2020-02-03')}>
+    <DateField
+      className="max-w-xs"
+      aria-label="Event date"
+      defaultValue={parseDate('2020-02-03')}
+    >
       <DateInput />
     </DateField>
   )

--- a/www/src/registry/ui/date-picker/demos/basic.tsx
+++ b/www/src/registry/ui/date-picker/demos/basic.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
-      className="max-w-xs"
+      className="w-52"
       aria-label="Meeting date"
       defaultValue={parseDate('2020-02-03')}
     >

--- a/www/src/registry/ui/date-picker/demos/basic.tsx
+++ b/www/src/registry/ui/date-picker/demos/basic.tsx
@@ -11,6 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
+      className="max-w-xs"
       aria-label="Meeting date"
       defaultValue={parseDate('2020-02-03')}
     >

--- a/www/src/registry/ui/date-picker/demos/composition.tsx
+++ b/www/src/registry/ui/date-picker/demos/composition.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker>
+    <DatePicker className="max-w-xs">
       <Label>Meeting date</Label>
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/composition.tsx
+++ b/www/src/registry/ui/date-picker/demos/composition.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker className="max-w-xs">
+    <DatePicker className="w-52">
       <Label>Meeting date</Label>
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/controlled.tsx
+++ b/www/src/registry/ui/date-picker/demos/controlled.tsx
@@ -18,7 +18,7 @@ export default function Demo() {
     parseDate('2020-02-03'),
   )
   return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
+    <div className="flex w-52 flex-col gap-6">
       <DatePicker value={value} onChange={setValue}>
         <Label>Meeting date</Label>
         <InputGroup>

--- a/www/src/registry/ui/date-picker/demos/controlled.tsx
+++ b/www/src/registry/ui/date-picker/demos/controlled.tsx
@@ -18,7 +18,7 @@ export default function Demo() {
     parseDate('2020-02-03'),
   )
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DatePicker value={value} onChange={setValue}>
         <Label>Meeting date</Label>
         <InputGroup>
@@ -38,6 +38,6 @@ export default function Demo() {
       <p className="text-sm text-fg-muted">
         selected date: {value?.toString()}
       </p>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-picker/demos/description.tsx
+++ b/www/src/registry/ui/date-picker/demos/description.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker>
+    <DatePicker className="max-w-xs">
       <Label>Appointment</Label>
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/description.tsx
+++ b/www/src/registry/ui/date-picker/demos/description.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker className="max-w-xs">
+    <DatePicker className="w-52">
       <Label>Appointment</Label>
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/disabled.tsx
+++ b/www/src/registry/ui/date-picker/demos/disabled.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker aria-label="Event date" isDisabled>
+    <DatePicker className="max-w-xs" aria-label="Event date" isDisabled>
       <InputGroup>
         <DateInput />
         <InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/disabled.tsx
+++ b/www/src/registry/ui/date-picker/demos/disabled.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker className="max-w-xs" aria-label="Event date" isDisabled>
+    <DatePicker className="w-52" aria-label="Event date" isDisabled>
       <InputGroup>
         <DateInput />
         <InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/error-message.tsx
+++ b/www/src/registry/ui/date-picker/demos/error-message.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker className="max-w-xs" aria-label="Meeting date" isInvalid>
+    <DatePicker className="w-52" aria-label="Meeting date" isInvalid>
       <Label>Meeting date</Label>
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/error-message.tsx
+++ b/www/src/registry/ui/date-picker/demos/error-message.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker aria-label="Meeting date" isInvalid>
+    <DatePicker className="max-w-xs" aria-label="Meeting date" isInvalid>
       <Label>Meeting date</Label>
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/granularity.tsx
+++ b/www/src/registry/ui/date-picker/demos/granularity.tsx
@@ -13,7 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DatePicker
         granularity="hour"
         defaultValue={parseAbsoluteToLocal('2021-04-07T18:45:22Z')}
@@ -73,6 +73,6 @@ export default function Demo() {
           </DialogContent>
         </Popover>
       </DatePicker>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-picker/demos/granularity.tsx
+++ b/www/src/registry/ui/date-picker/demos/granularity.tsx
@@ -13,7 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
+    <div className="flex w-52 flex-col gap-6">
       <DatePicker
         granularity="hour"
         defaultValue={parseAbsoluteToLocal('2021-04-07T18:45:22Z')}

--- a/www/src/registry/ui/date-picker/demos/hide-time-zone.tsx
+++ b/www/src/registry/ui/date-picker/demos/hide-time-zone.tsx
@@ -14,7 +14,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
-      className="max-w-xs"
+      className="w-52"
       granularity="minute"
       defaultValue={parseZonedDateTime('2022-11-07T10:45[America/Los_Angeles]')}
       hideTimeZone

--- a/www/src/registry/ui/date-picker/demos/hide-time-zone.tsx
+++ b/www/src/registry/ui/date-picker/demos/hide-time-zone.tsx
@@ -14,6 +14,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
+      className="max-w-xs"
       granularity="minute"
       defaultValue={parseZonedDateTime('2022-11-07T10:45[America/Los_Angeles]')}
       hideTimeZone

--- a/www/src/registry/ui/date-picker/demos/hour-cycle.tsx
+++ b/www/src/registry/ui/date-picker/demos/hour-cycle.tsx
@@ -12,6 +12,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
+      className="max-w-xs"
       aria-label="Appointment date"
       granularity="minute"
       hourCycle={24}

--- a/www/src/registry/ui/date-picker/demos/hour-cycle.tsx
+++ b/www/src/registry/ui/date-picker/demos/hour-cycle.tsx
@@ -12,7 +12,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
-      className="max-w-xs"
+      className="w-52"
       aria-label="Appointment date"
       granularity="minute"
       hourCycle={24}

--- a/www/src/registry/ui/date-picker/demos/label.tsx
+++ b/www/src/registry/ui/date-picker/demos/label.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
+    <div className="flex w-52 flex-col gap-6">
       <DatePicker>
         <Label>Meeting date</Label>
         <InputGroup>

--- a/www/src/registry/ui/date-picker/demos/label.tsx
+++ b/www/src/registry/ui/date-picker/demos/label.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DatePicker>
         <Label>Meeting date</Label>
         <InputGroup>
@@ -41,6 +41,6 @@ export default function Demo() {
           </DialogContent>
         </Popover>
       </DatePicker>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-picker/demos/placeholder.tsx
+++ b/www/src/registry/ui/date-picker/demos/placeholder.tsx
@@ -13,7 +13,10 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker placeholderValue={new CalendarDate(1980, 1, 1)}>
+    <DatePicker
+      className="max-w-xs"
+      placeholderValue={new CalendarDate(1980, 1, 1)}
+    >
       <Label>Meeting date</Label>
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/placeholder.tsx
+++ b/www/src/registry/ui/date-picker/demos/placeholder.tsx
@@ -14,7 +14,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
-      className="max-w-xs"
+      className="w-52"
       placeholderValue={new CalendarDate(1980, 1, 1)}
     >
       <Label>Meeting date</Label>

--- a/www/src/registry/ui/date-picker/demos/playground.tsx
+++ b/www/src/registry/ui/date-picker/demos/playground.tsx
@@ -22,7 +22,7 @@ export function DatePickerPlayground({
 }: DatePickerPlaygroundProps) {
   return (
     <DatePicker
-      className="max-w-xs"
+      className="w-52"
       isDisabled={isDisabled}
       isReadOnly={isReadOnly}
     >

--- a/www/src/registry/ui/date-picker/demos/playground.tsx
+++ b/www/src/registry/ui/date-picker/demos/playground.tsx
@@ -21,7 +21,11 @@ export function DatePickerPlayground({
   isReadOnly = false,
 }: DatePickerPlaygroundProps) {
   return (
-    <DatePicker isDisabled={isDisabled} isReadOnly={isReadOnly}>
+    <DatePicker
+      className="max-w-xs"
+      isDisabled={isDisabled}
+      isReadOnly={isReadOnly}
+    >
       {label && <Label>{label}</Label>}
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/range/basic.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/basic.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
-      className="max-w-xs"
+      className="w-52"
       aria-label="Meeting date"
       defaultValue={{
         start: parseDate('2020-02-03'),

--- a/www/src/registry/ui/date-picker/demos/range/basic.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/basic.tsx
@@ -11,6 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
+      className="max-w-xs"
       aria-label="Meeting date"
       defaultValue={{
         start: parseDate('2020-02-03'),

--- a/www/src/registry/ui/date-picker/demos/range/composition.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/composition.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker>
+    <DateRangePicker className="max-w-xs">
       <Label>Meeting date</Label>
       <InputGroup>
         <DateInput slot="start" />

--- a/www/src/registry/ui/date-picker/demos/range/composition.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/composition.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker className="max-w-xs">
+    <DateRangePicker className="w-52">
       <Label>Meeting date</Label>
       <InputGroup>
         <DateInput slot="start" />

--- a/www/src/registry/ui/date-picker/demos/range/controlled.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/controlled.tsx
@@ -23,7 +23,7 @@ export default function Demo() {
   const formatter = useDateFormatter({ dateStyle: 'long' })
 
   return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
+    <div className="flex w-52 flex-col gap-6">
       <DateRangePicker value={value} onChange={setValue}>
         <Label>Meeting date</Label>
         <InputGroup>

--- a/www/src/registry/ui/date-picker/demos/range/controlled.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/controlled.tsx
@@ -23,7 +23,7 @@ export default function Demo() {
   const formatter = useDateFormatter({ dateStyle: 'long' })
 
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DateRangePicker value={value} onChange={setValue}>
         <Label>Meeting date</Label>
         <InputGroup>
@@ -51,6 +51,6 @@ export default function Demo() {
             `${formatter.format(value.start.toDate(getLocalTimeZone()))} – ${formatter.format(value.end.toDate(getLocalTimeZone()))}`
           : '--'}
       </p>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-picker/demos/range/description.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/description.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker className="max-w-xs">
+    <DateRangePicker className="w-52">
       <Label>Appointment</Label>
       <InputGroup>
         <DateInput slot="start" />

--- a/www/src/registry/ui/date-picker/demos/range/description.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/description.tsx
@@ -11,7 +11,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker>
+    <DateRangePicker className="max-w-xs">
       <Label>Appointment</Label>
       <InputGroup>
         <DateInput slot="start" />

--- a/www/src/registry/ui/date-picker/demos/range/disabled.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/disabled.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker className="max-w-xs" aria-label="Event date" isDisabled>
+    <DateRangePicker className="w-52" aria-label="Event date" isDisabled>
       <InputGroup>
         <DateInput slot="start" />
         <span>–</span>

--- a/www/src/registry/ui/date-picker/demos/range/disabled.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/disabled.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker aria-label="Event date" isDisabled>
+    <DateRangePicker className="max-w-xs" aria-label="Event date" isDisabled>
       <InputGroup>
         <DateInput slot="start" />
         <span>–</span>

--- a/www/src/registry/ui/date-picker/demos/range/error-message.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/error-message.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker className="max-w-xs" aria-label="Meeting date" isInvalid>
+    <DateRangePicker className="w-52" aria-label="Meeting date" isInvalid>
       <Label>Meeting date</Label>
       <InputGroup>
         <DateInput slot="start" />

--- a/www/src/registry/ui/date-picker/demos/range/error-message.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/error-message.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker aria-label="Meeting date" isInvalid>
+    <DateRangePicker className="max-w-xs" aria-label="Meeting date" isInvalid>
       <Label>Meeting date</Label>
       <InputGroup>
         <DateInput slot="start" />

--- a/www/src/registry/ui/date-picker/demos/range/granularity.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/granularity.tsx
@@ -18,7 +18,7 @@ export default function Demo() {
   }
 
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DateRangePicker granularity="hour" defaultValue={dates}>
         <Label>Hour</Label>
         <InputGroup>
@@ -75,6 +75,6 @@ export default function Demo() {
           </DialogContent>
         </Popover>
       </DateRangePicker>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-picker/demos/range/granularity.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/granularity.tsx
@@ -18,7 +18,7 @@ export default function Demo() {
   }
 
   return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
+    <div className="flex w-52 flex-col gap-6">
       <DateRangePicker granularity="hour" defaultValue={dates}>
         <Label>Hour</Label>
         <InputGroup>

--- a/www/src/registry/ui/date-picker/demos/range/hide-time-zone.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/hide-time-zone.tsx
@@ -14,6 +14,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
+      className="max-w-xs"
       granularity="minute"
       defaultValue={{
         start: parseAbsoluteToLocal('2021-04-07T18:45:22Z'),

--- a/www/src/registry/ui/date-picker/demos/range/hide-time-zone.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/hide-time-zone.tsx
@@ -14,7 +14,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
-      className="max-w-xs"
+      className="w-52"
       granularity="minute"
       defaultValue={{
         start: parseAbsoluteToLocal('2021-04-07T18:45:22Z'),

--- a/www/src/registry/ui/date-picker/demos/range/hour-cycle.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/hour-cycle.tsx
@@ -12,6 +12,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
+      className="max-w-xs"
       aria-label="Appointment date"
       granularity="minute"
       hourCycle={24}

--- a/www/src/registry/ui/date-picker/demos/range/hour-cycle.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/hour-cycle.tsx
@@ -12,7 +12,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
-      className="max-w-xs"
+      className="w-52"
       aria-label="Appointment date"
       granularity="minute"
       hourCycle={24}

--- a/www/src/registry/ui/date-picker/demos/range/label.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/label.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <div className="flex w-full max-w-xs flex-col gap-6">
+    <div className="flex w-52 flex-col gap-6">
       <DateRangePicker>
         <Label>Meeting date</Label>
         <InputGroup>

--- a/www/src/registry/ui/date-picker/demos/range/label.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/label.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DateRangePicker>
         <Label>Meeting date</Label>
         <InputGroup>
@@ -45,6 +45,6 @@ export default function Demo() {
           </DialogContent>
         </Popover>
       </DateRangePicker>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/date-picker/demos/range/placeholder.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/placeholder.tsx
@@ -14,7 +14,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
-      className="max-w-xs"
+      className="w-52"
       placeholderValue={new CalendarDate(1980, 1, 1)}
     >
       <Label>Meeting date</Label>

--- a/www/src/registry/ui/date-picker/demos/range/placeholder.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/placeholder.tsx
@@ -13,7 +13,10 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker placeholderValue={new CalendarDate(1980, 1, 1)}>
+    <DateRangePicker
+      className="max-w-xs"
+      placeholderValue={new CalendarDate(1980, 1, 1)}
+    >
       <Label>Meeting date</Label>
       <InputGroup>
         <DateInput slot="start" />

--- a/www/src/registry/ui/date-picker/demos/range/playground.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/playground.tsx
@@ -22,7 +22,7 @@ export function DateRangePickerPlayground({
 }: DateRangePickerPlaygroundProps) {
   return (
     <DateRangePicker
-      className="max-w-xs"
+      className="w-52"
       isDisabled={isDisabled}
       isReadOnly={isReadOnly}
     >

--- a/www/src/registry/ui/date-picker/demos/range/playground.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/playground.tsx
@@ -21,7 +21,11 @@ export function DateRangePickerPlayground({
   isReadOnly = false,
 }: DateRangePickerPlaygroundProps) {
   return (
-    <DateRangePicker isDisabled={isDisabled} isReadOnly={isReadOnly}>
+    <DateRangePicker
+      className="max-w-xs"
+      isDisabled={isDisabled}
+      isReadOnly={isReadOnly}
+    >
       {label && <Label>{label}</Label>}
       <InputGroup>
         <DateInput slot="start" />

--- a/www/src/registry/ui/date-picker/demos/range/read-only.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/read-only.tsx
@@ -14,6 +14,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
+      className="max-w-xs"
       value={{
         start: parseAbsoluteToLocal('2021-04-07T18:45:22Z'),
         end: parseAbsoluteToLocal('2021-04-08T20:00:00Z'),

--- a/www/src/registry/ui/date-picker/demos/range/read-only.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/read-only.tsx
@@ -14,7 +14,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
-      className="max-w-xs"
+      className="w-52"
       value={{
         start: parseAbsoluteToLocal('2021-04-07T18:45:22Z'),
         end: parseAbsoluteToLocal('2021-04-08T20:00:00Z'),

--- a/www/src/registry/ui/date-picker/demos/range/required.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/required.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker className="max-w-xs" isRequired>
+    <DateRangePicker className="w-52" isRequired>
       <Label>Event date</Label>
       <InputGroup>
         <DateInput slot="start" />

--- a/www/src/registry/ui/date-picker/demos/range/required.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/required.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DateRangePicker isRequired>
+    <DateRangePicker className="max-w-xs" isRequired>
       <Label>Event date</Label>
       <InputGroup>
         <DateInput slot="start" />

--- a/www/src/registry/ui/date-picker/demos/range/time-zones.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/time-zones.tsx
@@ -13,7 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
-      className="max-w-xs"
+      className="w-52"
       aria-label="Date picker with time zones"
       defaultValue={{
         start: parseAbsoluteToLocal('2021-04-07T18:45:22Z'),

--- a/www/src/registry/ui/date-picker/demos/range/time-zones.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/time-zones.tsx
@@ -13,6 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
+      className="max-w-xs"
       aria-label="Date picker with time zones"
       defaultValue={{
         start: parseAbsoluteToLocal('2021-04-07T18:45:22Z'),

--- a/www/src/registry/ui/date-picker/demos/range/uncontrolled.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/uncontrolled.tsx
@@ -13,6 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
+      className="max-w-xs"
       aria-label="Meeting date"
       defaultValue={{
         start: parseDate('2020-02-03'),

--- a/www/src/registry/ui/date-picker/demos/range/uncontrolled.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/uncontrolled.tsx
@@ -13,7 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DateRangePicker
-      className="max-w-xs"
+      className="w-52"
       aria-label="Meeting date"
       defaultValue={{
         start: parseDate('2020-02-03'),

--- a/www/src/registry/ui/date-picker/demos/range/with-drawer.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/with-drawer.tsx
@@ -8,7 +8,7 @@ import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DateRangePicker aria-label="Meeting date">
+    <DateRangePicker className="max-w-xs" aria-label="Meeting date">
       <InputGroup>
         <DateInput slot="start" />
         <span>–</span>

--- a/www/src/registry/ui/date-picker/demos/range/with-drawer.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/with-drawer.tsx
@@ -8,7 +8,7 @@ import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DateRangePicker className="max-w-xs" aria-label="Meeting date">
+    <DateRangePicker className="w-52" aria-label="Meeting date">
       <InputGroup>
         <DateInput slot="start" />
         <span>–</span>

--- a/www/src/registry/ui/date-picker/demos/range/with-modal.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/with-modal.tsx
@@ -8,7 +8,7 @@ import { Modal } from '@/registry/ui/modal'
 
 export default function Demo() {
   return (
-    <DateRangePicker className="max-w-xs" aria-label="Meeting date">
+    <DateRangePicker className="w-52" aria-label="Meeting date">
       <InputGroup>
         <DateInput slot="start" />
         <span>–</span>

--- a/www/src/registry/ui/date-picker/demos/range/with-modal.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/with-modal.tsx
@@ -8,7 +8,7 @@ import { Modal } from '@/registry/ui/modal'
 
 export default function Demo() {
   return (
-    <DateRangePicker aria-label="Meeting date">
+    <DateRangePicker className="max-w-xs" aria-label="Meeting date">
       <InputGroup>
         <DateInput slot="start" />
         <span>–</span>

--- a/www/src/registry/ui/date-picker/demos/read-only.tsx
+++ b/www/src/registry/ui/date-picker/demos/read-only.tsx
@@ -13,7 +13,11 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker value={new CalendarDate(1980, 1, 1)} isReadOnly>
+    <DatePicker
+      className="max-w-xs"
+      value={new CalendarDate(1980, 1, 1)}
+      isReadOnly
+    >
       <Label>Event date</Label>
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/read-only.tsx
+++ b/www/src/registry/ui/date-picker/demos/read-only.tsx
@@ -14,7 +14,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
-      className="max-w-xs"
+      className="w-52"
       value={new CalendarDate(1980, 1, 1)}
       isReadOnly
     >

--- a/www/src/registry/ui/date-picker/demos/required.tsx
+++ b/www/src/registry/ui/date-picker/demos/required.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker className="max-w-xs" isRequired>
+    <DatePicker className="w-52" isRequired>
       <Label>Event date</Label>
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/required.tsx
+++ b/www/src/registry/ui/date-picker/demos/required.tsx
@@ -9,7 +9,7 @@ import { Popover } from '@/registry/ui/popover'
 
 export default function Demo() {
   return (
-    <DatePicker isRequired>
+    <DatePicker className="max-w-xs" isRequired>
       <Label>Event date</Label>
       <InputGroup>
         <DateInput />

--- a/www/src/registry/ui/date-picker/demos/time-zones.tsx
+++ b/www/src/registry/ui/date-picker/demos/time-zones.tsx
@@ -13,7 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
-      className="max-w-xs"
+      className="w-52"
       aria-label="Date picker with time zones"
       defaultValue={parseAbsoluteToLocal('2021-11-07T07:45:00Z')}
     >

--- a/www/src/registry/ui/date-picker/demos/time-zones.tsx
+++ b/www/src/registry/ui/date-picker/demos/time-zones.tsx
@@ -13,6 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
+      className="max-w-xs"
       aria-label="Date picker with time zones"
       defaultValue={parseAbsoluteToLocal('2021-11-07T07:45:00Z')}
     >

--- a/www/src/registry/ui/date-picker/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/date-picker/demos/uncontrolled.tsx
@@ -13,6 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
+      className="max-w-xs"
       aria-label="Meeting date"
       defaultValue={parseDate('2020-02-03')}
     >

--- a/www/src/registry/ui/date-picker/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/date-picker/demos/uncontrolled.tsx
@@ -13,7 +13,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <DatePicker
-      className="max-w-xs"
+      className="w-52"
       aria-label="Meeting date"
       defaultValue={parseDate('2020-02-03')}
     >

--- a/www/src/registry/ui/date-picker/demos/with-drawer.tsx
+++ b/www/src/registry/ui/date-picker/demos/with-drawer.tsx
@@ -8,7 +8,7 @@ import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DatePicker className="max-w-xs" aria-label="Meeting date">
+    <DatePicker className="w-52" aria-label="Meeting date">
       <InputGroup>
         <DateInput />
         <InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/with-drawer.tsx
+++ b/www/src/registry/ui/date-picker/demos/with-drawer.tsx
@@ -8,7 +8,7 @@ import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <DatePicker aria-label="Meeting date">
+    <DatePicker className="max-w-xs" aria-label="Meeting date">
       <InputGroup>
         <DateInput />
         <InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/with-modal.tsx
+++ b/www/src/registry/ui/date-picker/demos/with-modal.tsx
@@ -8,7 +8,7 @@ import { Modal } from '@/registry/ui/modal'
 
 export default function Demo() {
   return (
-    <DatePicker className="max-w-xs" aria-label="Meeting date">
+    <DatePicker className="w-52" aria-label="Meeting date">
       <InputGroup>
         <DateInput />
         <InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/with-modal.tsx
+++ b/www/src/registry/ui/date-picker/demos/with-modal.tsx
@@ -8,7 +8,7 @@ import { Modal } from '@/registry/ui/modal'
 
 export default function Demo() {
   return (
-    <DatePicker aria-label="Meeting date">
+    <DatePicker className="max-w-xs" aria-label="Meeting date">
       <InputGroup>
         <DateInput />
         <InputGroupAddon>

--- a/www/src/registry/ui/input-group/demos/addons.tsx
+++ b/www/src/registry/ui/input-group/demos/addons.tsx
@@ -14,7 +14,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TextField>
         <Label>label</Label>
         <InputGroup>
@@ -82,6 +82,6 @@ export default function Demo() {
           <InputGroupAddon>(optional)</InputGroupAddon>
         </InputGroup>
       </TextField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/input-group/demos/basic.tsx
+++ b/www/src/registry/ui/input-group/demos/basic.tsx
@@ -4,7 +4,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TextField>
         <Label>Default (no InputGroup)</Label>
         <Input placeholder="Placeholder" />
@@ -39,6 +39,6 @@ export default function Demo() {
           <Input />
         </InputGroup>
       </TextField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/input-group/demos/buttons.tsx
+++ b/www/src/registry/ui/input-group/demos/buttons.tsx
@@ -15,7 +15,7 @@ const variants = [
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       {variants.map((variant) => (
         <TextField key={variant} aria-label={variant}>
           <InputGroup>
@@ -54,6 +54,6 @@ export default function Demo() {
           </InputGroupAddon>
         </InputGroup>
       </TextField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/input-group/demos/date.tsx
+++ b/www/src/registry/ui/input-group/demos/date.tsx
@@ -3,7 +3,7 @@ import { DateInput, InputGroup } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <DateField aria-label="Date">
         <DateInput />
       </DateField>
@@ -12,6 +12,6 @@ export default function Demo() {
           <DateInput />
         </InputGroup>
       </DateField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/input-group/demos/in-card.tsx
+++ b/www/src/registry/ui/input-group/demos/in-card.tsx
@@ -21,7 +21,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <Card className="w-full">
+    <Card className="w-full max-w-xs">
       <CardHeader>
         <CardTitle>Card with Input Group</CardTitle>
         <CardDescription>This is a card with an input group.</CardDescription>

--- a/www/src/registry/ui/input-group/demos/input-group.tsx
+++ b/www/src/registry/ui/input-group/demos/input-group.tsx
@@ -2,7 +2,7 @@ import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <InputGroup>
+    <InputGroup className="max-w-xs">
       <InputGroupAddon>https://</InputGroupAddon>
       <Input placeholder="example.com" />
     </InputGroup>

--- a/www/src/registry/ui/input-group/demos/kbd.tsx
+++ b/www/src/registry/ui/input-group/demos/kbd.tsx
@@ -14,7 +14,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TextField aria-label="Search">
         <InputGroup>
           <Input />
@@ -120,6 +120,6 @@ export default function Demo() {
           </InputGroup>
         </TextField>
       </div>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/input-group/demos/sizes.tsx
+++ b/www/src/registry/ui/input-group/demos/sizes.tsx
@@ -14,7 +14,7 @@ const sizes = ['sm', 'md', 'lg'] as const
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <div className="flex w-full flex-col gap-2">
         {sizes.map((size) => (
           <TextField key={size} aria-label={`Size ${size}`}>
@@ -109,6 +109,6 @@ export default function Demo() {
           </TextField>
         ))}
       </div>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/input-group/demos/textarea.tsx
+++ b/www/src/registry/ui/input-group/demos/textarea.tsx
@@ -13,7 +13,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TextField>
         <Label>Default Textarea (no InputGroup)</Label>
         <TextArea placeholder="Enter your text here..." />
@@ -105,6 +105,6 @@ export default function Demo() {
           </InputGroupAddon>
         </InputGroup>
       </TextField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/input-group/demos/tooltip-dropdown-popover.tsx
+++ b/www/src/registry/ui/input-group/demos/tooltip-dropdown-popover.tsx
@@ -19,7 +19,7 @@ import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
 export default function Demo() {
   const [country, setCountry] = useState('+1')
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TextField>
         <Label>Tooltip</Label>
         <InputGroup>
@@ -85,6 +85,6 @@ export default function Demo() {
         </InputGroup>
         <Description>This is a description of the input group.</Description>
       </TextField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/input-group/demos/vertical-group.tsx
+++ b/www/src/registry/ui/input-group/demos/vertical-group.tsx
@@ -3,7 +3,7 @@ import { InputGroup, InputGroupAddon, TextArea } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <InputGroup>
+    <InputGroup className="max-w-xs">
       <TextArea placeholder="Write a comment..." />
       <InputGroupAddon>
         <Button size="sm" variant="primary" className="ml-auto">

--- a/www/src/registry/ui/input/demos/default.tsx
+++ b/www/src/registry/ui/input/demos/default.tsx
@@ -1,5 +1,5 @@
 import { Input } from '@/registry/ui/input'
 
 export default function Demo() {
-  return <Input placeholder="Enter text..." />
+  return <Input className="max-w-xs" placeholder="Enter text..." />
 }

--- a/www/src/registry/ui/input/demos/disabled.tsx
+++ b/www/src/registry/ui/input/demos/disabled.tsx
@@ -1,5 +1,5 @@
 import { Input } from '@/registry/ui/input'
 
 export default function Demo() {
-  return <Input disabled placeholder="Disabled input" />
+  return <Input className="max-w-xs" disabled placeholder="Disabled input" />
 }

--- a/www/src/registry/ui/input/demos/invalid.tsx
+++ b/www/src/registry/ui/input/demos/invalid.tsx
@@ -4,7 +4,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <TextField>
+    <TextField className="max-w-xs">
       <Label>Invalid</Label>
       <Input placeholder="Invalid input" />
     </TextField>

--- a/www/src/registry/ui/input/demos/playground.tsx
+++ b/www/src/registry/ui/input/demos/playground.tsx
@@ -10,6 +10,7 @@ export default function Demo({
 }: InputProps = {}) {
   return (
     <Input
+      className="max-w-xs"
       placeholder={placeholder}
       size={size}
       disabled={disabled}

--- a/www/src/registry/ui/input/demos/sizes.tsx
+++ b/www/src/registry/ui/input/demos/sizes.tsx
@@ -2,7 +2,7 @@ import { Input } from '@/registry/ui/input'
 
 export default function Demo() {
   return (
-    <div className="flex w-full flex-col gap-2">
+    <div className="flex w-full max-w-xs flex-col gap-2">
       <Input size="sm" placeholder="Small" />
       <Input size="md" placeholder="Medium" />
       <Input size="lg" placeholder="Large" />

--- a/www/src/registry/ui/input/demos/textarea.tsx
+++ b/www/src/registry/ui/input/demos/textarea.tsx
@@ -1,5 +1,5 @@
 import { TextArea } from '@/registry/ui/input'
 
 export default function Demo() {
-  return <TextArea placeholder="Write something..." />
+  return <TextArea className="max-w-xs" placeholder="Write something..." />
 }

--- a/www/src/registry/ui/number-field/demos/basic.tsx
+++ b/www/src/registry/ui/number-field/demos/basic.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <NumberField aria-label="Width" defaultValue={1024}>
+    <NumberField className="max-w-xs" aria-label="Width" defaultValue={1024}>
       <Group>
         <NumberFieldDecrement />
         <Input />

--- a/www/src/registry/ui/number-field/demos/controlled.tsx
+++ b/www/src/registry/ui/number-field/demos/controlled.tsx
@@ -13,7 +13,7 @@ import {
 export default function Demo() {
   const [inputValue, setInputValue] = React.useState(69)
   return (
-    <div className="flex flex-col items-center gap-4">
+    <div className="flex max-w-xs flex-col items-center gap-4">
       <NumberField
         aria-label="Width"
         value={inputValue}

--- a/www/src/registry/ui/number-field/demos/description.tsx
+++ b/www/src/registry/ui/number-field/demos/description.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function Demo() {
   return (
-    <NumberField defaultValue={1024}>
+    <NumberField className="max-w-xs" defaultValue={1024}>
       <Label>Width</Label>
       <Group>
         <NumberFieldDecrement />

--- a/www/src/registry/ui/number-field/demos/disabled.tsx
+++ b/www/src/registry/ui/number-field/demos/disabled.tsx
@@ -9,7 +9,12 @@ import {
 
 export default function Demo() {
   return (
-    <NumberField aria-label="Width" defaultValue={20} isDisabled>
+    <NumberField
+      className="max-w-xs"
+      aria-label="Width"
+      defaultValue={20}
+      isDisabled
+    >
       <Label>Width</Label>
       <Group>
         <NumberFieldDecrement />

--- a/www/src/registry/ui/number-field/demos/error-message.tsx
+++ b/www/src/registry/ui/number-field/demos/error-message.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function Demo() {
   return (
-    <NumberField defaultValue={1024} isInvalid>
+    <NumberField className="max-w-xs" defaultValue={1024} isInvalid>
       <Label>Width</Label>
       <Group>
         <NumberFieldDecrement />

--- a/www/src/registry/ui/number-field/demos/label.tsx
+++ b/www/src/registry/ui/number-field/demos/label.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function Demo() {
   return (
-    <div className="space-y-4">
+    <div className="max-w-xs space-y-4">
       <NumberField defaultValue={1024}>
         <Label>Width</Label>
         <Group>

--- a/www/src/registry/ui/number-field/demos/playground.tsx
+++ b/www/src/registry/ui/number-field/demos/playground.tsx
@@ -17,6 +17,7 @@ export default function Demo({
 } = {}) {
   return (
     <NumberField
+      className="max-w-xs"
       defaultValue={1}
       isDisabled={isDisabled}
       isReadOnly={isReadOnly}

--- a/www/src/registry/ui/number-field/demos/read-only.tsx
+++ b/www/src/registry/ui/number-field/demos/read-only.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <NumberField aria-label="Width" isReadOnly value={69}>
+    <NumberField className="max-w-xs" aria-label="Width" isReadOnly value={69}>
       <Group>
         <NumberFieldDecrement />
         <Input />

--- a/www/src/registry/ui/number-field/demos/required.tsx
+++ b/www/src/registry/ui/number-field/demos/required.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function Demo() {
   return (
-    <NumberField defaultValue={1024} isRequired>
+    <NumberField className="max-w-xs" defaultValue={1024} isRequired>
       <Label>Width</Label>
       <Group>
         <NumberFieldDecrement />

--- a/www/src/registry/ui/number-field/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/number-field/demos/uncontrolled.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <NumberField aria-label="Width" defaultValue={80}>
+    <NumberField className="max-w-xs" aria-label="Width" defaultValue={80}>
       <Group>
         <NumberFieldDecrement />
         <Input />

--- a/www/src/registry/ui/number-field/demos/with-input-group.tsx
+++ b/www/src/registry/ui/number-field/demos/with-input-group.tsx
@@ -7,7 +7,7 @@ import {
 
 export default function Demo() {
   return (
-    <NumberField aria-label="Width" defaultValue={1024}>
+    <NumberField className="max-w-xs" aria-label="Width" defaultValue={1024}>
       <InputGroup>
         <Input />
         <InputGroupAddon>

--- a/www/src/registry/ui/search-field/demos/controlled.tsx
+++ b/www/src/registry/ui/search-field/demos/controlled.tsx
@@ -10,7 +10,7 @@ export default function Demo() {
     'Is dotUI the next-gen ui lib?',
   )
   return (
-    <div className="flex flex-col items-center gap-4">
+    <div className="flex max-w-xs flex-col items-center gap-4">
       <SearchField
         aria-label="Search"
         value={inputValue}

--- a/www/src/registry/ui/search-field/demos/default.tsx
+++ b/www/src/registry/ui/search-field/demos/default.tsx
@@ -3,7 +3,7 @@ import { SearchField } from '@/registry/ui/search-field'
 
 export default function Demo() {
   return (
-    <SearchField aria-label="Search">
+    <SearchField className="max-w-xs" aria-label="Search">
       <Input />
     </SearchField>
   )

--- a/www/src/registry/ui/search-field/demos/description.tsx
+++ b/www/src/registry/ui/search-field/demos/description.tsx
@@ -4,7 +4,7 @@ import { SearchField } from '@/registry/ui/search-field'
 
 export default function Demo() {
   return (
-    <SearchField>
+    <SearchField className="max-w-xs">
       <Label>Search</Label>
       <Input />
       <Description>Enter your search query</Description>

--- a/www/src/registry/ui/search-field/demos/disabled.tsx
+++ b/www/src/registry/ui/search-field/demos/disabled.tsx
@@ -4,6 +4,7 @@ import { SearchField } from '@/registry/ui/search-field'
 export default function Demo() {
   return (
     <SearchField
+      className="max-w-xs"
       aria-label="Search"
       defaultValue="Is dotUI the best ui library?"
       isDisabled

--- a/www/src/registry/ui/search-field/demos/error-message.tsx
+++ b/www/src/registry/ui/search-field/demos/error-message.tsx
@@ -4,7 +4,7 @@ import { SearchField } from '@/registry/ui/search-field'
 
 export default function Demo() {
   return (
-    <SearchField isInvalid>
+    <SearchField className="max-w-xs" isInvalid>
       <Label>Search</Label>
       <Input />
       <FieldError>Please fill out this field.</FieldError>

--- a/www/src/registry/ui/search-field/demos/filterable-list.tsx
+++ b/www/src/registry/ui/search-field/demos/filterable-list.tsx
@@ -23,7 +23,7 @@ export default function Demo() {
   )
 
   return (
-    <div className="flex w-full max-w-sm flex-col gap-3 rounded-lg border bg-bg p-4">
+    <div className="flex w-full max-w-xs flex-col gap-3 rounded-lg border bg-bg p-4">
       <SearchField
         aria-label="Search members"
         value={query}

--- a/www/src/registry/ui/search-field/demos/header-search.tsx
+++ b/www/src/registry/ui/search-field/demos/header-search.tsx
@@ -6,7 +6,7 @@ import { SearchField } from '@/registry/ui/search-field'
 
 export default function Demo() {
   return (
-    <div className="flex w-full max-w-sm items-center gap-3 rounded-lg border bg-bg px-3 py-2">
+    <div className="flex w-full max-w-xs items-center gap-3 rounded-lg border bg-bg px-3 py-2">
       <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-primary text-fg-on-primary">
         <LayoutGrid className="size-4" />
       </div>

--- a/www/src/registry/ui/search-field/demos/label.tsx
+++ b/www/src/registry/ui/search-field/demos/label.tsx
@@ -4,7 +4,7 @@ import { SearchField } from '@/registry/ui/search-field'
 
 export default function Demo() {
   return (
-    <div className="space-y-4">
+    <div className="max-w-xs space-y-4">
       <SearchField>
         <Label>Search</Label>
         <Input placeholder="Visible label" />

--- a/www/src/registry/ui/search-field/demos/playground.tsx
+++ b/www/src/registry/ui/search-field/demos/playground.tsx
@@ -11,7 +11,11 @@ export default function Demo({
   isReadOnly = false,
 } = {}) {
   return (
-    <SearchField isDisabled={isDisabled} isReadOnly={isReadOnly}>
+    <SearchField
+      className="max-w-xs"
+      isDisabled={isDisabled}
+      isReadOnly={isReadOnly}
+    >
       {label && <Label>{label}</Label>}
       <Input data-control-target placeholder={placeholder} />
     </SearchField>

--- a/www/src/registry/ui/search-field/demos/read-only.tsx
+++ b/www/src/registry/ui/search-field/demos/read-only.tsx
@@ -4,7 +4,7 @@ import { SearchField } from '@/registry/ui/search-field'
 
 export default function Demo() {
   return (
-    <SearchField isReadOnly defaultValue="Marvel movies">
+    <SearchField className="max-w-xs" isReadOnly defaultValue="Marvel movies">
       <Label>Search</Label>
       <Input />
     </SearchField>

--- a/www/src/registry/ui/search-field/demos/required.tsx
+++ b/www/src/registry/ui/search-field/demos/required.tsx
@@ -4,7 +4,7 @@ import { SearchField } from '@/registry/ui/search-field'
 
 export default function Demo() {
   return (
-    <SearchField isRequired>
+    <SearchField className="max-w-xs" isRequired>
       <Label>Search</Label>
       <Input />
     </SearchField>

--- a/www/src/registry/ui/search-field/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/search-field/demos/uncontrolled.tsx
@@ -3,7 +3,11 @@ import { SearchField } from '@/registry/ui/search-field'
 
 export default function Demo() {
   return (
-    <SearchField aria-label="Search" defaultValue="Marvel movies">
+    <SearchField
+      className="max-w-xs"
+      aria-label="Search"
+      defaultValue="Marvel movies"
+    >
       <Input />
     </SearchField>
   )

--- a/www/src/registry/ui/select/demos/async-loading.tsx
+++ b/www/src/registry/ui/select/demos/async-loading.tsx
@@ -30,7 +30,7 @@ export default function Demo() {
   })
 
   return (
-    <Select aria-label="Pokemon">
+    <Select className="max-w-xs" aria-label="Pokemon">
       <SelectTrigger />
       <SelectContent
         className="max-h-64 overflow-auto overscroll-none"

--- a/www/src/registry/ui/select/demos/async-loading.tsx
+++ b/www/src/registry/ui/select/demos/async-loading.tsx
@@ -30,7 +30,7 @@ export default function Demo() {
   })
 
   return (
-    <Select className="max-w-xs" aria-label="Pokemon">
+    <Select className="w-52" aria-label="Pokemon">
       <SelectTrigger />
       <SelectContent
         className="max-h-64 overflow-auto overscroll-none"

--- a/www/src/registry/ui/select/demos/basic.tsx
+++ b/www/src/registry/ui/select/demos/basic.tsx
@@ -26,7 +26,7 @@ export default function Demo({
 
   return (
     <Select
-      className="max-w-xs"
+      className="w-52"
       aria-label={trimmedLabel ? undefined : 'Provider'}
       placeholder={trimmedPlaceholder || undefined}
       isDisabled={isDisabled}

--- a/www/src/registry/ui/select/demos/basic.tsx
+++ b/www/src/registry/ui/select/demos/basic.tsx
@@ -26,6 +26,7 @@ export default function Demo({
 
   return (
     <Select
+      className="max-w-xs"
       aria-label={trimmedLabel ? undefined : 'Provider'}
       placeholder={trimmedPlaceholder || undefined}
       isDisabled={isDisabled}

--- a/www/src/registry/ui/select/demos/composition.tsx
+++ b/www/src/registry/ui/select/demos/composition.tsx
@@ -7,7 +7,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select className="max-w-xs" aria-label="Provider">
+    <Select className="w-52" aria-label="Provider">
       <SelectTrigger />
       <SelectContent>
         <SelectItem>Perplexity</SelectItem>

--- a/www/src/registry/ui/select/demos/composition.tsx
+++ b/www/src/registry/ui/select/demos/composition.tsx
@@ -7,7 +7,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select aria-label="Provider">
+    <Select className="max-w-xs" aria-label="Provider">
       <SelectTrigger />
       <SelectContent>
         <SelectItem>Perplexity</SelectItem>

--- a/www/src/registry/ui/select/demos/controlled.tsx
+++ b/www/src/registry/ui/select/demos/controlled.tsx
@@ -15,7 +15,7 @@ export default function Demo() {
     'eleven-labs',
   )
   return (
-    <div className="flex max-w-xs flex-col items-center gap-6">
+    <div className="flex w-52 flex-col items-center gap-6">
       <Select aria-label="Provider" value={provider} onChange={setProvider}>
         <SelectTrigger />
         <SelectContent>

--- a/www/src/registry/ui/select/demos/controlled.tsx
+++ b/www/src/registry/ui/select/demos/controlled.tsx
@@ -15,7 +15,7 @@ export default function Demo() {
     'eleven-labs',
   )
   return (
-    <div className="flex flex-col items-center gap-6">
+    <div className="flex max-w-xs flex-col items-center gap-6">
       <Select aria-label="Provider" value={provider} onChange={setProvider}>
         <SelectTrigger />
         <SelectContent>

--- a/www/src/registry/ui/select/demos/description.tsx
+++ b/www/src/registry/ui/select/demos/description.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select>
+    <Select className="max-w-xs">
       <Label>Provider</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/description.tsx
+++ b/www/src/registry/ui/select/demos/description.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select className="max-w-xs">
+    <Select className="w-52">
       <Label>Provider</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/disabled.tsx
+++ b/www/src/registry/ui/select/demos/disabled.tsx
@@ -7,7 +7,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select className="max-w-xs" aria-label="Provider" isDisabled>
+    <Select className="w-52" aria-label="Provider" isDisabled>
       <SelectTrigger />
       <SelectContent>
         <SelectItem>Perplexity</SelectItem>

--- a/www/src/registry/ui/select/demos/disabled.tsx
+++ b/www/src/registry/ui/select/demos/disabled.tsx
@@ -7,7 +7,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select aria-label="Provider" isDisabled>
+    <Select className="max-w-xs" aria-label="Provider" isDisabled>
       <SelectTrigger />
       <SelectContent>
         <SelectItem>Perplexity</SelectItem>

--- a/www/src/registry/ui/select/demos/label.tsx
+++ b/www/src/registry/ui/select/demos/label.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select>
+    <Select className="max-w-xs">
       <Label>Provider</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/label.tsx
+++ b/www/src/registry/ui/select/demos/label.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select className="max-w-xs">
+    <Select className="w-52">
       <Label>Provider</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/links.tsx
+++ b/www/src/registry/ui/select/demos/links.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select className="max-w-xs">
+    <Select className="w-52">
       <Label>Project</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/links.tsx
+++ b/www/src/registry/ui/select/demos/links.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select>
+    <Select className="max-w-xs">
       <Label>Project</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/loading.tsx
+++ b/www/src/registry/ui/select/demos/loading.tsx
@@ -7,7 +7,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select aria-label="Provider">
+    <Select className="max-w-xs" aria-label="Provider">
       <SelectTrigger />
       <SelectContent isLoading>
         <SelectItem>Perplexity</SelectItem>

--- a/www/src/registry/ui/select/demos/loading.tsx
+++ b/www/src/registry/ui/select/demos/loading.tsx
@@ -7,7 +7,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select className="max-w-xs" aria-label="Provider">
+    <Select className="w-52" aria-label="Provider">
       <SelectTrigger />
       <SelectContent isLoading>
         <SelectItem>Perplexity</SelectItem>

--- a/www/src/registry/ui/select/demos/placeholder.tsx
+++ b/www/src/registry/ui/select/demos/placeholder.tsx
@@ -8,7 +8,11 @@ import {
 
 export default function Demo() {
   return (
-    <Select aria-label="Provider" placeholder="Select a provider">
+    <Select
+      className="max-w-xs"
+      aria-label="Provider"
+      placeholder="Select a provider"
+    >
       <SelectTrigger>
         <SelectValue />
       </SelectTrigger>

--- a/www/src/registry/ui/select/demos/placeholder.tsx
+++ b/www/src/registry/ui/select/demos/placeholder.tsx
@@ -9,7 +9,7 @@ import {
 export default function Demo() {
   return (
     <Select
-      className="max-w-xs"
+      className="w-52"
       aria-label="Provider"
       placeholder="Select a provider"
     >

--- a/www/src/registry/ui/select/demos/playground.tsx
+++ b/www/src/registry/ui/select/demos/playground.tsx
@@ -16,6 +16,7 @@ export default function Demo({
 } = {}) {
   return (
     <Select
+      className="max-w-xs"
       placeholder={placeholder}
       isDisabled={isDisabled}
       isInvalid={isInvalid}

--- a/www/src/registry/ui/select/demos/playground.tsx
+++ b/www/src/registry/ui/select/demos/playground.tsx
@@ -16,7 +16,7 @@ export default function Demo({
 } = {}) {
   return (
     <Select
-      className="max-w-xs"
+      className="w-52"
       placeholder={placeholder}
       isDisabled={isDisabled}
       isInvalid={isInvalid}

--- a/www/src/registry/ui/select/demos/required.tsx
+++ b/www/src/registry/ui/select/demos/required.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select className="max-w-xs" isRequired>
+    <Select className="w-52" isRequired>
       <Label>Provider</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/required.tsx
+++ b/www/src/registry/ui/select/demos/required.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select isRequired>
+    <Select className="max-w-xs" isRequired>
       <Label>Provider</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/sections.tsx
+++ b/www/src/registry/ui/select/demos/sections.tsx
@@ -11,7 +11,7 @@ import { Separator } from '@/registry/ui/separator'
 
 export default function Demo() {
   return (
-    <Select className="max-w-xs">
+    <Select className="w-52">
       <Label>Model</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/sections.tsx
+++ b/www/src/registry/ui/select/demos/sections.tsx
@@ -11,7 +11,7 @@ import { Separator } from '@/registry/ui/separator'
 
 export default function Demo() {
   return (
-    <Select>
+    <Select className="max-w-xs">
       <Label>Model</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/select/demos/uncontrolled.tsx
@@ -8,7 +8,7 @@ import {
 export default function Demo() {
   return (
     <Select
-      className="max-w-xs"
+      className="w-52"
       aria-label="Provider"
       defaultSelectedKey="eleven-labs"
     >

--- a/www/src/registry/ui/select/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/select/demos/uncontrolled.tsx
@@ -7,7 +7,11 @@ import {
 
 export default function Demo() {
   return (
-    <Select aria-label="Provider" defaultSelectedKey="eleven-labs">
+    <Select
+      className="max-w-xs"
+      aria-label="Provider"
+      defaultSelectedKey="eleven-labs"
+    >
       <SelectTrigger />
       <SelectContent>
         <SelectItem id="perplexity">Perplexity</SelectItem>

--- a/www/src/registry/ui/select/demos/validation.tsx
+++ b/www/src/registry/ui/select/demos/validation.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select isInvalid>
+    <Select className="max-w-xs" isInvalid>
       <Label>Provider</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/select/demos/validation.tsx
+++ b/www/src/registry/ui/select/demos/validation.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Demo() {
   return (
-    <Select className="max-w-xs" isInvalid>
+    <Select className="w-52" isInvalid>
       <Label>Provider</Label>
       <SelectTrigger />
       <SelectContent>

--- a/www/src/registry/ui/text-field/demos/basic.tsx
+++ b/www/src/registry/ui/text-field/demos/basic.tsx
@@ -3,7 +3,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <TextField aria-label="Email">
+    <TextField className="max-w-xs" aria-label="Email">
       <Input placeholder="hello@example.com" />
     </TextField>
   )

--- a/www/src/registry/ui/text-field/demos/controlled.tsx
+++ b/www/src/registry/ui/text-field/demos/controlled.tsx
@@ -8,7 +8,7 @@ import { TextField } from '@/registry/ui/text-field'
 export default function Demo() {
   const [inputValue, setInputValue] = React.useState('Hello world!')
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TextField
         aria-label="Controlled text field"
         value={inputValue}
@@ -17,6 +17,6 @@ export default function Demo() {
         <Input />
       </TextField>
       <p className="text-sm text-fg-muted">mirrored text: {inputValue}</p>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/text-field/demos/default.tsx
+++ b/www/src/registry/ui/text-field/demos/default.tsx
@@ -4,7 +4,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <TextField aria-label="Email">
+    <TextField className="max-w-xs" aria-label="Email">
       <Label>Email</Label>
       <Input placeholder="hello@example.com" />
     </TextField>

--- a/www/src/registry/ui/text-field/demos/description.tsx
+++ b/www/src/registry/ui/text-field/demos/description.tsx
@@ -6,7 +6,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <TextField>
+    <TextField className="max-w-xs">
       <Label>Email</Label>
       <Input placeholder="hello@example.com" />
       <Description>Enter your email.</Description>

--- a/www/src/registry/ui/text-field/demos/disabled.tsx
+++ b/www/src/registry/ui/text-field/demos/disabled.tsx
@@ -3,7 +3,12 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <TextField aria-label="Email" value="hello@example.com" isDisabled>
+    <TextField
+      className="max-w-xs"
+      aria-label="Email"
+      value="hello@example.com"
+      isDisabled
+    >
       <Input />
     </TextField>
   )

--- a/www/src/registry/ui/text-field/demos/error-message.tsx
+++ b/www/src/registry/ui/text-field/demos/error-message.tsx
@@ -6,7 +6,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <TextField defaultValue="hello@example.com" isInvalid>
+    <TextField className="max-w-xs" defaultValue="hello@example.com" isInvalid>
       <Label>Email</Label>
       <Input />
       <FieldError>Enter a valid email address.</FieldError>

--- a/www/src/registry/ui/text-field/demos/label.tsx
+++ b/www/src/registry/ui/text-field/demos/label.tsx
@@ -4,7 +4,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TextField>
         <Label>Email</Label>
         <Input />
@@ -12,6 +12,6 @@ export default function Demo() {
       <TextField aria-label="Email">
         <Input />
       </TextField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/text-field/demos/playground.tsx
+++ b/www/src/registry/ui/text-field/demos/playground.tsx
@@ -14,6 +14,7 @@ export default function Demo({
 } = {}) {
   return (
     <TextField
+      className="max-w-xs"
       isDisabled={isDisabled}
       isReadOnly={isReadOnly}
       isInvalid={isInvalid}

--- a/www/src/registry/ui/text-field/demos/prefix-and-suffix.tsx
+++ b/www/src/registry/ui/text-field/demos/prefix-and-suffix.tsx
@@ -13,7 +13,7 @@ export default function Demo() {
   const [inputValue, setInputValue] = React.useState('Hello world!')
   const inputRef = React.useRef<HTMLInputElement>(null)
   return (
-    <div className="space-y-2">
+    <div className="max-w-xs space-y-2">
       <TextField>
         <Label>Website</Label>
         <InputGroup>

--- a/www/src/registry/ui/text-field/demos/read-only.tsx
+++ b/www/src/registry/ui/text-field/demos/read-only.tsx
@@ -6,7 +6,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <TextField isReadOnly defaultValue="hello@example.com">
+    <TextField className="max-w-xs" isReadOnly defaultValue="hello@example.com">
       <Label>Email</Label>
       <Input />
     </TextField>

--- a/www/src/registry/ui/text-field/demos/required.tsx
+++ b/www/src/registry/ui/text-field/demos/required.tsx
@@ -4,7 +4,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <TextField isRequired>
+    <TextField className="max-w-xs" isRequired>
       <Label>Email</Label>
       <Input />
     </TextField>

--- a/www/src/registry/ui/text-field/demos/sizes.tsx
+++ b/www/src/registry/ui/text-field/demos/sizes.tsx
@@ -4,7 +4,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TextField>
         <Label>small (sm)</Label>
         <Input size="sm" />
@@ -17,6 +17,6 @@ export default function Demo() {
         <Label>large (lg)</Label>
         <Input size="lg" />
       </TextField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/text-field/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/text-field/demos/uncontrolled.tsx
@@ -4,7 +4,7 @@ import { TextField } from '@/registry/ui/text-field'
 
 export default function Demo() {
   return (
-    <TextField defaultValue="Ada">
+    <TextField className="max-w-xs" defaultValue="Ada">
       <Label>Name</Label>
       <Input />
     </TextField>

--- a/www/src/registry/ui/time-field/demos/basic.tsx
+++ b/www/src/registry/ui/time-field/demos/basic.tsx
@@ -3,7 +3,7 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <TimeField aria-label="Event time">
+    <TimeField className="max-w-xs" aria-label="Event time">
       <DateInput />
     </TimeField>
   )

--- a/www/src/registry/ui/time-field/demos/controlled.tsx
+++ b/www/src/registry/ui/time-field/demos/controlled.tsx
@@ -12,13 +12,13 @@ export default function Demo() {
     new Time(11, 45),
   )
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TimeField aria-label="Event time" value={time} onChange={setTime}>
         <DateInput />
       </TimeField>
       <p className="text-sm text-fg-muted">
         selected time: {time ? time.toString() : 'none'}
       </p>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/time-field/demos/default.tsx
+++ b/www/src/registry/ui/time-field/demos/default.tsx
@@ -4,7 +4,7 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <TimeField>
+    <TimeField className="max-w-xs">
       <Label>Event time</Label>
       <DateInput />
     </TimeField>

--- a/www/src/registry/ui/time-field/demos/description.tsx
+++ b/www/src/registry/ui/time-field/demos/description.tsx
@@ -6,7 +6,7 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <TimeField>
+    <TimeField className="max-w-xs">
       <Label>Appointment time</Label>
       <DateInput />
       <Description>Please select a time between 9 AM and 5 PM.</Description>

--- a/www/src/registry/ui/time-field/demos/disabled.tsx
+++ b/www/src/registry/ui/time-field/demos/disabled.tsx
@@ -4,7 +4,7 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <TimeField isDisabled>
+    <TimeField className="max-w-xs" isDisabled>
       <Label>Event time</Label>
       <DateInput />
     </TimeField>

--- a/www/src/registry/ui/time-field/demos/error-message.tsx
+++ b/www/src/registry/ui/time-field/demos/error-message.tsx
@@ -4,7 +4,7 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <TimeField isInvalid>
+    <TimeField className="max-w-xs" isInvalid>
       <Label>Meeting time</Label>
       <DateInput />
       <FieldError>Meetings start every 15 minutes.</FieldError>

--- a/www/src/registry/ui/time-field/demos/granularity.tsx
+++ b/www/src/registry/ui/time-field/demos/granularity.tsx
@@ -8,7 +8,7 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TimeField granularity="hour" defaultValue={new Time(11, 45, 22)}>
         <Label>Hour</Label>
         <DateInput />
@@ -21,6 +21,6 @@ export default function Demo() {
         <Label>Second</Label>
         <DateInput />
       </TimeField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/time-field/demos/hide-time-zone.tsx
+++ b/www/src/registry/ui/time-field/demos/hide-time-zone.tsx
@@ -9,6 +9,7 @@ import { TimeField } from '@/registry/ui/time-field'
 export default function Demo() {
   return (
     <TimeField
+      className="max-w-xs"
       defaultValue={parseZonedDateTime('2022-11-07T10:45[America/Los_Angeles]')}
       hideTimeZone
     >

--- a/www/src/registry/ui/time-field/demos/hour-cycle.tsx
+++ b/www/src/registry/ui/time-field/demos/hour-cycle.tsx
@@ -11,7 +11,7 @@ export default function Demo() {
       aria-label="Appointment time"
       defaultValue={new Time(18, 45)}
       hourCycle={24}
-      className="w-auto"
+      className="w-auto max-w-xs"
     >
       <DateInput />
     </TimeField>

--- a/www/src/registry/ui/time-field/demos/label.tsx
+++ b/www/src/registry/ui/time-field/demos/label.tsx
@@ -4,12 +4,12 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TimeField>
         <Label>Event time</Label>
         <DateInput />
       </TimeField>
       <TimeField aria-label="Event time" />
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/time-field/demos/placeholder.tsx
+++ b/www/src/registry/ui/time-field/demos/placeholder.tsx
@@ -8,7 +8,7 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <TimeField placeholderValue={new Time(9)}>
+    <TimeField className="max-w-xs" placeholderValue={new Time(9)}>
       <Label>Event time</Label>
       <DateInput />
     </TimeField>

--- a/www/src/registry/ui/time-field/demos/playground.tsx
+++ b/www/src/registry/ui/time-field/demos/playground.tsx
@@ -12,6 +12,7 @@ export default function Demo({
 } = {}) {
   return (
     <TimeField
+      className="max-w-xs"
       isDisabled={isDisabled}
       isReadOnly={isReadOnly}
       isInvalid={isInvalid}

--- a/www/src/registry/ui/time-field/demos/prefix-and-suffix.tsx
+++ b/www/src/registry/ui/time-field/demos/prefix-and-suffix.tsx
@@ -4,7 +4,7 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TimeField aria-label="Event time">
         <InputGroup>
           <InputGroupAddon>
@@ -21,6 +21,6 @@ export default function Demo() {
           </InputGroupAddon>
         </InputGroup>
       </TimeField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/time-field/demos/read-only.tsx
+++ b/www/src/registry/ui/time-field/demos/read-only.tsx
@@ -7,7 +7,12 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <TimeField aria-label="Event time" value={new Time(11)} isReadOnly>
+    <TimeField
+      className="max-w-xs"
+      aria-label="Event time"
+      value={new Time(11)}
+      isReadOnly
+    >
       <DateInput />
     </TimeField>
   )

--- a/www/src/registry/ui/time-field/demos/required.tsx
+++ b/www/src/registry/ui/time-field/demos/required.tsx
@@ -4,7 +4,7 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <TimeField isRequired>
+    <TimeField className="max-w-xs" isRequired>
       <Label>Event time</Label>
       <DateInput />
     </TimeField>

--- a/www/src/registry/ui/time-field/demos/sizes.tsx
+++ b/www/src/registry/ui/time-field/demos/sizes.tsx
@@ -4,7 +4,7 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <>
+    <div className="flex w-full max-w-xs flex-col gap-6">
       <TimeField>
         <Label>small (sm)</Label>
         <DateInput size="sm" />
@@ -17,6 +17,6 @@ export default function Demo() {
         <Label>large (lg)</Label>
         <DateInput size="lg" />
       </TimeField>
-    </>
+    </div>
   )
 }

--- a/www/src/registry/ui/time-field/demos/time-zones.tsx
+++ b/www/src/registry/ui/time-field/demos/time-zones.tsx
@@ -8,6 +8,7 @@ import { TimeField } from '@/registry/ui/time-field'
 export default function Demo() {
   return (
     <TimeField
+      className="max-w-xs"
       aria-label="Meeting time"
       defaultValue={parseZonedDateTime('2022-11-07T00:45[America/Los_Angeles]')}
     >

--- a/www/src/registry/ui/time-field/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/time-field/demos/uncontrolled.tsx
@@ -7,7 +7,11 @@ import { TimeField } from '@/registry/ui/time-field'
 
 export default function Demo() {
   return (
-    <TimeField aria-label="Event time" defaultValue={new Time(11, 45)}>
+    <TimeField
+      className="max-w-xs"
+      aria-label="Event time"
+      defaultValue={new Time(11, 45)}
+    >
       <DateInput />
     </TimeField>
   )


### PR DESCRIPTION
## Summary

Give the input/field/picker demos a sensible width instead of stretching to the full preview/card width:
- **Inputs & fields** → capped at `max-w-xs` (320px).
- **Pickers** (combobox, date-picker, select) → fixed `w-52` (208px), which reads better for a dropdown trigger.

**Rule applied uniformly:**
- Single-root demo → width class on the field root (`Input`, `TextField`, `Combobox`, `Select`, `DatePicker`/`DateRangePicker`, `DateField`, `SearchField`, `NumberField`, `TimeField`, `ColorField`, plus `Card`/`form`/`div` wrappers).
- Multi-item demo (Fragment of stacked fields) → wrapped in a flex column constrained to the same width (`gap-6` matches the preview containers, so spacing is unchanged).
- Overlay content (`Popover`/`ListBox`/`Calendar`/`DialogContent`) is never constrained — only the inline field/trigger root.

**Components covered**
- `max-w-xs`: input, input-group, text-field, date-field, search-field, number-field, time-field, color-field.
- `w-52`: combobox, date-picker (incl. `range/`), select.
- `mention` — kept at its existing `w-[320px]` (comment textarea; `w-52` would be too cramped). `field` + some text-field/date-field form demos already had `max-w-xs`.

**Intentionally left wide** — multi-up comparison / special layouts where a narrow cap would squish: `search-field/sizes`, `number-field/sizes`, `number-field/format-options`, `color-field/color-channel`, `combobox/sides`, `combobox/in-dialog`.

**Excluded by design:** `otp-field` (segmented fixed-width slots) and `color-picker` (icon-button trigger).

## Notes for reviewers

- The field-style roots all use the shared `field` slot (`flex w-full …`) and merge `className`, so the width class just caps/sets width — no other layout change.
- `date-picker/range` at `w-52` (208px) is tight for two dates + separator — flag if you'd prefer the range pickers wider.
- No `__generated__/*` drift: demos are referenced by path + lazy import, not inlined. `pnpm check`, `pnpm typecheck`, and `build:registry` all pass.