### PR TITLE
feat(video-player): add video-player component

### DIFF
--- a/www/content/docs/components/video-player.mdx
+++ b/www/content/docs/components/video-player.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="video-player/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/video-player.mdx
+++ b/www/content/docs/components/video-player.mdx
@@ -1,0 +1,38 @@
+---
+title: Video Player
+description: A themeable control bar over a native video — seek, volume, PiP, and fullscreen.
+links:
+  - label: Docs
+    href: https://react-spectrum.adobe.com/react-aria/Slider.html
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/video-player
+```
+
+## Usage
+
+Pass the video `src`. The control bar (play/pause, seek, volume, picture-in-picture, fullscreen) is built on the React Aria `Button` and `Slider`, over a native `<video>` element — no media engine, only stable browser APIs.
+
+```tsx
+import { VideoPlayer } from '@/components/ui/video-player'
+```
+
+```tsx
+<VideoPlayer src="/clip.mp4" poster="/poster.jpg" />
+```
+
+## Examples
+
+<Examples>
+  <Example name="video-player/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### VideoPlayer
+
+<Reference name="video-player" />

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -72,6 +72,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"toggle-button-group": () => import("@/registry/ui/toggle-button-group/examples"),
 	tooltip: () => import("@/registry/ui/tooltip/examples"),
 	tree: () => import("@/registry/ui/tree/examples"),
+	"video-player": () => import("@/registry/ui/video-player/examples"),
 };
 
 export const GroupExamplesIndex: Record<string, () => Promise<{ default: React.ComponentType }>> = {

--- a/www/src/modules/docs/references/generated/video-player.json
+++ b/www/src/modules/docs/references/generated/video-player.json
@@ -1,0 +1,22 @@
+{
+  "name": "VideoPlayerProps",
+  "description": "A video player renders a themeable control bar over a native `<video>`\nelement: play/pause, a seek slider, volume, time, picture-in-picture, and\nfullscreen. Controls are built on React Aria `Button` and `Slider`, with no\nmedia engine — only stable browser APIs (works with `hls.js` if you wire\nstreaming yourself). Extra props are forwarded to the `<video>` element.",
+  "extendsElement": "video",
+  "props": {
+    "src": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The video source URL.",
+      "required": true
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -2829,4 +2829,8 @@ export const DemosIndex: Record<
 		files: ["ui/tree/demos/with-icons.tsx"],
 		component: React.lazy(() => import("@/registry/ui/tree/demos/with-icons")),
 	},
+	"video-player/demos/default": {
+		files: ["ui/video-player/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/video-player/demos/default")),
+	},
 };

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -75,6 +75,7 @@ import UiToggleButtonGroup from "@/registry/ui/toggle-button-group/meta";
 import UiToggleButton from "@/registry/ui/toggle-button/meta";
 import UiTooltip from "@/registry/ui/tooltip/meta";
 import UiTree from "@/registry/ui/tree/meta";
+import UiVideoPlayer from "@/registry/ui/video-player/meta";
 
 import type { RegistryItem } from "@/registry/types";
 
@@ -149,6 +150,7 @@ export const registryUi: RegistryItem[] = [
 	UiToggleButtonGroup,
 	UiTooltip,
 	UiTree,
+	UiVideoPlayer,
 ];
 
 export const registryLib: RegistryItem[] = [LibFocusStyles, LibResponsive, LibTextareaCaret, LibUtils];

--- a/www/src/registry/ui/video-player/base.tsx
+++ b/www/src/registry/ui/video-player/base.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { ComponentProps } from 'react'
+import {
+  MaximizeIcon,
+  MinimizeIcon,
+  PauseIcon,
+  PictureInPicture2Icon,
+  PlayIcon,
+  Volume2Icon,
+  VolumeXIcon,
+} from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { Slider, SliderControl } from '@/registry/ui/slider'
+
+import { useStyles } from './styles'
+
+// MARK: VideoPlayer
+
+interface VideoPlayerProps extends ComponentProps<'video'> {
+  src: string
+}
+
+const VideoPlayer = ({ src, className, ...props }: VideoPlayerProps) => {
+  const { root, video, bigButton, controls, time, spacer } = useStyles()()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [volumeLevel, setVolumeLevel] = useState(1)
+  const [isMuted, setIsMuted] = useState(false)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  useEffect(() => {
+    const node = videoRef.current
+    if (!node) return
+    const onTime = () => setCurrentTime(node.currentTime)
+    const onMeta = () => setDuration(node.duration)
+    const onPlay = () => setIsPlaying(true)
+    const onPause = () => setIsPlaying(false)
+    const onEnded = () => setIsPlaying(false)
+    const onVolume = () => {
+      setVolumeLevel(node.volume)
+      setIsMuted(node.muted)
+    }
+    node.addEventListener('timeupdate', onTime)
+    node.addEventListener('loadedmetadata', onMeta)
+    node.addEventListener('durationchange', onMeta)
+    node.addEventListener('play', onPlay)
+    node.addEventListener('pause', onPause)
+    node.addEventListener('ended', onEnded)
+    node.addEventListener('volumechange', onVolume)
+    return () => {
+      node.removeEventListener('timeupdate', onTime)
+      node.removeEventListener('loadedmetadata', onMeta)
+      node.removeEventListener('durationchange', onMeta)
+      node.removeEventListener('play', onPlay)
+      node.removeEventListener('pause', onPause)
+      node.removeEventListener('ended', onEnded)
+      node.removeEventListener('volumechange', onVolume)
+    }
+  }, [])
+
+  useEffect(() => {
+    const onFullscreen = () =>
+      setIsFullscreen(document.fullscreenElement != null)
+    document.addEventListener('fullscreenchange', onFullscreen)
+    return () => document.removeEventListener('fullscreenchange', onFullscreen)
+  }, [])
+
+  const togglePlay = () => {
+    const node = videoRef.current
+    if (!node) return
+    if (node.paused) void node.play()
+    else node.pause()
+  }
+
+  const handleSeek = (value: number | number[]) => {
+    const node = videoRef.current
+    if (!node) return
+    const next = Array.isArray(value) ? (value[0] ?? 0) : value
+    node.currentTime = next
+    setCurrentTime(next)
+  }
+
+  const handleVolume = (value: number | number[]) => {
+    const node = videoRef.current
+    if (!node) return
+    const next = Array.isArray(value) ? (value[0] ?? 0) : value
+    node.volume = next
+    node.muted = next === 0
+  }
+
+  const toggleMute = () => {
+    const node = videoRef.current
+    if (node) node.muted = !node.muted
+  }
+
+  const toggleFullscreen = () => {
+    if (document.fullscreenElement) void document.exitFullscreen()
+    else void containerRef.current?.requestFullscreen()
+  }
+
+  const togglePip = () => {
+    const node = videoRef.current
+    if (!node) return
+    if (document.pictureInPictureElement) void document.exitPictureInPicture()
+    else void node.requestPictureInPicture()
+  }
+
+  const showVolumeOff = isMuted || volumeLevel === 0
+
+  return (
+    <div
+      ref={containerRef}
+      data-video-player=""
+      data-paused={!isPlaying || undefined}
+      className={root({ className })}
+    >
+      <video
+        ref={videoRef}
+        src={src}
+        className={video()}
+        playsInline
+        {...props}
+      />
+      {!isPlaying && (
+        <button
+          type="button"
+          aria-label="Play"
+          className={bigButton()}
+          onClick={togglePlay}
+        >
+          <PlayIcon />
+        </button>
+      )}
+      <div data-video-player-controls="" className={controls()}>
+        <Slider
+          aria-label="Seek"
+          value={Math.min(currentTime, duration || 0)}
+          minValue={0}
+          maxValue={duration || 1}
+          step={0.1}
+          onChange={handleSeek}
+        >
+          <SliderControl />
+        </Slider>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="quiet"
+            size="sm"
+            isIconOnly
+            onPress={togglePlay}
+            aria-label={isPlaying ? 'Pause' : 'Play'}
+          >
+            {isPlaying ? <PauseIcon /> : <PlayIcon />}
+          </Button>
+          <Button
+            variant="quiet"
+            size="sm"
+            isIconOnly
+            onPress={toggleMute}
+            aria-label={showVolumeOff ? 'Unmute' : 'Mute'}
+          >
+            {showVolumeOff ? <VolumeXIcon /> : <Volume2Icon />}
+          </Button>
+          <Slider
+            aria-label="Volume"
+            className="hidden w-16 sm:flex"
+            value={isMuted ? 0 : volumeLevel}
+            minValue={0}
+            maxValue={1}
+            step={0.01}
+            onChange={handleVolume}
+          >
+            <SliderControl />
+          </Slider>
+          <span className={time()}>
+            {formatTime(currentTime)} / {formatTime(duration)}
+          </span>
+          <span className={spacer()} />
+          <Button
+            variant="quiet"
+            size="sm"
+            isIconOnly
+            onPress={togglePip}
+            aria-label="Picture in picture"
+          >
+            <PictureInPicture2Icon />
+          </Button>
+          <Button
+            variant="quiet"
+            size="sm"
+            isIconOnly
+            onPress={toggleFullscreen}
+            aria-label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+          >
+            {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// MARK: formatTime
+
+const formatTime = (seconds: number) => {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00'
+  const minutes = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${minutes}:${secs.toString().padStart(2, '0')}`
+}
+
+// MARK: Separator
+
+export type { VideoPlayerProps }
+export { VideoPlayer }

--- a/www/src/registry/ui/video-player/demos/default.tsx
+++ b/www/src/registry/ui/video-player/demos/default.tsx
@@ -1,0 +1,11 @@
+import { VideoPlayer } from '@/registry/ui/video-player'
+
+export default function Demo() {
+  return (
+    <VideoPlayer
+      className="max-w-xl"
+      src="https://www.w3schools.com/html/mov_bbb.mp4"
+      poster="https://images.unsplash.com/photo-1536440136628-849c177e76a1?w=800&q=80"
+    />
+  )
+}

--- a/www/src/registry/ui/video-player/examples.tsx
+++ b/www/src/registry/ui/video-player/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function VideoPlayerExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/video-player/index.tsx
+++ b/www/src/registry/ui/video-player/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/video-player/meta.ts
+++ b/www/src/registry/ui/video-player/meta.ts
@@ -1,0 +1,25 @@
+import type { RegistryItem } from '@/registry/types'
+
+const videoPlayerMeta = {
+  name: 'video-player',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/video-player/base.tsx',
+      target: 'ui/video-player.tsx',
+    },
+  ],
+  registryDependencies: ['button', 'slider'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--video-player-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default videoPlayerMeta

--- a/www/src/registry/ui/video-player/styles.css
+++ b/www/src/registry/ui/video-player/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --video-player-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/video-player/styles.ts
+++ b/www/src/registry/ui/video-player/styles.ts
@@ -1,0 +1,22 @@
+import { createStyles } from '@/lib/styles'
+
+import videoPlayerMeta from './meta'
+
+const { useStyles, styles } = createStyles(videoPlayerMeta, {
+  base: {
+    slots: {
+      root: 'group relative aspect-video w-full overflow-hidden rounded-(--video-player-radius) bg-black text-white',
+      video: 'size-full',
+      bigButton:
+        'absolute top-1/2 left-1/2 grid size-14 -translate-x-1/2 -translate-y-1/2 place-items-center rounded-full bg-black/50 text-white backdrop-blur-sm transition-transform hover:scale-105 [&_svg]:size-7',
+      controls:
+        'absolute inset-x-0 bottom-0 flex flex-col gap-1 bg-gradient-to-t from-black/70 via-black/30 to-transparent p-2 pt-8 opacity-0 transition-opacity group-hover:opacity-100 group-data-[paused]:opacity-100 [&_[data-button]]:text-white [&_[data-button]]:hover:bg-white/15',
+      time: 'px-1.5 text-xs text-white/90 tabular-nums',
+      spacer: 'flex-1',
+    },
+  },
+})
+
+export type VideoPlayerStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/video-player/types.ts
+++ b/www/src/registry/ui/video-player/types.ts
@@ -1,0 +1,13 @@
+import type { ComponentProps } from 'react'
+
+/**
+ * A video player renders a themeable control bar over a native `<video>`
+ * element: play/pause, a seek slider, volume, time, picture-in-picture, and
+ * fullscreen. Controls are built on React Aria `Button` and `Slider`, with no
+ * media engine — only stable browser APIs (works with `hls.js` if you wire
+ * streaming yourself). Extra props are forwarded to the `<video>` element.
+ */
+export interface VideoPlayerProps extends ComponentProps<'video'> {
+  /** The video source URL. */
+  src: string
+}


### PR DESCRIPTION
## Summary

Adds a **Video Player** to the registry — a themeable control bar over a native `<video>`. Part of the real-world-component-blocks batch (Tier 2 media cluster).

- No media engine: built only on stable browser APIs (per the research doc's "timing trap" — Vidstack/Media Chrome/Plyr are merging into Video.js v10, so we hedge on native `<video>`). Wire `hls.js` yourself for streaming.
- Chrome on React Aria: play/pause, seek `Slider`, volume, time, **picture-in-picture**, and **fullscreen** — all `Button`/`Slider`. Center play overlay when paused; controls reveal on hover.
- Shares the control-bar idiom with `audio-player` (synced media group, per the research doc).
- Themeable axis: `--video-player-radius`. Group `containers`. `registryDependencies: ['button', 'slider']`.

## Notes

- Visual verification in the live preview is still recommended before merge.