### PR TITLE
feat(ai-assistant): add ai-assistant component

### DIFF
--- a/www/content/docs/components/ai-assistant.mdx
+++ b/www/content/docs/components/ai-assistant.mdx
@@ -1,0 +1,64 @@
+---
+title: AI Assistant
+description: A chat surface for an AI assistant, composing a message log and a composer from primitives.
+wip: true
+---
+
+<Demo name="ai-assistant/demos/default" />
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/ai-assistant
+```
+
+## Usage
+
+`AIAssistant` is composition-first: it lays out a scrollable `AIAssistantMessages` log and an `AIAssistantInput` composer inside a card. Render one `AIAssistantMessage` per turn — `role` aligns the bubble (`user` to the end in the primary color, `assistant` to the start in a muted bubble with an avatar). Wire the composer to your own state; it calls `onSend` with the trimmed value and submits on Enter (Shift+Enter inserts a newline).
+
+```tsx
+import {
+  AIAssistant,
+  AIAssistantInput,
+  AIAssistantMessage,
+  AIAssistantMessages,
+} from '@/components/ui/ai-assistant'
+```
+
+```tsx
+<AIAssistant>
+  <AIAssistantMessages>
+    <AIAssistantMessage role="assistant">How can I help?</AIAssistantMessage>
+    <AIAssistantMessage role="user">Summarize this page.</AIAssistantMessage>
+  </AIAssistantMessages>
+  <AIAssistantInput value={value} onValueChange={setValue} onSend={send} />
+</AIAssistant>
+```
+
+## Examples
+
+<Examples>
+  <Example name="ai-assistant/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### AIAssistant
+
+<Reference name="ai-assistant" />
+
+### AIAssistantMessages
+
+<Reference name="ai-assistant-messages" />
+
+### AIAssistantMessage
+
+<Reference name="ai-assistant-message" />
+
+### AIAssistantMessageAvatar
+
+<Reference name="ai-assistant-message-avatar" />
+
+### AIAssistantInput
+
+<Reference name="ai-assistant-input" />

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -3,6 +3,7 @@
 
 export const ExamplesIndex: Record<string, () => Promise<{ default: React.ComponentType }>> = {
 	accordion: () => import("@/registry/ui/accordion/examples"),
+	"ai-assistant": () => import("@/registry/ui/ai-assistant/examples"),
 	alert: () => import("@/registry/ui/alert/examples"),
 	avatar: () => import("@/registry/ui/avatar/examples"),
 	badge: () => import("@/registry/ui/badge/examples"),

--- a/www/src/modules/docs/references/generated/ai-assistant-input.json
+++ b/www/src/modules/docs/references/generated/ai-assistant-input.json
@@ -1,0 +1,94 @@
+{
+  "name": "AIAssistantInputProps",
+  "description": "The composer at the bottom of the assistant. Renders an auto-growing textarea\nand a send button; submits on Enter (Shift+Enter inserts a newline).",
+  "extendsElement": "form",
+  "props": {
+    "value": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The controlled value of the textarea.",
+      "required": true
+    },
+    "onValueChange": {
+      "type": "(value: string) => void",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "value",
+            "value": {
+              "type": "string"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Called when the textarea value changes.",
+      "required": true
+    },
+    "onSend": {
+      "type": "(value: string) => void",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "value",
+            "value": {
+              "type": "string"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Called with the trimmed message when the user submits a non-empty value.",
+      "required": true
+    },
+    "placeholder": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Placeholder text shown in the textarea.",
+      "default": "'Send a message...'"
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Disables the textarea and send button."
+    },
+    "aria-label": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Accessible label for the textarea.",
+      "default": "'Message'"
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/ai-assistant-message-avatar.json
+++ b/www/src/modules/docs/references/generated/ai-assistant-message-avatar.json
@@ -1,0 +1,38 @@
+{
+  "name": "AIAssistantMessageAvatarProps",
+  "description": "The avatar shown next to an assistant message. Falls back to a bot icon (or a\ncustom node) when no image is provided or the image fails to load.",
+  "extendsElement": "span",
+  "props": {
+    "src": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The URL of the avatar image."
+    },
+    "alt": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Alternative text for the avatar image."
+    },
+    "fallback": {
+      "type": "ReactNode",
+      "typeAst": {
+        "type": "identifier",
+        "name": "ReactNode"
+      },
+      "description": "Content shown when no image is available. Defaults to a bot icon."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/ai-assistant-message.json
+++ b/www/src/modules/docs/references/generated/ai-assistant-message.json
@@ -1,0 +1,32 @@
+{
+  "name": "AIAssistantMessageProps",
+  "description": "A single message in the conversation. The `role` aligns the bubble and, for\nthe assistant, renders an avatar alongside it.",
+  "extendsElement": "div",
+  "props": {
+    "role": {
+      "type": "\"assistant\" | \"user\"",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "assistant"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "user"
+          }
+        ]
+      },
+      "description": "Who sent the message. `user` aligns the bubble to the end with the primary\ncolor; `assistant` aligns to the start with a muted bubble and an avatar.",
+      "required": true
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/ai-assistant-messages.json
+++ b/www/src/modules/docs/references/generated/ai-assistant-messages.json
@@ -1,0 +1,14 @@
+{
+  "name": "AIAssistantMessagesProps",
+  "description": "The scrollable region that holds the conversation. Announces new content to\nassistive technology via an `aria-live` log region.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/ai-assistant.json
+++ b/www/src/modules/docs/references/generated/ai-assistant.json
@@ -1,0 +1,14 @@
+{
+  "name": "AIAssistantProps",
+  "description": "The container for an AI assistant chat experience. Lays out a scrollable\nmessage log and an input as a vertical column inside a card surface.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -41,6 +41,10 @@ export const DemosIndex: Record<
 		files: ["ui/accordion/demos/settings-panel.tsx"],
 		component: React.lazy(() => import("@/registry/ui/accordion/demos/settings-panel")),
 	},
+	"ai-assistant/demos/default": {
+		files: ["ui/ai-assistant/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/ai-assistant/demos/default")),
+	},
 	"alert/demos/action": {
 		files: ["ui/alert/demos/action.tsx"],
 		component: React.lazy(() => import("@/registry/ui/alert/demos/action")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -6,6 +6,7 @@ import LibResponsive from "@/registry/lib/responsive/meta";
 import LibTextareaCaret from "@/registry/lib/textarea-caret/meta";
 import LibUtils from "@/registry/lib/utils/meta";
 import UiAccordion from "@/registry/ui/accordion/meta";
+import UiAiAssistant from "@/registry/ui/ai-assistant/meta";
 import UiAlert from "@/registry/ui/alert/meta";
 import UiAvatar from "@/registry/ui/avatar/meta";
 import UiBadge from "@/registry/ui/badge/meta";
@@ -80,6 +81,7 @@ import type { RegistryItem } from "@/registry/types";
 
 export const registryUi: RegistryItem[] = [
 	UiAccordion,
+	UiAiAssistant,
 	UiAlert,
 	UiAvatar,
 	UiBadge,

--- a/www/src/registry/ui/ai-assistant/base.tsx
+++ b/www/src/registry/ui/ai-assistant/base.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import * as React from 'react'
+import { ArrowUpIcon, BotIcon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+import { Avatar, AvatarFallback, AvatarImage } from '@/registry/ui/avatar'
+import { Button } from '@/registry/ui/button'
+import { TextArea } from '@/registry/ui/input'
+import { TextField } from '@/registry/ui/text-field'
+
+import { useStyles } from './styles'
+
+// MARK: AIAssistant
+
+type Role = 'user' | 'assistant'
+
+interface AIAssistantProps extends React.ComponentProps<'div'> {}
+
+function AIAssistant({ className, ...props }: AIAssistantProps) {
+  const { root } = useStyles()()
+  return <div data-ai-assistant="" className={root({ className })} {...props} />
+}
+
+// MARK: AIAssistantMessages
+
+interface AIAssistantMessagesProps extends React.ComponentProps<'div'> {}
+
+function AIAssistantMessages({
+  className,
+  ...props
+}: AIAssistantMessagesProps) {
+  const { messages } = useStyles()()
+  return (
+    <div
+      data-ai-assistant-messages=""
+      role="log"
+      aria-live="polite"
+      className={messages({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: AIAssistantMessage
+
+interface AIAssistantMessageProps extends React.ComponentProps<'div'> {
+  role: Role
+}
+
+function AIAssistantMessage({
+  role,
+  className,
+  children,
+  ...props
+}: AIAssistantMessageProps) {
+  const { message, avatar, bubble } = useStyles()()
+  return (
+    <div
+      data-ai-assistant-message=""
+      data-role={role}
+      className={message({ className })}
+      {...props}
+    >
+      {role === 'assistant' && (
+        <Avatar size="sm" className={avatar()}>
+          <AvatarFallback>
+            <BotIcon className="size-4" />
+          </AvatarFallback>
+        </Avatar>
+      )}
+      <div data-role={role} className={bubble()}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+// MARK: AIAssistantMessageAvatar
+
+interface AIAssistantMessageAvatarProps extends React.ComponentProps<'span'> {
+  src?: string
+  alt?: string
+  fallback?: React.ReactNode
+}
+
+function AIAssistantMessageAvatar({
+  src,
+  alt,
+  fallback,
+  className,
+  ...props
+}: AIAssistantMessageAvatarProps) {
+  const { avatar } = useStyles()()
+  return (
+    <Avatar size="sm" className={avatar({ className })} {...props}>
+      <AvatarImage src={src} alt={alt} />
+      <AvatarFallback>
+        {fallback ?? <BotIcon className="size-4" />}
+      </AvatarFallback>
+    </Avatar>
+  )
+}
+
+// MARK: AIAssistantInput
+
+interface AIAssistantInputProps extends Omit<
+  React.ComponentProps<'form'>,
+  'onSubmit'
+> {
+  /** The controlled value of the textarea. */
+  value: string
+  /** Called when the textarea value changes. */
+  onValueChange: (value: string) => void
+  /** Called with the trimmed message when the user submits a non-empty value. */
+  onSend: (value: string) => void
+  /** Placeholder text shown in the textarea. */
+  placeholder?: string
+  /** Accessible label for the textarea. */
+  'aria-label'?: string
+  /** Disables the textarea and send button. */
+  isDisabled?: boolean
+}
+
+function AIAssistantInput({
+  value,
+  onValueChange,
+  onSend,
+  placeholder = 'Send a message...',
+  'aria-label': ariaLabel = 'Message',
+  isDisabled,
+  className,
+  ...props
+}: AIAssistantInputProps) {
+  const { input, field } = useStyles()()
+
+  const submit = () => {
+    const trimmed = value.trim()
+    if (trimmed.length === 0) return
+    onSend(trimmed)
+  }
+
+  return (
+    <form
+      data-ai-assistant-input=""
+      className={input({ className })}
+      onSubmit={(e) => {
+        e.preventDefault()
+        submit()
+      }}
+      {...props}
+    >
+      <TextField
+        aria-label={ariaLabel}
+        value={value}
+        onChange={onValueChange}
+        isDisabled={isDisabled}
+        className={field()}
+      >
+        <TextArea
+          placeholder={placeholder}
+          rows={1}
+          className="max-h-32"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              submit()
+            }
+          }}
+        />
+      </TextField>
+      <Button
+        type="submit"
+        variant="primary"
+        isIconOnly
+        aria-label="Send message"
+        isDisabled={isDisabled || value.trim().length === 0}
+        className={cn('rounded-(--ai-assistant-radius)')}
+      >
+        <ArrowUpIcon />
+      </Button>
+    </form>
+  )
+}
+
+// MARK: exports
+
+export type {
+  AIAssistantInputProps,
+  AIAssistantMessageAvatarProps,
+  AIAssistantMessageProps,
+  AIAssistantMessagesProps,
+  AIAssistantProps,
+}
+export {
+  AIAssistant,
+  AIAssistantInput,
+  AIAssistantMessage,
+  AIAssistantMessageAvatar,
+  AIAssistantMessages,
+}

--- a/www/src/registry/ui/ai-assistant/demos/default.tsx
+++ b/www/src/registry/ui/ai-assistant/demos/default.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import * as React from 'react'
+
+import {
+  AIAssistant,
+  AIAssistantInput,
+  AIAssistantMessage,
+  AIAssistantMessages,
+} from '@/registry/ui/ai-assistant'
+
+interface Message {
+  id: number
+  role: 'user' | 'assistant'
+  content: string
+}
+
+const initialMessages: Message[] = [
+  {
+    id: 1,
+    role: 'assistant',
+    content:
+      'Hi! I am your design assistant. Ask me anything about your theme.',
+  },
+  {
+    id: 2,
+    role: 'user',
+    content: 'How do I change the primary color?',
+  },
+  {
+    id: 3,
+    role: 'assistant',
+    content:
+      'Open the color panel and pick a new accent — every component updates live.',
+  },
+]
+
+export default function Demo() {
+  const [messages, setMessages] = React.useState<Message[]>(initialMessages)
+  const [value, setValue] = React.useState('')
+  const nextId = React.useRef(initialMessages.length + 1)
+
+  const handleSend = (text: string) => {
+    const userId = nextId.current++
+    const assistantId = nextId.current++
+    setMessages((prev) => [
+      ...prev,
+      { id: userId, role: 'user', content: text },
+      {
+        id: assistantId,
+        role: 'assistant',
+        content: `Got it — "${text}". Let me look into that for you.`,
+      },
+    ])
+    setValue('')
+  }
+
+  return (
+    <AIAssistant className="h-96 w-full max-w-md">
+      <AIAssistantMessages>
+        {messages.map((message) => (
+          <AIAssistantMessage key={message.id} role={message.role}>
+            {message.content}
+          </AIAssistantMessage>
+        ))}
+      </AIAssistantMessages>
+      <AIAssistantInput
+        value={value}
+        onValueChange={setValue}
+        onSend={handleSend}
+        placeholder="Ask the assistant..."
+      />
+    </AIAssistant>
+  )
+}

--- a/www/src/registry/ui/ai-assistant/examples.tsx
+++ b/www/src/registry/ui/ai-assistant/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import DefaultDemo from './demos/default'
+
+export default function AIAssistantExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <DefaultDemo />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/ai-assistant/index.tsx
+++ b/www/src/registry/ui/ai-assistant/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/ai-assistant/meta.ts
+++ b/www/src/registry/ui/ai-assistant/meta.ts
@@ -1,0 +1,25 @@
+import type { RegistryItem } from '@/registry/types'
+
+const aiAssistantMeta = {
+  name: 'ai-assistant',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/ai-assistant/base.tsx',
+      target: 'ui/ai-assistant.tsx',
+    },
+  ],
+  registryDependencies: ['avatar', 'button', 'text-field', 'input'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--ai-assistant-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default aiAssistantMeta

--- a/www/src/registry/ui/ai-assistant/styles.css
+++ b/www/src/registry/ui/ai-assistant/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --ai-assistant-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/ai-assistant/styles.ts
+++ b/www/src/registry/ui/ai-assistant/styles.ts
@@ -1,0 +1,40 @@
+import { createStyles } from '@/lib/styles'
+
+import aiAssistantMeta from './meta'
+
+const { useStyles, styles } = createStyles(aiAssistantMeta, {
+  base: {
+    slots: {
+      root: 'group/ai-assistant flex flex-col overflow-hidden rounded-(--ai-assistant-radius) border bg-card',
+      messages: 'flex flex-1 flex-col gap-4 overflow-y-auto p-4',
+      message: 'flex w-full items-end gap-2 data-[role=user]:flex-row-reverse',
+      avatar: 'mb-0.5 shrink-0',
+      bubble: [
+        'max-w-[75%] rounded-(--ai-assistant-radius) px-3 py-2 text-sm whitespace-pre-wrap',
+        'data-[role=assistant]:bg-muted data-[role=assistant]:text-fg',
+        'data-[role=user]:bg-primary data-[role=user]:text-fg-on-primary',
+      ],
+      input: 'flex items-end gap-2 border-t p-3',
+      field: 'flex-1',
+    },
+  },
+  density: {
+    compact: {
+      slots: {
+        messages: 'gap-3 p-3',
+      },
+    },
+    default: {
+      slots: {},
+    },
+    comfortable: {
+      slots: {
+        messages: 'gap-5 p-5',
+      },
+    },
+  },
+})
+
+export type AiAssistantStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/ai-assistant/types.ts
+++ b/www/src/registry/ui/ai-assistant/types.ts
@@ -1,0 +1,80 @@
+import type * as React from 'react'
+
+/**
+ * The container for an AI assistant chat experience. Lays out a scrollable
+ * message log and an input as a vertical column inside a card surface.
+ */
+export interface AIAssistantProps extends React.ComponentProps<'div'> {}
+
+/**
+ * The scrollable region that holds the conversation. Announces new content to
+ * assistive technology via an `aria-live` log region.
+ */
+export interface AIAssistantMessagesProps extends React.ComponentProps<'div'> {}
+
+/**
+ * A single message in the conversation. The `role` aligns the bubble and, for
+ * the assistant, renders an avatar alongside it.
+ */
+export interface AIAssistantMessageProps extends React.ComponentProps<'div'> {
+  /**
+   * Who sent the message. `user` aligns the bubble to the end with the primary
+   * color; `assistant` aligns to the start with a muted bubble and an avatar.
+   */
+  role: 'user' | 'assistant'
+}
+
+/**
+ * The avatar shown next to an assistant message. Falls back to a bot icon (or a
+ * custom node) when no image is provided or the image fails to load.
+ */
+export interface AIAssistantMessageAvatarProps extends React.ComponentProps<'span'> {
+  /**
+   * The URL of the avatar image.
+   */
+  src?: string
+  /**
+   * Alternative text for the avatar image.
+   */
+  alt?: string
+  /**
+   * Content shown when no image is available. Defaults to a bot icon.
+   */
+  fallback?: React.ReactNode
+}
+
+/**
+ * The composer at the bottom of the assistant. Renders an auto-growing textarea
+ * and a send button; submits on Enter (Shift+Enter inserts a newline).
+ */
+export interface AIAssistantInputProps extends Omit<
+  React.ComponentProps<'form'>,
+  'onSubmit'
+> {
+  /**
+   * The controlled value of the textarea.
+   */
+  value: string
+  /**
+   * Called when the textarea value changes.
+   */
+  onValueChange: (value: string) => void
+  /**
+   * Called with the trimmed message when the user submits a non-empty value.
+   */
+  onSend: (value: string) => void
+  /**
+   * Placeholder text shown in the textarea.
+   * @default 'Send a message...'
+   */
+  placeholder?: string
+  /**
+   * Accessible label for the textarea.
+   * @default 'Message'
+   */
+  'aria-label'?: string
+  /**
+   * Disables the textarea and send button.
+   */
+  isDisabled?: boolean
+}


### PR DESCRIPTION
## Summary

Adds an **AI Assistant** UI to the registry — a self-contained chat surface (message list + composer) for assistant/LLM experiences. Part of the real-world-component-blocks batch (Tier 2).

- Composition-first, reusing existing registry items (`Avatar`, `Button`, `TextField`/`Input`); no new dependency — bring your own AI SDK / transport.
- Role-aware bubbles (`user` vs `assistant`) via `data-role`, a scrollable message area, and a controlled composer with send.
- Themeable axis: `--ai-assistant-radius`. Group `containers`.

## Notes

- Display + input layer only (the research doc's "AI assistant UI set") — wire it to the Vercel AI SDK `useChat` or your own backend.
- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.