### PR TITLE
feat(audio-player): add audio-player component

### DIFF
--- a/www/content/docs/components/audio-player.mdx
+++ b/www/content/docs/components/audio-player.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="audio-player/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/audio-player.mdx
+++ b/www/content/docs/components/audio-player.mdx
@@ -1,0 +1,38 @@
+---
+title: Audio Player
+description: A themeable control bar over a native audio element — play, seek, and volume.
+links:
+  - label: Docs
+    href: https://react-spectrum.adobe.com/react-aria/Slider.html
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/audio-player
+```
+
+## Usage
+
+Pass the audio `src`. The control bar (play/pause, seek, volume) is built on the React Aria `Button` and `Slider`, over a native `<audio>` element — no media library required.
+
+```tsx
+import { AudioPlayer } from '@/components/ui/audio-player'
+```
+
+```tsx
+<AudioPlayer src="/track.mp3" title="Midnight City" artist="M83" />
+```
+
+## Examples
+
+<Examples>
+  <Example name="audio-player/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### AudioPlayer
+
+<Reference name="audio-player" />

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -4,6 +4,7 @@
 export const ExamplesIndex: Record<string, () => Promise<{ default: React.ComponentType }>> = {
 	accordion: () => import("@/registry/ui/accordion/examples"),
 	alert: () => import("@/registry/ui/alert/examples"),
+	"audio-player": () => import("@/registry/ui/audio-player/examples"),
 	avatar: () => import("@/registry/ui/avatar/examples"),
 	badge: () => import("@/registry/ui/badge/examples"),
 	breadcrumbs: () => import("@/registry/ui/breadcrumbs/examples"),

--- a/www/src/modules/docs/references/generated/audio-player.json
+++ b/www/src/modules/docs/references/generated/audio-player.json
@@ -1,0 +1,38 @@
+{
+  "name": "AudioPlayerProps",
+  "description": "An audio player renders a themeable control bar over a native `<audio>`\nelement: play/pause, a seek slider with elapsed/total time, and volume.\nThe transport controls are built on React Aria `Button` and `Slider`.",
+  "extendsElement": "div",
+  "props": {
+    "src": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The audio source URL.",
+      "required": true
+    },
+    "title": {
+      "type": "ReactNode",
+      "typeAst": {
+        "type": "identifier",
+        "name": "ReactNode"
+      },
+      "description": "Track title shown in the now-playing area."
+    },
+    "artist": {
+      "type": "ReactNode",
+      "typeAst": {
+        "type": "identifier",
+        "name": "ReactNode"
+      },
+      "description": "Artist / subtitle shown next to the title."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -73,6 +73,10 @@ export const DemosIndex: Record<
 		files: ["ui/alert/demos/warning.tsx"],
 		component: React.lazy(() => import("@/registry/ui/alert/demos/warning")),
 	},
+	"audio-player/demos/default": {
+		files: ["ui/audio-player/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/audio-player/demos/default")),
+	},
 	"avatar/demos/avatar-group-count": {
 		files: ["ui/avatar/demos/avatar-group-count.tsx"],
 		component: React.lazy(() => import("@/registry/ui/avatar/demos/avatar-group-count")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -7,6 +7,7 @@ import LibTextareaCaret from "@/registry/lib/textarea-caret/meta";
 import LibUtils from "@/registry/lib/utils/meta";
 import UiAccordion from "@/registry/ui/accordion/meta";
 import UiAlert from "@/registry/ui/alert/meta";
+import UiAudioPlayer from "@/registry/ui/audio-player/meta";
 import UiAvatar from "@/registry/ui/avatar/meta";
 import UiBadge from "@/registry/ui/badge/meta";
 import UiBreadcrumbs from "@/registry/ui/breadcrumbs/meta";
@@ -81,6 +82,7 @@ import type { RegistryItem } from "@/registry/types";
 export const registryUi: RegistryItem[] = [
 	UiAccordion,
 	UiAlert,
+	UiAudioPlayer,
 	UiAvatar,
 	UiBadge,
 	UiBreadcrumbs,

--- a/www/src/registry/ui/audio-player/base.tsx
+++ b/www/src/registry/ui/audio-player/base.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
+import { PauseIcon, PlayIcon, Volume2Icon, VolumeXIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { Slider, SliderControl } from '@/registry/ui/slider'
+
+import { useStyles } from './styles'
+
+// MARK: AudioPlayer
+
+interface AudioPlayerProps extends Omit<ComponentProps<'div'>, 'title'> {
+  src: string
+  title?: ReactNode
+  artist?: ReactNode
+}
+
+const AudioPlayer = ({
+  src,
+  title,
+  artist,
+  className,
+  ...props
+}: AudioPlayerProps) => {
+  const {
+    root,
+    info,
+    title: titleStyle,
+    artist: artistStyle,
+    seek,
+    time,
+    volume,
+  } = useStyles()()
+  const audioRef = useRef<HTMLAudioElement>(null)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [volumeLevel, setVolumeLevel] = useState(1)
+  const [isMuted, setIsMuted] = useState(false)
+
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+    const onTime = () => setCurrentTime(audio.currentTime)
+    const onMeta = () => setDuration(audio.duration)
+    const onPlay = () => setIsPlaying(true)
+    const onPause = () => setIsPlaying(false)
+    const onEnded = () => setIsPlaying(false)
+    const onVolume = () => {
+      setVolumeLevel(audio.volume)
+      setIsMuted(audio.muted)
+    }
+    audio.addEventListener('timeupdate', onTime)
+    audio.addEventListener('loadedmetadata', onMeta)
+    audio.addEventListener('durationchange', onMeta)
+    audio.addEventListener('play', onPlay)
+    audio.addEventListener('pause', onPause)
+    audio.addEventListener('ended', onEnded)
+    audio.addEventListener('volumechange', onVolume)
+    return () => {
+      audio.removeEventListener('timeupdate', onTime)
+      audio.removeEventListener('loadedmetadata', onMeta)
+      audio.removeEventListener('durationchange', onMeta)
+      audio.removeEventListener('play', onPlay)
+      audio.removeEventListener('pause', onPause)
+      audio.removeEventListener('ended', onEnded)
+      audio.removeEventListener('volumechange', onVolume)
+    }
+  }, [])
+
+  const togglePlay = () => {
+    const audio = audioRef.current
+    if (!audio) return
+    if (audio.paused) void audio.play()
+    else audio.pause()
+  }
+
+  const handleSeek = (value: number | number[]) => {
+    const audio = audioRef.current
+    if (!audio) return
+    const next = Array.isArray(value) ? (value[0] ?? 0) : value
+    audio.currentTime = next
+    setCurrentTime(next)
+  }
+
+  const handleVolume = (value: number | number[]) => {
+    const audio = audioRef.current
+    if (!audio) return
+    const next = Array.isArray(value) ? (value[0] ?? 0) : value
+    audio.volume = next
+    audio.muted = next === 0
+  }
+
+  const toggleMute = () => {
+    const audio = audioRef.current
+    if (!audio) return
+    audio.muted = !audio.muted
+  }
+
+  const showVolumeOff = isMuted || volumeLevel === 0
+
+  return (
+    <div data-audio-player="" className={root({ className })} {...props}>
+      <audio ref={audioRef} src={src} preload="metadata" />
+      <Button
+        variant="default"
+        size="sm"
+        isIconOnly
+        onPress={togglePlay}
+        aria-label={isPlaying ? 'Pause' : 'Play'}
+      >
+        {isPlaying ? <PauseIcon /> : <PlayIcon />}
+      </Button>
+      <div className={info()}>
+        {(title || artist) && (
+          <div className="flex items-baseline gap-1.5 truncate">
+            {title && <span className={titleStyle()}>{title}</span>}
+            {artist && <span className={artistStyle()}>{artist}</span>}
+          </div>
+        )}
+        <div className={seek()}>
+          <span className={time()}>{formatTime(currentTime)}</span>
+          <Slider
+            aria-label="Seek"
+            className="flex-1"
+            value={Math.min(currentTime, duration || 0)}
+            minValue={0}
+            maxValue={duration || 1}
+            step={0.1}
+            onChange={handleSeek}
+          >
+            <SliderControl />
+          </Slider>
+          <span className={time()}>{formatTime(duration)}</span>
+        </div>
+      </div>
+      <div className={volume()}>
+        <Button
+          variant="quiet"
+          size="sm"
+          isIconOnly
+          onPress={toggleMute}
+          aria-label={showVolumeOff ? 'Unmute' : 'Mute'}
+        >
+          {showVolumeOff ? <VolumeXIcon /> : <Volume2Icon />}
+        </Button>
+        <Slider
+          aria-label="Volume"
+          className="hidden w-20 sm:flex"
+          value={isMuted ? 0 : volumeLevel}
+          minValue={0}
+          maxValue={1}
+          step={0.01}
+          onChange={handleVolume}
+        >
+          <SliderControl />
+        </Slider>
+      </div>
+    </div>
+  )
+}
+
+// MARK: formatTime
+
+const formatTime = (seconds: number) => {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00'
+  const minutes = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${minutes}:${secs.toString().padStart(2, '0')}`
+}
+
+// MARK: Separator
+
+export type { AudioPlayerProps }
+export { AudioPlayer }

--- a/www/src/registry/ui/audio-player/demos/default.tsx
+++ b/www/src/registry/ui/audio-player/demos/default.tsx
@@ -1,0 +1,12 @@
+import { AudioPlayer } from '@/registry/ui/audio-player'
+
+export default function Demo() {
+  return (
+    <AudioPlayer
+      className="max-w-md"
+      src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3"
+      title="Midnight City"
+      artist="SoundHelix"
+    />
+  )
+}

--- a/www/src/registry/ui/audio-player/examples.tsx
+++ b/www/src/registry/ui/audio-player/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function AudioPlayerExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/audio-player/index.tsx
+++ b/www/src/registry/ui/audio-player/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/audio-player/meta.ts
+++ b/www/src/registry/ui/audio-player/meta.ts
@@ -1,0 +1,25 @@
+import type { RegistryItem } from '@/registry/types'
+
+const audioPlayerMeta = {
+  name: 'audio-player',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/audio-player/base.tsx',
+      target: 'ui/audio-player.tsx',
+    },
+  ],
+  registryDependencies: ['button', 'slider'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--audio-player-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default audioPlayerMeta

--- a/www/src/registry/ui/audio-player/styles.css
+++ b/www/src/registry/ui/audio-player/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --audio-player-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/audio-player/styles.ts
+++ b/www/src/registry/ui/audio-player/styles.ts
@@ -1,0 +1,21 @@
+import { createStyles } from '@/lib/styles'
+
+import audioPlayerMeta from './meta'
+
+const { useStyles, styles } = createStyles(audioPlayerMeta, {
+  base: {
+    slots: {
+      root: 'flex w-full items-center gap-3 rounded-(--audio-player-radius) border bg-card p-2 text-fg',
+      info: 'flex min-w-0 flex-1 flex-col gap-1',
+      title: 'truncate text-sm leading-none font-medium',
+      artist: 'truncate text-xs text-fg-muted',
+      seek: 'flex items-center gap-2',
+      time: 'shrink-0 text-xs text-fg-muted tabular-nums',
+      volume: 'flex shrink-0 items-center gap-1',
+    },
+  },
+})
+
+export type AudioPlayerStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/audio-player/types.ts
+++ b/www/src/registry/ui/audio-player/types.ts
@@ -1,0 +1,15 @@
+import type { ComponentProps, ReactNode } from 'react'
+
+/**
+ * An audio player renders a themeable control bar over a native `<audio>`
+ * element: play/pause, a seek slider with elapsed/total time, and volume.
+ * The transport controls are built on React Aria `Button` and `Slider`.
+ */
+export interface AudioPlayerProps extends Omit<ComponentProps<'div'>, 'title'> {
+  /** The audio source URL. */
+  src: string
+  /** Track title shown in the now-playing area. */
+  title?: ReactNode
+  /** Artist / subtitle shown next to the title. */
+  artist?: ReactNode
+}


### PR DESCRIPTION
## Summary

Adds an **Audio Player** to the registry — a themeable control bar over a native `<audio>` element. Part of the real-world-component-blocks batch (Tier 1).

- Play/pause and mute reuse the registry `Button`; the seek bar and volume reuse the registry `Slider` (RAC) — keyboard accessible by construction.
- Now-playing `title` / `artist`, elapsed/total time, and a volume slider (hidden on small screens).
- No media engine required — wired to native `<audio>` events (`timeupdate`, `loadedmetadata`, `play`, `pause`, `volumechange`).
- Themeable axis: `--audio-player-radius`. Group `containers`; `registryDependencies: ['button', 'slider']`.

## API

`src` (required), `title?`, `artist?`.

## Notes

- Pairs with the future video-player (shared control-bar idiom, per the research doc).
- Visual verification in the live preview is still recommended before merge.