### PR TITLE
feat(lightbox): add lightbox component

### DIFF
--- a/www/content/docs/components/lightbox.mdx
+++ b/www/content/docs/components/lightbox.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="lightbox/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/lightbox.mdx
+++ b/www/content/docs/components/lightbox.mdx
@@ -1,0 +1,48 @@
+---
+title: Lightbox
+description: A media lightbox that opens a fullscreen viewer from a thumbnail grid.
+links:
+  - label: Docs
+    href: https://react-spectrum.adobe.com/react-aria/Modal.html
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/lightbox
+```
+
+## Usage
+
+Pass an array of images. The lightbox renders a responsive grid of thumbnails; clicking one opens a fullscreen viewer with previous/next navigation, a close button, and keyboard support (ArrowLeft, ArrowRight, Escape).
+
+```tsx
+import { Lightbox } from '@/components/ui/lightbox'
+```
+
+```tsx
+<Lightbox
+  images={[
+    { src: '/photos/1.jpg', alt: 'Mountain lake at sunrise' },
+    { src: '/photos/2.jpg', alt: 'Foggy forest valley' },
+    { src: '/photos/3.jpg', alt: 'Green valley with a river' },
+  ]}
+/>
+```
+
+## Examples
+
+<Examples>
+  <Example name="lightbox/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### Lightbox
+
+<Reference name="lightbox" />
+
+### LightboxViewer
+
+<Reference name="lightbox-viewer" />

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -42,6 +42,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	input: () => import("@/registry/ui/input/examples"),
 	"input-group": () => import("@/registry/ui/input-group/examples"),
 	kbd: () => import("@/registry/ui/kbd/examples"),
+	lightbox: () => import("@/registry/ui/lightbox/examples"),
 	"list-box": () => import("@/registry/ui/list-box/examples"),
 	loader: () => import("@/registry/ui/loader/examples"),
 	mention: () => import("@/registry/ui/mention/examples"),

--- a/www/src/modules/docs/references/generated/lightbox-viewer.json
+++ b/www/src/modules/docs/references/generated/lightbox-viewer.json
@@ -1,0 +1,103 @@
+{
+  "name": "LightboxViewerProps",
+  "description": "The fullscreen viewer rendered inside the modal. Displays the active image\nwith previous/next controls, a counter, and an optional caption. Exposed for\nadvanced use; most consumers should use `Lightbox`.",
+  "props": {
+    "images": {
+      "type": "LightboxImage[]",
+      "typeAst": {
+        "type": "array",
+        "elementType": {
+          "type": "link",
+          "id": "src/registry/ui/lightbox/types.ts:LightboxImage",
+          "name": "LightboxImage"
+        }
+      },
+      "description": "The full set of images to navigate between.",
+      "required": true
+    },
+    "index": {
+      "type": "number",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "The index of the currently displayed image.",
+      "required": true
+    },
+    "onIndexChange": {
+      "type": "(index: number) => void",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "index",
+            "value": {
+              "type": "number"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Called with the next index when the user navigates.",
+      "required": true
+    },
+    "onClose": {
+      "type": "() => void",
+      "typeAst": {
+        "type": "function",
+        "parameters": [],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Called when the user requests to close the viewer.",
+      "required": true
+    }
+  },
+  "typeLinks": {
+    "src/registry/ui/lightbox/types.ts:LightboxImage": {
+      "type": "interface",
+      "id": "src/registry/ui/lightbox/types.ts:LightboxImage",
+      "name": "LightboxImage",
+      "extends": [],
+      "properties": {
+        "alt": {
+          "type": "property",
+          "name": "alt",
+          "value": {
+            "type": "union",
+            "elements": [
+              {
+                "type": "undefined"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "optional": true,
+          "readonly": false,
+          "description": "Alternative text for the image. Also used as the viewer caption and the\nthumbnail's accessible label."
+        },
+        "src": {
+          "type": "property",
+          "name": "src",
+          "value": {
+            "type": "string"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The image source URL."
+        }
+      },
+      "typeParameters": [],
+      "description": "A single image entry rendered in the lightbox grid and viewer."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/lightbox.json
+++ b/www/src/modules/docs/references/generated/lightbox.json
@@ -1,0 +1,67 @@
+{
+  "name": "LightboxProps",
+  "description": "A media lightbox: a responsive grid of thumbnails that opens a fullscreen\nviewer with previous/next navigation, a close button, and keyboard support\n(ArrowLeft, ArrowRight, Escape).",
+  "extendsElement": "div",
+  "props": {
+    "images": {
+      "type": "LightboxImage[]",
+      "typeAst": {
+        "type": "array",
+        "elementType": {
+          "type": "link",
+          "id": "src/registry/ui/lightbox/types.ts:LightboxImage",
+          "name": "LightboxImage"
+        }
+      },
+      "description": "The images to display in the grid and viewer.",
+      "required": true
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  },
+  "typeLinks": {
+    "src/registry/ui/lightbox/types.ts:LightboxImage": {
+      "type": "interface",
+      "id": "src/registry/ui/lightbox/types.ts:LightboxImage",
+      "name": "LightboxImage",
+      "extends": [],
+      "properties": {
+        "alt": {
+          "type": "property",
+          "name": "alt",
+          "value": {
+            "type": "union",
+            "elements": [
+              {
+                "type": "undefined"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "optional": true,
+          "readonly": false,
+          "description": "Alternative text for the image. Also used as the viewer caption and the\nthumbnail's accessible label."
+        },
+        "src": {
+          "type": "property",
+          "name": "src",
+          "value": {
+            "type": "string"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The image source URL."
+        }
+      },
+      "typeParameters": [],
+      "description": "A single image entry rendered in the lightbox grid and viewer."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -1557,6 +1557,10 @@ export const DemosIndex: Record<
 		files: ["ui/kbd/demos/with-samp.tsx"],
 		component: React.lazy(() => import("@/registry/ui/kbd/demos/with-samp")),
 	},
+	"lightbox/demos/default": {
+		files: ["ui/lightbox/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/lightbox/demos/default")),
+	},
 	"link/demos/default": {
 		files: ["ui/link/demos/default.tsx"],
 		component: React.lazy(() => import("@/registry/ui/link/demos/default")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -45,6 +45,7 @@ import UiFileTrigger from "@/registry/ui/file-trigger/meta";
 import UiGroup from "@/registry/ui/group/meta";
 import UiInput from "@/registry/ui/input/meta";
 import UiKbd from "@/registry/ui/kbd/meta";
+import UiLightbox from "@/registry/ui/lightbox/meta";
 import UiLink from "@/registry/ui/link/meta";
 import UiListBox from "@/registry/ui/list-box/meta";
 import UiLoader from "@/registry/ui/loader/meta";
@@ -119,6 +120,7 @@ export const registryUi: RegistryItem[] = [
 	UiGroup,
 	UiInput,
 	UiKbd,
+	UiLightbox,
 	UiLink,
 	UiListBox,
 	UiLoader,

--- a/www/src/registry/ui/lightbox/base.tsx
+++ b/www/src/registry/ui/lightbox/base.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import * as React from 'react'
+import { ChevronLeftIcon, ChevronRightIcon, XIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Modal } from '@/registry/ui/modal'
+
+import { useStyles } from './styles'
+
+// MARK: lightboxStyles
+
+interface LightboxImage {
+  src: string
+  alt?: string
+}
+
+// MARK: Lightbox
+
+interface LightboxProps extends React.ComponentProps<'div'> {
+  images: LightboxImage[]
+}
+
+const Lightbox = ({ images, className, ...props }: LightboxProps) => {
+  const { root, grid, thumbnail, thumbnailImage } = useStyles()()
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(null)
+  // Retains the last viewed index through the close animation so the modal's
+  // exit transition still has an image to render after `activeIndex` clears.
+  const [displayedIndex, setDisplayedIndex] = React.useState(0)
+
+  const isOpen = activeIndex !== null
+
+  const select = React.useCallback((index: number) => {
+    setActiveIndex(index)
+    setDisplayedIndex(index)
+  }, [])
+
+  const close = React.useCallback(() => setActiveIndex(null), [])
+
+  return (
+    <div className={root({ className })} {...props}>
+      <div className={grid()}>
+        {images.map((image, index) => (
+          <button
+            // oxlint-disable-next-line react/no-array-index-key -- images is a positional gallery with no stable id
+            key={index}
+            type="button"
+            className={thumbnail()}
+            aria-label={image.alt ?? `Open image ${index + 1}`}
+            onClick={() => select(index)}
+          >
+            <img
+              src={image.src}
+              alt={image.alt ?? ''}
+              className={thumbnailImage()}
+              loading="lazy"
+            />
+          </button>
+        ))}
+      </div>
+      <Modal
+        isOpen={isOpen}
+        onOpenChange={(value) => {
+          if (!value) close()
+        }}
+        className="border-0 bg-transparent! shadow-none"
+      >
+        <LightboxViewer
+          images={images}
+          index={displayedIndex}
+          onIndexChange={select}
+          onClose={close}
+        />
+      </Modal>
+    </div>
+  )
+}
+
+// MARK: LightboxViewer
+
+interface LightboxViewerProps {
+  images: LightboxImage[]
+  index: number
+  onIndexChange: (index: number) => void
+  onClose: () => void
+}
+
+const LightboxViewer = ({
+  images,
+  index,
+  onIndexChange,
+  onClose,
+}: LightboxViewerProps) => {
+  const {
+    viewer,
+    figure,
+    image,
+    caption,
+    controls,
+    navButton,
+    closeButton,
+    counter,
+  } = useStyles()()
+
+  const count = images.length
+  const active = images[index]
+
+  const goPrev = React.useCallback(() => {
+    onIndexChange((index - 1 + count) % count)
+  }, [index, count, onIndexChange])
+
+  const goNext = React.useCallback(() => {
+    onIndexChange((index + 1) % count)
+  }, [index, count, onIndexChange])
+
+  // Arrow keys navigate between images while the viewer is mounted. Escape is
+  // already handled by the underlying Modal.
+  React.useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault()
+        goPrev()
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault()
+        goNext()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [goPrev, goNext])
+
+  if (!active) {
+    return null
+  }
+
+  return (
+    <DialogContent
+      aria-label={active.alt ?? `Image ${index + 1} of ${count}`}
+      className={viewer()}
+    >
+      <Button
+        variant="quiet"
+        size="sm"
+        isIconOnly
+        aria-label="Close"
+        className={closeButton()}
+        onPress={onClose}
+      >
+        <XIcon />
+      </Button>
+      <figure className={figure()}>
+        <img src={active.src} alt={active.alt ?? ''} className={image()} />
+        {count > 1 && (
+          <>
+            <div className={controls()}>
+              <Button
+                variant="default"
+                size="sm"
+                isIconOnly
+                aria-label="Previous image"
+                className={navButton()}
+                onPress={goPrev}
+              >
+                <ChevronLeftIcon />
+              </Button>
+              <Button
+                variant="default"
+                size="sm"
+                isIconOnly
+                aria-label="Next image"
+                className={navButton()}
+                onPress={goNext}
+              >
+                <ChevronRightIcon />
+              </Button>
+            </div>
+            <span className={counter()}>
+              {index + 1} / {count}
+            </span>
+          </>
+        )}
+      </figure>
+      {active.alt && (
+        <figcaption className={caption()}>{active.alt}</figcaption>
+      )}
+    </DialogContent>
+  )
+}
+
+// MARK: Exports
+
+export type { LightboxImage, LightboxProps, LightboxViewerProps }
+export { Lightbox, LightboxViewer }

--- a/www/src/registry/ui/lightbox/demos/default.tsx
+++ b/www/src/registry/ui/lightbox/demos/default.tsx
@@ -1,0 +1,28 @@
+import { Lightbox } from '@/registry/ui/lightbox'
+
+const images = [
+  {
+    src: 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=800&q=80',
+    alt: 'Mountain lake at sunrise',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=800&q=80',
+    alt: 'Foggy forest valley',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1426604966848-d7adac402bff?w=800&q=80',
+    alt: 'Green valley with a river',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1505765050516-f72dcac9c60e?w=800&q=80',
+    alt: 'Sunlit rolling hills',
+  },
+]
+
+export default function Demo() {
+  return (
+    <div className="w-full max-w-xl">
+      <Lightbox images={images} />
+    </div>
+  )
+}

--- a/www/src/registry/ui/lightbox/examples.tsx
+++ b/www/src/registry/ui/lightbox/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function LightboxExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/lightbox/index.tsx
+++ b/www/src/registry/ui/lightbox/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/lightbox/meta.ts
+++ b/www/src/registry/ui/lightbox/meta.ts
@@ -1,0 +1,27 @@
+import type { RegistryItem } from '@/registry/types'
+
+const lightboxMeta = {
+  name: 'lightbox',
+  type: 'registry:ui',
+  group: 'overlays',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/lightbox/base.tsx',
+      target: 'ui/lightbox.tsx',
+    },
+  ],
+  registryDependencies: ['button', 'modal', 'dialog', 'focus-styles'],
+  dependencies: [],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--lightbox-radius',
+      default: '--radius-lg',
+      description: 'Corner radius of the thumbnail tiles.',
+    },
+  },
+} satisfies RegistryItem
+
+export default lightboxMeta

--- a/www/src/registry/ui/lightbox/styles.css
+++ b/www/src/registry/ui/lightbox/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --lightbox-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/lightbox/styles.ts
+++ b/www/src/registry/ui/lightbox/styles.ts
@@ -1,0 +1,34 @@
+import { createStyles } from '@/lib/styles'
+
+import lightboxMeta from './meta'
+
+const { useStyles, styles } = createStyles(lightboxMeta, {
+  base: {
+    slots: {
+      root: 'flex flex-col gap-2',
+      grid: 'grid grid-cols-2 gap-2 sm:grid-cols-3',
+      thumbnail: [
+        'group/thumb relative aspect-square overflow-hidden rounded-(--lightbox-radius) bg-muted',
+        'cursor-pointer transition-opacity outline-none',
+        'hover:opacity-90 focus-visible:focus-ring active:opacity-80',
+      ],
+      thumbnailImage:
+        'size-full object-cover transition-transform duration-200 group-hover/thumb:scale-105',
+      viewer: 'flex flex-col items-center gap-3 p-0',
+      figure:
+        'relative flex w-full items-center justify-center overflow-hidden rounded-(--lightbox-radius) bg-black',
+      image: 'max-h-[70vh] w-auto max-w-full object-contain',
+      caption: 'text-center text-sm text-fg-muted',
+      controls:
+        'pointer-events-none absolute inset-0 flex items-center justify-between p-2',
+      navButton: 'pointer-events-auto',
+      closeButton: 'absolute top-2 right-2 z-10',
+      counter:
+        'absolute bottom-2 left-1/2 -translate-x-1/2 rounded-full bg-black/60 px-2 py-0.5 text-xs text-white',
+    },
+  },
+})
+
+export type LightboxStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/lightbox/types.ts
+++ b/www/src/registry/ui/lightbox/types.ts
@@ -1,0 +1,38 @@
+/**
+ * A single image entry rendered in the lightbox grid and viewer.
+ */
+export interface LightboxImage {
+  /** The image source URL. */
+  src: string
+  /**
+   * Alternative text for the image. Also used as the viewer caption and the
+   * thumbnail's accessible label.
+   */
+  alt?: string
+}
+
+/**
+ * A media lightbox: a responsive grid of thumbnails that opens a fullscreen
+ * viewer with previous/next navigation, a close button, and keyboard support
+ * (ArrowLeft, ArrowRight, Escape).
+ */
+export interface LightboxProps extends React.ComponentProps<'div'> {
+  /** The images to display in the grid and viewer. */
+  images: LightboxImage[]
+}
+
+/**
+ * The fullscreen viewer rendered inside the modal. Displays the active image
+ * with previous/next controls, a counter, and an optional caption. Exposed for
+ * advanced use; most consumers should use `Lightbox`.
+ */
+export interface LightboxViewerProps {
+  /** The full set of images to navigate between. */
+  images: LightboxImage[]
+  /** The index of the currently displayed image. */
+  index: number
+  /** Called with the next index when the user navigates. */
+  onIndexChange: (index: number) => void
+  /** Called when the user requests to close the viewer. */
+  onClose: () => void
+}


### PR DESCRIPTION
## Summary

Adds a **Lightbox** / media gallery to the registry — a thumbnail grid that opens a fullscreen viewer with prev/next and keyboard navigation. Part of the real-world-component-blocks batch (Tier 2).

- No engine: built on the dotUI `Modal`/`Dialog` overlay and `Button` (RAC) — keyboard (←/→/Esc) and focus handling come for free.
- Composition-first; `images` array drives the grid and the viewer; active index tracked in state.
- Themeable axis: `--lightbox-radius` (thumbnail tiles). Group `overlays`. `registryDependencies: ['button', 'modal', 'dialog', 'focus-styles']`.

## Notes

- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.