### PR TITLE
feat(rating): add rating component

### DIFF
--- a/www/content/docs/components/rating.mdx
+++ b/www/content/docs/components/rating.mdx
@@ -1,0 +1,36 @@
+---
+title: Rating
+description: Lets the user select a score, such as a number of stars, within a range.
+links:
+  - label: Docs
+    href: https://react-spectrum.adobe.com/react-aria/RadioGroup.html
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/rating
+```
+
+## Usage
+
+```tsx
+import { Rating } from '@/components/ui/rating'
+```
+
+```tsx
+<Rating aria-label="Rating" defaultValue={3} />
+```
+
+## Examples
+
+<Examples>
+  <Example name="rating/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### Rating
+
+<Reference name="rating" />

--- a/www/content/docs/components/rating.mdx
+++ b/www/content/docs/components/rating.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="rating/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -53,6 +53,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	popover: () => import("@/registry/ui/popover/examples"),
 	"progress-bar": () => import("@/registry/ui/progress-bar/examples"),
 	"radio-group": () => import("@/registry/ui/radio-group/examples"),
+	rating: () => import("@/registry/ui/rating/examples"),
 	"react-hook-form": () => import("@/registry/ui/react-hook-form/examples"),
 	"search-field": () => import("@/registry/ui/search-field/examples"),
 	select: () => import("@/registry/ui/select/examples"),

--- a/www/src/modules/docs/references/generated/rating.json
+++ b/www/src/modules/docs/references/generated/rating.json
@@ -1,0 +1,573 @@
+{
+  "name": "RatingProps",
+  "description": "A rating lets the user select a score, such as a number of stars, within a\nrange. Built on a React Aria radio group, so it is fully keyboard accessible.",
+  "props": {
+    "max": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "The number of items to display.",
+      "default": "5"
+    },
+    "value": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "The selected rating (controlled)."
+    },
+    "defaultValue": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "The default rating (uncontrolled)."
+    },
+    "onChange": {
+      "type": "((value: number) => void)",
+      "detailedType": "((value: number) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "value",
+            "value": {
+              "type": "link",
+              "id": "number",
+              "name": "number"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler called when the selected rating changes."
+    },
+    "onFocus": {
+      "type": "((e: FocusEvent<Element, Element>) => void)",
+      "detailedType": "| ((e: FocusEvent<Element, Element>) => void)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "e",
+                "value": {
+                  "type": "identifier",
+                  "name": "FocusEvent"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Handler that is called when the element receives focus."
+    },
+    "onBlur": {
+      "type": "((e: FocusEvent<Element, Element>) => void)",
+      "detailedType": "| ((e: FocusEvent<Element, Element>) => void)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "e",
+                "value": {
+                  "type": "identifier",
+                  "name": "FocusEvent"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Handler that is called when the element loses focus."
+    },
+    "onFocusChange": {
+      "type": "((isFocused: boolean) => void)",
+      "detailedType": "((isFocused: boolean) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "isFocused",
+            "value": {
+              "type": "link",
+              "id": "boolean",
+              "name": "boolean"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when the element's focus status changes."
+    },
+    "aria-describedby": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that describes the object."
+    },
+    "aria-details": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that provide a detailed, extended description for the\nobject."
+    },
+    "aria-errormessage": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element that provides an error message for the object."
+    },
+    "aria-label": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Defines a string value that labels the current element."
+    },
+    "aria-labelledby": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that labels the current element."
+    },
+    "className": {
+      "type": "string | (values: RadioGroupRenderProps) => string",
+      "detailedType": "string | (values: RadioGroupRenderProps) => string | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "RadioGroupRenderProps",
+                  "name": "RadioGroupRenderProps"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "string"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the\nelement. A function may be provided to compute the class based on component state."
+    },
+    "form": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The `<form>` element to associate the input with.\nThe value of this attribute must be the id of a `<form>` in the same document.\nSee [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#form)."
+    },
+    "id": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The element's unique identifier. See\n[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)."
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the input is disabled."
+    },
+    "isInvalid": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the input value is invalid."
+    },
+    "isReadOnly": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the input can be selected but not changed by the user."
+    },
+    "isRequired": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether user input is required on the input before form submission."
+    },
+    "name": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The name of the input element, used when submitting an HTML form. See\n[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname)."
+    },
+    "render": {
+      "type": "DOMRenderFunction<\"div\", RadioGroupRenderProps>",
+      "detailedType": "| DOMRenderFunction<'div', RadioGroupRenderProps>\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "application",
+            "base": {
+              "type": "identifier",
+              "name": "DOMRenderFunction"
+            },
+            "typeParameters": [
+              {
+                "type": "stringLiteral",
+                "value": "div"
+              },
+              {
+                "type": "link",
+                "id": "react-aria-components/dist/types/src/RadioGroup.d.ts:RadioGroupRenderProps",
+                "name": "RadioGroupRenderProps"
+              }
+            ]
+          }
+        ]
+      },
+      "description": "Overrides the default DOM element with a custom render function.\nThis allows rendering existing components with built-in styles and behaviors\nsuch as router links, animation libraries, and pre-styled components.\n\nRequirements:\n\n- You must render the expected element type (e.g. if `<button>` is expected, you cannot render an\n  `<a>`).\n- Only a single root DOM element can be rendered (no fragments).\n- You must pass through props and ref to the underlying DOM element, merging with your own prop\n  as appropriate."
+    },
+    "slot": {
+      "type": "null | string",
+      "detailedType": "null | string | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "description": "A slot name for the component. Slots allow the component to receive props from a parent\ncomponent. An explicit `null` value indicates that the local props completely override all\nprops received from a parent."
+    },
+    "style": {
+      "type": "CSSProperties | (values: RadioGroupRenderProps) => CSSProperties",
+      "detailedType": "CSSProperties | (values: RadioGroupRenderProps) => CSSProperties | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "identifier",
+            "name": "CSSProperties"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "RadioGroupRenderProps",
+                  "name": "RadioGroupRenderProps"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "identifier",
+              "name": "CSSProperties"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
+    },
+    "validate": {
+      "type": "((value: string) => true | ValidationError | null | undefined)",
+      "detailedType": "| ((\n    value: string,\n  ) => true | ValidationError | null | undefined)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "value",
+                "value": {
+                  "type": "string"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "union",
+              "elements": [
+                {
+                  "type": "booleanLiteral",
+                  "value": true
+                },
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "undefined"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "elementType": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "A function that returns an error message if a given value is invalid.\nValidation errors are displayed to the user when the form is submitted\nif `validationBehavior=\"native\"`. For realtime validation, use the `isInvalid`\nprop instead."
+    },
+    "validationBehavior": {
+      "type": "\"aria\" | \"native\"",
+      "detailedType": "'aria' | 'native' | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "aria"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "native"
+          }
+        ]
+      },
+      "description": "Whether to use native HTML form validation to prevent form submission\nwhen the value is missing or invalid, or mark the field as required\nor invalid via ARIA.",
+      "default": "'native'"
+    }
+  },
+  "typeLinks": {
+    "RadioGroupRenderProps": {
+      "type": "interface",
+      "name": "RadioGroupRenderProps",
+      "properties": {
+        "isDisabled": {
+          "type": "property",
+          "name": "isDisabled",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the radio group is disabled."
+        },
+        "isInvalid": {
+          "type": "property",
+          "name": "isInvalid",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the radio group is invalid."
+        },
+        "isReadOnly": {
+          "type": "property",
+          "name": "isReadOnly",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the radio group is read only."
+        },
+        "isRequired": {
+          "type": "property",
+          "name": "isRequired",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the radio group is required."
+        },
+        "orientation": {
+          "type": "property",
+          "name": "orientation",
+          "value": {
+            "type": "identifier",
+            "name": "Orientation"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The orientation of the radio group."
+        },
+        "state": {
+          "type": "property",
+          "name": "state",
+          "value": {
+            "type": "identifier",
+            "name": "RadioGroupState"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "State of the radio group."
+        }
+      }
+    },
+    "react-aria-components/dist/types/src/RadioGroup.d.ts:RadioGroupRenderProps": {
+      "type": "interface",
+      "id": "react-aria-components/dist/types/src/RadioGroup.d.ts:RadioGroupRenderProps",
+      "name": "RadioGroupRenderProps",
+      "extends": [],
+      "properties": {
+        "isDisabled": {
+          "type": "property",
+          "name": "isDisabled",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the radio group is disabled."
+        },
+        "isInvalid": {
+          "type": "property",
+          "name": "isInvalid",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the radio group is invalid."
+        },
+        "isReadOnly": {
+          "type": "property",
+          "name": "isReadOnly",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the radio group is read only."
+        },
+        "isRequired": {
+          "type": "property",
+          "name": "isRequired",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the radio group is required."
+        },
+        "orientation": {
+          "type": "property",
+          "name": "orientation",
+          "value": {
+            "type": "identifier",
+            "name": "Orientation"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The orientation of the radio group."
+        },
+        "state": {
+          "type": "property",
+          "name": "state",
+          "value": {
+            "type": "link",
+            "id": "react-stately/dist/types/src/radio/useRadioGroupState.d.ts:RadioGroupState",
+            "name": "RadioGroupState"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "State of the radio group."
+        }
+      },
+      "typeParameters": [],
+      "description": ""
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -2057,6 +2057,10 @@ export const DemosIndex: Record<
 		files: ["ui/radio-group/demos/uncontrolled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/radio-group/demos/uncontrolled")),
 	},
+	"rating/demos/default": {
+		files: ["ui/rating/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/rating/demos/default")),
+	},
 	"react-hook-form/demos/register": {
 		files: ["ui/react-hook-form/demos/register.tsx"],
 		component: React.lazy(() => import("@/registry/ui/react-hook-form/demos/register")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -57,6 +57,7 @@ import UiPagination from "@/registry/ui/pagination/meta";
 import UiPopover from "@/registry/ui/popover/meta";
 import UiProgressBar from "@/registry/ui/progress-bar/meta";
 import UiRadioGroup from "@/registry/ui/radio-group/meta";
+import UiRating from "@/registry/ui/rating/meta";
 import UiSearchField from "@/registry/ui/search-field/meta";
 import UiSelect from "@/registry/ui/select/meta";
 import UiSeparator from "@/registry/ui/separator/meta";
@@ -131,6 +132,7 @@ export const registryUi: RegistryItem[] = [
 	UiPopover,
 	UiProgressBar,
 	UiRadioGroup,
+	UiRating,
 	UiSearchField,
 	UiSelect,
 	UiSeparator,

--- a/www/src/registry/ui/rating/base.tsx
+++ b/www/src/registry/ui/rating/base.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState } from 'react'
+import { composeRenderProps } from 'react-aria-components/composeRenderProps'
+import * as RadioGroupPrimitive from 'react-aria-components/RadioGroup'
+
+import { useStyles } from './styles'
+
+// MARK: Rating
+
+interface RatingProps extends Omit<
+  RadioGroupPrimitive.RadioGroupProps,
+  'value' | 'defaultValue' | 'onChange' | 'children' | 'orientation'
+> {
+  max?: number
+  value?: number
+  defaultValue?: number
+  onChange?: (value: number) => void
+}
+
+const Rating = ({
+  className,
+  max = 5,
+  value,
+  defaultValue,
+  onChange,
+  ...props
+}: RatingProps) => {
+  const { root, item } = useStyles()()
+  const [hovered, setHovered] = useState<number | null>(null)
+  const interactive = !props.isReadOnly && !props.isDisabled
+  return (
+    <RadioGroupPrimitive.RadioGroup
+      data-rating=""
+      orientation="horizontal"
+      value={value != null ? String(value) : undefined}
+      defaultValue={defaultValue != null ? String(defaultValue) : undefined}
+      onChange={onChange ? (next) => onChange(Number(next)) : undefined}
+      className={composeRenderProps(className, (cn) => root({ className: cn }))}
+      {...props}
+    >
+      {({ state }) => {
+        const selected = state.selectedValue ? Number(state.selectedValue) : 0
+        const active = hovered ?? selected
+        return Array.from({ length: max }, (_, i) => {
+          const ratingValue = i + 1
+          return (
+            <RadioGroupPrimitive.Radio
+              key={ratingValue}
+              value={String(ratingValue)}
+              aria-label={`${ratingValue} ${ratingValue === 1 ? 'star' : 'stars'}`}
+              data-active={ratingValue <= active || undefined}
+              className={item()}
+              onHoverStart={
+                interactive ? () => setHovered(ratingValue) : undefined
+              }
+              onHoverEnd={interactive ? () => setHovered(null) : undefined}
+            >
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 2.5l2.92 5.92 6.54.95-4.73 4.61 1.12 6.51L12 17.93l-5.85 3.07 1.12-6.51L2.54 9.87l6.54-.95L12 2.5z" />
+              </svg>
+            </RadioGroupPrimitive.Radio>
+          )
+        })
+      }}
+    </RadioGroupPrimitive.RadioGroup>
+  )
+}
+
+// MARK: Separator
+
+export type { RatingProps }
+export { Rating }

--- a/www/src/registry/ui/rating/demos/default.tsx
+++ b/www/src/registry/ui/rating/demos/default.tsx
@@ -1,0 +1,5 @@
+import { Rating } from '@/registry/ui/rating'
+
+export default function Demo() {
+  return <Rating aria-label="Rating" defaultValue={3} />
+}

--- a/www/src/registry/ui/rating/examples.tsx
+++ b/www/src/registry/ui/rating/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function RatingExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/rating/index.tsx
+++ b/www/src/registry/ui/rating/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/rating/meta.ts
+++ b/www/src/registry/ui/rating/meta.ts
@@ -1,0 +1,41 @@
+import type { RegistryItem } from '@/registry/types'
+
+const ratingMeta = {
+  name: 'rating',
+  type: 'registry:ui',
+  group: 'selection-controls',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/rating/base.tsx',
+      target: 'ui/rating.tsx',
+    },
+  ],
+  registryDependencies: ['focus-styles'],
+  dependencies: ['react-aria'],
+  params: {
+    color: {
+      kind: 'scalar',
+      type: 'color',
+      cssVar: '--rating-color',
+      default: '--color-primary',
+    },
+    size: {
+      kind: 'scalar',
+      type: 'spacing',
+      cssVar: '--rating-size',
+      default: 'calc(var(--spacing) * 5)',
+      minValue: 3,
+      maxValue: 8,
+      step: 0.25,
+    },
+    'default-cursor': {
+      kind: 'scalar',
+      type: 'cursor',
+      cssVar: '--rating-cursor',
+      default: '--cursor-interactive',
+    },
+  },
+} satisfies RegistryItem
+
+export default ratingMeta

--- a/www/src/registry/ui/rating/styles.css
+++ b/www/src/registry/ui/rating/styles.css
@@ -1,0 +1,5 @@
+:root {
+  --rating-color: var(--color-primary);
+  --rating-size: calc(var(--spacing) * 5);
+  --rating-cursor: var(--cursor-interactive);
+}

--- a/www/src/registry/ui/rating/styles.ts
+++ b/www/src/registry/ui/rating/styles.ts
@@ -1,0 +1,16 @@
+import { createStyles } from '@/lib/styles'
+
+import ratingMeta from './meta'
+
+const { useStyles, styles } = createStyles(ratingMeta, {
+  base: {
+    slots: {
+      root: 'group/rating inline-flex items-center gap-0.5',
+      item: 'cursor-(--rating-cursor) rounded-sm text-fg-muted outline-hidden transition-colors focus-visible:focus-ring disabled:cursor-disabled disabled:text-fg-disabled data-[active]:text-(--rating-color) [&>svg]:size-(--rating-size)',
+    },
+  },
+})
+
+export type RatingStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/rating/types.ts
+++ b/www/src/registry/ui/rating/types.ts
@@ -1,0 +1,19 @@
+import type * as RadioGroupPrimitives from 'react-aria-components/RadioGroup'
+
+/**
+ * A rating lets the user select a score, such as a number of stars, within a
+ * range. Built on a React Aria radio group, so it is fully keyboard accessible.
+ */
+export interface RatingProps extends Omit<
+  RadioGroupPrimitives.RadioGroupProps,
+  'value' | 'defaultValue' | 'onChange' | 'children' | 'orientation'
+> {
+  /** The number of items to display. @default 5 */
+  max?: number
+  /** The selected rating (controlled). */
+  value?: number
+  /** The default rating (uncontrolled). */
+  defaultValue?: number
+  /** Handler called when the selected rating changes. */
+  onChange?: (value: number) => void
+}


### PR DESCRIPTION
## Summary

Adds a **Rating** component to the registry — a star rating built on the React Aria `RadioGroup`/`Radio` primitives, so it's keyboard accessible (arrow keys move/select) and screen-reader friendly out of the box. Part of the real-world-component-blocks batch (Tier 1).

- `Rating` renders `max` stars as radio options; hover preview + selected fill via `data-active`.
- Fully themeable axes (scalar params): `--rating-color`, `--rating-size`, `--rating-cursor`.
- Group: `selection-controls`. Depends on `focus-styles` + `react-aria`.

## Files

- `www/src/registry/ui/rating/*` — base/styles/meta/types/index/examples/demo.
- `www/content/docs/components/rating.mdx` — docs page.
- Regenerated registry bundles + API reference (`rating.json`).

## Notes

- Built from scratch (no engine), matching the research doc's Tier 1 plan.
- Visual verification in the live preview is still recommended before merge.