### PR TITLE
feat(comment-thread): add comment-thread component

### DIFF
--- a/www/content/docs/components/comment-thread.mdx
+++ b/www/content/docs/components/comment-thread.mdx
@@ -1,0 +1,59 @@
+---
+title: Comment Thread
+description: A composable comment thread with avatars, nested replies, and actions.
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/comment-thread
+```
+
+## Usage
+
+Compose `Comment`s inside a `CommentThread`. Each comment is an `Avatar` followed by `CommentContent` (header, body, actions). Nest a `CommentThread` inside a comment for indented replies.
+
+```tsx
+import {
+  Comment,
+  CommentActions,
+  CommentAuthor,
+  CommentBody,
+  CommentContent,
+  CommentHeader,
+  CommentThread,
+  CommentTimestamp,
+} from '@/components/ui/comment-thread'
+```
+
+```tsx
+<CommentThread>
+  <Comment>
+    <Avatar size="sm">…</Avatar>
+    <CommentContent>
+      <CommentHeader>
+        <CommentAuthor>Sofia Davis</CommentAuthor>
+        <CommentTimestamp>2h ago</CommentTimestamp>
+      </CommentHeader>
+      <CommentBody>Looks great!</CommentBody>
+    </CommentContent>
+  </Comment>
+</CommentThread>
+```
+
+## Examples
+
+<Examples>
+  <Example name="comment-thread/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### CommentThread
+
+<Reference name="comment-thread" />
+
+### Comment
+
+<Reference name="comment" />

--- a/www/content/docs/components/comment-thread.mdx
+++ b/www/content/docs/components/comment-thread.mdx
@@ -4,6 +4,8 @@ description: A composable comment thread with avatars, nested replies, and actio
 wip: true
 ---
 
+<Demo name="comment-thread/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -27,6 +27,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"color-swatch-picker": () => import("@/registry/ui/color-swatch-picker/examples"),
 	combobox: () => import("@/registry/ui/combobox/examples"),
 	command: () => import("@/registry/ui/command/examples"),
+	"comment-thread": () => import("@/registry/ui/comment-thread/examples"),
 	"context-menu": () => import("@/registry/ui/context-menu/examples"),
 	"date-field": () => import("@/registry/ui/date-field/examples"),
 	"date-picker": () => import("@/registry/ui/date-picker/examples"),

--- a/www/src/modules/docs/references/generated/comment-thread.json
+++ b/www/src/modules/docs/references/generated/comment-thread.json
@@ -1,0 +1,14 @@
+{
+  "name": "CommentThreadProps",
+  "description": "A comment thread — a composable display block for discussions. Compose\n`Comment`s (each an `Avatar` + `CommentContent`) inside; nest a\n`CommentThread` within a comment for indented replies.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/comment.json
+++ b/www/src/modules/docs/references/generated/comment.json
@@ -1,0 +1,14 @@
+{
+  "name": "CommentProps",
+  "description": "A single comment row: an avatar followed by its `CommentContent`.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -925,6 +925,10 @@ export const DemosIndex: Record<
 		files: ["ui/command/demos/with-tag-group.tsx"],
 		component: React.lazy(() => import("@/registry/ui/command/demos/with-tag-group")),
 	},
+	"comment-thread/demos/default": {
+		files: ["ui/comment-thread/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/comment-thread/demos/default")),
+	},
 	"context-menu/demos/basic": {
 		files: ["ui/context-menu/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/context-menu/demos/basic")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -32,6 +32,7 @@ import UiColorSwatch from "@/registry/ui/color-swatch/meta";
 import UiColorThumb from "@/registry/ui/color-thumb/meta";
 import UiCombobox from "@/registry/ui/combobox/meta";
 import UiCommand from "@/registry/ui/command/meta";
+import UiCommentThread from "@/registry/ui/comment-thread/meta";
 import UiContextMenu from "@/registry/ui/context-menu/meta";
 import UiDateField from "@/registry/ui/date-field/meta";
 import UiDatePicker from "@/registry/ui/date-picker/meta";
@@ -106,6 +107,7 @@ export const registryUi: RegistryItem[] = [
 	UiColorThumb,
 	UiCombobox,
 	UiCommand,
+	UiCommentThread,
 	UiContextMenu,
 	UiDateField,
 	UiDatePicker,

--- a/www/src/registry/ui/comment-thread/base.tsx
+++ b/www/src/registry/ui/comment-thread/base.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import type { ComponentProps } from 'react'
+
+import { useStyles } from './styles'
+
+// MARK: CommentThread
+
+const CommentThread = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { root } = useStyles()()
+  return (
+    <div data-comment-thread="" className={root({ className })} {...props} />
+  )
+}
+
+// MARK: Comment
+
+const Comment = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { comment } = useStyles()()
+  return <div data-comment="" className={comment({ className })} {...props} />
+}
+
+// MARK: CommentContent
+
+const CommentContent = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { content } = useStyles()()
+  return (
+    <div
+      data-comment-content=""
+      className={content({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: CommentHeader
+
+const CommentHeader = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { header } = useStyles()()
+  return (
+    <div data-comment-header="" className={header({ className })} {...props} />
+  )
+}
+
+// MARK: CommentAuthor
+
+const CommentAuthor = ({ className, ...props }: ComponentProps<'span'>) => {
+  const { author } = useStyles()()
+  return (
+    <span data-comment-author="" className={author({ className })} {...props} />
+  )
+}
+
+// MARK: CommentTimestamp
+
+const CommentTimestamp = ({ className, ...props }: ComponentProps<'span'>) => {
+  const { timestamp } = useStyles()()
+  return (
+    <span
+      data-comment-timestamp=""
+      className={timestamp({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: CommentBody
+
+const CommentBody = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { body } = useStyles()()
+  return <div data-comment-body="" className={body({ className })} {...props} />
+}
+
+// MARK: CommentActions
+
+const CommentActions = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { actions } = useStyles()()
+  return (
+    <div
+      data-comment-actions=""
+      className={actions({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: Separator
+
+export {
+  CommentThread,
+  Comment,
+  CommentContent,
+  CommentHeader,
+  CommentAuthor,
+  CommentTimestamp,
+  CommentBody,
+  CommentActions,
+}

--- a/www/src/registry/ui/comment-thread/demos/default.tsx
+++ b/www/src/registry/ui/comment-thread/demos/default.tsx
@@ -1,0 +1,60 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/registry/ui/avatar'
+import { Button } from '@/registry/ui/button'
+import {
+  Comment,
+  CommentActions,
+  CommentAuthor,
+  CommentBody,
+  CommentContent,
+  CommentHeader,
+  CommentThread,
+  CommentTimestamp,
+} from '@/registry/ui/comment-thread'
+
+export default function Demo() {
+  return (
+    <CommentThread className="w-full max-w-md">
+      <Comment>
+        <Avatar size="sm">
+          <AvatarImage src="https://i.pravatar.cc/80?img=1" alt="Sofia Davis" />
+          <AvatarFallback>SD</AvatarFallback>
+        </Avatar>
+        <CommentContent>
+          <CommentHeader>
+            <CommentAuthor>Sofia Davis</CommentAuthor>
+            <CommentTimestamp>2h ago</CommentTimestamp>
+          </CommentHeader>
+          <CommentBody>
+            This pattern is exactly what we needed. Shipping it.
+          </CommentBody>
+          <CommentActions>
+            <Button variant="quiet" size="xs">
+              Reply
+            </Button>
+            <Button variant="quiet" size="xs">
+              Like
+            </Button>
+          </CommentActions>
+          <CommentThread>
+            <Comment>
+              <Avatar size="sm">
+                <AvatarImage
+                  src="https://i.pravatar.cc/80?img=5"
+                  alt="Max Leiter"
+                />
+                <AvatarFallback>ML</AvatarFallback>
+              </Avatar>
+              <CommentContent>
+                <CommentHeader>
+                  <CommentAuthor>Max Leiter</CommentAuthor>
+                  <CommentTimestamp>1h ago</CommentTimestamp>
+                </CommentHeader>
+                <CommentBody>Agreed — clean composition.</CommentBody>
+              </CommentContent>
+            </Comment>
+          </CommentThread>
+        </CommentContent>
+      </Comment>
+    </CommentThread>
+  )
+}

--- a/www/src/registry/ui/comment-thread/examples.tsx
+++ b/www/src/registry/ui/comment-thread/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function CommentThreadExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/comment-thread/index.tsx
+++ b/www/src/registry/ui/comment-thread/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/comment-thread/meta.ts
+++ b/www/src/registry/ui/comment-thread/meta.ts
@@ -1,0 +1,17 @@
+import type { RegistryItem } from '@/registry/types'
+
+const commentThreadMeta = {
+  name: 'comment-thread',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/comment-thread/base.tsx',
+      target: 'ui/comment-thread.tsx',
+    },
+  ],
+  registryDependencies: ['avatar', 'button'],
+} satisfies RegistryItem
+
+export default commentThreadMeta

--- a/www/src/registry/ui/comment-thread/styles.ts
+++ b/www/src/registry/ui/comment-thread/styles.ts
@@ -1,0 +1,22 @@
+import { createStyles } from '@/lib/styles'
+
+import commentThreadMeta from './meta'
+
+const { useStyles, styles } = createStyles(commentThreadMeta, {
+  base: {
+    slots: {
+      root: 'flex flex-col gap-4 [&_[data-comment-thread]]:mt-4 [&_[data-comment-thread]]:border-l [&_[data-comment-thread]]:pl-5',
+      comment: 'flex gap-3',
+      content: 'flex min-w-0 flex-1 flex-col gap-1',
+      header: 'flex flex-wrap items-baseline gap-x-2',
+      author: 'text-sm font-medium',
+      timestamp: 'text-xs text-fg-muted',
+      body: 'text-sm whitespace-pre-line text-fg',
+      actions: 'mt-0.5 flex items-center gap-1',
+    },
+  },
+})
+
+export type CommentThreadStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/comment-thread/types.ts
+++ b/www/src/registry/ui/comment-thread/types.ts
@@ -1,0 +1,11 @@
+import type { ComponentProps } from 'react'
+
+/**
+ * A comment thread — a composable display block for discussions. Compose
+ * `Comment`s (each an `Avatar` + `CommentContent`) inside; nest a
+ * `CommentThread` within a comment for indented replies.
+ */
+export interface CommentThreadProps extends ComponentProps<'div'> {}
+
+/** A single comment row: an avatar followed by its `CommentContent`. */
+export interface CommentProps extends ComponentProps<'div'> {}


### PR DESCRIPTION
## Summary

Adds a **Comment Thread** to the registry — a composable display block for discussions, with avatars, nested replies, and actions. Part of the real-world-component-blocks batch (Tier 2).

- Pure composition over existing registry items — reuses `Avatar` and `Button`; no new dependency.
- Composition-first parts (`Comment`, `CommentContent`, `CommentHeader`, `CommentAuthor`, `CommentTimestamp`, `CommentBody`, `CommentActions`), matching the dotUI house style.
- Nest a `CommentThread` inside a comment for auto-indented replies (left rule + padding via CSS).
- Group `containers`. `registryDependencies: ['avatar', 'button']`.

## Notes

- Display-only by design — bring your own composer (the docs show pairing it with a `TextField`).
- Visual verification in the live preview is still recommended before merge.