### PR TITLE
feat(emoji-picker): add emoji-picker component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       cnfast:
         specifier: ^0.0.8
         version: 0.0.8
+      frimousse:
+        specifier: ^0.3.0
+        version: 0.3.0(react@19.2.1)(typescript@6.0.3)
       fumadocs-core:
         specifier: ^16.8.11
         version: 16.8.11(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.2)(lucide-react@1.16.0(react@19.2.1))(next@16.0.8(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
@@ -4007,6 +4010,15 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  frimousse@0.3.0:
+    resolution: {integrity: sha512-kO6LMoKY/cLAYEhXXtqLRaLIE6L/DagpFPrUZaLv3LsUa1/8Iza3HhwZcgN8eZ+weXnhv69eoclNUPohcCa/IQ==}
+    peerDependencies:
+      react: ^18 || ^19
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
@@ -8112,7 +8124,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':
@@ -9649,6 +9661,12 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
 
   fresh@2.0.0: {}
+
+  frimousse@0.3.0(react@19.2.1)(typescript@6.0.3):
+    dependencies:
+      react: 19.2.1
+    optionalDependencies:
+      typescript: 6.0.3
 
   fs-extra@11.3.5:
     dependencies:

--- a/www/content/docs/components/emoji-picker.mdx
+++ b/www/content/docs/components/emoji-picker.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="emoji-picker/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/emoji-picker.mdx
+++ b/www/content/docs/components/emoji-picker.mdx
@@ -1,0 +1,46 @@
+---
+title: Emoji Picker
+description: A searchable emoji picker with categories, built on frimousse.
+links:
+  - label: frimousse
+    href: https://frimousse.liveblocks.io
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/emoji-picker
+```
+
+## Usage
+
+`EmojiPicker` is the picker panel — search, categories, and a virtualized grid — built on the headless [frimousse](https://frimousse.liveblocks.io) engine (installed as a dependency) with dotUI chrome. Drop it inside a React Aria `Popover` for the usual trigger-and-overlay pattern.
+
+```tsx
+import { Button } from '@/components/ui/button'
+import { Dialog } from '@/components/ui/dialog'
+import { EmojiPicker } from '@/components/ui/emoji-picker'
+import { Popover } from '@/components/ui/popover'
+```
+
+```tsx
+<Dialog>
+  <Button>Add reaction</Button>
+  <Popover>
+    <EmojiPicker onEmojiSelect={(emoji) => console.log(emoji.emoji)} />
+  </Popover>
+</Dialog>
+```
+
+## Examples
+
+<Examples>
+  <Example name="emoji-picker/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### EmojiPicker
+
+<Reference name="emoji-picker" />

--- a/www/package.json
+++ b/www/package.json
@@ -36,6 +36,7 @@
     "@tanstack/router-plugin": "^1.168.2",
     "@vercel/og": "^0.11.1",
     "cnfast": "^0.0.8",
+    "frimousse": "^0.3.0",
     "fumadocs-core": "^16.8.11",
     "fumadocs-mdx": "^15.0.5",
     "globals-docs": "^2.4.1",

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -34,6 +34,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	disclosure: () => import("@/registry/ui/disclosure/examples"),
 	drawer: () => import("@/registry/ui/drawer/examples"),
 	"drop-zone": () => import("@/registry/ui/drop-zone/examples"),
+	"emoji-picker": () => import("@/registry/ui/emoji-picker/examples"),
 	empty: () => import("@/registry/ui/empty/examples"),
 	field: () => import("@/registry/ui/field/examples"),
 	"file-trigger": () => import("@/registry/ui/file-trigger/examples"),

--- a/www/src/modules/docs/references/generated/emoji-picker.json
+++ b/www/src/modules/docs/references/generated/emoji-picker.json
@@ -1,0 +1,101 @@
+{
+  "name": "EmojiPickerProps",
+  "description": "An emoji picker panel — search, categories, and a virtualized grid — built\non the headless [frimousse](https://frimousse.liveblocks.io) engine with\ndotUI chrome. Drop it inside a React Aria `Popover` for the usual\ntrigger-and-overlay pattern. `onEmojiSelect` fires with the chosen emoji.",
+  "props": {
+    "onEmojiSelect": {
+      "type": "((emoji: { emoji: string; label: string; }) => void)",
+      "detailedType": "| ((emoji: { emoji: string; label: string }) => void)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "emoji",
+                "value": {
+                  "type": "identifier",
+                  "name": "{ emoji: string; label: string; }"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "A callback invoked when an emoji is selected."
+    },
+    "locale": {
+      "type": "Locale",
+      "detailedType": "Locale | undefined",
+      "typeAst": {
+        "type": "identifier",
+        "name": "Locale"
+      },
+      "description": "The locale of the emoji picker.",
+      "default": "\"en\""
+    },
+    "skinTone": {
+      "type": "SkinTone",
+      "detailedType": "SkinTone | undefined",
+      "typeAst": {
+        "type": "identifier",
+        "name": "SkinTone"
+      },
+      "description": "The skin tone of the emoji picker.",
+      "default": "\"none\""
+    },
+    "columns": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "The number of columns in the list.",
+      "default": "10"
+    },
+    "emojiVersion": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "Which {@link https://emojipedia.org/emoji-versions Emoji version} to use,\nto manually control which emojis are visible regardless of the current\nbrowser's supported Emoji versions.",
+      "default": "The most recent version supported by the current browser"
+    },
+    "emojibaseUrl": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The base URL of where the {@link https://emojibase.dev/docs/datasets/ Emojibase data}\nshould be fetched from, used as follows: `${emojibaseUrl}/${locale}/${file}.json`.\n(e.g. `${emojibaseUrl}/en/data.json`).\n\nThe URL can be set to another CDN hosting the {@link https://www.npmjs.com/package/emojibase-data `emojibase-data`}\npackage and its raw JSON files, or to a self-hosted location. When self-hosting\nwith a single locale (e.g. `en`), only that locale's directory needs to be hosted\ninstead of the entire package.",
+      "default": "\"https://cdn.jsdelivr.net/npm/emojibase-data\""
+    },
+    "sticky": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the category headers should be sticky.",
+      "default": "true"
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -1305,6 +1305,10 @@ export const DemosIndex: Record<
 		files: ["ui/drop-zone/demos/visual-feedback.tsx"],
 		component: React.lazy(() => import("@/registry/ui/drop-zone/demos/visual-feedback")),
 	},
+	"emoji-picker/demos/default": {
+		files: ["ui/emoji-picker/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/emoji-picker/demos/default")),
+	},
 	"empty/demos/basic": {
 		files: ["ui/empty/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/empty/demos/basic")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -39,6 +39,7 @@ import UiDialog from "@/registry/ui/dialog/meta";
 import UiDisclosure from "@/registry/ui/disclosure/meta";
 import UiDrawer from "@/registry/ui/drawer/meta";
 import UiDropZone from "@/registry/ui/drop-zone/meta";
+import UiEmojiPicker from "@/registry/ui/emoji-picker/meta";
 import UiEmpty from "@/registry/ui/empty/meta";
 import UiField from "@/registry/ui/field/meta";
 import UiFileTrigger from "@/registry/ui/file-trigger/meta";
@@ -113,6 +114,7 @@ export const registryUi: RegistryItem[] = [
 	UiDisclosure,
 	UiDrawer,
 	UiDropZone,
+	UiEmojiPicker,
 	UiEmpty,
 	UiField,
 	UiFileTrigger,

--- a/www/src/registry/ui/emoji-picker/base.tsx
+++ b/www/src/registry/ui/emoji-picker/base.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { EmojiPicker as EmojiPickerPrimitive } from 'frimousse'
+import type {
+  EmojiPickerListCategoryHeaderProps,
+  EmojiPickerListEmojiProps,
+  EmojiPickerListRowProps,
+  EmojiPickerRootProps,
+} from 'frimousse'
+
+import { useStyles } from './styles'
+
+// MARK: EmojiPicker
+
+interface EmojiPickerProps extends EmojiPickerRootProps {}
+
+const EmojiPicker = ({ className, ...props }: EmojiPickerProps) => {
+  const { root, search, viewport, list, message } = useStyles()()
+  return (
+    <EmojiPickerPrimitive.Root
+      data-emoji-picker=""
+      className={root({ className })}
+      {...props}
+    >
+      <EmojiPickerPrimitive.Search
+        className={search()}
+        placeholder="Search emoji…"
+      />
+      <EmojiPickerPrimitive.Viewport className={viewport()}>
+        <EmojiPickerPrimitive.Loading className={message()}>
+          Loading…
+        </EmojiPickerPrimitive.Loading>
+        <EmojiPickerPrimitive.Empty className={message()}>
+          No emoji found.
+        </EmojiPickerPrimitive.Empty>
+        <EmojiPickerPrimitive.List
+          className={list()}
+          components={{ CategoryHeader, Row, Emoji }}
+        />
+      </EmojiPickerPrimitive.Viewport>
+    </EmojiPickerPrimitive.Root>
+  )
+}
+
+// MARK: List components
+
+const CategoryHeader = ({
+  category,
+  className,
+  ...props
+}: EmojiPickerListCategoryHeaderProps) => {
+  const { categoryHeader } = useStyles()()
+  return (
+    <div className={categoryHeader({ className })} {...props}>
+      {category.label}
+    </div>
+  )
+}
+
+const Row = ({ className, ...props }: EmojiPickerListRowProps) => {
+  const { row } = useStyles()()
+  return <div className={row({ className })} {...props} />
+}
+
+const Emoji = ({ emoji, className, ...props }: EmojiPickerListEmojiProps) => {
+  const { emoji: emojiButton } = useStyles()()
+  return (
+    <button
+      data-active={emoji.isActive || undefined}
+      className={emojiButton({ className })}
+      {...props}
+    >
+      {emoji.emoji}
+    </button>
+  )
+}
+
+// MARK: Separator
+
+export type { EmojiPickerProps }
+export { EmojiPicker }

--- a/www/src/registry/ui/emoji-picker/demos/default.tsx
+++ b/www/src/registry/ui/emoji-picker/demos/default.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Button } from '@/registry/ui/button'
+import { Dialog } from '@/registry/ui/dialog'
+import { EmojiPicker } from '@/registry/ui/emoji-picker'
+import { Popover } from '@/registry/ui/popover'
+
+export default function Demo() {
+  const [emoji, setEmoji] = useState('🙂')
+  return (
+    <Dialog>
+      <Button variant="default">
+        <span aria-hidden="true">{emoji}</span>
+        Add reaction
+      </Button>
+      <Popover>
+        <EmojiPicker onEmojiSelect={(selected) => setEmoji(selected.emoji)} />
+      </Popover>
+    </Dialog>
+  )
+}

--- a/www/src/registry/ui/emoji-picker/examples.tsx
+++ b/www/src/registry/ui/emoji-picker/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function EmojiPickerExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/emoji-picker/index.tsx
+++ b/www/src/registry/ui/emoji-picker/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/emoji-picker/meta.ts
+++ b/www/src/registry/ui/emoji-picker/meta.ts
@@ -1,0 +1,26 @@
+import type { RegistryItem } from '@/registry/types'
+
+const emojiPickerMeta = {
+  name: 'emoji-picker',
+  type: 'registry:ui',
+  group: 'pickers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/emoji-picker/base.tsx',
+      target: 'ui/emoji-picker.tsx',
+    },
+  ],
+  registryDependencies: ['popover', 'dialog', 'button', 'focus-styles'],
+  dependencies: ['frimousse'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--emoji-picker-radius',
+      default: '--radius-md',
+    },
+  },
+} satisfies RegistryItem
+
+export default emojiPickerMeta

--- a/www/src/registry/ui/emoji-picker/styles.css
+++ b/www/src/registry/ui/emoji-picker/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --emoji-picker-radius: var(--radius-md);
+}

--- a/www/src/registry/ui/emoji-picker/styles.ts
+++ b/www/src/registry/ui/emoji-picker/styles.ts
@@ -1,0 +1,26 @@
+import { createStyles } from '@/lib/styles'
+
+import emojiPickerMeta from './meta'
+
+const { useStyles, styles } = createStyles(emojiPickerMeta, {
+  base: {
+    slots: {
+      root: 'flex h-[342px] w-72 flex-col p-1 text-fg',
+      search:
+        'mb-1 h-9 w-full rounded-(--emoji-picker-radius) border bg-bg px-2.5 text-sm outline-hidden placeholder:text-fg-muted focus-visible:focus-ring',
+      viewport: 'relative flex-1 outline-hidden',
+      list: 'pb-1 select-none',
+      categoryHeader:
+        'sticky top-0 z-10 bg-popover px-1.5 pt-2 pb-1 text-xs font-medium text-fg-muted',
+      row: 'scroll-my-1 px-1',
+      emoji:
+        'flex size-8 items-center justify-center rounded-(--emoji-picker-radius) text-lg data-[active]:bg-muted',
+      message:
+        'absolute inset-0 flex items-center justify-center text-sm text-fg-muted',
+    },
+  },
+})
+
+export type EmojiPickerStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/emoji-picker/types.ts
+++ b/www/src/registry/ui/emoji-picker/types.ts
@@ -1,0 +1,9 @@
+import type { EmojiPickerRootProps } from 'frimousse'
+
+/**
+ * An emoji picker panel — search, categories, and a virtualized grid — built
+ * on the headless [frimousse](https://frimousse.liveblocks.io) engine with
+ * dotUI chrome. Drop it inside a React Aria `Popover` for the usual
+ * trigger-and-overlay pattern. `onEmojiSelect` fires with the chosen emoji.
+ */
+export interface EmojiPickerProps extends EmojiPickerRootProps {}


### PR DESCRIPTION
## Summary

Adds an **Emoji Picker** to the registry — searchable, categorized, virtualized. Part of the real-world-component-blocks batch (Tier 1, the media/chat cluster).

- Engine: **frimousse** (headless, Tailwind-first emoji engine), installed as a dependency. dotUI owns the chrome: themed search input, sticky category headers, and emoji-button hover/active states.
- Max-RAC shell: the panel is meant to live inside a React Aria `Popover` (`Dialog` trigger + `Button`), shown in the demo — the dotUI overlay pattern wrapping the engine.
- Themeable axis: `--emoji-picker-radius`. Group `pickers`. `registryDependencies: ['popover', 'dialog', 'button', 'focus-styles']`, `dependencies: ['frimousse']`.

## Notes

- `EmojiPicker` is the inline panel; compose your own trigger (the demo uses the dotUI Popover) so it stays flexible — consistent with how dotUI ships Popover.
- Visual verification in the live preview is still recommended before merge.