### PR TITLE
feat(kanban): add kanban component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,15 @@ importers:
       '@base-ui/react':
         specifier: 1.4.1
         version: 1.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.1)
       '@dotui/colors':
         specifier: workspace:*
         version: link:../packages/colors
@@ -564,6 +573,28 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.66.0':
     resolution: {integrity: sha512-qlQFhHUjhRDybrinqLAD0MClVZDOrsq80O8eD5iSjz3Qa/4f3Jg7SQrOaSobrRyP1QaWIYLGtGpj2c7H0D8NUw==}
@@ -6808,6 +6839,31 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0':
     optional: true
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      tslib: 2.8.1
+
   '@dotenvx/dotenvx@1.66.0':
     dependencies:
       commander: 11.1.0
@@ -8112,7 +8168,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':

--- a/www/content/docs/components/kanban.mdx
+++ b/www/content/docs/components/kanban.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="kanban/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/kanban.mdx
+++ b/www/content/docs/components/kanban.mdx
@@ -1,0 +1,70 @@
+---
+title: Kanban
+description: A drag-and-drop kanban board with columns and cards, powered by dnd-kit.
+links:
+  - label: dnd-kit
+    href: https://dndkit.com
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/kanban
+```
+
+## Usage
+
+Compose `KanbanColumn`s inside a controlled `KanbanBoard` (`columns` + `onColumnsChange`); each column holds a `KanbanCardList` of `KanbanCard`s. Cards drag within and between columns. The drag chrome is dotUI; [dnd-kit](https://dndkit.com) is the engine (installed as a dependency).
+
+```tsx
+import {
+  KanbanBoard,
+  KanbanCard,
+  KanbanCardList,
+  KanbanColumn,
+  KanbanColumnCount,
+  KanbanColumnHeader,
+  KanbanColumnTitle,
+} from '@/components/ui/kanban'
+```
+
+```tsx
+<KanbanBoard columns={columns} onColumnsChange={setColumns}>
+  {(column) => (
+    <KanbanColumn id={column.id}>
+      <KanbanColumnHeader>
+        <KanbanColumnTitle>{column.title}</KanbanColumnTitle>
+        <KanbanColumnCount>{column.cards.length}</KanbanColumnCount>
+      </KanbanColumnHeader>
+      <KanbanCardList>
+        {column.cards.map((card) => (
+          <KanbanCard key={card.id} id={card.id}>
+            {card.title}
+          </KanbanCard>
+        ))}
+      </KanbanCardList>
+    </KanbanColumn>
+  )}
+</KanbanBoard>
+```
+
+## Examples
+
+<Examples>
+  <Example name="kanban/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### KanbanBoard
+
+<Reference name="kanban-board" />
+
+### KanbanColumn
+
+<Reference name="kanban-column" />
+
+### KanbanCard
+
+<Reference name="kanban-card" />

--- a/www/package.json
+++ b/www/package.json
@@ -16,6 +16,9 @@
   },
   "dependencies": {
     "@base-ui/react": "1.4.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@dotui/colors": "workspace:*",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/josefin-sans": "^5.2.8",

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -41,6 +41,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	group: () => import("@/registry/ui/group/examples"),
 	input: () => import("@/registry/ui/input/examples"),
 	"input-group": () => import("@/registry/ui/input-group/examples"),
+	kanban: () => import("@/registry/ui/kanban/examples"),
 	kbd: () => import("@/registry/ui/kbd/examples"),
 	"list-box": () => import("@/registry/ui/list-box/examples"),
 	loader: () => import("@/registry/ui/loader/examples"),

--- a/www/src/modules/docs/references/generated/kanban-board.json
+++ b/www/src/modules/docs/references/generated/kanban-board.json
@@ -1,0 +1,110 @@
+{
+  "name": "KanbanBoardProps",
+  "description": "The board root. Wraps the drag-and-drop context and implements moving cards\nwithin and between columns. Compose `KanbanColumn`s inside it, mirroring the\n`columns` data.",
+  "props": {
+    "columns": {
+      "type": "TColumn[]",
+      "typeAst": {
+        "type": "array",
+        "elementType": {
+          "type": "typeParameter",
+          "name": "TColumn",
+          "constraint": {
+            "type": "link",
+            "id": "src/registry/ui/kanban/base.tsx:KanbanColumnData",
+            "name": "KanbanColumnData"
+          },
+          "default": {
+            "type": "link",
+            "id": "src/registry/ui/kanban/base.tsx:KanbanColumnData",
+            "name": "KanbanColumnData"
+          }
+        }
+      },
+      "description": "The columns and their cards. The board reorders this on drag.",
+      "required": true
+    },
+    "onColumnsChange": {
+      "type": "(columns: TColumn[]) => void",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "columns",
+            "value": {
+              "type": "array",
+              "elementType": {
+                "type": "typeParameter",
+                "name": "TColumn",
+                "constraint": {
+                  "type": "link",
+                  "id": "src/registry/ui/kanban/base.tsx:KanbanColumnData",
+                  "name": "KanbanColumnData"
+                },
+                "default": {
+                  "type": "link",
+                  "id": "src/registry/ui/kanban/base.tsx:KanbanColumnData",
+                  "name": "KanbanColumnData"
+                }
+              }
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Called with the next column layout after a card is moved or reordered.",
+      "required": true
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  },
+  "typeLinks": {
+    "src/registry/ui/kanban/base.tsx:KanbanColumnData": {
+      "type": "interface",
+      "id": "src/registry/ui/kanban/base.tsx:KanbanColumnData",
+      "name": "KanbanColumnData",
+      "extends": [],
+      "properties": {
+        "id": {
+          "type": "property",
+          "name": "id",
+          "value": {
+            "type": "identifier",
+            "name": "UniqueIdentifier"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": ""
+        },
+        "items": {
+          "type": "property",
+          "name": "items",
+          "value": {
+            "type": "array",
+            "elementType": {
+              "type": "link",
+              "id": "src/registry/ui/kanban/base.tsx:KanbanItem",
+              "name": "KanbanItem"
+            }
+          },
+          "optional": false,
+          "readonly": false,
+          "description": ""
+        }
+      },
+      "typeParameters": [],
+      "description": "A column and the cards it holds. Add column fields (e.g. a `title`) freely."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/kanban-card-handle.json
+++ b/www/src/modules/docs/references/generated/kanban-card-handle.json
@@ -1,0 +1,14 @@
+{
+  "name": "KanbanCardHandleProps",
+  "description": "An explicit drag handle for a `KanbanCard` rendered with `withHandle`. Only\nit initiates a drag.",
+  "extendsElement": "button",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/kanban-card-list.json
+++ b/www/src/modules/docs/references/generated/kanban-card-list.json
@@ -1,0 +1,14 @@
+{
+  "name": "KanbanCardListProps",
+  "description": "The scrollable area that holds a column's cards.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/kanban-card.json
+++ b/www/src/modules/docs/references/generated/kanban-card.json
@@ -1,0 +1,32 @@
+{
+  "name": "KanbanCardProps",
+  "description": "A draggable, sortable card.",
+  "extendsElement": "div",
+  "props": {
+    "id": {
+      "type": "UniqueIdentifier",
+      "typeAst": {
+        "type": "identifier",
+        "name": "UniqueIdentifier"
+      },
+      "description": "Must match the `id` of the corresponding item in the board's `columns`.",
+      "required": true
+    },
+    "withHandle": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Restrict dragging to a `KanbanCardHandle` instead of the whole card, so the\nrest of the card stays interactive.",
+      "default": "false"
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/kanban-column-count.json
+++ b/www/src/modules/docs/references/generated/kanban-column-count.json
@@ -1,0 +1,14 @@
+{
+  "name": "KanbanColumnCountProps",
+  "description": "A small badge showing the number of cards in the column.",
+  "extendsElement": "span",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/kanban-column-header.json
+++ b/www/src/modules/docs/references/generated/kanban-column-header.json
@@ -1,0 +1,14 @@
+{
+  "name": "KanbanColumnHeaderProps",
+  "description": "The column header row, typically containing a `KanbanColumnTitle` and a\n`KanbanColumnCount`.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/kanban-column-title.json
+++ b/www/src/modules/docs/references/generated/kanban-column-title.json
@@ -1,0 +1,14 @@
+{
+  "name": "KanbanColumnTitleProps",
+  "description": "The column's title.",
+  "extendsElement": "h3",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/kanban-column.json
+++ b/www/src/modules/docs/references/generated/kanban-column.json
@@ -1,0 +1,34 @@
+{
+  "name": "KanbanColumnProps",
+  "description": "A droppable column with its own sortable context. Holds a header and the\ncolumn's cards.",
+  "props": {
+    "id": {
+      "type": "UniqueIdentifier",
+      "typeAst": {
+        "type": "identifier",
+        "name": "UniqueIdentifier"
+      },
+      "description": "Must match the `id` of the corresponding entry in the board's `columns`.",
+      "required": true
+    },
+    "itemIds": {
+      "type": "UniqueIdentifier[]",
+      "typeAst": {
+        "type": "array",
+        "elementType": {
+          "type": "identifier",
+          "name": "UniqueIdentifier"
+        }
+      },
+      "description": "The card ids in this column, top to bottom — drives the sortable order.",
+      "required": true
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/kanban-drag-overlay.json
+++ b/www/src/modules/docs/references/generated/kanban-drag-overlay.json
@@ -1,0 +1,32 @@
+{
+  "name": "KanbanDragOverlayProps",
+  "description": "Renders a floating copy of the card under the cursor while dragging, detached\nfrom the column's scroll and overflow.",
+  "props": {
+    "children": {
+      "type": "((activeId: UniqueIdentifier) => ReactNode)",
+      "detailedType": "| ((activeId: UniqueIdentifier) => ReactNode)\n| undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "activeId",
+            "value": {
+              "type": "link",
+              "id": "UniqueIdentifier",
+              "name": "UniqueIdentifier"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "identifier",
+          "name": "ReactNode"
+        },
+        "typeParameters": []
+      },
+      "description": "Called with the active card id to render the overlay contents."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -1521,6 +1521,10 @@ export const DemosIndex: Record<
 		files: ["ui/input-group/demos/vertical-group.tsx"],
 		component: React.lazy(() => import("@/registry/ui/input-group/demos/vertical-group")),
 	},
+	"kanban/demos/default": {
+		files: ["ui/kanban/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/kanban/demos/default")),
+	},
 	"kbd/demos/arrow-keys": {
 		files: ["ui/kbd/demos/arrow-keys.tsx"],
 		component: React.lazy(() => import("@/registry/ui/kbd/demos/arrow-keys")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -44,6 +44,7 @@ import UiField from "@/registry/ui/field/meta";
 import UiFileTrigger from "@/registry/ui/file-trigger/meta";
 import UiGroup from "@/registry/ui/group/meta";
 import UiInput from "@/registry/ui/input/meta";
+import UiKanban from "@/registry/ui/kanban/meta";
 import UiKbd from "@/registry/ui/kbd/meta";
 import UiLink from "@/registry/ui/link/meta";
 import UiListBox from "@/registry/ui/list-box/meta";
@@ -118,6 +119,7 @@ export const registryUi: RegistryItem[] = [
 	UiFileTrigger,
 	UiGroup,
 	UiInput,
+	UiKanban,
 	UiKbd,
 	UiLink,
 	UiListBox,

--- a/www/src/registry/ui/kanban/base.tsx
+++ b/www/src/registry/ui/kanban/base.tsx
@@ -1,0 +1,475 @@
+'use client'
+
+import * as React from 'react'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  pointerWithin,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import type {
+  DragEndEvent,
+  DragOverEvent,
+  DragStartEvent,
+  UniqueIdentifier,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { GripVerticalIcon } from 'lucide-react'
+
+import { createContext } from '@/registry/lib/context'
+
+import { useStyles } from './styles'
+
+// MARK: kanbanStyles
+
+// MARK: types
+
+/** A single card. The board only requires an `id`; add whatever fields your cards need. */
+interface KanbanItem {
+  id: UniqueIdentifier
+}
+
+/** A column and the cards it holds. Add column fields (e.g. a `title`) freely. */
+interface KanbanColumnData<TItem extends KanbanItem = KanbanItem> {
+  id: UniqueIdentifier
+  items: TItem[]
+}
+
+// MARK: context
+
+interface KanbanContextValue {
+  /** The id of the card currently being dragged, or `null`. */
+  activeId: UniqueIdentifier | null
+}
+
+const [KanbanContext, useKanbanContext] = createContext<KanbanContextValue>({
+  name: 'KanbanBoard',
+})
+
+interface KanbanColumnContextValue {
+  columnId: UniqueIdentifier
+}
+
+const [KanbanColumnContext, useKanbanColumnContext] =
+  createContext<KanbanColumnContextValue>({ name: 'KanbanColumn' })
+
+interface KanbanCardHandleContextValue {
+  attributes: ReturnType<typeof useSortable>['attributes']
+  listeners: ReturnType<typeof useSortable>['listeners']
+}
+
+const [KanbanCardHandleContext, useKanbanCardHandleContext] =
+  createContext<KanbanCardHandleContextValue>({ name: 'KanbanCard' })
+
+// MARK: helpers
+
+/**
+ * Find which column an id belongs to: a column id matches directly, a card id
+ * is searched in each column's items.
+ */
+function findColumnId<TItem extends KanbanItem>(
+  columns: KanbanColumnData<TItem>[],
+  id: UniqueIdentifier,
+): UniqueIdentifier | null {
+  if (columns.some((column) => column.id === id)) return id
+  const owner = columns.find((column) =>
+    column.items.some((item) => item.id === id),
+  )
+  return owner ? owner.id : null
+}
+
+// MARK: KanbanBoard
+
+interface KanbanBoardProps<TColumn extends KanbanColumnData> {
+  /** The columns and their cards. The board reorders this on drag. */
+  columns: TColumn[]
+  /** Called with the next column layout after a card is moved or reordered. */
+  onColumnsChange: (columns: TColumn[]) => void
+  className?: string
+  children?: React.ReactNode
+}
+
+/**
+ * The board root. Wraps a dnd-kit `DndContext` and implements the
+ * multi-container move: `onDragOver` relocates a card across columns mid-drag,
+ * `onDragEnd` settles its final order. Compose `KanbanColumn`s (mirroring
+ * `columns`) inside, each holding `KanbanCard`s.
+ */
+function KanbanBoard<TColumn extends KanbanColumnData>({
+  columns,
+  onColumnsChange,
+  className,
+  children,
+}: KanbanBoardProps<TColumn>) {
+  const { root } = useStyles()()
+  const [activeId, setActiveId] = React.useState<UniqueIdentifier | null>(null)
+
+  // The pointer must travel a few pixels before a drag starts, so clicks and
+  // text selection inside a card still work.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  )
+
+  // `columns` changes between renders (controlled state); read it from a ref
+  // inside the handlers so they always see the latest layout.
+  const columnsRef = React.useRef(columns)
+  columnsRef.current = columns
+
+  const onDragStart = React.useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id)
+  }, [])
+
+  // While dragging over another column, move the card into it immediately so the
+  // user sees the relocation in real time. We slot it just before the card under
+  // the pointer (or at the end when hovering the empty column body).
+  const onDragOver = React.useCallback(
+    (event: DragOverEvent) => {
+      const { active, over } = event
+      if (!over) return
+      const draggedId = active.id
+      const overId = over.id
+      const current = columnsRef.current
+      const fromColumnId = findColumnId(current, draggedId)
+      const toColumnId = findColumnId(current, overId)
+      if (
+        fromColumnId == null ||
+        toColumnId == null ||
+        fromColumnId === toColumnId
+      ) {
+        return
+      }
+
+      const fromColumn = current.find((column) => column.id === fromColumnId)
+      const toColumn = current.find((column) => column.id === toColumnId)
+      if (!fromColumn || !toColumn) return
+      const movingItem = fromColumn.items.find((item) => item.id === draggedId)
+      if (!movingItem) return
+
+      const overIndex = toColumn.items.findIndex((item) => item.id === overId)
+      const insertIndex = overIndex >= 0 ? overIndex : toColumn.items.length
+
+      onColumnsChange(
+        current.map((column) => {
+          if (column.id === fromColumnId) {
+            return {
+              ...column,
+              items: column.items.filter((item) => item.id !== draggedId),
+            }
+          }
+          if (column.id === toColumnId) {
+            const items = [...column.items]
+            items.splice(insertIndex, 0, movingItem)
+            return { ...column, items }
+          }
+          return column
+        }),
+      )
+    },
+    [onColumnsChange],
+  )
+
+  // Settle the order within the destination column once the drag ends. By now
+  // `onDragOver` has already placed the card in the right column, so this only
+  // reorders inside it.
+  const onDragEnd = React.useCallback(
+    (event: DragEndEvent) => {
+      setActiveId(null)
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+      const current = columnsRef.current
+      const columnId = findColumnId(current, over.id)
+      if (columnId == null) return
+      const column = current.find((entry) => entry.id === columnId)
+      if (!column) return
+      const oldIndex = column.items.findIndex((item) => item.id === active.id)
+      const newIndex = column.items.findIndex((item) => item.id === over.id)
+      if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return
+
+      onColumnsChange(
+        current.map((entry) =>
+          entry.id === columnId
+            ? { ...entry, items: arrayMove(entry.items, oldIndex, newIndex) }
+            : entry,
+        ),
+      )
+    },
+    [onColumnsChange],
+  )
+
+  const onDragCancel = React.useCallback(() => {
+    setActiveId(null)
+  }, [])
+
+  const contextValue = React.useMemo<KanbanContextValue>(
+    () => ({ activeId }),
+    [activeId],
+  )
+
+  return (
+    <KanbanContext value={contextValue}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={pointerWithin}
+        onDragStart={onDragStart}
+        onDragOver={onDragOver}
+        onDragEnd={onDragEnd}
+        onDragCancel={onDragCancel}
+      >
+        <div data-kanban="" className={root({ className })}>
+          {children}
+        </div>
+      </DndContext>
+    </KanbanContext>
+  )
+}
+
+// MARK: KanbanColumn
+
+interface KanbanColumnProps {
+  /** Must match the `id` of the corresponding entry in the board's `columns`. */
+  id: UniqueIdentifier
+  /** The card ids in this column, top to bottom — drives the sortable order. */
+  itemIds: UniqueIdentifier[]
+  className?: string
+  children?: React.ReactNode
+}
+
+/**
+ * A droppable column with its own `SortableContext`. Compose a
+ * `KanbanColumnHeader` and the column's `KanbanCard`s inside it. `itemIds` must
+ * list the card ids in their current order.
+ */
+function KanbanColumn({ id, itemIds, className, children }: KanbanColumnProps) {
+  const { column } = useStyles()()
+  const { setNodeRef } = useDroppable({ id })
+  const contextValue = React.useMemo<KanbanColumnContextValue>(
+    () => ({ columnId: id }),
+    [id],
+  )
+  return (
+    <KanbanColumnContext value={contextValue}>
+      <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+        <div
+          ref={setNodeRef}
+          data-kanban-column=""
+          className={column({ className })}
+        >
+          {children}
+        </div>
+      </SortableContext>
+    </KanbanColumnContext>
+  )
+}
+
+// MARK: KanbanColumnHeader
+
+interface KanbanColumnHeaderProps extends React.ComponentProps<'div'> {}
+
+/** The column header row — typically a `KanbanColumnTitle` and a `KanbanColumnCount`. */
+function KanbanColumnHeader({ className, ...props }: KanbanColumnHeaderProps) {
+  const { columnHeader } = useStyles()()
+  return (
+    <div
+      data-kanban-column-header=""
+      className={columnHeader({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: KanbanColumnTitle
+
+interface KanbanColumnTitleProps extends React.ComponentProps<'h3'> {}
+
+/** The column's title. */
+function KanbanColumnTitle({ className, ...props }: KanbanColumnTitleProps) {
+  const { columnTitle } = useStyles()()
+  return (
+    <h3
+      data-kanban-column-title=""
+      className={columnTitle({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: KanbanColumnCount
+
+interface KanbanColumnCountProps extends React.ComponentProps<'span'> {}
+
+/** A small badge showing the number of cards in the column. */
+function KanbanColumnCount({ className, ...props }: KanbanColumnCountProps) {
+  const { columnCount } = useStyles()()
+  return (
+    <span
+      data-kanban-column-count=""
+      className={columnCount({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: KanbanCardList
+
+interface KanbanCardListProps extends React.ComponentProps<'div'> {}
+
+/** The scrollable area that holds a column's cards. */
+function KanbanCardList({ className, ...props }: KanbanCardListProps) {
+  const { list } = useStyles()()
+  return <div data-kanban-list="" className={list({ className })} {...props} />
+}
+
+// MARK: KanbanCard
+
+interface KanbanCardProps extends Omit<React.ComponentProps<'div'>, 'id'> {
+  /** Must match the `id` of the corresponding item in the board's `columns`. */
+  id: UniqueIdentifier
+  /**
+   * Restrict dragging to a `KanbanCardHandle` instead of the whole card, so the
+   * rest of the card stays interactive. @default false
+   */
+  withHandle?: boolean
+}
+
+/**
+ * A draggable, sortable card. By default the entire card is the drag handle;
+ * pass `withHandle` to restrict dragging to a `KanbanCardHandle` placed inside.
+ */
+function KanbanCard({
+  id,
+  withHandle = false,
+  className,
+  children,
+  ...props
+}: KanbanCardProps) {
+  const { card } = useStyles()()
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+  }
+
+  const handleContext = React.useMemo<KanbanCardHandleContextValue>(
+    () => ({ attributes, listeners }),
+    [attributes, listeners],
+  )
+
+  // Without an explicit handle, the whole card is the handle: spread the drag
+  // listeners + a11y attributes onto the root.
+  const dragProps = withHandle ? {} : { ...attributes, ...listeners }
+
+  return (
+    <KanbanCardHandleContext value={handleContext}>
+      <div
+        ref={setNodeRef}
+        data-kanban-card=""
+        data-dragging={isDragging ? '' : undefined}
+        style={style}
+        className={card({ className })}
+        {...dragProps}
+        {...props}
+      >
+        {children}
+      </div>
+    </KanbanCardHandleContext>
+  )
+}
+
+// MARK: KanbanCardHandle
+
+interface KanbanCardHandleProps extends React.ComponentProps<'button'> {}
+
+/**
+ * An explicit drag handle for a `KanbanCard` rendered with `withHandle`. Place
+ * it anywhere inside the card; only it initiates a drag.
+ */
+function KanbanCardHandle({
+  className,
+  children,
+  ...props
+}: KanbanCardHandleProps) {
+  const { attributes, listeners } =
+    useKanbanCardHandleContext('KanbanCardHandle')
+  return (
+    <button
+      type="button"
+      data-kanban-card-handle=""
+      aria-label="Drag card"
+      className={className}
+      {...attributes}
+      {...listeners}
+      {...props}
+    >
+      {children ?? <GripVerticalIcon className="size-4" />}
+    </button>
+  )
+}
+
+// MARK: KanbanDragOverlay
+
+interface KanbanDragOverlayProps {
+  children?: (activeId: UniqueIdentifier) => React.ReactNode
+}
+
+/**
+ * Renders a floating copy of the card under the cursor while dragging, detached
+ * from the column's scroll/overflow. `children` is called with the active id.
+ */
+function KanbanDragOverlay({ children }: KanbanDragOverlayProps) {
+  const { activeId } = useKanbanContext('KanbanDragOverlay')
+  return (
+    <DragOverlay>
+      {activeId != null && children ? children(activeId) : null}
+    </DragOverlay>
+  )
+}
+
+// MARK: separator
+
+export type {
+  KanbanBoardProps,
+  KanbanCardHandleContextValue,
+  KanbanCardHandleProps,
+  KanbanCardListProps,
+  KanbanCardProps,
+  KanbanColumnContextValue,
+  KanbanColumnCountProps,
+  KanbanColumnData,
+  KanbanColumnHeaderProps,
+  KanbanColumnProps,
+  KanbanColumnTitleProps,
+  KanbanContextValue,
+  KanbanDragOverlayProps,
+  KanbanItem,
+}
+export {
+  KanbanBoard,
+  KanbanCard,
+  KanbanCardHandle,
+  KanbanCardList,
+  KanbanColumn,
+  KanbanColumnCount,
+  KanbanColumnHeader,
+  KanbanColumnTitle,
+  KanbanDragOverlay,
+  useKanbanCardHandleContext,
+  useKanbanColumnContext,
+  useKanbanContext,
+}

--- a/www/src/registry/ui/kanban/demos/default.tsx
+++ b/www/src/registry/ui/kanban/demos/default.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import * as React from 'react'
+
+import {
+  KanbanBoard,
+  KanbanCard,
+  KanbanCardList,
+  KanbanColumn,
+  KanbanColumnCount,
+  KanbanColumnHeader,
+  KanbanColumnTitle,
+  KanbanDragOverlay,
+} from '@/registry/ui/kanban'
+import type { KanbanColumnData } from '@/registry/ui/kanban'
+
+interface Task {
+  id: string
+  title: string
+  assignee: number
+}
+
+type Column = KanbanColumnData<Task> & { title: string }
+
+const initialColumns: Column[] = [
+  {
+    id: 'todo',
+    title: 'To do',
+    items: [
+      { id: 't-1', title: 'Audit onboarding funnel', assignee: 12 },
+      { id: 't-2', title: 'Draft Q3 roadmap', assignee: 5 },
+      { id: 't-3', title: 'Refresh marketing copy', assignee: 32 },
+    ],
+  },
+  {
+    id: 'in-progress',
+    title: 'In progress',
+    items: [
+      { id: 't-4', title: 'Build settings page', assignee: 8 },
+      { id: 't-5', title: 'Migrate auth to OAuth', assignee: 19 },
+    ],
+  },
+  {
+    id: 'done',
+    title: 'Done',
+    items: [{ id: 't-6', title: 'Ship dark mode', assignee: 24 }],
+  },
+]
+
+export default function Demo() {
+  const [columns, setColumns] = React.useState<Column[]>(initialColumns)
+
+  const taskById = React.useMemo(() => {
+    const map = new Map<string, Task>()
+    for (const column of columns) {
+      for (const item of column.items) map.set(item.id, item)
+    }
+    return map
+  }, [columns])
+
+  return (
+    <KanbanBoard
+      columns={columns}
+      onColumnsChange={setColumns}
+      className="w-full max-w-2xl pb-2"
+    >
+      {columns.map((column) => (
+        <KanbanColumn
+          key={column.id}
+          id={column.id}
+          itemIds={column.items.map((item) => item.id)}
+        >
+          <KanbanColumnHeader>
+            <KanbanColumnTitle>{column.title}</KanbanColumnTitle>
+            <KanbanColumnCount>{column.items.length}</KanbanColumnCount>
+          </KanbanColumnHeader>
+          <KanbanCardList>
+            {column.items.map((task) => (
+              <KanbanCard key={task.id} id={task.id} className="cursor-grab">
+                <TaskContent task={task} />
+              </KanbanCard>
+            ))}
+          </KanbanCardList>
+        </KanbanColumn>
+      ))}
+      <KanbanDragOverlay>
+        {(activeId) => {
+          const task = taskById.get(String(activeId))
+          return task ? (
+            <div className="rounded-(--kanban-radius) border bg-card p-3 text-sm shadow-md">
+              <TaskContent task={task} />
+            </div>
+          ) : null
+        }}
+      </KanbanDragOverlay>
+    </KanbanBoard>
+  )
+}
+
+function TaskContent({ task }: { task: Task }) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="font-medium">{task.title}</span>
+      <img
+        src={`https://i.pravatar.cc/80?img=${task.assignee}`}
+        alt=""
+        className="size-6 shrink-0 rounded-full"
+      />
+    </div>
+  )
+}

--- a/www/src/registry/ui/kanban/examples.tsx
+++ b/www/src/registry/ui/kanban/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import DefaultDemo from './demos/default'
+
+export default function KanbanExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <DefaultDemo />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/kanban/index.tsx
+++ b/www/src/registry/ui/kanban/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/kanban/meta.ts
+++ b/www/src/registry/ui/kanban/meta.ts
@@ -1,0 +1,26 @@
+import type { RegistryItem } from '@/registry/types'
+
+const kanbanMeta = {
+  name: 'kanban',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/kanban/base.tsx',
+      target: 'ui/kanban.tsx',
+    },
+  ],
+  registryDependencies: ['focus-styles'],
+  dependencies: ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--kanban-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default kanbanMeta

--- a/www/src/registry/ui/kanban/styles.css
+++ b/www/src/registry/ui/kanban/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --kanban-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/kanban/styles.ts
+++ b/www/src/registry/ui/kanban/styles.ts
@@ -1,0 +1,58 @@
+import { createStyles } from '@/lib/styles'
+
+import kanbanMeta from './meta'
+
+const { useStyles, styles } = createStyles(kanbanMeta, {
+  base: {
+    slots: {
+      root: 'group/kanban flex items-start overflow-x-auto overscroll-x-contain',
+      column:
+        'flex w-72 shrink-0 flex-col rounded-(--kanban-radius) border bg-muted',
+      columnHeader: 'flex items-center justify-between',
+      columnTitle: 'font-medium text-fg',
+      columnCount:
+        'inline-flex items-center justify-center rounded-full bg-bg text-fg-muted tabular-nums',
+      list: 'flex min-h-2 flex-1 flex-col overflow-y-auto',
+      card: 'rounded-(--kanban-radius) border bg-card text-fg shadow-xs outline-hidden focus-visible:focus-ring data-[dragging]:opacity-40 data-[overlay]:cursor-grabbing data-[overlay]:shadow-md',
+    },
+  },
+  density: {
+    compact: {
+      slots: {
+        root: 'gap-2',
+        column: 'gap-2 p-2 text-xs',
+        columnHeader: 'px-1',
+        columnTitle: 'text-xs',
+        columnCount: 'size-4 text-[10px]',
+        list: 'gap-2',
+        card: 'p-2 text-xs',
+      },
+    },
+    default: {
+      slots: {
+        root: 'gap-3',
+        column: 'gap-3 p-3 text-sm',
+        columnHeader: 'px-1',
+        columnTitle: 'text-sm',
+        columnCount: 'size-5 text-xs',
+        list: 'gap-2',
+        card: 'p-3 text-sm',
+      },
+    },
+    comfortable: {
+      slots: {
+        root: 'gap-4',
+        column: 'gap-4 p-4 text-sm',
+        columnHeader: 'px-1',
+        columnTitle: 'text-base',
+        columnCount: 'size-6 text-xs',
+        list: 'gap-3',
+        card: 'p-4 text-sm',
+      },
+    },
+  },
+})
+
+export type KanbanStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/kanban/types.ts
+++ b/www/src/registry/ui/kanban/types.ts
@@ -1,0 +1,77 @@
+import type { UniqueIdentifier } from '@dnd-kit/core'
+
+import type { KanbanColumnData } from './base'
+
+/**
+ * The board root. Wraps the drag-and-drop context and implements moving cards
+ * within and between columns. Compose `KanbanColumn`s inside it, mirroring the
+ * `columns` data.
+ */
+export interface KanbanBoardProps<
+  TColumn extends KanbanColumnData = KanbanColumnData,
+> {
+  /** The columns and their cards. The board reorders this on drag. */
+  columns: TColumn[]
+  /** Called with the next column layout after a card is moved or reordered. */
+  onColumnsChange: (columns: TColumn[]) => void
+  className?: string
+  children?: React.ReactNode
+}
+
+/**
+ * A droppable column with its own sortable context. Holds a header and the
+ * column's cards.
+ */
+export interface KanbanColumnProps {
+  /** Must match the `id` of the corresponding entry in the board's `columns`. */
+  id: UniqueIdentifier
+  /** The card ids in this column, top to bottom — drives the sortable order. */
+  itemIds: UniqueIdentifier[]
+  className?: string
+  children?: React.ReactNode
+}
+
+/**
+ * The column header row, typically containing a `KanbanColumnTitle` and a
+ * `KanbanColumnCount`.
+ */
+export interface KanbanColumnHeaderProps extends React.ComponentProps<'div'> {}
+
+/** The column's title. */
+export interface KanbanColumnTitleProps extends React.ComponentProps<'h3'> {}
+
+/** A small badge showing the number of cards in the column. */
+export interface KanbanColumnCountProps extends React.ComponentProps<'span'> {}
+
+/** The scrollable area that holds a column's cards. */
+export interface KanbanCardListProps extends React.ComponentProps<'div'> {}
+
+/** A draggable, sortable card. */
+export interface KanbanCardProps extends Omit<
+  React.ComponentProps<'div'>,
+  'id'
+> {
+  /** Must match the `id` of the corresponding item in the board's `columns`. */
+  id: UniqueIdentifier
+  /**
+   * Restrict dragging to a `KanbanCardHandle` instead of the whole card, so the
+   * rest of the card stays interactive.
+   * @default false
+   */
+  withHandle?: boolean
+}
+
+/**
+ * An explicit drag handle for a `KanbanCard` rendered with `withHandle`. Only
+ * it initiates a drag.
+ */
+export interface KanbanCardHandleProps extends React.ComponentProps<'button'> {}
+
+/**
+ * Renders a floating copy of the card under the cursor while dragging, detached
+ * from the column's scroll and overflow.
+ */
+export interface KanbanDragOverlayProps {
+  /** Called with the active card id to render the overlay contents. */
+  children?: (activeId: UniqueIdentifier) => React.ReactNode
+}


### PR DESCRIPTION
## Summary

Adds a **Kanban** board to the registry — columns of cards with drag-and-drop within and between columns. Part of the real-world-component-blocks batch (Tier 2).

- Engine: **dnd-kit**, installed as a dependency. dotUI owns the chrome (columns, headers + counts, card surfaces, a detached drag overlay).
- Composition-first: `KanbanBoard` (controlled `columns` + `onColumnsChange`, owns the cross-column move) + `KanbanColumn` / `KanbanColumnHeader` / `KanbanColumnTitle` / `KanbanColumnCount` / `KanbanCardList` / `KanbanCard` (+ optional `KanbanCardHandle`, `KanbanDragOverlay`).
- Real-time cross-container move on `onDragOver`, intra-column settle via `arrayMove` on `onDragEnd`.
- Themeable axis: `--kanban-radius`. Group `containers`. `dependencies: ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities']`.

## Notes

- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.