### PR TITLE
feat(code-block): add code-block component

### DIFF
--- a/www/content/docs/components/code-block.mdx
+++ b/www/content/docs/components/code-block.mdx
@@ -1,0 +1,38 @@
+---
+title: Code Block
+description: A syntax-highlighted code snippet with a filename header and copy button.
+links:
+  - label: Shiki
+    href: https://shiki.style
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/code-block
+```
+
+## Usage
+
+Pass the snippet as `code` and the language as `lang`. Highlighting is done with [Shiki](https://shiki.style) using dual light/dark themes.
+
+```tsx
+import { CodeBlock } from '@/components/ui/code-block'
+```
+
+```tsx
+<CodeBlock title="app.tsx" lang="tsx" code={`export const answer = 42`} />
+```
+
+## Examples
+
+<Examples>
+  <Example name="code-block/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### CodeBlock
+
+<Reference name="code-block" />

--- a/www/content/docs/components/code-block.mdx
+++ b/www/content/docs/components/code-block.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="code-block/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -18,6 +18,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"chart-radial": () => import("@/registry/ui/chart-radial/examples"),
 	checkbox: () => import("@/registry/ui/checkbox/examples"),
 	"checkbox-group": () => import("@/registry/ui/checkbox-group/examples"),
+	"code-block": () => import("@/registry/ui/code-block/examples"),
 	"color-area": () => import("@/registry/ui/color-area/examples"),
 	"color-editor": () => import("@/registry/ui/color-editor/examples"),
 	"color-field": () => import("@/registry/ui/color-field/examples"),

--- a/www/src/modules/docs/references/generated/code-block.json
+++ b/www/src/modules/docs/references/generated/code-block.json
@@ -1,0 +1,47 @@
+{
+  "name": "CodeBlockProps",
+  "description": "A code block highlights a snippet with Shiki using dual light/dark themes,\nwith an optional filename header and a copy-to-clipboard button.",
+  "extendsElement": "figure",
+  "props": {
+    "code": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The source code to display.",
+      "required": true
+    },
+    "lang": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The language to highlight.",
+      "default": "'tsx'"
+    },
+    "title": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Optional filename shown in the header."
+    },
+    "showLineNumbers": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Show a line-number gutter."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -649,6 +649,10 @@ export const DemosIndex: Record<
 		files: ["ui/checkbox-group/demos/uncontrolled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/checkbox-group/demos/uncontrolled")),
 	},
+	"code-block/demos/default": {
+		files: ["ui/code-block/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/code-block/demos/default")),
+	},
 	"color-area/demos/brand-color": {
 		files: ["ui/color-area/demos/brand-color.tsx"],
 		component: React.lazy(() => import("@/registry/ui/color-area/demos/brand-color")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -22,6 +22,7 @@ import UiChartRadial from "@/registry/ui/chart-radial/meta";
 import UiChart from "@/registry/ui/chart/meta";
 import UiCheckboxGroup from "@/registry/ui/checkbox-group/meta";
 import UiCheckbox from "@/registry/ui/checkbox/meta";
+import UiCodeBlock from "@/registry/ui/code-block/meta";
 import UiColorArea from "@/registry/ui/color-area/meta";
 import UiColorEditor from "@/registry/ui/color-editor/meta";
 import UiColorField from "@/registry/ui/color-field/meta";
@@ -96,6 +97,7 @@ export const registryUi: RegistryItem[] = [
 	UiChartRadial,
 	UiCheckbox,
 	UiCheckboxGroup,
+	UiCodeBlock,
 	UiColorArea,
 	UiColorEditor,
 	UiColorField,

--- a/www/src/registry/ui/code-block/base.tsx
+++ b/www/src/registry/ui/code-block/base.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { ComponentProps } from 'react'
+import { CheckIcon, CopyIcon } from 'lucide-react'
+import { codeToHtml } from 'shiki'
+
+import { Button } from '@/registry/ui/button'
+
+import { useStyles } from './styles'
+
+// MARK: CodeBlock
+
+interface CodeBlockProps extends Omit<ComponentProps<'figure'>, 'children'> {
+  code: string
+  lang?: string
+  title?: string
+  showLineNumbers?: boolean
+}
+
+const CodeBlock = ({
+  code,
+  lang = 'tsx',
+  title,
+  showLineNumbers,
+  className,
+  ...props
+}: CodeBlockProps) => {
+  const { root, header, title: titleStyle, body, content } = useStyles()()
+  const html = useHighlightedCode(code, lang)
+  return (
+    <figure data-code-block="" className={root({ className })} {...props}>
+      {title ? (
+        <div data-code-block-header="" className={header()}>
+          <figcaption className={titleStyle()}>{title}</figcaption>
+          <CopyButton code={code} />
+        </div>
+      ) : null}
+      <div data-code-block-body="" className={body()}>
+        {html ? (
+          <div
+            data-line-numbers={showLineNumbers || undefined}
+            className={content()}
+            // oxlint-disable-next-line no-danger -- Shiki-generated markup; code content is escaped by the highlighter
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        ) : (
+          <div
+            data-line-numbers={showLineNumbers || undefined}
+            className={content()}
+          >
+            <pre>
+              <code>{code}</code>
+            </pre>
+          </div>
+        )}
+        {title ? null : (
+          <div className="absolute top-2 right-2">
+            <CopyButton code={code} />
+          </div>
+        )}
+      </div>
+    </figure>
+  )
+}
+
+// MARK: CopyButton
+
+const CopyButton = ({ code }: { code: string }) => {
+  const [copied, setCopied] = useState(false)
+  const copy = () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return
+    void navigator.clipboard.writeText(code).then(() => {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    })
+  }
+  return (
+    <Button
+      variant="quiet"
+      size="xs"
+      isIconOnly
+      onPress={copy}
+      aria-label={copied ? 'Copied' : 'Copy code'}
+    >
+      {copied ? <CheckIcon /> : <CopyIcon />}
+    </Button>
+  )
+}
+
+// MARK: useHighlightedCode
+
+const useHighlightedCode = (code: string, lang: string) => {
+  const [html, setHtml] = useState<string | null>(null)
+  useEffect(() => {
+    let active = true
+    codeToHtml(code, {
+      lang,
+      themes: { light: 'github-light', dark: 'github-dark' },
+      defaultColor: false,
+    })
+      .then((result) => {
+        if (active) setHtml(result)
+      })
+      .catch(() => {
+        if (active) setHtml(null)
+      })
+    return () => {
+      active = false
+    }
+  }, [code, lang])
+  return html
+}
+
+// MARK: Separator
+
+export type { CodeBlockProps }
+export { CodeBlock }

--- a/www/src/registry/ui/code-block/demos/default.tsx
+++ b/www/src/registry/ui/code-block/demos/default.tsx
@@ -1,0 +1,19 @@
+import { CodeBlock } from '@/registry/ui/code-block'
+
+const code = `import { Button } from '@/components/ui/button'
+
+export function App() {
+  return <Button>Click me</Button>
+}`
+
+export default function Demo() {
+  return (
+    <CodeBlock
+      title="app.tsx"
+      lang="tsx"
+      code={code}
+      showLineNumbers
+      className="w-full max-w-lg"
+    />
+  )
+}

--- a/www/src/registry/ui/code-block/examples.tsx
+++ b/www/src/registry/ui/code-block/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function CodeBlockExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/code-block/index.tsx
+++ b/www/src/registry/ui/code-block/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/code-block/meta.ts
+++ b/www/src/registry/ui/code-block/meta.ts
@@ -1,0 +1,26 @@
+import type { RegistryItem } from '@/registry/types'
+
+const codeBlockMeta = {
+  name: 'code-block',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/code-block/base.tsx',
+      target: 'ui/code-block.tsx',
+    },
+  ],
+  registryDependencies: ['button'],
+  dependencies: ['shiki'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--code-block-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default codeBlockMeta

--- a/www/src/registry/ui/code-block/styles.css
+++ b/www/src/registry/ui/code-block/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --code-block-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/code-block/styles.ts
+++ b/www/src/registry/ui/code-block/styles.ts
@@ -1,0 +1,29 @@
+import { createStyles } from '@/lib/styles'
+
+import codeBlockMeta from './meta'
+
+const { useStyles, styles } = createStyles(codeBlockMeta, {
+  base: {
+    slots: {
+      root: 'overflow-hidden rounded-(--code-block-radius) border bg-card text-fg',
+      header:
+        'flex items-center justify-between gap-2 border-b py-1.5 pr-1.5 pl-3 [&_[data-button]]:text-fg-muted',
+      title: 'truncate font-mono text-[0.8125rem] text-fg-muted',
+      body: 'relative [&_[data-button]]:text-fg-muted',
+      content: [
+        'overflow-x-auto py-3 font-mono text-[0.8125rem] leading-relaxed',
+        '[&_pre]:bg-transparent! [&_pre]:[tab-size:2] [&_pre]:outline-hidden',
+        '[&_code]:grid [&_code]:min-w-full',
+        '[&_.line]:px-4',
+        '[&_code_span]:text-(--shiki-light) dark:[&_code_span]:text-(--shiki-dark)',
+        '[&[data-line-numbers]_code]:[counter-reset:line]',
+        '[&[data-line-numbers]_.line]:before:mr-4 [&[data-line-numbers]_.line]:before:inline-block [&[data-line-numbers]_.line]:before:w-[1ch] [&[data-line-numbers]_.line]:before:text-right [&[data-line-numbers]_.line]:before:text-fg-muted [&[data-line-numbers]_.line]:before:content-[counter(line)] [&[data-line-numbers]_.line]:before:[counter-increment:line]',
+        '[&_.highlighted]:bg-selected/60',
+      ],
+    },
+  },
+})
+
+export type CodeBlockStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/code-block/types.ts
+++ b/www/src/registry/ui/code-block/types.ts
@@ -1,0 +1,19 @@
+import type { ComponentProps } from 'react'
+
+/**
+ * A code block highlights a snippet with Shiki using dual light/dark themes,
+ * with an optional filename header and a copy-to-clipboard button.
+ */
+export interface CodeBlockProps extends Omit<
+  ComponentProps<'figure'>,
+  'children'
+> {
+  /** The source code to display. */
+  code: string
+  /** The language to highlight. @default 'tsx' */
+  lang?: string
+  /** Optional filename shown in the header. */
+  title?: string
+  /** Show a line-number gutter. */
+  showLineNumbers?: boolean
+}


### PR DESCRIPTION
## Summary

Adds a **Code Block** to the registry — a syntax-highlighted snippet with an optional filename header and a copy-to-clipboard button. Part of the real-world-component-blocks batch (Tier 1).

- Highlights with **Shiki** (already a dotUI dep) using dual `github-light`/`github-dark` themes via `--shiki-light`/`--shiki-dark` CSS vars, so it follows light/dark automatically.
- Copy button reuses the registry `Button` (RAC).
- Optional `showLineNumbers` gutter; `title` renders a filename header.
- Themeable axis: `--code-block-radius` (scalar `radius` param). Syntax colors stay engine plumbing (not tokenized), per the research doc.
- Group: `containers`. `registryDependencies: ['button']`, `dependencies: ['shiki']`.

## API

`code` (required), `lang` (default `tsx`), `title?`, `showLineNumbers?`.

## Notes

- `dangerouslySetInnerHTML` is used for Shiki's markup (escaped by the highlighter) — mirrors the existing `chart` component's pattern with the same `no-danger` suppression.
- Visual verification in the live preview is still recommended before merge.