### PR TITLE
feat(stepper): add stepper component

### DIFF
--- a/www/content/docs/components/stepper.mdx
+++ b/www/content/docs/components/stepper.mdx
@@ -4,6 +4,8 @@ description: A progress indicator for a numbered sequence of steps in a wizard o
 wip: true
 ---
 
+<Demo name="stepper/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/stepper.mdx
+++ b/www/content/docs/components/stepper.mdx
@@ -1,0 +1,53 @@
+---
+title: Stepper
+description: A progress indicator for a numbered sequence of steps in a wizard or flow.
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/stepper
+```
+
+## Usage
+
+Compose `StepperItem`s inside a `Stepper`, each with its own `step` index. Steps before `activeStep` render as completed, the matching one as active, and the rest as inactive.
+
+```tsx
+import {
+  Stepper,
+  StepperIndicator,
+  StepperItem,
+  StepperSeparator,
+  StepperTitle,
+} from '@/components/ui/stepper'
+```
+
+```tsx
+<Stepper activeStep={1}>
+  {['Account', 'Profile', 'Confirm'].map((label, index) => (
+    <StepperItem key={label} step={index}>
+      <StepperIndicator />
+      <StepperTitle>{label}</StepperTitle>
+      <StepperSeparator />
+    </StepperItem>
+  ))}
+</Stepper>
+```
+
+## Examples
+
+<Examples>
+  <Example name="stepper/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### Stepper
+
+<Reference name="stepper" />
+
+### StepperItem
+
+<Reference name="stepper-item" />

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -60,6 +60,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	sidebar: () => import("@/registry/ui/sidebar/examples"),
 	skeleton: () => import("@/registry/ui/skeleton/examples"),
 	slider: () => import("@/registry/ui/slider/examples"),
+	stepper: () => import("@/registry/ui/stepper/examples"),
 	switch: () => import("@/registry/ui/switch/examples"),
 	table: () => import("@/registry/ui/table/examples"),
 	tabs: () => import("@/registry/ui/tabs/examples"),

--- a/www/src/modules/docs/references/generated/stepper-item.json
+++ b/www/src/modules/docs/references/generated/stepper-item.json
@@ -1,0 +1,22 @@
+{
+  "name": "StepperItemProps",
+  "description": "A single step within a `Stepper`.",
+  "extendsElement": "div",
+  "props": {
+    "step": {
+      "type": "number",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "This step's index (0-based), compared against the stepper's `activeStep`.",
+      "required": true
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/stepper.json
+++ b/www/src/modules/docs/references/generated/stepper.json
@@ -1,0 +1,23 @@
+{
+  "name": "StepperProps",
+  "description": "A stepper communicates a user's progress through a numbered sequence of\nsteps. Composable: place `StepperItem`s inside, each with `StepperIndicator`,\noptional `StepperTitle`/`StepperDescription`, and a `StepperSeparator`.",
+  "extendsElement": "div",
+  "props": {
+    "activeStep": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "The index (0-based) of the active step. Earlier steps render as completed,\nlater steps as inactive.",
+      "default": "0"
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -2301,6 +2301,10 @@ export const DemosIndex: Record<
 		files: ["ui/slider/demos/vertical.tsx"],
 		component: React.lazy(() => import("@/registry/ui/slider/demos/vertical")),
 	},
+	"stepper/demos/default": {
+		files: ["ui/stepper/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/stepper/demos/default")),
+	},
 	"switch/demos/basic": {
 		files: ["ui/switch/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/switch/demos/basic")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -63,6 +63,7 @@ import UiSeparator from "@/registry/ui/separator/meta";
 import UiSidebar from "@/registry/ui/sidebar/meta";
 import UiSkeleton from "@/registry/ui/skeleton/meta";
 import UiSlider from "@/registry/ui/slider/meta";
+import UiStepper from "@/registry/ui/stepper/meta";
 import UiSwitch from "@/registry/ui/switch/meta";
 import UiTable from "@/registry/ui/table/meta";
 import UiTabs from "@/registry/ui/tabs/meta";
@@ -137,6 +138,7 @@ export const registryUi: RegistryItem[] = [
 	UiSidebar,
 	UiSkeleton,
 	UiSlider,
+	UiStepper,
 	UiSwitch,
 	UiTable,
 	UiTabs,

--- a/www/src/registry/ui/stepper/base.tsx
+++ b/www/src/registry/ui/stepper/base.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import type { ComponentProps } from 'react'
+import { CheckIcon } from 'lucide-react'
+
+import { useStyles } from './styles'
+
+// MARK: Context
+
+type StepStatus = 'completed' | 'active' | 'inactive'
+
+const StepperContext = createContext<{ activeStep: number }>({ activeStep: 0 })
+const StepperItemContext = createContext<{ step: number; status: StepStatus }>({
+  step: 0,
+  status: 'inactive',
+})
+
+// MARK: Stepper
+
+interface StepperProps extends ComponentProps<'div'> {
+  activeStep?: number
+}
+
+const Stepper = ({ activeStep = 0, className, ...props }: StepperProps) => {
+  const { root } = useStyles()()
+  return (
+    <StepperContext.Provider value={{ activeStep }}>
+      <div data-stepper="" className={root({ className })} {...props} />
+    </StepperContext.Provider>
+  )
+}
+
+// MARK: StepperItem
+
+interface StepperItemProps extends ComponentProps<'div'> {
+  step: number
+}
+
+const StepperItem = ({ step, className, ...props }: StepperItemProps) => {
+  const { activeStep } = useContext(StepperContext)
+  const { item } = useStyles()()
+  const status: StepStatus =
+    step < activeStep
+      ? 'completed'
+      : step === activeStep
+        ? 'active'
+        : 'inactive'
+  return (
+    <StepperItemContext.Provider value={{ step, status }}>
+      <div
+        data-stepper-item=""
+        data-status={status}
+        className={item({ className })}
+        {...props}
+      />
+    </StepperItemContext.Provider>
+  )
+}
+
+// MARK: StepperIndicator
+
+const StepperIndicator = ({
+  className,
+  children,
+  ...props
+}: ComponentProps<'div'>) => {
+  const { indicator } = useStyles()()
+  const { step, status } = useContext(StepperItemContext)
+  return (
+    <div
+      data-stepper-indicator=""
+      data-status={status}
+      className={indicator({ className })}
+      {...props}
+    >
+      {children ??
+        (status === 'completed' ? <CheckIcon /> : <span>{step + 1}</span>)}
+    </div>
+  )
+}
+
+// MARK: StepperSeparator
+
+const StepperSeparator = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { separator } = useStyles()()
+  const { status } = useContext(StepperItemContext)
+  return (
+    <div
+      data-stepper-separator=""
+      data-status={status}
+      aria-hidden="true"
+      className={separator({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: StepperTitle
+
+const StepperTitle = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { title } = useStyles()()
+  const { status } = useContext(StepperItemContext)
+  return (
+    <div
+      data-stepper-title=""
+      data-status={status}
+      className={title({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: StepperDescription
+
+const StepperDescription = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { description } = useStyles()()
+  return (
+    <div
+      data-stepper-description=""
+      className={description({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: Separator
+
+export type { StepperProps, StepperItemProps }
+export {
+  Stepper,
+  StepperItem,
+  StepperIndicator,
+  StepperSeparator,
+  StepperTitle,
+  StepperDescription,
+}

--- a/www/src/registry/ui/stepper/demos/default.tsx
+++ b/www/src/registry/ui/stepper/demos/default.tsx
@@ -1,0 +1,23 @@
+import {
+  Stepper,
+  StepperIndicator,
+  StepperItem,
+  StepperSeparator,
+  StepperTitle,
+} from '@/registry/ui/stepper'
+
+const steps = ['Account', 'Profile', 'Confirm']
+
+export default function Demo() {
+  return (
+    <Stepper activeStep={1} className="max-w-xl">
+      {steps.map((label, index) => (
+        <StepperItem key={label} step={index}>
+          <StepperIndicator />
+          <StepperTitle>{label}</StepperTitle>
+          <StepperSeparator />
+        </StepperItem>
+      ))}
+    </Stepper>
+  )
+}

--- a/www/src/registry/ui/stepper/examples.tsx
+++ b/www/src/registry/ui/stepper/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function StepperExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/stepper/index.tsx
+++ b/www/src/registry/ui/stepper/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/stepper/meta.ts
+++ b/www/src/registry/ui/stepper/meta.ts
@@ -1,0 +1,27 @@
+import type { RegistryItem } from '@/registry/types'
+
+const stepperMeta = {
+  name: 'stepper',
+  type: 'registry:ui',
+  group: 'navigation',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/stepper/base.tsx',
+      target: 'ui/stepper.tsx',
+    },
+  ],
+  params: {
+    'indicator-size': {
+      kind: 'scalar',
+      type: 'spacing',
+      cssVar: '--stepper-indicator-size',
+      default: 'calc(var(--spacing) * 8)',
+      minValue: 6,
+      maxValue: 12,
+      step: 0.5,
+    },
+  },
+} satisfies RegistryItem
+
+export default stepperMeta

--- a/www/src/registry/ui/stepper/styles.css
+++ b/www/src/registry/ui/stepper/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --stepper-indicator-size: calc(var(--spacing) * 8);
+}

--- a/www/src/registry/ui/stepper/styles.ts
+++ b/www/src/registry/ui/stepper/styles.ts
@@ -1,0 +1,27 @@
+import { createStyles } from '@/lib/styles'
+
+import stepperMeta from './meta'
+
+const { useStyles, styles } = createStyles(stepperMeta, {
+  base: {
+    slots: {
+      root: 'flex w-full items-center gap-3',
+      item: 'group/step flex flex-1 items-center gap-3 last:flex-none last:[&_[data-stepper-separator]]:hidden',
+      indicator: [
+        'flex size-(--stepper-indicator-size) shrink-0 items-center justify-center rounded-full border text-sm font-medium transition-colors [&_svg]:size-[1.1em]',
+        'data-[status=inactive]:border-border data-[status=inactive]:text-fg-muted',
+        'data-[status=active]:border-primary data-[status=active]:text-fg',
+        'data-[status=completed]:border-primary data-[status=completed]:bg-primary data-[status=completed]:text-fg-on-primary',
+      ],
+      separator:
+        'h-0.5 flex-1 rounded-full bg-border transition-colors data-[status=completed]:bg-primary',
+      title:
+        'text-sm leading-none font-medium whitespace-nowrap data-[status=inactive]:text-fg-muted',
+      description: 'mt-0.5 text-xs text-fg-muted',
+    },
+  },
+})
+
+export type StepperStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/stepper/types.ts
+++ b/www/src/registry/ui/stepper/types.ts
@@ -1,0 +1,21 @@
+import type { ComponentProps } from 'react'
+
+/**
+ * A stepper communicates a user's progress through a numbered sequence of
+ * steps. Composable: place `StepperItem`s inside, each with `StepperIndicator`,
+ * optional `StepperTitle`/`StepperDescription`, and a `StepperSeparator`.
+ */
+export interface StepperProps extends ComponentProps<'div'> {
+  /**
+   * The index (0-based) of the active step. Earlier steps render as completed,
+   * later steps as inactive.
+   * @default 0
+   */
+  activeStep?: number
+}
+
+/** A single step within a `Stepper`. */
+export interface StepperItemProps extends ComponentProps<'div'> {
+  /** This step's index (0-based), compared against the stepper's `activeStep`. */
+  step: number
+}


### PR DESCRIPTION
## Summary

Adds a **Stepper** to the registry — a composable progress indicator for a numbered sequence of steps (wizards, multi-step forms, checkouts). Part of the real-world-component-blocks batch (Tier 1).

- Composition-first: `Stepper` + `StepperItem` (+ `StepperIndicator`, `StepperTitle`, `StepperDescription`, `StepperSeparator`), matching the dotUI house style.
- Status (`completed` / `active` / `inactive`) is derived from `activeStep` and exposed via `data-status` for styling; completed steps show a check, others their number.
- The last item's separator is auto-hidden via CSS, so every item can include one uniformly.
- Themeable axis: `--stepper-indicator-size`. Group `navigation`; no engine dependency (built from scratch, per the research doc).

## Notes

- Horizontal layout for v1 (the canonical wizard stepper); a vertical variant is a natural follow-up.
- Visual verification in the live preview is still recommended before merge.