### PR TITLE
feat(gantt): add gantt component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: 1.4.1
-        version: 1.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 1.4.1(@types/react@19.2.2)(date-fns@4.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@dotui/colors':
         specifier: workspace:*
         version: link:../packages/colors
@@ -147,6 +147,9 @@ importers:
       cnfast:
         specifier: ^0.0.8
         version: 0.0.8
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       fumadocs-core:
         specifier: ^16.8.11
         version: 16.8.11(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.2)(lucide-react@1.16.0(react@19.2.1))(next@16.0.8(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
@@ -3501,6 +3504,9 @@ packages:
     resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
     engines: {node: '>=20'}
 
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
@@ -6753,7 +6759,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@base-ui/react@1.4.1(@types/react@19.2.2)(date-fns@4.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@base-ui/utils': 0.2.8(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -6764,6 +6770,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.1)
     optionalDependencies:
       '@types/react': 19.2.2
+      date-fns: 4.4.0
 
   '@base-ui/utils@0.2.8(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -8112,7 +8119,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':
@@ -9141,6 +9148,8 @@ snapshots:
       whatwg-mimetype: 5.0.0
       whatwg-url: 15.1.0
     optional: true
+
+  date-fns@4.4.0: {}
 
   dayjs@1.11.20: {}
 

--- a/www/content/docs/components/gantt.mdx
+++ b/www/content/docs/components/gantt.mdx
@@ -51,7 +51,3 @@ import { Gantt } from '@/components/ui/gantt'
 ### Gantt
 
 <Reference name="gantt" />
-
-### GanttTask
-
-<Reference name="gantt-task" />

--- a/www/content/docs/components/gantt.mdx
+++ b/www/content/docs/components/gantt.mdx
@@ -4,6 +4,8 @@ description: A Gantt chart lays out tasks across a horizontal date axis to visua
 wip: true
 ---
 
+<Demo name="gantt/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/gantt.mdx
+++ b/www/content/docs/components/gantt.mdx
@@ -1,0 +1,55 @@
+---
+title: Gantt
+description: A Gantt chart lays out tasks across a horizontal date axis to visualize a schedule.
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/gantt
+```
+
+## Usage
+
+Pass a list of tasks, each with a `start` and `end` date. The timeline range is
+derived from the tasks unless you set `start` and `end` explicitly.
+
+```tsx
+import { Gantt } from '@/components/ui/gantt'
+```
+
+```tsx
+<Gantt
+  tasks={[
+    {
+      id: 'design',
+      name: 'Design',
+      start: new Date('2025-01-01'),
+      end: new Date('2025-01-05'),
+    },
+    {
+      id: 'build',
+      name: 'Build',
+      start: new Date('2025-01-04'),
+      end: new Date('2025-01-12'),
+    },
+  ]}
+/>
+```
+
+## Examples
+
+<Examples>
+  <Example name="gantt/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### Gantt
+
+<Reference name="gantt" />
+
+### GanttTask
+
+<Reference name="gantt-task" />

--- a/www/package.json
+++ b/www/package.json
@@ -36,6 +36,7 @@
     "@tanstack/router-plugin": "^1.168.2",
     "@vercel/og": "^0.11.1",
     "cnfast": "^0.0.8",
+    "date-fns": "^4.4.0",
     "fumadocs-core": "^16.8.11",
     "fumadocs-mdx": "^15.0.5",
     "globals-docs": "^2.4.1",

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -38,6 +38,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	field: () => import("@/registry/ui/field/examples"),
 	"file-trigger": () => import("@/registry/ui/file-trigger/examples"),
 	form: () => import("@/registry/ui/form/examples"),
+	gantt: () => import("@/registry/ui/gantt/examples"),
 	group: () => import("@/registry/ui/group/examples"),
 	input: () => import("@/registry/ui/input/examples"),
 	"input-group": () => import("@/registry/ui/input-group/examples"),

--- a/www/src/modules/docs/references/generated/gantt.json
+++ b/www/src/modules/docs/references/generated/gantt.json
@@ -1,0 +1,117 @@
+{
+  "name": "GanttProps",
+  "description": "A Gantt chart lays out tasks across a horizontal date axis, with a sidebar of\ntask names beside a scrollable timeline. Each task renders a positioned bar\nwhose offset and width are derived from its start and end dates.",
+  "extendsElement": "div",
+  "props": {
+    "tasks": {
+      "type": "readonly GanttTask[]",
+      "typeAst": {
+        "type": "array",
+        "elementType": {
+          "type": "link",
+          "id": "src/registry/ui/gantt/types.ts:GanttTask",
+          "name": "GanttTask"
+        }
+      },
+      "description": "The tasks to lay out on the timeline.",
+      "required": true
+    },
+    "start": {
+      "type": "Date",
+      "detailedType": "Date | undefined",
+      "typeAst": {
+        "type": "identifier",
+        "name": "Date"
+      },
+      "description": "Start of the visible timeline range. Defaults to the earliest task start,\npadded by two days."
+    },
+    "end": {
+      "type": "Date",
+      "detailedType": "Date | undefined",
+      "typeAst": {
+        "type": "identifier",
+        "name": "Date"
+      },
+      "description": "End of the visible timeline range. Defaults to the latest task end, padded\nby two days."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  },
+  "typeLinks": {
+    "src/registry/ui/gantt/types.ts:GanttTask": {
+      "type": "interface",
+      "id": "src/registry/ui/gantt/types.ts:GanttTask",
+      "name": "GanttTask",
+      "extends": [],
+      "properties": {
+        "color": {
+          "type": "property",
+          "name": "color",
+          "value": {
+            "type": "union",
+            "elements": [
+              {
+                "type": "undefined"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "optional": true,
+          "readonly": false,
+          "description": "Tailwind background class applied to the task bar."
+        },
+        "end": {
+          "type": "property",
+          "name": "end",
+          "value": {
+            "type": "identifier",
+            "name": "Date"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "End date of the task (inclusive)."
+        },
+        "id": {
+          "type": "property",
+          "name": "id",
+          "value": {
+            "type": "string"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Unique identifier for the task."
+        },
+        "name": {
+          "type": "property",
+          "name": "name",
+          "value": {
+            "type": "string"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Display name shown in the sidebar and inside the task bar."
+        },
+        "start": {
+          "type": "property",
+          "name": "start",
+          "value": {
+            "type": "identifier",
+            "name": "Date"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Start date of the task (inclusive)."
+        }
+      },
+      "typeParameters": [],
+      "description": "A single task plotted on the Gantt timeline."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -1385,6 +1385,10 @@ export const DemosIndex: Record<
 		files: ["ui/form/demos/react-aria.tsx"],
 		component: React.lazy(() => import("@/registry/ui/form/demos/react-aria")),
 	},
+	"gantt/demos/default": {
+		files: ["ui/gantt/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/gantt/demos/default")),
+	},
 	"group/demos/basic": {
 		files: ["ui/group/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/group/demos/basic")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -42,6 +42,7 @@ import UiDropZone from "@/registry/ui/drop-zone/meta";
 import UiEmpty from "@/registry/ui/empty/meta";
 import UiField from "@/registry/ui/field/meta";
 import UiFileTrigger from "@/registry/ui/file-trigger/meta";
+import UiGantt from "@/registry/ui/gantt/meta";
 import UiGroup from "@/registry/ui/group/meta";
 import UiInput from "@/registry/ui/input/meta";
 import UiKbd from "@/registry/ui/kbd/meta";
@@ -116,6 +117,7 @@ export const registryUi: RegistryItem[] = [
 	UiEmpty,
 	UiField,
 	UiFileTrigger,
+	UiGantt,
 	UiGroup,
 	UiInput,
 	UiKbd,

--- a/www/src/registry/ui/gantt/base.tsx
+++ b/www/src/registry/ui/gantt/base.tsx
@@ -1,0 +1,197 @@
+'use client'
+
+import * as React from 'react'
+import {
+  differenceInCalendarDays,
+  eachDayOfInterval,
+  format,
+  isToday,
+  startOfDay,
+} from 'date-fns'
+
+import { useStyles } from './styles'
+
+// MARK: ganttStyles
+
+// MARK: helpers
+
+/** Width of a single day column, in pixels. */
+const DAY_WIDTH = 40
+
+interface GanttTask {
+  /** Unique identifier for the task. */
+  id: string
+  /** Display name shown in the sidebar and on the bar. */
+  name: string
+  /** Start date of the task (inclusive). */
+  start: Date
+  /** End date of the task (inclusive). */
+  end: Date
+  /**
+   * Tailwind background class for the task bar. Defaults to `bg-primary`.
+   */
+  color?: string
+}
+
+/** The smallest and largest dates across every task. */
+function tasksExtent(tasks: readonly GanttTask[]): {
+  min: Date
+  max: Date
+} | null {
+  let min: Date | null = null
+  let max: Date | null = null
+  for (const task of tasks) {
+    const start = startOfDay(task.start)
+    const end = startOfDay(task.end)
+    if (min === null || start < min) min = start
+    if (max === null || end > max) max = end
+  }
+  if (min === null || max === null) return null
+  return { min, max }
+}
+
+// MARK: Gantt
+
+interface GanttProps extends Omit<React.ComponentProps<'div'>, 'children'> {
+  /** The tasks to lay out on the timeline. */
+  tasks: readonly GanttTask[]
+  /**
+   * Start of the visible timeline range. Defaults to the earliest task start,
+   * padded by two days.
+   */
+  start?: Date
+  /**
+   * End of the visible timeline range. Defaults to the latest task end, padded
+   * by two days.
+   */
+  end?: Date
+}
+
+function Gantt({ tasks, start, end, className, ...props }: GanttProps) {
+  const {
+    root,
+    sidebar,
+    sidebarHeader,
+    sidebarRow,
+    timeline,
+    grid,
+    header,
+    headerCell,
+    headerWeekday,
+    headerDay,
+    body,
+    row,
+    cell,
+    bar,
+    barLabel,
+    today,
+  } = useStyles()()
+
+  const { rangeStart, days } = React.useMemo(() => {
+    const extent = tasksExtent(tasks)
+    const fallback = startOfDay(new Date())
+    const rangeStart = start
+      ? startOfDay(start)
+      : extent
+        ? new Date(extent.min.getTime() - 2 * 86_400_000)
+        : fallback
+    const rangeEnd = end
+      ? startOfDay(end)
+      : extent
+        ? new Date(extent.max.getTime() + 2 * 86_400_000)
+        : fallback
+    // Guard against an inverted range so eachDayOfInterval never throws.
+    const safeEnd = rangeEnd < rangeStart ? rangeStart : rangeEnd
+    return {
+      rangeStart,
+      days: eachDayOfInterval({ start: rangeStart, end: safeEnd }),
+    }
+  }, [tasks, start, end])
+
+  const totalWidth = days.length * DAY_WIDTH
+  const todayOffset = differenceInCalendarDays(
+    startOfDay(new Date()),
+    rangeStart,
+  )
+  const showToday = todayOffset >= 0 && todayOffset < days.length
+
+  return (
+    <div data-gantt="" className={root({ className })} {...props}>
+      <div data-gantt-sidebar="" className={sidebar()}>
+        <div className={sidebarHeader()}>Task</div>
+        {tasks.map((task) => (
+          <div key={task.id} className={sidebarRow()} title={task.name}>
+            {task.name}
+          </div>
+        ))}
+      </div>
+
+      <div data-gantt-timeline="" className={timeline()}>
+        <div className={grid()} style={{ width: totalWidth }}>
+          <div data-gantt-header="" className={header()}>
+            {days.map((day) => (
+              <div
+                key={day.toISOString()}
+                className={headerCell()}
+                style={{ width: DAY_WIDTH }}
+                data-today={isToday(day) ? '' : undefined}
+              >
+                <span className={headerWeekday()}>{format(day, 'EEEEE')}</span>
+                <span className={headerDay()}>{format(day, 'd')}</span>
+              </div>
+            ))}
+          </div>
+
+          <div data-gantt-body="" className={body()}>
+            {showToday && (
+              <div
+                data-gantt-today=""
+                className={today()}
+                style={{ left: todayOffset * DAY_WIDTH + DAY_WIDTH / 2 }}
+              />
+            )}
+
+            {tasks.map((task) => {
+              const offset = differenceInCalendarDays(
+                startOfDay(task.start),
+                rangeStart,
+              )
+              const span =
+                differenceInCalendarDays(
+                  startOfDay(task.end),
+                  startOfDay(task.start),
+                ) + 1
+              const left = offset * DAY_WIDTH
+              const width = Math.max(span, 1) * DAY_WIDTH
+
+              return (
+                <div key={task.id} className={row()}>
+                  {days.map((day) => (
+                    <div
+                      key={day.toISOString()}
+                      className={cell()}
+                      style={{ width: DAY_WIDTH }}
+                    />
+                  ))}
+                  <div
+                    data-gantt-bar=""
+                    className={bar({ className: task.color ?? 'bg-primary' })}
+                    style={{ left, width }}
+                    title={task.name}
+                  >
+                    <span className={barLabel()}>{task.name}</span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// MARK: separator
+
+export type { GanttProps, GanttTask }
+export { Gantt }

--- a/www/src/registry/ui/gantt/demos/default.tsx
+++ b/www/src/registry/ui/gantt/demos/default.tsx
@@ -1,0 +1,52 @@
+import { addDays, startOfDay } from 'date-fns'
+
+import { Gantt } from '@/registry/ui/gantt'
+import type { GanttTask } from '@/registry/ui/gantt'
+
+const today = startOfDay(new Date())
+
+const tasks: GanttTask[] = [
+  {
+    id: 'research',
+    name: 'Research',
+    start: today,
+    end: addDays(today, 3),
+    color: 'bg-primary',
+  },
+  {
+    id: 'design',
+    name: 'Design',
+    start: addDays(today, 3),
+    end: addDays(today, 7),
+    color: 'bg-accent text-fg-on-accent',
+  },
+  {
+    id: 'build',
+    name: 'Build',
+    start: addDays(today, 6),
+    end: addDays(today, 13),
+    color: 'bg-success text-fg-on-success',
+  },
+  {
+    id: 'qa',
+    name: 'QA & Review',
+    start: addDays(today, 12),
+    end: addDays(today, 16),
+    color: 'bg-warning text-fg-on-warning',
+  },
+  {
+    id: 'launch',
+    name: 'Launch',
+    start: addDays(today, 16),
+    end: addDays(today, 18),
+    color: 'bg-info text-fg-on-info',
+  },
+]
+
+export default function Demo() {
+  return (
+    <div className="w-full max-w-3xl">
+      <Gantt tasks={tasks} />
+    </div>
+  )
+}

--- a/www/src/registry/ui/gantt/examples.tsx
+++ b/www/src/registry/ui/gantt/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function GanttExamples() {
+  return (
+    <Examples>
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/gantt/index.tsx
+++ b/www/src/registry/ui/gantt/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/gantt/meta.ts
+++ b/www/src/registry/ui/gantt/meta.ts
@@ -1,0 +1,25 @@
+import type { RegistryItem } from '@/registry/types'
+
+const ganttMeta = {
+  name: 'gantt',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/gantt/base.tsx',
+      target: 'ui/gantt.tsx',
+    },
+  ],
+  dependencies: ['date-fns'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--gantt-radius',
+      default: '--radius-sm',
+    },
+  },
+} satisfies RegistryItem
+
+export default ganttMeta

--- a/www/src/registry/ui/gantt/styles.css
+++ b/www/src/registry/ui/gantt/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --gantt-radius: var(--radius-sm);
+}

--- a/www/src/registry/ui/gantt/styles.ts
+++ b/www/src/registry/ui/gantt/styles.ts
@@ -1,0 +1,68 @@
+import { createStyles } from '@/lib/styles'
+
+import ganttMeta from './meta'
+
+const { useStyles, styles } = createStyles(ganttMeta, {
+  base: {
+    slots: {
+      root: 'flex w-full overflow-hidden rounded-(--gantt-radius) border bg-card',
+      sidebar: 'flex shrink-0 flex-col border-r bg-card',
+      sidebarHeader: 'flex shrink-0 items-center border-b font-medium text-fg',
+      sidebarRow: 'flex items-center truncate border-b text-fg last:border-b-0',
+      timeline: 'relative flex-1 overflow-x-auto',
+      grid: 'relative w-max min-w-full',
+      header: 'flex border-b',
+      headerCell: 'shrink-0 border-r text-center text-fg-muted last:border-r-0',
+      headerWeekday: 'leading-none',
+      headerDay: 'leading-none font-medium text-fg',
+      body: 'relative',
+      row: 'relative flex border-b last:border-b-0',
+      cell: 'shrink-0 border-r last:border-r-0',
+      bar: 'absolute flex items-center overflow-hidden rounded-(--gantt-radius) text-fg-on-primary',
+      barLabel: 'truncate font-medium',
+      today: 'pointer-events-none absolute top-0 bottom-0 z-10 w-px bg-primary',
+    },
+  },
+  density: {
+    compact: {
+      slots: {
+        sidebarHeader: 'h-9 px-3 text-xs',
+        sidebarRow: 'h-9 px-3 text-xs',
+        header: 'h-9',
+        headerCell: 'flex flex-col items-center justify-center gap-0.5 py-1',
+        headerWeekday: 'text-[10px]',
+        headerDay: 'text-xs',
+        row: 'h-9',
+        bar: 'h-6 px-2 text-xs',
+      },
+    },
+    default: {
+      slots: {
+        sidebarHeader: 'h-10 px-3.5 text-sm',
+        sidebarRow: 'h-10 px-3.5 text-sm',
+        header: 'h-10',
+        headerCell: 'flex flex-col items-center justify-center gap-0.5 py-1',
+        headerWeekday: 'text-[10px]',
+        headerDay: 'text-xs',
+        row: 'h-10',
+        bar: 'h-7 px-2.5 text-sm',
+      },
+    },
+    comfortable: {
+      slots: {
+        sidebarHeader: 'h-12 px-4 text-sm',
+        sidebarRow: 'h-12 px-4 text-sm',
+        header: 'h-12',
+        headerCell: 'flex flex-col items-center justify-center gap-1 py-1.5',
+        headerWeekday: 'text-[11px]',
+        headerDay: 'text-sm',
+        row: 'h-12',
+        bar: 'h-8 px-3 text-sm',
+      },
+    },
+  },
+})
+
+export type GanttStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/gantt/types.ts
+++ b/www/src/registry/ui/gantt/types.ts
@@ -1,0 +1,57 @@
+/**
+ * A single task plotted on the Gantt timeline.
+ */
+export interface GanttTask {
+  /**
+   * Unique identifier for the task.
+   */
+  id: string
+
+  /**
+   * Display name shown in the sidebar and inside the task bar.
+   */
+  name: string
+
+  /**
+   * Start date of the task (inclusive).
+   */
+  start: Date
+
+  /**
+   * End date of the task (inclusive).
+   */
+  end: Date
+
+  /**
+   * Tailwind background class applied to the task bar.
+   * @default 'bg-primary'
+   */
+  color?: string
+}
+
+/**
+ * A Gantt chart lays out tasks across a horizontal date axis, with a sidebar of
+ * task names beside a scrollable timeline. Each task renders a positioned bar
+ * whose offset and width are derived from its start and end dates.
+ */
+export interface GanttProps extends Omit<
+  React.ComponentProps<'div'>,
+  'children'
+> {
+  /**
+   * The tasks to lay out on the timeline.
+   */
+  tasks: readonly GanttTask[]
+
+  /**
+   * Start of the visible timeline range. Defaults to the earliest task start,
+   * padded by two days.
+   */
+  start?: Date
+
+  /**
+   * End of the visible timeline range. Defaults to the latest task end, padded
+   * by two days.
+   */
+  end?: Date
+}


### PR DESCRIPTION
## Summary

Adds a **Gantt** timeline to the registry — task bars across a date axis. Part of the real-world-component-blocks batch (Tier 3).

- Engine: **date-fns** for the time scale (installed as a dependency); the rendering/chrome is pure dotUI.
- A left task-name column + a scrollable timeline with a date header, one row per task, positioned bars (offset + width from each task's start/end), and a subtle "today" marker.
- Props: `tasks` (id, name, start, end, color?) and an optional `start`/`end` range.
- Themeable axis: `--gantt-radius`. Group `containers`. `dependencies: ['date-fns']`.

## Notes

- Static (no drag) for v1 reliability; drag-to-reschedule (dnd-kit) is a natural follow-up.
- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.