### PR TITLE
feat(sortable-list): add sortable-list component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,18 @@ importers:
       '@base-ui/react':
         specifier: 1.4.1
         version: 1.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.1)
       '@dotui/colors':
         specifier: workspace:*
         version: link:../packages/colors
@@ -564,6 +576,34 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.66.0':
     resolution: {integrity: sha512-qlQFhHUjhRDybrinqLAD0MClVZDOrsq80O8eD5iSjz3Qa/4f3Jg7SQrOaSobrRyP1QaWIYLGtGpj2c7H0D8NUw==}
@@ -6808,6 +6848,38 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0':
     optional: true
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      tslib: 2.8.1
+
   '@dotenvx/dotenvx@1.66.0':
     dependencies:
       commander: 11.1.0
@@ -8112,7 +8184,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':

--- a/www/content/docs/components/sortable-list.mdx
+++ b/www/content/docs/components/sortable-list.mdx
@@ -1,0 +1,64 @@
+---
+title: Sortable List
+description: A vertical list whose items can be reordered by dragging.
+wip: true
+---
+
+<Demo name="sortable-list/demos/default" />
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/sortable-list
+```
+
+## Usage
+
+```tsx
+import {
+  SortableItem,
+  SortableItemContent,
+  SortableItemHandle,
+  SortableList,
+} from '@/components/ui/sortable-list'
+```
+
+```tsx
+const [items, setItems] = useState([
+  { id: '1', title: 'First' },
+  { id: '2', title: 'Second' },
+])
+
+<SortableList items={items} onReorder={setItems}>
+  {(item) => (
+    <SortableItem id={item.id}>
+      <SortableItemHandle />
+      <SortableItemContent>{item.title}</SortableItemContent>
+    </SortableItem>
+  )}
+</SortableList>
+```
+
+## Examples
+
+<Examples>
+  <Example name="sortable-list/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### SortableList
+
+<Reference name="sortable-list" />
+
+### SortableItem
+
+<Reference name="sortable-item" />
+
+### SortableItemHandle
+
+<Reference name="sortable-item-handle" />
+
+### SortableItemContent
+
+<Reference name="sortable-item-content" />

--- a/www/package.json
+++ b/www/package.json
@@ -16,6 +16,10 @@
   },
   "dependencies": {
     "@base-ui/react": "1.4.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@dotui/colors": "workspace:*",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/josefin-sans": "^5.2.8",

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -60,6 +60,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	sidebar: () => import("@/registry/ui/sidebar/examples"),
 	skeleton: () => import("@/registry/ui/skeleton/examples"),
 	slider: () => import("@/registry/ui/slider/examples"),
+	"sortable-list": () => import("@/registry/ui/sortable-list/examples"),
 	switch: () => import("@/registry/ui/switch/examples"),
 	table: () => import("@/registry/ui/table/examples"),
 	tabs: () => import("@/registry/ui/tabs/examples"),

--- a/www/src/modules/docs/references/generated/sortable-item-content.json
+++ b/www/src/modules/docs/references/generated/sortable-item-content.json
@@ -1,0 +1,14 @@
+{
+  "name": "SortableItemContentProps",
+  "description": "The content region of a `SortableItem`, sitting next to the drag handle.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/sortable-item-handle.json
+++ b/www/src/modules/docs/references/generated/sortable-item-handle.json
@@ -1,0 +1,14 @@
+{
+  "name": "SortableItemHandleProps",
+  "description": "The drag handle for a `SortableItem`. Renders a grip icon by default and\ncarries the drag listeners; keyboard-accessible (focus it and use the arrow\nkeys to reorder).",
+  "extendsElement": "button",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/sortable-item.json
+++ b/www/src/modules/docs/references/generated/sortable-item.json
@@ -1,0 +1,38 @@
+{
+  "name": "SortableItemProps",
+  "description": "A single sortable row. Wrap each item from the list's render prop in a\n`SortableItem`, giving it the same `id` as the underlying data.",
+  "extendsElement": "div",
+  "props": {
+    "id": {
+      "type": "number | string",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "description": "The item's unique identifier, matching its data `id`.",
+      "required": true
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether this item is locked in place and cannot be dragged."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/sortable-list.json
+++ b/www/src/modules/docs/references/generated/sortable-list.json
@@ -1,0 +1,135 @@
+{
+  "name": "SortableListProps",
+  "description": "A vertical list whose items can be reordered by dragging. Controlled: it\nrenders the `items` you pass and calls `onReorder` with the next order after\na drag completes. Render each row through the `children` render prop.",
+  "extendsElement": "div",
+  "props": {
+    "items": {
+      "type": "T[]",
+      "typeAst": {
+        "type": "array",
+        "elementType": {
+          "type": "typeParameter",
+          "name": "T",
+          "constraint": {
+            "type": "link",
+            "id": "src/registry/ui/sortable-list/types.ts:SortableItemData",
+            "name": "SortableItemData"
+          },
+          "default": null
+        }
+      },
+      "description": "The ordered list of items to render. Each item needs a unique `id`.",
+      "required": true
+    },
+    "onReorder": {
+      "type": "(items: T[]) => void",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "items",
+            "value": {
+              "type": "array",
+              "elementType": {
+                "type": "typeParameter",
+                "name": "T",
+                "constraint": {
+                  "type": "link",
+                  "id": "src/registry/ui/sortable-list/types.ts:SortableItemData",
+                  "name": "SortableItemData"
+                },
+                "default": null
+              }
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Called with the next ordered array after a drag-and-drop reorder.",
+      "required": true
+    },
+    "children": {
+      "type": "(item: T, index: number) => ReactNode",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "item",
+            "value": {
+              "type": "typeParameter",
+              "name": "T",
+              "constraint": {
+                "type": "link",
+                "id": "src/registry/ui/sortable-list/types.ts:SortableItemData",
+                "name": "SortableItemData"
+              },
+              "default": null
+            },
+            "optional": false,
+            "rest": false
+          },
+          {
+            "type": "parameter",
+            "name": "index",
+            "value": {
+              "type": "number"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "identifier",
+          "name": "ReactNode"
+        },
+        "typeParameters": []
+      },
+      "description": "Render prop invoked for each item to produce its row.",
+      "required": true
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  },
+  "typeLinks": {
+    "src/registry/ui/sortable-list/types.ts:SortableItemData": {
+      "type": "interface",
+      "id": "src/registry/ui/sortable-list/types.ts:SortableItemData",
+      "name": "SortableItemData",
+      "extends": [],
+      "properties": {
+        "id": {
+          "type": "property",
+          "name": "id",
+          "value": {
+            "type": "union",
+            "elements": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Stable unique identifier for the item."
+        }
+      },
+      "typeParameters": [],
+      "description": "The shape every sortable item must satisfy: a stable, unique `id` used to\ntrack the item across reorders."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -2301,6 +2301,10 @@ export const DemosIndex: Record<
 		files: ["ui/slider/demos/vertical.tsx"],
 		component: React.lazy(() => import("@/registry/ui/slider/demos/vertical")),
 	},
+	"sortable-list/demos/default": {
+		files: ["ui/sortable-list/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/sortable-list/demos/default")),
+	},
 	"switch/demos/basic": {
 		files: ["ui/switch/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/switch/demos/basic")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -63,6 +63,7 @@ import UiSeparator from "@/registry/ui/separator/meta";
 import UiSidebar from "@/registry/ui/sidebar/meta";
 import UiSkeleton from "@/registry/ui/skeleton/meta";
 import UiSlider from "@/registry/ui/slider/meta";
+import UiSortableList from "@/registry/ui/sortable-list/meta";
 import UiSwitch from "@/registry/ui/switch/meta";
 import UiTable from "@/registry/ui/table/meta";
 import UiTabs from "@/registry/ui/tabs/meta";
@@ -137,6 +138,7 @@ export const registryUi: RegistryItem[] = [
 	UiSidebar,
 	UiSkeleton,
 	UiSlider,
+	UiSortableList,
 	UiSwitch,
 	UiTable,
 	UiTabs,

--- a/www/src/registry/ui/sortable-list/base.tsx
+++ b/www/src/registry/ui/sortable-list/base.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import type * as React from 'react'
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import type { DragEndEvent } from '@dnd-kit/core'
+import {
+  restrictToParentElement,
+  restrictToVerticalAxis,
+} from '@dnd-kit/modifiers'
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { GripVerticalIcon } from 'lucide-react'
+
+import { cn } from '@/registry/lib/utils'
+
+import { useStyles } from './styles'
+
+// MARK: sortableListStyles
+
+// MARK: SortableList
+
+interface SortableItemData {
+  id: string | number
+}
+
+interface SortableListProps<T extends SortableItemData> extends Omit<
+  React.ComponentProps<'div'>,
+  'children' | 'onChange'
+> {
+  items: T[]
+  onReorder: (items: T[]) => void
+  children: (item: T, index: number) => React.ReactNode
+}
+
+function SortableList<T extends SortableItemData>({
+  items,
+  onReorder,
+  children,
+  className,
+  ...props
+}: SortableListProps<T>) {
+  const { root } = useStyles()()
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 4 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  const onDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = items.findIndex((item) => item.id === active.id)
+    const newIndex = items.findIndex((item) => item.id === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+    onReorder(arrayMove(items, oldIndex, newIndex))
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+      onDragEnd={onDragEnd}
+    >
+      <SortableContext items={items} strategy={verticalListSortingStrategy}>
+        <div data-sortable-list="" className={root({ className })} {...props}>
+          {items.map((item, index) => children(item, index))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  )
+}
+
+// MARK: SortableItem
+
+interface SortableItemContextValue {
+  attributes: ReturnType<typeof useSortable>['attributes']
+  listeners: ReturnType<typeof useSortable>['listeners']
+  isDisabled: boolean
+}
+
+const SortableItemContext = createContext<SortableItemContextValue | null>(null)
+
+interface SortableItemProps extends Omit<React.ComponentProps<'div'>, 'id'> {
+  id: string | number
+  isDisabled?: boolean
+}
+
+function SortableItem({
+  id,
+  isDisabled = false,
+  className,
+  children,
+  ...props
+}: SortableItemProps) {
+  const { item } = useStyles()()
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled: isDisabled })
+
+  return (
+    <SortableItemContext.Provider value={{ attributes, listeners, isDisabled }}>
+      <div
+        ref={setNodeRef}
+        data-sortable-item=""
+        data-dragging={isDragging ? '' : undefined}
+        data-disabled={isDisabled ? '' : undefined}
+        style={{
+          transform: CSS.Transform.toString(transform),
+          transition,
+        }}
+        className={item({ className })}
+        {...props}
+      >
+        {children}
+      </div>
+    </SortableItemContext.Provider>
+  )
+}
+
+// MARK: SortableItemHandle
+
+interface SortableItemHandleProps extends React.ComponentProps<'button'> {}
+
+function SortableItemHandle({
+  className,
+  children,
+  ...props
+}: SortableItemHandleProps) {
+  const { handle } = useStyles()()
+  const context = useContext(SortableItemContext)
+
+  return (
+    <button
+      type="button"
+      data-sortable-handle=""
+      aria-label="Drag to reorder"
+      className={handle({ className })}
+      disabled={context?.isDisabled}
+      {...context?.attributes}
+      {...context?.listeners}
+      {...props}
+    >
+      {children ?? <GripVerticalIcon aria-hidden />}
+    </button>
+  )
+}
+
+// MARK: SortableItemContent
+
+interface SortableItemContentProps extends React.ComponentProps<'div'> {}
+
+function SortableItemContent({
+  className,
+  ...props
+}: SortableItemContentProps) {
+  const { content } = useStyles()()
+  return (
+    <div
+      data-sortable-content=""
+      className={cn(content(), className)}
+      {...props}
+    />
+  )
+}
+
+// MARK: separator
+
+export type {
+  SortableItemContentProps,
+  SortableItemData,
+  SortableItemHandleProps,
+  SortableItemProps,
+  SortableListProps,
+}
+export { SortableItem, SortableItemContent, SortableItemHandle, SortableList }

--- a/www/src/registry/ui/sortable-list/demos/default.tsx
+++ b/www/src/registry/ui/sortable-list/demos/default.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useState } from 'react'
+
+import {
+  SortableItem,
+  SortableItemContent,
+  SortableItemHandle,
+  SortableList,
+} from '@/registry/ui/sortable-list'
+
+interface Task {
+  id: string
+  title: string
+}
+
+const initialTasks: Task[] = [
+  { id: '1', title: 'Draft the launch announcement' },
+  { id: '2', title: 'Review pull request #42' },
+  { id: '3', title: 'Sync with the design team' },
+  { id: '4', title: 'Update the changelog' },
+]
+
+export default function Demo() {
+  const [tasks, setTasks] = useState<Task[]>(initialTasks)
+
+  return (
+    <SortableList
+      items={tasks}
+      onReorder={setTasks}
+      className="w-full max-w-md"
+    >
+      {(task) => (
+        <SortableItem id={task.id}>
+          <SortableItemHandle />
+          <SortableItemContent>{task.title}</SortableItemContent>
+        </SortableItem>
+      )}
+    </SortableList>
+  )
+}

--- a/www/src/registry/ui/sortable-list/examples.tsx
+++ b/www/src/registry/ui/sortable-list/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import DefaultDemo from './demos/default'
+
+export default function SortableListExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <DefaultDemo />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/sortable-list/index.tsx
+++ b/www/src/registry/ui/sortable-list/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/sortable-list/meta.ts
+++ b/www/src/registry/ui/sortable-list/meta.ts
@@ -1,0 +1,31 @@
+import type { RegistryItem } from '@/registry/types'
+
+const sortableListMeta = {
+  name: 'sortable-list',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/sortable-list/base.tsx',
+      target: 'ui/sortable-list.tsx',
+    },
+  ],
+  registryDependencies: ['focus-styles'],
+  dependencies: [
+    '@dnd-kit/core',
+    '@dnd-kit/sortable',
+    '@dnd-kit/modifiers',
+    '@dnd-kit/utilities',
+  ],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--sortable-list-radius',
+      default: '--radius-md',
+    },
+  },
+} satisfies RegistryItem
+
+export default sortableListMeta

--- a/www/src/registry/ui/sortable-list/styles.css
+++ b/www/src/registry/ui/sortable-list/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --sortable-list-radius: var(--radius-md);
+}

--- a/www/src/registry/ui/sortable-list/styles.ts
+++ b/www/src/registry/ui/sortable-list/styles.ts
@@ -1,0 +1,50 @@
+import { createStyles } from '@/lib/styles'
+
+import sortableListMeta from './meta'
+
+const { useStyles, styles } = createStyles(sortableListMeta, {
+  base: {
+    slots: {
+      root: 'flex flex-col',
+      item: [
+        'relative flex touch-none items-center rounded-(--sortable-list-radius) border bg-card text-fg',
+        'data-[dragging]:z-10 data-[dragging]:opacity-80 data-[dragging]:shadow-lg',
+      ],
+      handle: [
+        'flex shrink-0 cursor-grab items-center justify-center self-stretch rounded-l-(--sortable-list-radius) text-fg-muted',
+        'outline-hidden hover:text-fg focus-visible:focus-ring active:cursor-grabbing disabled:cursor-disabled',
+      ],
+      content: 'min-w-0 flex-1',
+    },
+  },
+  density: {
+    compact: {
+      slots: {
+        root: 'gap-1.5',
+        item: 'text-xs',
+        handle: 'w-7 *:[svg]:size-3.5',
+        content: 'py-2 pr-3',
+      },
+    },
+    default: {
+      slots: {
+        root: 'gap-2',
+        item: 'text-sm',
+        handle: 'w-8 *:[svg]:size-4',
+        content: 'py-2.5 pr-3.5',
+      },
+    },
+    comfortable: {
+      slots: {
+        root: 'gap-2.5',
+        item: 'text-sm',
+        handle: 'w-9 *:[svg]:size-4',
+        content: 'py-3 pr-4',
+      },
+    },
+  },
+})
+
+export type SortableListStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/sortable-list/types.ts
+++ b/www/src/registry/ui/sortable-list/types.ts
@@ -1,0 +1,51 @@
+/**
+ * The shape every sortable item must satisfy: a stable, unique `id` used to
+ * track the item across reorders.
+ */
+export interface SortableItemData {
+  /** Stable unique identifier for the item. */
+  id: string | number
+}
+
+/**
+ * A vertical list whose items can be reordered by dragging. Controlled: it
+ * renders the `items` you pass and calls `onReorder` with the next order after
+ * a drag completes. Render each row through the `children` render prop.
+ */
+export interface SortableListProps<T extends SortableItemData> extends Omit<
+  React.ComponentProps<'div'>,
+  'children' | 'onChange'
+> {
+  /** The ordered list of items to render. Each item needs a unique `id`. */
+  items: T[]
+  /** Called with the next ordered array after a drag-and-drop reorder. */
+  onReorder: (items: T[]) => void
+  /** Render prop invoked for each item to produce its row. */
+  children: (item: T, index: number) => React.ReactNode
+}
+
+/**
+ * A single sortable row. Wrap each item from the list's render prop in a
+ * `SortableItem`, giving it the same `id` as the underlying data.
+ */
+export interface SortableItemProps extends Omit<
+  React.ComponentProps<'div'>,
+  'id'
+> {
+  /** The item's unique identifier, matching its data `id`. */
+  id: string | number
+  /** Whether this item is locked in place and cannot be dragged. */
+  isDisabled?: boolean
+}
+
+/**
+ * The drag handle for a `SortableItem`. Renders a grip icon by default and
+ * carries the drag listeners; keyboard-accessible (focus it and use the arrow
+ * keys to reorder).
+ */
+export interface SortableItemHandleProps extends React.ComponentProps<'button'> {}
+
+/**
+ * The content region of a `SortableItem`, sitting next to the drag handle.
+ */
+export interface SortableItemContentProps extends React.ComponentProps<'div'> {}


### PR DESCRIPTION
## Summary

Adds a **Sortable List** to the registry — a drag-to-reorder list. Part of the real-world-component-blocks batch (Tier 2).

- Engine: **dnd-kit** (the registry-ecosystem default), installed as a dependency. Chrome is dotUI's: card rows, a keyboard-accessible grip handle (`SortableItemHandle`), and tokenized look.
- Composition-first: `SortableList` (controlled `items` + `onReorder`), `SortableItem`, `SortableItemHandle`, `SortableItemContent`.
- PointerSensor + KeyboardSensor (sortable coordinates), restrictToVerticalAxis + restrictToParentElement modifiers, `arrayMove` on drop.
- Themeable axis: `--sortable-list-radius`. Group `containers`. `dependencies: ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/modifiers', '@dnd-kit/utilities']`.

## Notes

- Fixed an `id` typing conflict (dnd-kit ids are `string | number`) during integration.
- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.