### PR TITLE
fix(router): stop scroll reset on initial page load

### DIFF
--- a/www/src/router.tsx
+++ b/www/src/router.tsx
@@ -14,5 +14,18 @@ export function getRouter() {
     defaultErrorComponent: DefaultError,
   })
 
+  // Don't reset scroll on the initial client render. With `scrollRestoration`,
+  // the router fires a post-hydration `onRendered` that — finding no cached
+  // position for a fresh visit — calls `window.scrollTo(0, 0)`. On a heavy page
+  // (the landing showcase hydrates ~1k nodes) the user can scroll during the
+  // hydration gap, and that late reset then snaps them back to the top. The SSR
+  // inline script already restored the correct position before paint, so this
+  // first reset is redundant. `resetNextScroll` flips back to `true` after that
+  // one render, so link navigations (scroll to top) and back/forward (restore
+  // cached position) are unaffected.
+  if (typeof window !== 'undefined') {
+    router.resetNextScroll = false
+  }
+
   return router
 }


### PR DESCRIPTION
## Summary

- Loading the home page and scrolling quickly snapped the scroll back to `0`. Root cause is TanStack Router's scroll restoration, not a layout shift: with `scrollRestoration: true`, the router runs an `onRendered` handler **after hydration** that — finding no cached position for a fresh visit — calls `window.scrollTo(0, 0)` (`scroll-restoration.js:167`). On a light page this is invisible (you're already at the top when it fires). The landing page is heavy (the showcase hydrates ~1k nodes), so hydration and thus the reset land **late**; a scroll done during that gap gets wiped.
- The reset isn't skipped because `resetNextScroll` starts `true` on a fresh load — it's only set `false` by the navigation path, which never runs during initial hydration.
- **Fix:** clear `router.resetNextScroll` for the initial client render in `getRouter()`. The first `onRendered` then early-returns (`scroll-restoration.js:119`) instead of resetting. The SSR inline script already positioned scroll before paint, so that post-hydration reset was pure redundancy.

## Why it's safe

`resetNextScroll` is a documented field on the router type. It flips back to `true` immediately after the first render, so **only the initial render is affected** — link navigation (scroll to top) and back/forward (restore cached position) run identical, unchanged code from the second render on.

## Verification

Deterministic before/after with CPU-throttled Puppeteer, capturing the stack of every `scrollTo`:

| | post-hydration `onRendered` | result |
|---|---|---|
| before | hits `scroll-restoration.js:167` → `scrollTo(0)` | scroll **reset to 0** |
| after | early-returns at `scroll-restoration.js:119` | scroll **preserved** |

At realistic CPU speed (no throttle): scrolling the home page to 1400px ends at `0` before the fix, `1400` after. Link-nav still scrolls to top (verified `/charts` → 0). `pnpm typecheck`, `pnpm check` (lint + format) all green.