### PR TITLE
feat(video-call-ui): add video-call-ui component

### DIFF
--- a/www/content/docs/components/video-call-ui.mdx
+++ b/www/content/docs/components/video-call-ui.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="video-call-ui/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/video-call-ui.mdx
+++ b/www/content/docs/components/video-call-ui.mdx
@@ -1,0 +1,102 @@
+---
+title: Video Call UI
+description: A presentational video-call surface — a dark stage of participant tiles and a control bar.
+links:
+  - label: LiveKit React
+    href: https://docs.livekit.io/reference/components/react/
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/video-call-ui
+```
+
+## Usage
+
+`VideoCallUI` is the dark stage that auto-grids its `VideoCallTile` children. Compose it with a `VideoCallControls` bar to build a complete call surface.
+
+```tsx
+import {
+  VideoCallControlButton,
+  VideoCallControls,
+  VideoCallLeaveButton,
+  VideoCallTile,
+  VideoCallUI,
+} from '@/components/ui/video-call-ui'
+```
+
+```tsx
+<VideoCallUI>
+  <VideoCallTile name="Ada Lovelace" poster="/frames/ada.jpg" />
+  <VideoCallTile name="Alan Turing" isMuted />
+  <VideoCallTile name="Grace Hopper" isCameraOff />
+  <VideoCallControls className="col-span-full">
+    <VideoCallControlButton aria-label="Mute">
+      <MicIcon />
+    </VideoCallControlButton>
+    <VideoCallControlButton aria-label="Camera">
+      <VideoIcon />
+    </VideoCallControlButton>
+    <VideoCallLeaveButton />
+  </VideoCallControls>
+</VideoCallUI>
+```
+
+This component is presentational only — it owns the chrome, not the media. To wire a real call, keep your media engine (e.g. [LiveKit](https://docs.livekit.io/reference/components/react/)) as a peer dependency and map its state onto these tiles. With LiveKit, read participants with `useParticipants()` / `useTracks()` and render one `VideoCallTile` per participant, driving `isMuted` and `isCameraOff` from each track's publication. Attach the live stream by rendering a `VideoCallTileVideo` inside the tile and pointing the track's `attach()` target at it (or wrapping LiveKit's own `<VideoTrack />`).
+
+```tsx
+import { useTracks } from '@livekit/components-react'
+import { Track } from 'livekit-client'
+
+function CallGrid() {
+  const tracks = useTracks([Track.Source.Camera, Track.Source.Microphone])
+  return (
+    <VideoCallUI>
+      {tracks.map(({ participant, publication }) => (
+        <VideoCallTile
+          key={participant.identity}
+          name={participant.name}
+          isMuted={participant.isMicrophoneEnabled === false}
+          isCameraOff={participant.isCameraEnabled === false}
+        >
+          <VideoCallTileVideo ref={(el) => publication?.track?.attach(el)} />
+        </VideoCallTile>
+      ))}
+    </VideoCallUI>
+  )
+}
+```
+
+## Examples
+
+<Examples>
+  <Example name="video-call-ui/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### VideoCallUI
+
+<Reference name="video-call-ui" />
+
+### VideoCallTile
+
+<Reference name="video-call-tile" />
+
+### VideoCallTileVideo
+
+<Reference name="video-call-tile-video" />
+
+### VideoCallControls
+
+<Reference name="video-call-controls" />
+
+### VideoCallControlButton
+
+<Reference name="video-call-control-button" />
+
+### VideoCallLeaveButton
+
+<Reference name="video-call-leave-button" />

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -72,6 +72,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"toggle-button-group": () => import("@/registry/ui/toggle-button-group/examples"),
 	tooltip: () => import("@/registry/ui/tooltip/examples"),
 	tree: () => import("@/registry/ui/tree/examples"),
+	"video-call-ui": () => import("@/registry/ui/video-call-ui/examples"),
 };
 
 export const GroupExamplesIndex: Record<string, () => Promise<{ default: React.ComponentType }>> = {

--- a/www/src/modules/docs/references/generated/video-call-control-button.json
+++ b/www/src/modules/docs/references/generated/video-call-control-button.json
@@ -1,0 +1,57 @@
+{
+  "name": "VideoCallControlButtonProps",
+  "description": "An icon-only toggle button for the control bar (mic, camera, screen share).\nReflects its on/off state via `aria-pressed` and a danger style when inactive.",
+  "extendsElement": "button",
+  "props": {
+    "isActive": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the control is active (e.g. mic on, camera on). When `false`, the\nbutton reads as the \"off\" state and adopts the danger style.",
+      "default": "true"
+    },
+    "variant": {
+      "type": "\"danger\" | \"default\" | \"link\" | \"primary\" | \"quiet\" | \"warning\"",
+      "detailedType": "| 'danger'\n| 'default'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'warning'\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "danger"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "default"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "link"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "primary"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "quiet"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "warning"
+          }
+        ]
+      },
+      "description": "The visual style of the underlying button. Overrides the active/inactive\ndefault styling when set."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/video-call-controls.json
+++ b/www/src/modules/docs/references/generated/video-call-controls.json
@@ -1,0 +1,14 @@
+{
+  "name": "VideoCallControlsProps",
+  "description": "The control bar of a video call. A horizontal toolbar that holds the call's\ntoggle buttons (mic, camera, screen share) and the leave button.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/video-call-leave-button.json
+++ b/www/src/modules/docs/references/generated/video-call-leave-button.json
@@ -1,0 +1,14 @@
+{
+  "name": "VideoCallLeaveButtonProps",
+  "description": "The danger button that ends/leaves the call. Defaults to a phone-off icon and\na \"Leave\" label; pass children to override.",
+  "extendsElement": "button",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/video-call-tile-video.json
+++ b/www/src/modules/docs/references/generated/video-call-tile-video.json
@@ -1,0 +1,14 @@
+{
+  "name": "VideoCallTileVideoProps",
+  "description": "A live `<video>` element scoped to a `VideoCallTile`. Wire a `MediaStream` or\na LiveKit track's `attach()` target to it. Renders nothing while the tile's\ncamera is off.",
+  "extendsElement": "video",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/video-call-tile.json
+++ b/www/src/modules/docs/references/generated/video-call-tile.json
@@ -1,0 +1,48 @@
+{
+  "name": "VideoCallTileProps",
+  "description": "A single participant tile. Renders a 16:9 video area (poster, live `<video>`\nvia `VideoCallTileVideo`, or custom children), the participant's name label,\nand a muted-mic indicator. When the camera is off it falls back to an avatar.",
+  "extendsElement": "div",
+  "props": {
+    "name": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The participant's display name, shown in the bottom-left label and used to\nderive the avatar fallback initials."
+    },
+    "poster": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Poster image rendered in the video area, e.g. the last received frame or a\nthumbnail. Ignored when the camera is off."
+    },
+    "isMuted": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the participant's microphone is muted. Shows a muted-mic indicator.",
+      "default": "false"
+    },
+    "isCameraOff": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the participant's camera is off. Falls back to the avatar (or custom\nchildren) placeholder instead of the video area.",
+      "default": "false"
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/video-call-ui.json
+++ b/www/src/modules/docs/references/generated/video-call-ui.json
@@ -1,0 +1,22 @@
+{
+  "name": "VideoCallUiProps",
+  "description": "The container for a video call. Renders a dark stage that auto-lays out its\nparticipant tiles into a responsive grid. Pair it with a `VideoCallControls`\nbar to build a complete call surface.",
+  "extendsElement": "div",
+  "props": {
+    "columns": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "Number of columns in the tile grid. When omitted, the grid lays out\nautomatically: 1 tile → 1 column, 2 → 2 columns, 3 or more → 3 columns."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -2829,4 +2829,8 @@ export const DemosIndex: Record<
 		files: ["ui/tree/demos/with-icons.tsx"],
 		component: React.lazy(() => import("@/registry/ui/tree/demos/with-icons")),
 	},
+	"video-call-ui/demos/default": {
+		files: ["ui/video-call-ui/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/video-call-ui/demos/default")),
+	},
 };

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -75,6 +75,7 @@ import UiToggleButtonGroup from "@/registry/ui/toggle-button-group/meta";
 import UiToggleButton from "@/registry/ui/toggle-button/meta";
 import UiTooltip from "@/registry/ui/tooltip/meta";
 import UiTree from "@/registry/ui/tree/meta";
+import UiVideoCallUi from "@/registry/ui/video-call-ui/meta";
 
 import type { RegistryItem } from "@/registry/types";
 
@@ -149,6 +150,7 @@ export const registryUi: RegistryItem[] = [
 	UiToggleButtonGroup,
 	UiTooltip,
 	UiTree,
+	UiVideoCallUi,
 ];
 
 export const registryLib: RegistryItem[] = [LibFocusStyles, LibResponsive, LibTextareaCaret, LibUtils];

--- a/www/src/registry/ui/video-call-ui/base.tsx
+++ b/www/src/registry/ui/video-call-ui/base.tsx
@@ -1,0 +1,241 @@
+'use client'
+
+import * as React from 'react'
+import { MicOffIcon, PhoneOffIcon } from 'lucide-react'
+
+import { createContext } from '@/registry/lib/context'
+import { Avatar, AvatarFallback } from '@/registry/ui/avatar'
+import { Button } from '@/registry/ui/button'
+
+import { useStyles } from './styles'
+
+// MARK: VideoCallUI
+
+interface VideoCallUiProps extends React.ComponentProps<'div'> {
+  /**
+   * Number of columns in the tile grid. When omitted, the grid lays out
+   * automatically from the number of `VideoCallTile` children: 1 → 1 column,
+   * 2 → 2 columns, 3 or more → 3 columns.
+   */
+  columns?: number
+}
+
+function VideoCallUI({
+  columns,
+  className,
+  style,
+  children,
+  ...props
+}: VideoCallUiProps) {
+  const { root } = useStyles()()
+
+  // Auto-grid is driven by tile count only, so a control bar passed as a child
+  // (with `col-span-full`) doesn't skew the column math.
+  const tileCount = React.Children.toArray(children).filter(
+    (child) => React.isValidElement(child) && child.type === VideoCallTile,
+  ).length
+  const resolvedColumns =
+    columns ?? (tileCount <= 1 ? 1 : tileCount === 2 ? 2 : 3)
+
+  return (
+    <div
+      data-video-call-ui=""
+      className={root({ className })}
+      style={{
+        gridTemplateColumns: `repeat(${resolvedColumns}, minmax(0, 1fr))`,
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// MARK: VideoCallTile
+
+interface TileContextValue {
+  isCameraOff: boolean
+}
+
+const [TileContext, useTileContext] = createContext<TileContextValue>({
+  name: 'VideoCallTile',
+  strict: true,
+})
+
+interface VideoCallTileProps extends React.ComponentProps<'div'> {
+  /** The participant's display name, shown in the bottom-left label. */
+  name?: string
+  /** Poster image rendered in the video area (e.g. last received frame). */
+  poster?: string
+  /** Whether the participant's microphone is muted. Shows a muted indicator. */
+  isMuted?: boolean
+  /**
+   * Whether the participant's camera is off. Falls back to the avatar/children
+   * placeholder instead of the video area.
+   */
+  isCameraOff?: boolean
+}
+
+function VideoCallTile({
+  name,
+  poster,
+  isMuted = false,
+  isCameraOff = false,
+  className,
+  children,
+  ...props
+}: VideoCallTileProps) {
+  const { tile, media, placeholder, label, labelText, mutedIndicator } =
+    useStyles()()
+
+  return (
+    <TileContext value={{ isCameraOff }}>
+      <div
+        data-video-call-tile=""
+        data-camera-off={isCameraOff ? '' : undefined}
+        data-muted={isMuted ? '' : undefined}
+        className={tile({ className })}
+        {...props}
+      >
+        {isCameraOff ? (
+          <div className={placeholder()}>
+            {children ?? (
+              <Avatar size="lg" className="size-16 text-lg">
+                <AvatarFallback>{getInitials(name)}</AvatarFallback>
+              </Avatar>
+            )}
+          </div>
+        ) : poster ? (
+          <img src={poster} alt={name ?? ''} className={media()} />
+        ) : (
+          children
+        )}
+        {name && (
+          <div className={label()}>
+            {isMuted && <MicOffIcon className="size-3 shrink-0" />}
+            <span className={labelText()}>{name}</span>
+          </div>
+        )}
+        {isMuted && !name && (
+          <div className={mutedIndicator()}>
+            <MicOffIcon />
+          </div>
+        )}
+      </div>
+    </TileContext>
+  )
+}
+
+// MARK: VideoCallTileVideo
+
+interface VideoCallTileVideoProps extends React.ComponentProps<'video'> {}
+
+function VideoCallTileVideo({ className, ...props }: VideoCallTileVideoProps) {
+  const { media } = useStyles()()
+  const { isCameraOff } = useTileContext('VideoCallTileVideo')
+  if (isCameraOff) return null
+  return (
+    <video
+      data-video-call-tile-video=""
+      className={media({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: VideoCallControls
+
+interface VideoCallControlsProps extends React.ComponentProps<'div'> {}
+
+function VideoCallControls({
+  className,
+  children,
+  ...props
+}: VideoCallControlsProps) {
+  const { controls } = useStyles()()
+  return (
+    <div
+      data-video-call-controls=""
+      className={controls({ className })}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// MARK: VideoCallControlButton
+
+interface VideoCallControlButtonProps extends React.ComponentProps<
+  typeof Button
+> {
+  /** When `false`, the button reads as the "off" state (e.g. muted, camera off). */
+  isActive?: boolean
+}
+
+function VideoCallControlButton({
+  isActive = true,
+  variant,
+  ...props
+}: VideoCallControlButtonProps) {
+  return (
+    <Button
+      isIconOnly
+      variant={variant ?? (isActive ? 'default' : 'danger')}
+      aria-pressed={!isActive}
+      {...props}
+    />
+  )
+}
+
+// MARK: VideoCallLeaveButton
+
+interface VideoCallLeaveButtonProps extends React.ComponentProps<
+  typeof Button
+> {}
+
+function VideoCallLeaveButton({
+  children,
+  ...props
+}: VideoCallLeaveButtonProps) {
+  return (
+    <Button variant="danger" {...props}>
+      {children ?? (
+        <>
+          <PhoneOffIcon data-icon-start="" />
+          Leave
+        </>
+      )}
+    </Button>
+  )
+}
+
+// MARK: Helpers
+
+function getInitials(name?: string): string {
+  if (!name) return '?'
+  const parts = name.trim().split(/\s+/)
+  const first = parts[0]?.[0] ?? ''
+  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : ''
+  return (first + last).toUpperCase() || '?'
+}
+
+// MARK: Exports
+
+export type {
+  VideoCallControlButtonProps,
+  VideoCallControlsProps,
+  VideoCallLeaveButtonProps,
+  VideoCallTileProps,
+  VideoCallTileVideoProps,
+  VideoCallUiProps,
+}
+export {
+  VideoCallControlButton,
+  VideoCallControls,
+  VideoCallLeaveButton,
+  VideoCallTile,
+  VideoCallTileVideo,
+  VideoCallUI,
+}

--- a/www/src/registry/ui/video-call-ui/demos/default.tsx
+++ b/www/src/registry/ui/video-call-ui/demos/default.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import * as React from 'react'
+import {
+  MicIcon,
+  MicOffIcon,
+  MonitorUpIcon,
+  VideoIcon,
+  VideoOffIcon,
+} from 'lucide-react'
+
+import {
+  VideoCallControlButton,
+  VideoCallControls,
+  VideoCallLeaveButton,
+  VideoCallTile,
+  VideoCallUI,
+} from '@/registry/ui/video-call-ui'
+
+const participants = [
+  {
+    id: '1',
+    name: 'Mehdi Ben Hadj Ali',
+    poster:
+      'https://images.unsplash.com/photo-1633332755192-727a05c4013d?w=640&q=80',
+    isMuted: false,
+    isCameraOff: false,
+  },
+  {
+    id: '2',
+    name: 'Jorge Zreik',
+    poster:
+      'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=640&q=80',
+    isMuted: true,
+    isCameraOff: false,
+  },
+  {
+    id: '3',
+    name: 'Pranathi P',
+    poster: undefined,
+    isMuted: false,
+    isCameraOff: true,
+  },
+  {
+    id: '4',
+    name: 'Max Leiter',
+    poster:
+      'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=640&q=80',
+    isMuted: true,
+    isCameraOff: false,
+  },
+]
+
+export default function Demo() {
+  const [micOn, setMicOn] = React.useState(true)
+  const [cameraOn, setCameraOn] = React.useState(true)
+  const [sharing, setSharing] = React.useState(false)
+
+  return (
+    <VideoCallUI className="w-full max-w-2xl">
+      {participants.map((participant) => (
+        <VideoCallTile
+          key={participant.id}
+          name={participant.name}
+          poster={participant.poster}
+          isMuted={participant.isMuted}
+          isCameraOff={participant.isCameraOff}
+        />
+      ))}
+      <VideoCallControls className="col-span-full">
+        <VideoCallControlButton
+          isActive={micOn}
+          aria-label={micOn ? 'Mute microphone' : 'Unmute microphone'}
+          onPress={() => setMicOn((prev) => !prev)}
+        >
+          {micOn ? <MicIcon /> : <MicOffIcon />}
+        </VideoCallControlButton>
+        <VideoCallControlButton
+          isActive={cameraOn}
+          aria-label={cameraOn ? 'Turn off camera' : 'Turn on camera'}
+          onPress={() => setCameraOn((prev) => !prev)}
+        >
+          {cameraOn ? <VideoIcon /> : <VideoOffIcon />}
+        </VideoCallControlButton>
+        <VideoCallControlButton
+          isActive={!sharing}
+          variant={sharing ? 'primary' : 'default'}
+          aria-label={sharing ? 'Stop sharing screen' : 'Share screen'}
+          onPress={() => setSharing((prev) => !prev)}
+        >
+          <MonitorUpIcon />
+        </VideoCallControlButton>
+        <VideoCallLeaveButton />
+      </VideoCallControls>
+    </VideoCallUI>
+  )
+}

--- a/www/src/registry/ui/video-call-ui/examples.tsx
+++ b/www/src/registry/ui/video-call-ui/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function VideoCallUiExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/video-call-ui/index.tsx
+++ b/www/src/registry/ui/video-call-ui/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/video-call-ui/meta.ts
+++ b/www/src/registry/ui/video-call-ui/meta.ts
@@ -1,0 +1,25 @@
+import type { RegistryItem } from '@/registry/types'
+
+const videoCallUiMeta = {
+  name: 'video-call-ui',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/video-call-ui/base.tsx',
+      target: 'ui/video-call-ui.tsx',
+    },
+  ],
+  registryDependencies: ['avatar', 'button', 'focus-styles'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--video-call-ui-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default videoCallUiMeta

--- a/www/src/registry/ui/video-call-ui/styles.css
+++ b/www/src/registry/ui/video-call-ui/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --video-call-ui-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/video-call-ui/styles.ts
+++ b/www/src/registry/ui/video-call-ui/styles.ts
@@ -1,0 +1,26 @@
+import { createStyles } from '@/lib/styles'
+
+import videoCallUiMeta from './meta'
+
+const { useStyles, styles } = createStyles(videoCallUiMeta, {
+  base: {
+    slots: {
+      root: 'grid gap-3 rounded-(--video-call-ui-radius) bg-zinc-950 p-3',
+      tile: 'group/tile relative aspect-video overflow-hidden rounded-(--video-call-ui-radius) bg-zinc-900 ring-1 ring-white/10',
+      media: 'absolute inset-0 size-full object-cover',
+      placeholder:
+        'absolute inset-0 flex items-center justify-center bg-zinc-800',
+      label:
+        'absolute bottom-2 left-2 flex max-w-[calc(100%-1rem)] items-center gap-1.5 rounded-md bg-black/55 px-2 py-1 text-xs font-medium text-white backdrop-blur-sm',
+      labelText: 'truncate',
+      mutedIndicator:
+        'absolute top-2 right-2 flex size-7 items-center justify-center rounded-full bg-black/55 text-white backdrop-blur-sm [&>svg]:size-3.5',
+      controls:
+        'flex items-center justify-center gap-2 rounded-(--video-call-ui-radius) bg-zinc-900 p-2',
+    },
+  },
+})
+
+export type VideoCallUiStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/video-call-ui/types.ts
+++ b/www/src/registry/ui/video-call-ui/types.ts
@@ -1,0 +1,82 @@
+/**
+ * The container for a video call. Renders a dark stage that auto-lays out its
+ * participant tiles into a responsive grid. Pair it with a `VideoCallControls`
+ * bar to build a complete call surface.
+ */
+export interface VideoCallUiProps extends React.ComponentProps<'div'> {
+  /**
+   * Number of columns in the tile grid. When omitted, the grid lays out
+   * automatically: 1 tile → 1 column, 2 → 2 columns, 3 or more → 3 columns.
+   */
+  columns?: number
+}
+
+/**
+ * A single participant tile. Renders a 16:9 video area (poster, live `<video>`
+ * via `VideoCallTileVideo`, or custom children), the participant's name label,
+ * and a muted-mic indicator. When the camera is off it falls back to an avatar.
+ */
+export interface VideoCallTileProps extends React.ComponentProps<'div'> {
+  /**
+   * The participant's display name, shown in the bottom-left label and used to
+   * derive the avatar fallback initials.
+   */
+  name?: string
+
+  /**
+   * Poster image rendered in the video area, e.g. the last received frame or a
+   * thumbnail. Ignored when the camera is off.
+   */
+  poster?: string
+
+  /**
+   * Whether the participant's microphone is muted. Shows a muted-mic indicator.
+   * @default false
+   */
+  isMuted?: boolean
+
+  /**
+   * Whether the participant's camera is off. Falls back to the avatar (or custom
+   * children) placeholder instead of the video area.
+   * @default false
+   */
+  isCameraOff?: boolean
+}
+
+/**
+ * A live `<video>` element scoped to a `VideoCallTile`. Wire a `MediaStream` or
+ * a LiveKit track's `attach()` target to it. Renders nothing while the tile's
+ * camera is off.
+ */
+export interface VideoCallTileVideoProps extends React.ComponentProps<'video'> {}
+
+/**
+ * The control bar of a video call. A horizontal toolbar that holds the call's
+ * toggle buttons (mic, camera, screen share) and the leave button.
+ */
+export interface VideoCallControlsProps extends React.ComponentProps<'div'> {}
+
+/**
+ * An icon-only toggle button for the control bar (mic, camera, screen share).
+ * Reflects its on/off state via `aria-pressed` and a danger style when inactive.
+ */
+export interface VideoCallControlButtonProps extends React.ComponentProps<'button'> {
+  /**
+   * Whether the control is active (e.g. mic on, camera on). When `false`, the
+   * button reads as the "off" state and adopts the danger style.
+   * @default true
+   */
+  isActive?: boolean
+
+  /**
+   * The visual style of the underlying button. Overrides the active/inactive
+   * default styling when set.
+   */
+  variant?: 'default' | 'primary' | 'quiet' | 'link' | 'warning' | 'danger'
+}
+
+/**
+ * The danger button that ends/leaves the call. Defaults to a phone-off icon and
+ * a "Leave" label; pass children to override.
+ */
+export interface VideoCallLeaveButtonProps extends React.ComponentProps<'button'> {}

--- a/www/src/registry/ui/video-call-ui/video-call-ui/base.tsx
+++ b/www/src/registry/ui/video-call-ui/video-call-ui/base.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import * as React from 'react'
+import { MicOffIcon, PhoneOffIcon } from 'lucide-react'
+
+import { createContext } from '@/registry/lib/context'
+import { Avatar, AvatarFallback } from '@/registry/ui/avatar'
+import { Button } from '@/registry/ui/button'
+
+import { useStyles } from './styles'
+
+// MARK: VideoCallUI
+
+interface VideoCallUiProps extends React.ComponentProps<'div'> {
+  /**
+   * Number of columns in the tile grid. When omitted, the grid lays out
+   * automatically: 1 tile → 1 column, 2 → 2 columns, 3+ → 3 columns.
+   */
+  columns?: number
+}
+
+function VideoCallUI({
+  columns,
+  className,
+  style,
+  children,
+  ...props
+}: VideoCallUiProps) {
+  const { root, grid } = useStyles()()
+  const tileCount = React.Children.count(children)
+  const resolvedColumns =
+    columns ?? (tileCount <= 1 ? 1 : tileCount === 2 ? 2 : 3)
+
+  return (
+    <div data-video-call-ui="" className={root({ className })} {...props}>
+      <div
+        data-video-call-grid=""
+        className={grid()}
+        style={{
+          gridTemplateColumns: `repeat(${resolvedColumns}, minmax(0, 1fr))`,
+          ...style,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+// MARK: VideoCallTile
+
+interface TileContextValue {
+  isCameraOff: boolean
+}
+
+const [TileContext, useTileContext] = createContext<TileContextValue>({
+  name: 'VideoCallTile',
+  strict: true,
+})
+
+interface VideoCallTileProps extends React.ComponentProps<'div'> {
+  /** The participant's display name, shown in the bottom-left label. */
+  name?: string
+  /** Poster image rendered in the video area (e.g. last received frame). */
+  poster?: string
+  /** Whether the participant's microphone is muted. Shows a muted indicator. */
+  isMuted?: boolean
+  /**
+   * Whether the participant's camera is off. Falls back to the avatar/children
+   * placeholder instead of the video area.
+   */
+  isCameraOff?: boolean
+}
+
+function VideoCallTile({
+  name,
+  poster,
+  isMuted = false,
+  isCameraOff = false,
+  className,
+  children,
+  ...props
+}: VideoCallTileProps) {
+  const { tile, media, placeholder, label, labelText, mutedIndicator } =
+    useStyles()()
+
+  return (
+    <TileContext value={{ isCameraOff }}>
+      <div
+        data-video-call-tile=""
+        data-camera-off={isCameraOff ? '' : undefined}
+        data-muted={isMuted ? '' : undefined}
+        className={tile({ className })}
+        {...props}
+      >
+        {isCameraOff ? (
+          <div className={placeholder()}>
+            {children ?? (
+              <Avatar size="lg" className="size-16 text-lg">
+                <AvatarFallback>{getInitials(name)}</AvatarFallback>
+              </Avatar>
+            )}
+          </div>
+        ) : poster ? (
+          <img src={poster} alt={name ?? ''} className={media()} />
+        ) : (
+          children
+        )}
+        {name && (
+          <div className={label()}>
+            {isMuted && <MicOffIcon className="size-3 shrink-0" />}
+            <span className={labelText()}>{name}</span>
+          </div>
+        )}
+        {isMuted && !name && (
+          <div className={mutedIndicator()}>
+            <MicOffIcon />
+          </div>
+        )}
+      </div>
+    </TileContext>
+  )
+}
+
+// MARK: VideoCallTileVideo
+
+interface VideoCallTileVideoProps extends React.ComponentProps<'video'> {}
+
+function VideoCallTileVideo({ className, ...props }: VideoCallTileVideoProps) {
+  const { media } = useStyles()()
+  const { isCameraOff } = useTileContext('VideoCallTileVideo')
+  if (isCameraOff) return null
+  return (
+    <video
+      data-video-call-tile-video=""
+      className={media({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: VideoCallControls
+
+interface VideoCallControlsProps extends React.ComponentProps<'div'> {}
+
+function VideoCallControls({
+  className,
+  children,
+  ...props
+}: VideoCallControlsProps) {
+  const { controls } = useStyles()()
+  return (
+    <div
+      data-video-call-controls=""
+      className={controls({ className })}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+// MARK: VideoCallControlButton
+
+interface VideoCallControlButtonProps extends React.ComponentProps<
+  typeof Button
+> {
+  /** When `false`, the button reads as the "off" state (e.g. muted, camera off). */
+  isActive?: boolean
+}
+
+function VideoCallControlButton({
+  isActive = true,
+  variant,
+  className,
+  ...props
+}: VideoCallControlButtonProps) {
+  return (
+    <Button
+      isIconOnly
+      variant={variant ?? (isActive ? 'default' : 'danger')}
+      aria-pressed={!isActive}
+      className={className}
+      {...props}
+    />
+  )
+}
+
+// MARK: VideoCallLeaveButton
+
+interface VideoCallLeaveButtonProps extends React.ComponentProps<
+  typeof Button
+> {}
+
+function VideoCallLeaveButton({
+  children,
+  className,
+  ...props
+}: VideoCallLeaveButtonProps) {
+  return (
+    <Button variant="danger" className={className} {...props}>
+      {children ?? (
+        <>
+          <PhoneOffIcon data-icon-start="" />
+          Leave
+        </>
+      )}
+    </Button>
+  )
+}
+
+// MARK: Helpers
+
+function getInitials(name?: string): string {
+  if (!name) return '?'
+  const parts = name.trim().split(/\s+/)
+  const first = parts[0]?.[0] ?? ''
+  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : ''
+  return (first + last).toUpperCase() || '?'
+}
+
+// MARK: Exports
+
+export type {
+  VideoCallControlButtonProps,
+  VideoCallControlsProps,
+  VideoCallLeaveButtonProps,
+  VideoCallTileProps,
+  VideoCallTileVideoProps,
+  VideoCallUiProps,
+}
+export {
+  VideoCallControlButton,
+  VideoCallControls,
+  VideoCallLeaveButton,
+  VideoCallTile,
+  VideoCallTileVideo,
+  VideoCallUI,
+}

--- a/www/src/registry/ui/video-call-ui/video-call-ui/index.tsx
+++ b/www/src/registry/ui/video-call-ui/video-call-ui/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/video-call-ui/video-call-ui/meta.ts
+++ b/www/src/registry/ui/video-call-ui/video-call-ui/meta.ts
@@ -1,0 +1,25 @@
+import type { RegistryItem } from '@/registry/types'
+
+const videoCallUiMeta = {
+  name: 'video-call-ui',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/video-call-ui/base.tsx',
+      target: 'ui/video-call-ui.tsx',
+    },
+  ],
+  registryDependencies: ['avatar', 'button', 'focus-styles'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--video-call-ui-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default videoCallUiMeta

--- a/www/src/registry/ui/video-call-ui/video-call-ui/styles.css
+++ b/www/src/registry/ui/video-call-ui/video-call-ui/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --video-call-ui-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/video-call-ui/video-call-ui/styles.ts
+++ b/www/src/registry/ui/video-call-ui/video-call-ui/styles.ts
@@ -1,0 +1,27 @@
+import { createStyles } from '@/lib/styles'
+
+import videoCallUiMeta from './meta'
+
+const { useStyles, styles } = createStyles(videoCallUiMeta, {
+  base: {
+    slots: {
+      root: 'flex flex-col gap-3 rounded-(--video-call-ui-radius) bg-zinc-950 p-3',
+      grid: 'grid flex-1 gap-3',
+      tile: 'group/tile relative aspect-video overflow-hidden rounded-(--video-call-ui-radius) bg-zinc-900 ring-1 ring-white/10',
+      media: 'absolute inset-0 size-full object-cover',
+      placeholder:
+        'absolute inset-0 flex items-center justify-center bg-zinc-800',
+      label:
+        'absolute bottom-2 left-2 flex max-w-[calc(100%-1rem)] items-center gap-1.5 rounded-md bg-black/55 px-2 py-1 text-xs font-medium text-white backdrop-blur-sm',
+      labelText: 'truncate',
+      mutedIndicator:
+        'absolute top-2 right-2 flex size-7 items-center justify-center rounded-full bg-black/55 text-white backdrop-blur-sm [&>svg]:size-3.5',
+      controls:
+        'flex items-center justify-center gap-2 rounded-(--video-call-ui-radius) bg-zinc-900 p-2',
+    },
+  },
+})
+
+export type VideoCallUiStyles = typeof styles
+
+export { useStyles }


### PR DESCRIPTION
## Summary

Adds a **Video Call UI** to the registry — a participant tile grid plus a call-control bar. Part of the real-world-component-blocks batch (Tier 3).

- **Presentational, with a documented engine boundary** (per the research doc): no LiveKit dependency is vendored. You map LiveKit's `useTracks`/participants onto the tiles; the chrome (tiles, name labels, mic indicators, mic/camera/screen-share/leave controls) is pure dotUI on `Avatar` + `Button`.
- Auto-grid tiles, camera-off falls back to an avatar, danger "leave" control.
- Themeable axis: `--video-call-ui-radius`. Group `containers`. `registryDependencies: ['avatar', 'button', 'focus-styles']`.

## Notes

- Keeps the SDK out of the registry item so it stays installable; the docs show where LiveKit tracks plug in.
- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.