### PR TITLE
feat(file-upload): add file-upload component

### DIFF
--- a/www/content/docs/components/file-upload.mdx
+++ b/www/content/docs/components/file-upload.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="file-upload/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/file-upload.mdx
+++ b/www/content/docs/components/file-upload.mdx
@@ -1,0 +1,49 @@
+---
+title: File Upload
+description: A drag-and-drop file upload block with a file list, progress, and remove.
+links:
+  - label: Docs
+    href: https://react-spectrum.adobe.com/react-aria/DropZone.html
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/file-upload
+```
+
+## Usage
+
+`FileUpload` is a React Aria `DropZone` + `FileTrigger` drag/browse target built on the existing `drop-zone`, `file-trigger` and `progress-bar`. Transport stays your job: `onAdd` hands back the selected `File`s and you render the list with `FileUploadItem` (passing `progress` while you upload).
+
+```tsx
+import {
+  FileUpload,
+  FileUploadItem,
+  FileUploadList,
+} from '@/components/ui/file-upload'
+```
+
+```tsx
+<FileUpload onAdd={(files) => upload(files)} />
+<FileUploadList>
+  <FileUploadItem name="report.pdf" size={248000} status="complete" onRemove={remove} />
+</FileUploadList>
+```
+
+## Examples
+
+<Examples>
+  <Example name="file-upload/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### FileUpload
+
+<Reference name="file-upload" />
+
+### FileUploadItem
+
+<Reference name="file-upload-item" />

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -37,6 +37,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	empty: () => import("@/registry/ui/empty/examples"),
 	field: () => import("@/registry/ui/field/examples"),
 	"file-trigger": () => import("@/registry/ui/file-trigger/examples"),
+	"file-upload": () => import("@/registry/ui/file-upload/examples"),
 	form: () => import("@/registry/ui/form/examples"),
 	group: () => import("@/registry/ui/group/examples"),
 	input: () => import("@/registry/ui/input/examples"),

--- a/www/src/modules/docs/references/generated/file-upload-item.json
+++ b/www/src/modules/docs/references/generated/file-upload-item.json
@@ -1,0 +1,85 @@
+{
+  "name": "FileUploadItemProps",
+  "description": "A single row in the uploaded-file list, with optional progress and remove.",
+  "extendsElement": "div",
+  "props": {
+    "name": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "File name.",
+      "required": true
+    },
+    "size": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "File size in bytes, formatted for display."
+    },
+    "progress": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "Upload progress 0–100; renders a progress bar while uploading."
+    },
+    "status": {
+      "type": "\"complete\" | \"error\" | \"pending\" | \"uploading\"",
+      "detailedType": "| 'complete'\n| 'error'\n| 'pending'\n| 'uploading'\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "complete"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "error"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "pending"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "uploading"
+          }
+        ]
+      },
+      "description": "Upload status, exposed as `data-status` for styling."
+    },
+    "onRemove": {
+      "type": "(() => void)",
+      "detailedType": "(() => void) | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Called when the remove button is pressed."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/file-upload.json
+++ b/www/src/modules/docs/references/generated/file-upload.json
@@ -1,0 +1,827 @@
+{
+  "name": "FileUploadProps",
+  "description": "A file-upload block — a React Aria `DropZone` + `FileTrigger` drag/browse\ntarget. Transport stays the consumer's job: `onAdd` hands back the selected\n`File`s and you render the list with `FileUploadItem`.",
+  "props": {
+    "onAdd": {
+      "type": "((files: File[]) => void)",
+      "detailedType": "((files: File[]) => void) | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "files",
+                "value": {
+                  "type": "array",
+                  "elementType": {
+                    "type": "identifier",
+                    "name": "File"
+                  }
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Called with the files added via drag-drop or the browse dialog."
+    },
+    "acceptedFileTypes": {
+      "type": "string[]",
+      "detailedType": "string[] | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "array",
+            "elementType": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "description": "MIME types / extensions accepted by the browse dialog."
+    },
+    "allowsMultiple": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Allow selecting more than one file.",
+      "default": "true"
+    },
+    "label": {
+      "type": "ReactNode",
+      "typeAst": {
+        "type": "identifier",
+        "name": "ReactNode"
+      },
+      "description": "Headline shown in the default prompt."
+    },
+    "description": {
+      "type": "ReactNode",
+      "typeAst": {
+        "type": "identifier",
+        "name": "ReactNode"
+      },
+      "description": "Secondary text shown under the label."
+    },
+    "children": {
+      "type": "ReactNode",
+      "typeAst": {
+        "type": "identifier",
+        "name": "ReactNode"
+      },
+      "description": "Custom drop-area content, replacing the default prompt."
+    },
+    "onHoverStart": {
+      "type": "((e: HoverEvent) => void)",
+      "detailedType": "((e: HoverEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "HoverEvent",
+              "name": "HoverEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a hover interaction starts."
+    },
+    "onHoverEnd": {
+      "type": "((e: HoverEvent) => void)",
+      "detailedType": "((e: HoverEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "HoverEvent",
+              "name": "HoverEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a hover interaction ends."
+    },
+    "onHoverChange": {
+      "type": "((isHovering: boolean) => void)",
+      "detailedType": "((isHovering: boolean) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "isHovering",
+            "value": {
+              "type": "link",
+              "id": "boolean",
+              "name": "boolean"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when the hover state changes."
+    },
+    "aria-describedby": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that describes the object."
+    },
+    "aria-details": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that provide a detailed, extended description for the\nobject."
+    },
+    "aria-label": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Defines a string value that labels the current element."
+    },
+    "aria-labelledby": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that labels the current element."
+    },
+    "className": {
+      "type": "string | (values: DropZoneRenderProps) => string",
+      "detailedType": "string | (values: DropZoneRenderProps) => string | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "DropZoneRenderProps",
+                  "name": "DropZoneRenderProps"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "string"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the\nelement. A function may be provided to compute the class based on component state."
+    },
+    "getDropOperation": {
+      "type": "((types: DragTypes, allowedOperations: DropOperation[]) => DropOperation)",
+      "detailedType": "| ((\n    types: DragTypes,\n    allowedOperations: DropOperation[],\n  ) => DropOperation)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "types",
+                "value": {
+                  "type": "link",
+                  "id": "@react-types/shared/src/dnd.d.ts:DragTypes",
+                  "name": "DragTypes"
+                },
+                "optional": false,
+                "rest": false
+              },
+              {
+                "type": "parameter",
+                "name": "allowedOperations",
+                "value": {
+                  "type": "array",
+                  "elementType": {
+                    "type": "identifier",
+                    "name": "DropOperation"
+                  }
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "identifier",
+              "name": "DropOperation"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "A function returning the drop operation to be performed when items matching the given types are\ndropped on the drop target."
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the drop target is disabled. If true, the drop target will not accept any drops."
+    },
+    "onDropActivate": {
+      "type": "((e: DropActivateEvent) => void)",
+      "detailedType": "((e: DropActivateEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "DropActivateEvent",
+              "name": "DropActivateEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called after a valid drag is held over the drop target for a period of time.\nThis typically opens the item so that the user can drop within it."
+    },
+    "onDropEnter": {
+      "type": "((e: DropEnterEvent) => void)",
+      "detailedType": "((e: DropEnterEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "DropEnterEvent",
+              "name": "DropEnterEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a valid drag enters the drop target."
+    },
+    "onDropExit": {
+      "type": "((e: DropExitEvent) => void)",
+      "detailedType": "((e: DropExitEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "DropExitEvent",
+              "name": "DropExitEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a valid drag exits the drop target."
+    },
+    "onDropMove": {
+      "type": "((e: DropMoveEvent) => void)",
+      "detailedType": "((e: DropMoveEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "DropMoveEvent",
+              "name": "DropMoveEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a valid drag is moved within the drop target."
+    },
+    "render": {
+      "type": "DOMRenderFunction<\"div\", DropZoneRenderProps>",
+      "detailedType": "| DOMRenderFunction<'div', DropZoneRenderProps>\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "application",
+            "base": {
+              "type": "identifier",
+              "name": "DOMRenderFunction"
+            },
+            "typeParameters": [
+              {
+                "type": "stringLiteral",
+                "value": "div"
+              },
+              {
+                "type": "link",
+                "id": "react-aria-components/dist/types/src/DropZone.d.ts:DropZoneRenderProps",
+                "name": "DropZoneRenderProps"
+              }
+            ]
+          }
+        ]
+      },
+      "description": "Overrides the default DOM element with a custom render function.\nThis allows rendering existing components with built-in styles and behaviors\nsuch as router links, animation libraries, and pre-styled components.\n\nRequirements:\n\n- You must render the expected element type (e.g. if `<button>` is expected, you cannot render an\n  `<a>`).\n- Only a single root DOM element can be rendered (no fragments).\n- You must pass through props and ref to the underlying DOM element, merging with your own prop\n  as appropriate."
+    },
+    "slot": {
+      "type": "null | string",
+      "detailedType": "null | string | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "description": "A slot name for the component. Slots allow the component to receive props from a parent\ncomponent. An explicit `null` value indicates that the local props completely override all\nprops received from a parent."
+    },
+    "style": {
+      "type": "CSSProperties | (values: DropZoneRenderProps) => CSSProperties",
+      "detailedType": "CSSProperties | (values: DropZoneRenderProps) => CSSProperties | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "identifier",
+            "name": "CSSProperties"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "DropZoneRenderProps",
+                  "name": "DropZoneRenderProps"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "identifier",
+              "name": "CSSProperties"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
+    }
+  },
+  "typeLinks": {
+    "@react-types/shared/src/dnd.d.ts:DragTypes": {
+      "type": "interface",
+      "id": "@react-types/shared/src/dnd.d.ts:DragTypes",
+      "name": "DragTypes",
+      "extends": [],
+      "properties": {
+        "has": {
+          "type": "method",
+          "name": "has",
+          "value": {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "type",
+                "value": {
+                  "type": "union",
+                  "elements": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "symbol"
+                    },
+                    {
+                      "type": "array",
+                      "elementType": {
+                        "type": "identifier",
+                        "name": "DragType"
+                      }
+                    }
+                  ]
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "boolean"
+            },
+            "typeParameters": []
+          },
+          "optional": false,
+          "description": "Returns whether the drag contains data of the given type."
+        }
+      },
+      "typeParameters": [],
+      "description": ""
+    },
+    "DropActivateEvent": {
+      "type": "interface",
+      "name": "DropActivateEvent",
+      "properties": {
+        "type": {
+          "type": "property",
+          "name": "type",
+          "value": {
+            "type": "identifier",
+            "name": "\"dropactivate\""
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The event type."
+        },
+        "x": {
+          "type": "property",
+          "name": "x",
+          "value": {
+            "type": "number"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The x coordinate of the event, relative to the target element."
+        },
+        "y": {
+          "type": "property",
+          "name": "y",
+          "value": {
+            "type": "number"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The y coordinate of the event, relative to the target element."
+        }
+      }
+    },
+    "DropEnterEvent": {
+      "type": "interface",
+      "name": "DropEnterEvent",
+      "properties": {
+        "type": {
+          "type": "property",
+          "name": "type",
+          "value": {
+            "type": "identifier",
+            "name": "\"dropenter\""
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The event type."
+        },
+        "x": {
+          "type": "property",
+          "name": "x",
+          "value": {
+            "type": "number"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The x coordinate of the event, relative to the target element."
+        },
+        "y": {
+          "type": "property",
+          "name": "y",
+          "value": {
+            "type": "number"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The y coordinate of the event, relative to the target element."
+        }
+      }
+    },
+    "DropExitEvent": {
+      "type": "interface",
+      "name": "DropExitEvent",
+      "properties": {
+        "type": {
+          "type": "property",
+          "name": "type",
+          "value": {
+            "type": "identifier",
+            "name": "\"dropexit\""
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The event type."
+        },
+        "x": {
+          "type": "property",
+          "name": "x",
+          "value": {
+            "type": "number"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The x coordinate of the event, relative to the target element."
+        },
+        "y": {
+          "type": "property",
+          "name": "y",
+          "value": {
+            "type": "number"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The y coordinate of the event, relative to the target element."
+        }
+      }
+    },
+    "DropMoveEvent": {
+      "type": "interface",
+      "name": "DropMoveEvent",
+      "properties": {
+        "type": {
+          "type": "property",
+          "name": "type",
+          "value": {
+            "type": "identifier",
+            "name": "\"dropmove\""
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The event type."
+        },
+        "x": {
+          "type": "property",
+          "name": "x",
+          "value": {
+            "type": "number"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The x coordinate of the event, relative to the target element."
+        },
+        "y": {
+          "type": "property",
+          "name": "y",
+          "value": {
+            "type": "number"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The y coordinate of the event, relative to the target element."
+        }
+      }
+    },
+    "DropZoneRenderProps": {
+      "type": "interface",
+      "name": "DropZoneRenderProps",
+      "properties": {
+        "isDisabled": {
+          "type": "property",
+          "name": "isDisabled",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the dropzone is disabled."
+        },
+        "isDropTarget": {
+          "type": "property",
+          "name": "isDropTarget",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the dropzone is the drop target."
+        },
+        "isFocused": {
+          "type": "property",
+          "name": "isFocused",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the dropzone is focused, either via a mouse or keyboard."
+        },
+        "isFocusVisible": {
+          "type": "property",
+          "name": "isFocusVisible",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the dropzone is keyboard focused."
+        },
+        "isHovered": {
+          "type": "property",
+          "name": "isHovered",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the dropzone is currently hovered with a mouse."
+        }
+      }
+    },
+    "HoverEvent": {
+      "type": "interface",
+      "name": "HoverEvent",
+      "properties": {
+        "pointerType": {
+          "type": "property",
+          "name": "pointerType",
+          "value": {
+            "type": "identifier",
+            "name": "\"mouse\" | \"pen\""
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The pointer type that triggered the hover event."
+        },
+        "target": {
+          "type": "property",
+          "name": "target",
+          "value": {
+            "type": "identifier",
+            "name": "HTMLElement"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The target element of the hover event."
+        },
+        "type": {
+          "type": "property",
+          "name": "type",
+          "value": {
+            "type": "identifier",
+            "name": "\"hoverstart\" | \"hoverend\""
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The type of hover event being fired."
+        }
+      }
+    },
+    "react-aria-components/dist/types/src/DropZone.d.ts:DropZoneRenderProps": {
+      "type": "interface",
+      "id": "react-aria-components/dist/types/src/DropZone.d.ts:DropZoneRenderProps",
+      "name": "DropZoneRenderProps",
+      "extends": [],
+      "properties": {
+        "isDisabled": {
+          "type": "property",
+          "name": "isDisabled",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the dropzone is disabled."
+        },
+        "isDropTarget": {
+          "type": "property",
+          "name": "isDropTarget",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the dropzone is the drop target."
+        },
+        "isFocused": {
+          "type": "property",
+          "name": "isFocused",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the dropzone is focused, either via a mouse or keyboard."
+        },
+        "isFocusVisible": {
+          "type": "property",
+          "name": "isFocusVisible",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the dropzone is keyboard focused."
+        },
+        "isHovered": {
+          "type": "property",
+          "name": "isHovered",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the dropzone is currently hovered with a mouse."
+        }
+      },
+      "typeParameters": [],
+      "description": ""
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -1377,6 +1377,10 @@ export const DemosIndex: Record<
 		files: ["ui/file-trigger/demos/profile-picture.tsx"],
 		component: React.lazy(() => import("@/registry/ui/file-trigger/demos/profile-picture")),
 	},
+	"file-upload/demos/default": {
+		files: ["ui/file-upload/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/file-upload/demos/default")),
+	},
 	"form/demos/basic": {
 		files: ["ui/form/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/form/demos/basic")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -42,6 +42,7 @@ import UiDropZone from "@/registry/ui/drop-zone/meta";
 import UiEmpty from "@/registry/ui/empty/meta";
 import UiField from "@/registry/ui/field/meta";
 import UiFileTrigger from "@/registry/ui/file-trigger/meta";
+import UiFileUpload from "@/registry/ui/file-upload/meta";
 import UiGroup from "@/registry/ui/group/meta";
 import UiInput from "@/registry/ui/input/meta";
 import UiKbd from "@/registry/ui/kbd/meta";
@@ -116,6 +117,7 @@ export const registryUi: RegistryItem[] = [
 	UiEmpty,
 	UiField,
 	UiFileTrigger,
+	UiFileUpload,
 	UiGroup,
 	UiInput,
 	UiKbd,

--- a/www/src/registry/ui/file-upload/base.tsx
+++ b/www/src/registry/ui/file-upload/base.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import type { ComponentProps, ReactNode } from 'react'
+import { FileIcon, UploadCloudIcon, XIcon } from 'lucide-react'
+import { isFileDropItem } from 'react-aria-components/useDrop'
+
+import { Button } from '@/registry/ui/button'
+import { DropZone } from '@/registry/ui/drop-zone'
+import { FileTrigger } from '@/registry/ui/file-trigger'
+import { ProgressBar } from '@/registry/ui/progress-bar'
+
+import { useStyles } from './styles'
+
+// MARK: FileUpload
+
+interface FileUploadProps extends Omit<
+  ComponentProps<typeof DropZone>,
+  'onDrop' | 'children'
+> {
+  onAdd?: (files: File[]) => void
+  acceptedFileTypes?: string[]
+  allowsMultiple?: boolean
+  label?: ReactNode
+  description?: ReactNode
+  children?: ReactNode
+}
+
+const FileUpload = ({
+  onAdd,
+  acceptedFileTypes,
+  allowsMultiple = true,
+  label,
+  description,
+  children,
+  ...props
+}: FileUploadProps) => {
+  const { prompt, icon, promptLabel, promptDescription } = useStyles()()
+
+  const handleSelect = (files: FileList | null) => {
+    const list = Array.from(files ?? [])
+    if (list.length) onAdd?.(list)
+  }
+
+  return (
+    <DropZone
+      aria-label="File upload"
+      onDrop={async (event) => {
+        const files = await Promise.all(
+          event.items.filter(isFileDropItem).map((item) => item.getFile()),
+        )
+        if (files.length) onAdd?.(files)
+      }}
+      {...props}
+    >
+      {children ?? (
+        <div className={prompt()}>
+          <UploadCloudIcon className={icon()} />
+          <div className="flex flex-col gap-0.5">
+            <span className={promptLabel()}>
+              {label ?? 'Drag and drop files here'}
+            </span>
+            {description ? (
+              <span className={promptDescription()}>{description}</span>
+            ) : null}
+          </div>
+          <FileTrigger
+            acceptedFileTypes={acceptedFileTypes}
+            allowsMultiple={allowsMultiple}
+            onSelect={handleSelect}
+          >
+            <Button variant="default" size="sm">
+              Browse files
+            </Button>
+          </FileTrigger>
+        </div>
+      )}
+    </DropZone>
+  )
+}
+
+// MARK: FileUploadList
+
+const FileUploadList = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { list } = useStyles()()
+  return (
+    <div data-file-upload-list="" className={list({ className })} {...props} />
+  )
+}
+
+// MARK: FileUploadItem
+
+interface FileUploadItemProps extends Omit<ComponentProps<'div'>, 'onError'> {
+  name: string
+  size?: number
+  progress?: number
+  status?: 'pending' | 'uploading' | 'complete' | 'error'
+  onRemove?: () => void
+}
+
+const FileUploadItem = ({
+  name,
+  size,
+  progress,
+  status = 'pending',
+  onRemove,
+  className,
+  ...props
+}: FileUploadItemProps) => {
+  const { item, itemIcon, itemInfo, itemName, itemMeta } = useStyles()()
+  const showProgress = typeof progress === 'number' && status !== 'complete'
+  return (
+    <div
+      data-file-upload-item=""
+      data-status={status}
+      className={item({ className })}
+      {...props}
+    >
+      <FileIcon className={itemIcon()} />
+      <div className={itemInfo()}>
+        <span className={itemName()}>{name}</span>
+        {showProgress ? (
+          <ProgressBar
+            aria-label={`Uploading ${name}`}
+            value={progress}
+            className="mt-1.5"
+          />
+        ) : size != null ? (
+          <span className={itemMeta()}>{formatBytes(size)}</span>
+        ) : null}
+      </div>
+      {onRemove ? (
+        <Button
+          variant="quiet"
+          size="sm"
+          isIconOnly
+          onPress={onRemove}
+          aria-label={`Remove ${name}`}
+        >
+          <XIcon />
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+// MARK: formatBytes
+
+const formatBytes = (bytes: number) => {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  )
+  const value = bytes / 1024 ** exponent
+  return `${value.toFixed(value < 10 && exponent > 0 ? 1 : 0)} ${units[exponent]}`
+}
+
+// MARK: Separator
+
+export type { FileUploadProps, FileUploadItemProps }
+export { FileUpload, FileUploadList, FileUploadItem }

--- a/www/src/registry/ui/file-upload/demos/default.tsx
+++ b/www/src/registry/ui/file-upload/demos/default.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useState } from 'react'
+
+import {
+  FileUpload,
+  FileUploadItem,
+  FileUploadList,
+} from '@/registry/ui/file-upload'
+
+interface UploadedFile {
+  id: string
+  name: string
+  size: number
+}
+
+export default function Demo() {
+  const [files, setFiles] = useState<UploadedFile[]>([
+    { id: 'design-spec.pdf', name: 'design-spec.pdf', size: 248_000 },
+  ])
+
+  return (
+    <div className="w-full max-w-md">
+      <FileUpload
+        description="PNG, JPG or PDF, up to 10MB"
+        onAdd={(added) =>
+          setFiles((prev) => [
+            ...prev,
+            ...added.map((file) => ({
+              id: `${file.name}-${file.lastModified}`,
+              name: file.name,
+              size: file.size,
+            })),
+          ])
+        }
+      />
+      {files.length > 0 && (
+        <FileUploadList>
+          {files.map((file) => (
+            <FileUploadItem
+              key={file.id}
+              name={file.name}
+              size={file.size}
+              status="complete"
+              onRemove={() =>
+                setFiles((prev) => prev.filter((item) => item.id !== file.id))
+              }
+            />
+          ))}
+        </FileUploadList>
+      )}
+    </div>
+  )
+}

--- a/www/src/registry/ui/file-upload/examples.tsx
+++ b/www/src/registry/ui/file-upload/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function FileUploadExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/file-upload/index.tsx
+++ b/www/src/registry/ui/file-upload/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/file-upload/meta.ts
+++ b/www/src/registry/ui/file-upload/meta.ts
@@ -1,0 +1,25 @@
+import type { RegistryItem } from '@/registry/types'
+
+const fileUploadMeta = {
+  name: 'file-upload',
+  type: 'registry:ui',
+  group: 'drop-zone',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/file-upload/base.tsx',
+      target: 'ui/file-upload.tsx',
+    },
+  ],
+  registryDependencies: ['drop-zone', 'file-trigger', 'progress-bar', 'button'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--file-upload-radius',
+      default: '--radius-md',
+    },
+  },
+} satisfies RegistryItem
+
+export default fileUploadMeta

--- a/www/src/registry/ui/file-upload/styles.css
+++ b/www/src/registry/ui/file-upload/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --file-upload-radius: var(--radius-md);
+}

--- a/www/src/registry/ui/file-upload/styles.ts
+++ b/www/src/registry/ui/file-upload/styles.ts
@@ -1,0 +1,24 @@
+import { createStyles } from '@/lib/styles'
+
+import fileUploadMeta from './meta'
+
+const { useStyles, styles } = createStyles(fileUploadMeta, {
+  base: {
+    slots: {
+      prompt: 'flex flex-col items-center justify-center gap-2 text-center',
+      icon: 'size-6 text-fg-muted',
+      promptLabel: 'text-sm font-medium',
+      promptDescription: 'text-xs text-fg-muted',
+      list: 'mt-3 flex flex-col gap-2',
+      item: 'flex items-center gap-3 rounded-(--file-upload-radius) border bg-card p-2.5 data-[status=error]:border-border-danger',
+      itemIcon: 'size-5 shrink-0 text-fg-muted',
+      itemInfo: 'flex min-w-0 flex-1 flex-col',
+      itemName: 'truncate text-sm font-medium',
+      itemMeta: 'text-xs text-fg-muted',
+    },
+  },
+})
+
+export type FileUploadStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/file-upload/types.ts
+++ b/www/src/registry/ui/file-upload/types.ts
@@ -1,0 +1,43 @@
+import type { ComponentProps, ReactNode } from 'react'
+
+import type { DropZone } from '@/registry/ui/drop-zone'
+
+/**
+ * A file-upload block — a React Aria `DropZone` + `FileTrigger` drag/browse
+ * target. Transport stays the consumer's job: `onAdd` hands back the selected
+ * `File`s and you render the list with `FileUploadItem`.
+ */
+export interface FileUploadProps extends Omit<
+  ComponentProps<typeof DropZone>,
+  'onDrop' | 'children'
+> {
+  /** Called with the files added via drag-drop or the browse dialog. */
+  onAdd?: (files: File[]) => void
+  /** MIME types / extensions accepted by the browse dialog. */
+  acceptedFileTypes?: string[]
+  /** Allow selecting more than one file. @default true */
+  allowsMultiple?: boolean
+  /** Headline shown in the default prompt. */
+  label?: ReactNode
+  /** Secondary text shown under the label. */
+  description?: ReactNode
+  /** Custom drop-area content, replacing the default prompt. */
+  children?: ReactNode
+}
+
+/** A single row in the uploaded-file list, with optional progress and remove. */
+export interface FileUploadItemProps extends Omit<
+  ComponentProps<'div'>,
+  'onError'
+> {
+  /** File name. */
+  name: string
+  /** File size in bytes, formatted for display. */
+  size?: number
+  /** Upload progress 0–100; renders a progress bar while uploading. */
+  progress?: number
+  /** Upload status, exposed as `data-status` for styling. */
+  status?: 'pending' | 'uploading' | 'complete' | 'error'
+  /** Called when the remove button is pressed. */
+  onRemove?: () => void
+}


### PR DESCRIPTION
## Summary

Adds a **File Upload** block to the registry — a drag-and-drop target with a file list, per-file progress, and remove. Part of the real-world-component-blocks batch (Tier 1).

- Pure composition over existing registry items: React Aria `DropZone` (drag) + `FileTrigger` (browse) for the target, `ProgressBar` for upload progress, `Button` for browse/remove.
- Transport stays the consumer's job (mirrors how `drop-zone` already leaves upload transport out): `onAdd` returns the selected `File`s; you render rows with `FileUploadItem` and feed `progress`/`status` as your upload runs.
- `FileUploadItem` shows name, formatted size, an inline progress bar while uploading, and a remove button; `data-status` exposes pending/uploading/complete/error for styling.
- Themeable axis: `--file-upload-radius`. Group `drop-zone` (synced with the drop-zone family). `registryDependencies: ['drop-zone', 'file-trigger', 'progress-bar', 'button']`.

## Notes

- No new engine dependency.
- Visual verification in the live preview is still recommended before merge.