### PR TITLE
feat(carousel): add carousel component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       cnfast:
         specifier: ^0.0.8
         version: 0.0.8
+      embla-carousel-react:
+        specifier: ^8.6.0
+        version: 8.6.0(react@19.2.1)
       fumadocs-core:
         specifier: ^16.8.11
         version: 16.8.11(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.2)(lucide-react@1.16.0(react@19.2.1))(next@16.0.8(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
@@ -3720,6 +3723,19 @@ packages:
 
   electron-to-chromium@1.5.357:
     resolution: {integrity: sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==}
+
+  embla-carousel-react@8.6.0:
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  embla-carousel-reactive-utils@8.6.0:
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
   emoji-regex-xs@2.0.1:
     resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
@@ -8112,7 +8128,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':
@@ -9236,6 +9252,18 @@ snapshots:
   electron-to-chromium@1.5.267: {}
 
   electron-to-chromium@1.5.357: {}
+
+  embla-carousel-react@8.6.0(react@19.2.1):
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      react: 19.2.1
+
+  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0: {}
 
   emoji-regex-xs@2.0.1: {}
 

--- a/www/content/docs/components/carousel.mdx
+++ b/www/content/docs/components/carousel.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="carousel/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/carousel.mdx
+++ b/www/content/docs/components/carousel.mdx
@@ -1,0 +1,53 @@
+---
+title: Carousel
+description: A slides carousel with arrows, dots, and autoplay, powered by Embla.
+links:
+  - label: Embla
+    href: https://www.embla-carousel.com
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/carousel
+```
+
+## Usage
+
+Compose slides inside `CarouselContent` / `CarouselItem`, then add `CarouselPrevious`, `CarouselNext`, and `CarouselDots`. The arrows and dots are React Aria; [Embla](https://www.embla-carousel.com) is the scroll engine (installed as a dependency).
+
+```tsx
+import {
+  Carousel,
+  CarouselContent,
+  CarouselDots,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/ui/carousel'
+```
+
+```tsx
+<Carousel opts={{ loop: true }}>
+  <CarouselContent>
+    <CarouselItem>Slide 1</CarouselItem>
+    <CarouselItem>Slide 2</CarouselItem>
+  </CarouselContent>
+  <CarouselPrevious />
+  <CarouselNext />
+  <CarouselDots />
+</Carousel>
+```
+
+## Examples
+
+<Examples>
+  <Example name="carousel/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### Carousel
+
+<Reference name="carousel" />

--- a/www/package.json
+++ b/www/package.json
@@ -36,6 +36,7 @@
     "@tanstack/router-plugin": "^1.168.2",
     "@vercel/og": "^0.11.1",
     "cnfast": "^0.0.8",
+    "embla-carousel-react": "^8.6.0",
     "fumadocs-core": "^16.8.11",
     "fumadocs-mdx": "^15.0.5",
     "globals-docs": "^2.4.1",

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -10,6 +10,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	button: () => import("@/registry/ui/button/examples"),
 	calendar: () => import("@/registry/ui/calendar/examples"),
 	card: () => import("@/registry/ui/card/examples"),
+	carousel: () => import("@/registry/ui/carousel/examples"),
 	"chart-area": () => import("@/registry/ui/chart-area/examples"),
 	"chart-bar": () => import("@/registry/ui/chart-bar/examples"),
 	"chart-line": () => import("@/registry/ui/chart-line/examples"),

--- a/www/src/modules/docs/references/generated/carousel.json
+++ b/www/src/modules/docs/references/generated/carousel.json
@@ -1,0 +1,117 @@
+{
+  "name": "CarouselProps",
+  "description": "A carousel — slides, arrows, and dots — built on Embla. The chrome\n(`CarouselPrevious`/`CarouselNext` arrows, `CarouselDots`) is React Aria;\nEmbla is the (peer-dependency) scroll engine.",
+  "extendsElement": "div",
+  "props": {
+    "opts": {
+      "type": "Partial<OptionsType>",
+      "detailedType": "Partial<OptionsType> | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "application",
+            "base": {
+              "type": "identifier",
+              "name": "Partial"
+            },
+            "typeParameters": [
+              {
+                "type": "identifier",
+                "name": "OptionsType"
+              }
+            ]
+          }
+        ]
+      },
+      "description": "Embla options (loop, align, dragFree, …)."
+    },
+    "orientation": {
+      "type": "\"horizontal\" | \"vertical\"",
+      "detailedType": "'horizontal' | 'vertical' | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "horizontal"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "vertical"
+          }
+        ]
+      },
+      "description": "Scroll axis.",
+      "default": "'horizontal'"
+    },
+    "autoplay": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Auto-advance slides on an interval.",
+      "default": "false"
+    },
+    "autoplayDelay": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "Autoplay interval in milliseconds.",
+      "default": "4000"
+    },
+    "setApi": {
+      "type": "((api: EmblaCarouselType | undefined) => void)",
+      "detailedType": "| ((api: EmblaCarouselType | undefined) => void)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "api",
+                "value": {
+                  "type": "union",
+                  "elements": [
+                    {
+                      "type": "undefined"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "EmblaCarouselType"
+                    }
+                  ]
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Receives the Embla API once ready, for external control."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -317,6 +317,10 @@ export const DemosIndex: Record<
 		files: ["ui/card/demos/with-image.tsx"],
 		component: React.lazy(() => import("@/registry/ui/card/demos/with-image")),
 	},
+	"carousel/demos/default": {
+		files: ["ui/carousel/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/carousel/demos/default")),
+	},
 	"chart-area/demos/axes": {
 		files: ["ui/chart-area/demos/axes.tsx"],
 		component: React.lazy(() => import("@/registry/ui/chart-area/demos/axes")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -13,6 +13,7 @@ import UiBreadcrumbs from "@/registry/ui/breadcrumbs/meta";
 import UiButton from "@/registry/ui/button/meta";
 import UiCalendar from "@/registry/ui/calendar/meta";
 import UiCard from "@/registry/ui/card/meta";
+import UiCarousel from "@/registry/ui/carousel/meta";
 import UiChartArea from "@/registry/ui/chart-area/meta";
 import UiChartBar from "@/registry/ui/chart-bar/meta";
 import UiChartLine from "@/registry/ui/chart-line/meta";
@@ -87,6 +88,7 @@ export const registryUi: RegistryItem[] = [
 	UiButton,
 	UiCalendar,
 	UiCard,
+	UiCarousel,
 	UiChart,
 	UiChartArea,
 	UiChartBar,

--- a/www/src/registry/ui/carousel/base.tsx
+++ b/www/src/registry/ui/carousel/base.tsx
@@ -1,0 +1,271 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
+import type { ComponentProps, KeyboardEvent } from 'react'
+import useEmblaCarousel from 'embla-carousel-react'
+import type { UseEmblaCarouselType } from 'embla-carousel-react'
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+
+import { useStyles } from './styles'
+
+// MARK: Context
+
+type CarouselApi = UseEmblaCarouselType[1]
+type CarouselRef = UseEmblaCarouselType[0]
+type CarouselOptions = NonNullable<Parameters<typeof useEmblaCarousel>[0]>
+type Orientation = 'horizontal' | 'vertical'
+
+interface CarouselContextValue {
+  carouselRef: CarouselRef
+  api: CarouselApi
+  orientation: Orientation
+  scrollPrev: () => void
+  scrollNext: () => void
+  scrollTo: (index: number) => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+  selectedIndex: number
+  scrollSnaps: number[]
+}
+
+const CarouselContext = createContext<CarouselContextValue | null>(null)
+
+const useCarousel = () => {
+  const context = useContext(CarouselContext)
+  if (!context) {
+    throw new Error('useCarousel must be used within a <Carousel />')
+  }
+  return context
+}
+
+// MARK: Carousel
+
+interface CarouselProps extends ComponentProps<'div'> {
+  opts?: CarouselOptions
+  orientation?: Orientation
+  autoplay?: boolean
+  autoplayDelay?: number
+  setApi?: (api: CarouselApi) => void
+}
+
+const Carousel = ({
+  opts,
+  orientation = 'horizontal',
+  autoplay = false,
+  autoplayDelay = 4000,
+  setApi,
+  className,
+  children,
+  ...props
+}: CarouselProps) => {
+  const { root } = useStyles()()
+  const [carouselRef, api] = useEmblaCarousel({
+    ...opts,
+    axis: orientation === 'horizontal' ? 'x' : 'y',
+  })
+  const [canScrollPrev, setCanScrollPrev] = useState(false)
+  const [canScrollNext, setCanScrollNext] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [scrollSnaps, setScrollSnaps] = useState<number[]>([])
+
+  const onSelect = useCallback((emblaApi: CarouselApi) => {
+    if (!emblaApi) return
+    setCanScrollPrev(emblaApi.canScrollPrev())
+    setCanScrollNext(emblaApi.canScrollNext())
+    setSelectedIndex(emblaApi.selectedScrollSnap())
+  }, [])
+
+  const scrollPrev = useCallback(() => api?.scrollPrev(), [api])
+  const scrollNext = useCallback(() => api?.scrollNext(), [api])
+  const scrollTo = useCallback((index: number) => api?.scrollTo(index), [api])
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      scrollPrev()
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      scrollNext()
+    }
+  }
+
+  useEffect(() => {
+    if (api && setApi) setApi(api)
+  }, [api, setApi])
+
+  useEffect(() => {
+    if (!api) return
+    setScrollSnaps(api.scrollSnapList())
+    onSelect(api)
+    api.on('reInit', onSelect)
+    api.on('select', onSelect)
+    return () => {
+      api.off('reInit', onSelect)
+      api.off('select', onSelect)
+    }
+  }, [api, onSelect])
+
+  useEffect(() => {
+    if (!api || !autoplay) return
+    const id = window.setInterval(() => {
+      if (api.canScrollNext()) api.scrollNext()
+      else api.scrollTo(0)
+    }, autoplayDelay)
+    return () => window.clearInterval(id)
+  }, [api, autoplay, autoplayDelay])
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api,
+        orientation,
+        scrollPrev,
+        scrollNext,
+        scrollTo,
+        canScrollPrev,
+        canScrollNext,
+        selectedIndex,
+        scrollSnaps,
+      }}
+    >
+      <div
+        data-carousel=""
+        role="region"
+        aria-roledescription="carousel"
+        onKeyDown={handleKeyDown}
+        className={root({ className })}
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  )
+}
+
+// MARK: CarouselContent
+
+const CarouselContent = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { carouselRef, orientation } = useCarousel()
+  const { viewport, container } = useStyles()()
+  return (
+    <div ref={carouselRef} data-carousel-content="" className={viewport()}>
+      <div
+        data-orientation={orientation}
+        className={container({ className })}
+        {...props}
+      />
+    </div>
+  )
+}
+
+// MARK: CarouselItem
+
+const CarouselItem = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { orientation } = useCarousel()
+  const { item } = useStyles()()
+  return (
+    <div
+      data-carousel-item=""
+      role="group"
+      aria-roledescription="slide"
+      data-orientation={orientation}
+      className={item({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: CarouselPrevious
+
+interface CarouselButtonProps extends Omit<
+  ComponentProps<typeof Button>,
+  'className'
+> {
+  className?: string
+}
+
+const CarouselPrevious = ({ className, ...props }: CarouselButtonProps) => {
+  const { scrollPrev, canScrollPrev, orientation } = useCarousel()
+  const { previous } = useStyles()()
+  return (
+    <Button
+      data-orientation={orientation}
+      variant="default"
+      size="sm"
+      isIconOnly
+      aria-label="Previous slide"
+      isDisabled={!canScrollPrev}
+      onPress={scrollPrev}
+      className={previous({ className })}
+      {...props}
+    >
+      <ChevronLeftIcon />
+    </Button>
+  )
+}
+
+// MARK: CarouselNext
+
+const CarouselNext = ({ className, ...props }: CarouselButtonProps) => {
+  const { scrollNext, canScrollNext, orientation } = useCarousel()
+  const { next } = useStyles()()
+  return (
+    <Button
+      data-orientation={orientation}
+      variant="default"
+      size="sm"
+      isIconOnly
+      aria-label="Next slide"
+      isDisabled={!canScrollNext}
+      onPress={scrollNext}
+      className={next({ className })}
+      {...props}
+    >
+      <ChevronRightIcon />
+    </Button>
+  )
+}
+
+// MARK: CarouselDots
+
+const CarouselDots = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { scrollSnaps, selectedIndex, scrollTo } = useCarousel()
+  const { dots, dot } = useStyles()()
+  return (
+    <div data-carousel-dots="" className={dots({ className })} {...props}>
+      {scrollSnaps.map((_, index) => (
+        <button
+          // oxlint-disable-next-line react/no-array-index-key -- dots are positional and stable
+          key={index}
+          type="button"
+          aria-label={`Go to slide ${index + 1}`}
+          aria-current={index === selectedIndex}
+          data-active={index === selectedIndex || undefined}
+          className={dot()}
+          onClick={() => scrollTo(index)}
+        />
+      ))}
+    </div>
+  )
+}
+
+// MARK: Separator
+
+export type { CarouselProps, CarouselApi }
+export {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+  CarouselDots,
+}

--- a/www/src/registry/ui/carousel/demos/default.tsx
+++ b/www/src/registry/ui/carousel/demos/default.tsx
@@ -1,0 +1,29 @@
+import {
+  Carousel,
+  CarouselContent,
+  CarouselDots,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/registry/ui/carousel'
+
+const slides = ['1', '2', '3', '4', '5']
+
+export default function Demo() {
+  return (
+    <Carousel className="w-full max-w-xs" opts={{ loop: true }}>
+      <CarouselContent>
+        {slides.map((label) => (
+          <CarouselItem key={label}>
+            <div className="flex aspect-square items-center justify-center rounded-lg border bg-muted text-4xl font-semibold text-fg-muted">
+              {label}
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+      <CarouselDots />
+    </Carousel>
+  )
+}

--- a/www/src/registry/ui/carousel/examples.tsx
+++ b/www/src/registry/ui/carousel/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function CarouselExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/carousel/index.tsx
+++ b/www/src/registry/ui/carousel/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/carousel/meta.ts
+++ b/www/src/registry/ui/carousel/meta.ts
@@ -1,0 +1,18 @@
+import type { RegistryItem } from '@/registry/types'
+
+const carouselMeta = {
+  name: 'carousel',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/carousel/base.tsx',
+      target: 'ui/carousel.tsx',
+    },
+  ],
+  registryDependencies: ['button'],
+  dependencies: ['embla-carousel-react'],
+} satisfies RegistryItem
+
+export default carouselMeta

--- a/www/src/registry/ui/carousel/styles.ts
+++ b/www/src/registry/ui/carousel/styles.ts
@@ -1,0 +1,24 @@
+import { createStyles } from '@/lib/styles'
+
+import carouselMeta from './meta'
+
+const { useStyles, styles } = createStyles(carouselMeta, {
+  base: {
+    slots: {
+      root: 'relative',
+      viewport: 'overflow-hidden',
+      container:
+        'flex data-[orientation=horizontal]:-ml-4 data-[orientation=vertical]:-mt-4 data-[orientation=vertical]:flex-col',
+      item: 'min-w-0 shrink-0 grow-0 basis-full data-[orientation=horizontal]:pl-4 data-[orientation=vertical]:pt-4',
+      previous:
+        'absolute top-1/2 left-3 -translate-y-1/2 data-[orientation=vertical]:top-3 data-[orientation=vertical]:left-1/2 data-[orientation=vertical]:-translate-x-1/2 data-[orientation=vertical]:translate-y-0 data-[orientation=vertical]:rotate-90',
+      next: 'absolute top-1/2 right-3 -translate-y-1/2 data-[orientation=vertical]:top-auto data-[orientation=vertical]:right-auto data-[orientation=vertical]:bottom-3 data-[orientation=vertical]:left-1/2 data-[orientation=vertical]:-translate-x-1/2 data-[orientation=vertical]:translate-y-0 data-[orientation=vertical]:rotate-90',
+      dots: 'mt-3 flex items-center justify-center gap-2',
+      dot: 'size-2 rounded-full bg-border transition-colors data-[active]:bg-primary',
+    },
+  },
+})
+
+export type CarouselStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/carousel/types.ts
+++ b/www/src/registry/ui/carousel/types.ts
@@ -1,0 +1,22 @@
+import type { ComponentProps } from 'react'
+import type useEmblaCarousel from 'embla-carousel-react'
+
+type CarouselOptions = NonNullable<Parameters<typeof useEmblaCarousel>[0]>
+
+/**
+ * A carousel — slides, arrows, and dots — built on Embla. The chrome
+ * (`CarouselPrevious`/`CarouselNext` arrows, `CarouselDots`) is React Aria;
+ * Embla is the (peer-dependency) scroll engine.
+ */
+export interface CarouselProps extends ComponentProps<'div'> {
+  /** Embla options (loop, align, dragFree, …). */
+  opts?: CarouselOptions
+  /** Scroll axis. @default 'horizontal' */
+  orientation?: 'horizontal' | 'vertical'
+  /** Auto-advance slides on an interval. @default false */
+  autoplay?: boolean
+  /** Autoplay interval in milliseconds. @default 4000 */
+  autoplayDelay?: number
+  /** Receives the Embla API once ready, for external control. */
+  setApi?: (api: ReturnType<typeof useEmblaCarousel>[1]) => void
+}


### PR DESCRIPTION
## Summary

Adds a **Carousel** to the registry — slides, arrows, dots, and optional autoplay. Part of the real-world-component-blocks batch (Tier 1).

- Engine: **Embla** (`embla-carousel-react`, the shadcn-standard carousel engine), installed as a dependency. The chrome is dotUI's: `CarouselPrevious`/`CarouselNext` are React Aria `Button`s (disabled at the ends), `CarouselDots` are accessible tab-to-slide buttons.
- Composable API mirroring the familiar shadcn shape: `Carousel` + `CarouselContent` + `CarouselItem` + `CarouselPrevious` / `CarouselNext` / `CarouselDots`.
- Horizontal & vertical orientation, `opts` pass-through to Embla, keyboard arrow nav, and a dependency-free `autoplay`.
- Group `containers`. `registryDependencies: ['button']`, `dependencies: ['embla-carousel-react']`.

## Notes

- Autoplay is implemented with a simple interval (no extra Embla plugin dependency).
- Visual verification in the live preview is still recommended before merge.