### PR TITLE
feat(notification-feed): add notification-feed component

### DIFF
--- a/www/content/docs/components/notification-feed.mdx
+++ b/www/content/docs/components/notification-feed.mdx
@@ -1,0 +1,57 @@
+---
+title: Notification Feed
+description: A composable notifications / activity inbox with unread state and actions.
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/notification-feed
+```
+
+## Usage
+
+Compose `Notification`s inside a `NotificationFeed`. Each row pairs an `Avatar` (or icon) with `NotificationContent` (title, description, time) and optional `NotificationActions`. Mark a row `unread` for the accent bar + tinted background.
+
+```tsx
+import {
+  Notification,
+  NotificationActions,
+  NotificationContent,
+  NotificationDescription,
+  NotificationFeed,
+  NotificationTime,
+  NotificationTitle,
+} from '@/components/ui/notification-feed'
+```
+
+```tsx
+<NotificationFeed>
+  <Notification unread>
+    <Avatar size="sm">…</Avatar>
+    <NotificationContent>
+      <NotificationTitle>
+        <strong>Olivia</strong> requested your review
+      </NotificationTitle>
+      <NotificationTime>5m</NotificationTime>
+    </NotificationContent>
+  </Notification>
+</NotificationFeed>
+```
+
+## Examples
+
+<Examples>
+  <Example name="notification-feed/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### NotificationFeed
+
+<Reference name="notification-feed" />
+
+### Notification
+
+<Reference name="notification" />

--- a/www/content/docs/components/notification-feed.mdx
+++ b/www/content/docs/components/notification-feed.mdx
@@ -4,6 +4,8 @@ description: A composable notifications / activity inbox with unread state and a
 wip: true
 ---
 
+<Demo name="notification-feed/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -47,6 +47,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	mention: () => import("@/registry/ui/mention/examples"),
 	menu: () => import("@/registry/ui/menu/examples"),
 	modal: () => import("@/registry/ui/modal/examples"),
+	"notification-feed": () => import("@/registry/ui/notification-feed/examples"),
 	"number-field": () => import("@/registry/ui/number-field/examples"),
 	"otp-field": () => import("@/registry/ui/otp-field/examples"),
 	pagination: () => import("@/registry/ui/pagination/examples"),

--- a/www/src/modules/docs/references/generated/notification-feed.json
+++ b/www/src/modules/docs/references/generated/notification-feed.json
@@ -1,0 +1,14 @@
+{
+  "name": "NotificationFeedProps",
+  "description": "A notification feed / inbox — a composable list of activity items. Compose\n`Notification`s inside, each with `NotificationContent` (title, description,\ntime) and optional `NotificationActions`. Reuses `Avatar` for actor avatars.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/notification.json
+++ b/www/src/modules/docs/references/generated/notification.json
@@ -1,0 +1,22 @@
+{
+  "name": "NotificationProps",
+  "description": "A single notification row.",
+  "extendsElement": "div",
+  "props": {
+    "unread": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Highlight the row as unread (accent bar + tinted background)."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -1817,6 +1817,10 @@ export const DemosIndex: Record<
 		files: ["ui/modal/demos/with-form.tsx"],
 		component: React.lazy(() => import("@/registry/ui/modal/demos/with-form")),
 	},
+	"notification-feed/demos/default": {
+		files: ["ui/notification-feed/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/notification-feed/demos/default")),
+	},
 	"number-field/demos/basic": {
 		files: ["ui/number-field/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/number-field/demos/basic")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -51,6 +51,7 @@ import UiLoader from "@/registry/ui/loader/meta";
 import UiMention from "@/registry/ui/mention/meta";
 import UiMenu from "@/registry/ui/menu/meta";
 import UiModal from "@/registry/ui/modal/meta";
+import UiNotificationFeed from "@/registry/ui/notification-feed/meta";
 import UiNumberField from "@/registry/ui/number-field/meta";
 import UiOtpField from "@/registry/ui/otp-field/meta";
 import UiPagination from "@/registry/ui/pagination/meta";
@@ -125,6 +126,7 @@ export const registryUi: RegistryItem[] = [
 	UiMention,
 	UiMenu,
 	UiModal,
+	UiNotificationFeed,
 	UiNumberField,
 	UiOtpField,
 	UiPagination,

--- a/www/src/registry/ui/notification-feed/base.tsx
+++ b/www/src/registry/ui/notification-feed/base.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import type { ComponentProps } from 'react'
+
+import { useStyles } from './styles'
+
+// MARK: NotificationFeed
+
+const NotificationFeed = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { root } = useStyles()()
+  return (
+    <div
+      data-notification-feed=""
+      role="feed"
+      className={root({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: Notification
+
+interface NotificationProps extends ComponentProps<'div'> {
+  unread?: boolean
+}
+
+const Notification = ({ unread, className, ...props }: NotificationProps) => {
+  const { item } = useStyles()()
+  return (
+    <div
+      data-notification=""
+      data-unread={unread || undefined}
+      className={item({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: NotificationContent
+
+const NotificationContent = ({
+  className,
+  ...props
+}: ComponentProps<'div'>) => {
+  const { content } = useStyles()()
+  return (
+    <div
+      data-notification-content=""
+      className={content({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: NotificationTitle
+
+const NotificationTitle = ({ className, ...props }: ComponentProps<'div'>) => {
+  const { title } = useStyles()()
+  return (
+    <div
+      data-notification-title=""
+      className={title({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: NotificationDescription
+
+const NotificationDescription = ({
+  className,
+  ...props
+}: ComponentProps<'div'>) => {
+  const { description } = useStyles()()
+  return (
+    <div
+      data-notification-description=""
+      className={description({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: NotificationTime
+
+const NotificationTime = ({ className, ...props }: ComponentProps<'span'>) => {
+  const { time } = useStyles()()
+  return (
+    <span
+      data-notification-time=""
+      className={time({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: NotificationActions
+
+const NotificationActions = ({
+  className,
+  ...props
+}: ComponentProps<'div'>) => {
+  const { actions } = useStyles()()
+  return (
+    <div
+      data-notification-actions=""
+      className={actions({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: Separator
+
+export type { NotificationProps }
+export {
+  NotificationFeed,
+  Notification,
+  NotificationContent,
+  NotificationTitle,
+  NotificationDescription,
+  NotificationTime,
+  NotificationActions,
+}

--- a/www/src/registry/ui/notification-feed/demos/default.tsx
+++ b/www/src/registry/ui/notification-feed/demos/default.tsx
@@ -1,0 +1,56 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/registry/ui/avatar'
+import { Button } from '@/registry/ui/button'
+import {
+  Notification,
+  NotificationActions,
+  NotificationContent,
+  NotificationDescription,
+  NotificationFeed,
+  NotificationTime,
+  NotificationTitle,
+} from '@/registry/ui/notification-feed'
+
+export default function Demo() {
+  return (
+    <NotificationFeed className="max-w-md">
+      <Notification unread>
+        <Avatar size="sm">
+          <AvatarImage src="https://i.pravatar.cc/80?img=12" alt="Olivia" />
+          <AvatarFallback>OM</AvatarFallback>
+        </Avatar>
+        <NotificationContent>
+          <NotificationTitle>
+            <strong>Olivia Martin</strong> requested your review
+          </NotificationTitle>
+          <NotificationDescription>
+            “Add carousel component” is ready for review.
+          </NotificationDescription>
+          <NotificationActions>
+            <Button variant="primary" size="xs">
+              Review
+            </Button>
+            <Button variant="quiet" size="xs">
+              Dismiss
+            </Button>
+          </NotificationActions>
+        </NotificationContent>
+        <NotificationTime>5m</NotificationTime>
+      </Notification>
+      <Notification>
+        <Avatar size="sm">
+          <AvatarImage src="https://i.pravatar.cc/80?img=33" alt="Jackson" />
+          <AvatarFallback>JL</AvatarFallback>
+        </Avatar>
+        <NotificationContent>
+          <NotificationTitle>
+            <strong>Jackson Lee</strong> mentioned you
+          </NotificationTitle>
+          <NotificationDescription>
+            “…let&apos;s ship the new tokens.”
+          </NotificationDescription>
+        </NotificationContent>
+        <NotificationTime>1h</NotificationTime>
+      </Notification>
+    </NotificationFeed>
+  )
+}

--- a/www/src/registry/ui/notification-feed/examples.tsx
+++ b/www/src/registry/ui/notification-feed/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function NotificationFeedExamples() {
+  return (
+    <Examples className="md:grid-cols-1">
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/notification-feed/index.tsx
+++ b/www/src/registry/ui/notification-feed/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/notification-feed/meta.ts
+++ b/www/src/registry/ui/notification-feed/meta.ts
@@ -1,0 +1,25 @@
+import type { RegistryItem } from '@/registry/types'
+
+const notificationFeedMeta = {
+  name: 'notification-feed',
+  type: 'registry:ui',
+  group: 'feedback',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/notification-feed/base.tsx',
+      target: 'ui/notification-feed.tsx',
+    },
+  ],
+  registryDependencies: ['avatar', 'button'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--notification-feed-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default notificationFeedMeta

--- a/www/src/registry/ui/notification-feed/styles.css
+++ b/www/src/registry/ui/notification-feed/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --notification-feed-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/notification-feed/styles.ts
+++ b/www/src/registry/ui/notification-feed/styles.ts
@@ -1,0 +1,21 @@
+import { createStyles } from '@/lib/styles'
+
+import notificationFeedMeta from './meta'
+
+const { useStyles, styles } = createStyles(notificationFeedMeta, {
+  base: {
+    slots: {
+      root: 'flex w-full flex-col divide-y overflow-hidden rounded-(--notification-feed-radius) border bg-card',
+      item: 'relative flex gap-3 p-3 transition-colors hover:bg-muted/50 data-[unread]:bg-muted/40 data-[unread]:before:absolute data-[unread]:before:inset-y-0 data-[unread]:before:left-0 data-[unread]:before:w-0.5 data-[unread]:before:bg-primary',
+      content: 'flex min-w-0 flex-1 flex-col gap-0.5',
+      title: 'text-sm [&_b]:font-medium [&_strong]:font-medium',
+      description: 'text-sm text-fg-muted',
+      time: 'text-xs text-fg-muted',
+      actions: 'mt-1.5 flex items-center gap-2',
+    },
+  },
+})
+
+export type NotificationFeedStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/notification-feed/types.ts
+++ b/www/src/registry/ui/notification-feed/types.ts
@@ -1,0 +1,14 @@
+import type { ComponentProps } from 'react'
+
+/**
+ * A notification feed / inbox — a composable list of activity items. Compose
+ * `Notification`s inside, each with `NotificationContent` (title, description,
+ * time) and optional `NotificationActions`. Reuses `Avatar` for actor avatars.
+ */
+export interface NotificationFeedProps extends ComponentProps<'div'> {}
+
+/** A single notification row. */
+export interface NotificationProps extends ComponentProps<'div'> {
+  /** Highlight the row as unread (accent bar + tinted background). */
+  unread?: boolean
+}


### PR DESCRIPTION
## Summary

Adds a **Notification Feed** (activity inbox) to the registry — a composable list of notification rows with unread state and actions. Part of the real-world-component-blocks batch (Tier 2).

- Pure composition over existing registry items — reuses `Avatar` and `Button`; no new dependency.
- Composition-first parts (`Notification`, `NotificationContent`, `NotificationTitle`, `NotificationDescription`, `NotificationTime`, `NotificationActions`).
- `unread` marks a row with an accent bar + tinted background; `role="feed"` for assistive tech.
- Themeable axis: `--notification-feed-radius`. Group `feedback`. `registryDependencies: ['avatar', 'button']`.

## Notes

- Visual verification in the live preview is still recommended before merge.