### PR TITLE
feat(comparison-slider): add comparison-slider component

### DIFF
--- a/www/content/docs/components/comparison-slider.mdx
+++ b/www/content/docs/components/comparison-slider.mdx
@@ -1,0 +1,43 @@
+---
+title: Comparison Slider
+description: A draggable handle that reveals one layer over another, for before/after comparisons.
+links:
+  - label: Docs
+    href: https://react-spectrum.adobe.com/react-aria/Slider.html
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/comparison-slider
+```
+
+## Usage
+
+Pass the base layer as `children` and the clipped overlay as `reveal`.
+
+```tsx
+import { ComparisonSlider } from '@/components/ui/comparison-slider'
+```
+
+```tsx
+<ComparisonSlider
+  aria-label="Compare"
+  reveal={<img src="/before.jpg" alt="Before" />}
+>
+  <img src="/after.jpg" alt="After" />
+</ComparisonSlider>
+```
+
+## Examples
+
+<Examples>
+  <Example name="comparison-slider/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### ComparisonSlider
+
+<Reference name="comparison-slider" />

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -27,6 +27,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"color-swatch-picker": () => import("@/registry/ui/color-swatch-picker/examples"),
 	combobox: () => import("@/registry/ui/combobox/examples"),
 	command: () => import("@/registry/ui/command/examples"),
+	"comparison-slider": () => import("@/registry/ui/comparison-slider/examples"),
 	"context-menu": () => import("@/registry/ui/context-menu/examples"),
 	"date-field": () => import("@/registry/ui/date-field/examples"),
 	"date-picker": () => import("@/registry/ui/date-picker/examples"),

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -925,6 +925,10 @@ export const DemosIndex: Record<
 		files: ["ui/command/demos/with-tag-group.tsx"],
 		component: React.lazy(() => import("@/registry/ui/command/demos/with-tag-group")),
 	},
+	"comparison-slider/demos/default": {
+		files: ["ui/comparison-slider/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/comparison-slider/demos/default")),
+	},
 	"context-menu/demos/basic": {
 		files: ["ui/context-menu/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/context-menu/demos/basic")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -32,6 +32,7 @@ import UiColorSwatch from "@/registry/ui/color-swatch/meta";
 import UiColorThumb from "@/registry/ui/color-thumb/meta";
 import UiCombobox from "@/registry/ui/combobox/meta";
 import UiCommand from "@/registry/ui/command/meta";
+import UiComparisonSlider from "@/registry/ui/comparison-slider/meta";
 import UiContextMenu from "@/registry/ui/context-menu/meta";
 import UiDateField from "@/registry/ui/date-field/meta";
 import UiDatePicker from "@/registry/ui/date-picker/meta";
@@ -106,6 +107,7 @@ export const registryUi: RegistryItem[] = [
 	UiColorThumb,
 	UiCombobox,
 	UiCommand,
+	UiComparisonSlider,
 	UiContextMenu,
 	UiDateField,
 	UiDatePicker,

--- a/www/src/registry/ui/comparison-slider/base.tsx
+++ b/www/src/registry/ui/comparison-slider/base.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useContext } from 'react'
+import { composeRenderProps } from 'react-aria-components/composeRenderProps'
+import * as SliderPrimitive from 'react-aria-components/Slider'
+
+import { useStyles } from './styles'
+
+// MARK: ComparisonSlider
+
+interface ComparisonSliderProps extends Omit<
+  React.ComponentProps<typeof SliderPrimitive.Slider>,
+  'children'
+> {
+  children: React.ReactNode
+  reveal: React.ReactNode
+  handle?: React.ReactNode
+}
+
+const ComparisonSlider = ({
+  className,
+  children,
+  reveal,
+  handle,
+  ...props
+}: ComparisonSliderProps) => {
+  const { root } = useStyles()()
+  return (
+    <SliderPrimitive.Slider
+      data-comparison-slider=""
+      minValue={0}
+      maxValue={100}
+      defaultValue={50}
+      className={composeRenderProps(className, (cn) => root({ className: cn }))}
+      {...props}
+    >
+      <ComparisonSliderLayers reveal={reveal} handle={handle}>
+        {children}
+      </ComparisonSliderLayers>
+    </SliderPrimitive.Slider>
+  )
+}
+
+// MARK: Separator
+
+interface ComparisonSliderLayersProps {
+  children: React.ReactNode
+  reveal: React.ReactNode
+  handle?: React.ReactNode
+}
+
+const ComparisonSliderLayers = ({
+  children,
+  reveal,
+  handle,
+}: ComparisonSliderLayersProps) => {
+  const { after, before, control, divider, thumb } = useStyles()()
+  const state = useContext(SliderPrimitive.SliderStateContext)
+  const percent = (state?.getThumbPercent(0) ?? 0.5) * 100
+  return (
+    <>
+      <div data-comparison-slider-after="" className={after()}>
+        {children}
+      </div>
+      <div
+        data-comparison-slider-before=""
+        className={before()}
+        style={{ clipPath: `inset(0 ${100 - percent}% 0 0)` }}
+      >
+        {reveal}
+      </div>
+      <SliderPrimitive.SliderTrack
+        data-comparison-slider-control=""
+        className={control()}
+      >
+        <div
+          data-comparison-slider-divider=""
+          aria-hidden="true"
+          className={divider()}
+          style={{ insetInlineStart: `${percent}%` }}
+        />
+        <SliderPrimitive.SliderThumb
+          data-comparison-slider-thumb=""
+          className={thumb()}
+        >
+          {handle ?? (
+            <svg
+              viewBox="0 0 24 24"
+              className="size-1/2"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m9 7-5 5 5 5" />
+              <path d="m15 7 5 5-5 5" />
+            </svg>
+          )}
+        </SliderPrimitive.SliderThumb>
+      </SliderPrimitive.SliderTrack>
+    </>
+  )
+}
+
+// MARK: Separator
+
+export type { ComparisonSliderProps }
+export { ComparisonSlider }

--- a/www/src/registry/ui/comparison-slider/demos/default.tsx
+++ b/www/src/registry/ui/comparison-slider/demos/default.tsx
@@ -1,0 +1,19 @@
+import { ComparisonSlider } from '@/registry/ui/comparison-slider'
+
+export default function Demo() {
+  return (
+    <ComparisonSlider
+      aria-label="Compare before and after"
+      className="aspect-video max-w-sm"
+      reveal={
+        <div className="grid place-items-center bg-neutral text-fg-muted">
+          Before
+        </div>
+      }
+    >
+      <div className="grid aspect-video place-items-center bg-primary text-fg-on-primary">
+        After
+      </div>
+    </ComparisonSlider>
+  )
+}

--- a/www/src/registry/ui/comparison-slider/examples.tsx
+++ b/www/src/registry/ui/comparison-slider/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function ComparisonSliderExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/comparison-slider/index.tsx
+++ b/www/src/registry/ui/comparison-slider/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/comparison-slider/meta.ts
+++ b/www/src/registry/ui/comparison-slider/meta.ts
@@ -1,0 +1,62 @@
+import type { RegistryItem } from '@/registry/types'
+
+const comparisonSliderMeta = {
+  name: 'comparison-slider',
+  type: 'registry:ui',
+  group: 'sliders',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/comparison-slider/base.tsx',
+      target: 'ui/comparison-slider.tsx',
+    },
+  ],
+  registryDependencies: ['focus-styles'],
+  dependencies: ['react-aria'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--comparison-slider-radius',
+      default: '--radius-lg',
+    },
+    'handle-size': {
+      kind: 'scalar',
+      type: 'spacing',
+      cssVar: '--comparison-slider-handle-size',
+      default: 'calc(var(--spacing) * 8)',
+      minValue: 5,
+      maxValue: 12,
+      step: 0.5,
+    },
+    'handle-color': {
+      kind: 'scalar',
+      type: 'color',
+      cssVar: '--comparison-slider-handle-color',
+      default: '--color-bg',
+    },
+    'divider-width': {
+      kind: 'scalar',
+      type: 'spacing',
+      cssVar: '--comparison-slider-divider-width',
+      default: 'calc(var(--spacing) * 0.5)',
+      minValue: 0.25,
+      maxValue: 2,
+      step: 0.25,
+    },
+    'divider-color': {
+      kind: 'scalar',
+      type: 'color',
+      cssVar: '--comparison-slider-divider-color',
+      default: '--color-bg',
+    },
+    'default-cursor': {
+      kind: 'scalar',
+      type: 'cursor',
+      cssVar: '--comparison-slider-cursor',
+      default: '--cursor-interactive',
+    },
+  },
+} satisfies RegistryItem
+
+export default comparisonSliderMeta

--- a/www/src/registry/ui/comparison-slider/styles.css
+++ b/www/src/registry/ui/comparison-slider/styles.css
@@ -1,0 +1,8 @@
+:root {
+  --comparison-slider-radius: var(--radius-lg);
+  --comparison-slider-handle-size: calc(var(--spacing) * 8);
+  --comparison-slider-handle-color: var(--color-bg);
+  --comparison-slider-divider-width: calc(var(--spacing) * 0.5);
+  --comparison-slider-divider-color: var(--color-bg);
+  --comparison-slider-cursor: var(--cursor-interactive);
+}

--- a/www/src/registry/ui/comparison-slider/styles.ts
+++ b/www/src/registry/ui/comparison-slider/styles.ts
@@ -1,0 +1,23 @@
+import { createStyles } from '@/lib/styles'
+
+import comparisonSliderMeta from './meta'
+
+const { useStyles, styles } = createStyles(comparisonSliderMeta, {
+  base: {
+    slots: {
+      root: 'relative isolate w-full touch-none overflow-hidden rounded-(--comparison-slider-radius) select-none',
+      after: 'block w-full select-none [&>*]:block [&>*]:w-full',
+      before:
+        'pointer-events-none absolute inset-0 overflow-hidden [&>*]:size-full [&>*]:object-cover',
+      control: 'absolute inset-0',
+      divider:
+        'pointer-events-none absolute inset-y-0 z-10 w-(--comparison-slider-divider-width) -translate-x-1/2 bg-(--comparison-slider-divider-color)',
+      thumb:
+        'absolute top-1/2 z-20 grid size-(--comparison-slider-handle-size) -translate-y-1/2 cursor-(--comparison-slider-cursor) place-items-center rounded-full bg-(--comparison-slider-handle-color) text-fg shadow-md outline-hidden focus-visible:focus-ring',
+    },
+  },
+})
+
+export type ComparisonSliderStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/comparison-slider/types.ts
+++ b/www/src/registry/ui/comparison-slider/types.ts
@@ -1,0 +1,18 @@
+import type * as SliderPrimitives from 'react-aria-components/Slider'
+
+/**
+ * A comparison slider reveals one layer over another as the user drags a handle,
+ * commonly used for before/after image comparisons. Built on a React Aria slider,
+ * so it is fully keyboard accessible.
+ */
+export interface ComparisonSliderProps extends Omit<
+  React.ComponentProps<typeof SliderPrimitives.Slider>,
+  'children'
+> {
+  /** Base layer, revealed to the right of the handle (e.g. the "after" image). */
+  children: React.ReactNode
+  /** Overlay layer, clipped to the left of the handle (e.g. the "before" image). */
+  reveal: React.ReactNode
+  /** Content rendered inside the draggable handle. */
+  handle?: React.ReactNode
+}


### PR DESCRIPTION
Adds a `comparison-slider` (before/after) registry component.

**dotUI touch**
- Built on the **React Aria** `Slider` primitive — fully keyboard accessible (arrows/home/end), `aria-valuetext` via the slider, drag + touch handled by RAC.
- The handle is a real `SliderThumb`; the slider value drives both the divider position and the `clip-path` of the revealed ("before") layer via `SliderStateContext`.
- Compound API: `children` = base layer (after), `reveal` = clipped overlay (before), optional `handle`.
- Scalar style params only (radius, handle size/color, divider width/color, cursor) → themable via the builder; no new builder axes invented.

**Checks:** `build:registry` ✅ · `typecheck` ✅ · `oxlint` ✅ (0 errors) · `oxfmt` ✅.

Part of the Tier 1 real-world components set (see [research doc](https://github.com/mehdibha/dotUI/pull/307)). Registry-drift CI may go red until rebased after sibling component PRs merge.

> Note: visual verification (handle positioning / clip alignment) still recommended in a running preview.