### PR TITLE
feat(event-calendar): add event-calendar component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: 1.4.1
-        version: 1.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 1.4.1(@types/react@19.2.2)(date-fns@4.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@dotui/colors':
         specifier: workspace:*
         version: link:../packages/colors
@@ -147,6 +147,9 @@ importers:
       cnfast:
         specifier: ^0.0.8
         version: 0.0.8
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       fumadocs-core:
         specifier: ^16.8.11
         version: 16.8.11(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.2)(lucide-react@1.16.0(react@19.2.1))(next@16.0.8(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
@@ -3501,6 +3504,9 @@ packages:
     resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
     engines: {node: '>=20'}
 
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
@@ -6753,7 +6759,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@base-ui/react@1.4.1(@types/react@19.2.2)(date-fns@4.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@base-ui/utils': 0.2.8(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -6764,6 +6770,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.1)
     optionalDependencies:
       '@types/react': 19.2.2
+      date-fns: 4.4.0
 
   '@base-ui/utils@0.2.8(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -8112,7 +8119,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':
@@ -9141,6 +9148,8 @@ snapshots:
       whatwg-mimetype: 5.0.0
       whatwg-url: 15.1.0
     optional: true
+
+  date-fns@4.4.0: {}
 
   dayjs@1.11.20: {}
 

--- a/www/content/docs/components/event-calendar.mdx
+++ b/www/content/docs/components/event-calendar.mdx
@@ -1,0 +1,99 @@
+---
+title: Event Calendar
+description: A month-grid calendar that displays events as colored chips.
+wip: true
+links:
+  - label: date-fns
+    href: https://date-fns.org/
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/event-calendar
+```
+
+## Usage
+
+Pass an array of `events` and an optional starting `month`. The calendar renders a
+month grid with each event shown as a colored chip on its day.
+
+```tsx
+import { EventCalendar } from '@/components/ui/event-calendar'
+```
+
+```tsx
+<EventCalendar
+  events={[{ id: '1', title: 'Standup', date: new Date(), color: 'primary' }]}
+/>
+```
+
+Control the visible month with `month` and `onMonthChange`.
+
+```tsx
+import { useState } from 'react'
+
+const [month, setMonth] = useState(new Date())
+
+;<EventCalendar events={events} month={month} onMonthChange={setMonth} />
+```
+
+## Composition
+
+For full control, compose the calendar from its parts.
+
+```tsx
+import {
+  EventCalendar,
+  EventCalendarHeader,
+  EventCalendarHeading,
+  EventCalendarNav,
+  EventCalendarGrid,
+} from '@/components/ui/event-calendar'
+```
+
+```tsx
+<EventCalendar events={events}>
+  <EventCalendarHeader>
+    <EventCalendarHeading />
+    <EventCalendarNav />
+  </EventCalendarHeader>
+  <EventCalendarGrid />
+</EventCalendar>
+```
+
+## Examples
+
+<Examples>
+  <Example name="event-calendar/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### EventCalendar
+
+<Reference name="event-calendar" />
+
+### EventCalendarHeader
+
+<Reference name="event-calendar-header" />
+
+### EventCalendarHeading
+
+<Reference name="event-calendar-heading" />
+
+### EventCalendarNav
+
+<Reference name="event-calendar-nav" />
+
+### EventCalendarGrid
+
+<Reference name="event-calendar-grid" />
+
+### EventCalendarDay
+
+<Reference name="event-calendar-day" />
+
+### EventCalendarChip
+
+<Reference name="event-calendar-chip" />

--- a/www/content/docs/components/event-calendar.mdx
+++ b/www/content/docs/components/event-calendar.mdx
@@ -7,6 +7,8 @@ links:
     href: https://date-fns.org/
 ---
 
+<Demo name="event-calendar/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/package.json
+++ b/www/package.json
@@ -36,6 +36,7 @@
     "@tanstack/router-plugin": "^1.168.2",
     "@vercel/og": "^0.11.1",
     "cnfast": "^0.0.8",
+    "date-fns": "^4.4.0",
     "fumadocs-core": "^16.8.11",
     "fumadocs-mdx": "^15.0.5",
     "globals-docs": "^2.4.1",

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -35,6 +35,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	drawer: () => import("@/registry/ui/drawer/examples"),
 	"drop-zone": () => import("@/registry/ui/drop-zone/examples"),
 	empty: () => import("@/registry/ui/empty/examples"),
+	"event-calendar": () => import("@/registry/ui/event-calendar/examples"),
 	field: () => import("@/registry/ui/field/examples"),
 	"file-trigger": () => import("@/registry/ui/file-trigger/examples"),
 	form: () => import("@/registry/ui/form/examples"),

--- a/www/src/modules/docs/references/generated/event-calendar-chip.json
+++ b/www/src/modules/docs/references/generated/event-calendar-chip.json
@@ -1,0 +1,23 @@
+{
+  "name": "EventCalendarChipProps",
+  "description": "A colored event chip rendered inside a day cell.",
+  "extendsElement": "span",
+  "props": {
+    "event": {
+      "type": "CalendarEvent",
+      "typeAst": {
+        "type": "identifier",
+        "name": "CalendarEvent"
+      },
+      "description": "The event to render.",
+      "required": true
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/event-calendar-day.json
+++ b/www/src/modules/docs/references/generated/event-calendar-day.json
@@ -1,0 +1,122 @@
+{
+  "name": "EventCalendarDayProps",
+  "description": "A single day cell, showing the day number and its event chips with overflow.",
+  "extendsElement": "div",
+  "props": {
+    "day": {
+      "type": "Date",
+      "typeAst": {
+        "type": "identifier",
+        "name": "Date"
+      },
+      "description": "The day this cell represents.",
+      "required": true
+    },
+    "events": {
+      "type": "CalendarEvent[]",
+      "typeAst": {
+        "type": "array",
+        "elementType": {
+          "type": "link",
+          "id": "src/registry/ui/event-calendar/types.ts:CalendarEvent",
+          "name": "CalendarEvent"
+        }
+      },
+      "description": "The events that fall on this day.",
+      "required": true
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  },
+  "typeLinks": {
+    "src/registry/ui/event-calendar/types.ts:CalendarEvent": {
+      "type": "interface",
+      "id": "src/registry/ui/event-calendar/types.ts:CalendarEvent",
+      "name": "CalendarEvent",
+      "extends": [],
+      "properties": {
+        "color": {
+          "type": "property",
+          "name": "color",
+          "value": {
+            "type": "union",
+            "elements": [
+              {
+                "type": "stringLiteral",
+                "value": "accent"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "danger"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "info"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "neutral"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "primary"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "success"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "warning"
+              },
+              {
+                "type": "undefined"
+              }
+            ]
+          },
+          "optional": true,
+          "readonly": false,
+          "description": "The semantic color of the event chip."
+        },
+        "date": {
+          "type": "property",
+          "name": "date",
+          "value": {
+            "type": "identifier",
+            "name": "Date"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The day the event falls on. Only the date portion is compared."
+        },
+        "id": {
+          "type": "property",
+          "name": "id",
+          "value": {
+            "type": "string"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Stable unique identifier, used as the React key."
+        },
+        "title": {
+          "type": "property",
+          "name": "title",
+          "value": {
+            "type": "string"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The text shown on the event chip."
+        }
+      },
+      "typeParameters": [],
+      "description": "A single event rendered on the calendar grid."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/event-calendar-grid.json
+++ b/www/src/modules/docs/references/generated/event-calendar-grid.json
@@ -1,0 +1,111 @@
+{
+  "name": "EventCalendarGridProps",
+  "description": "The 7-column month grid: a row of weekday headers followed by day cells.",
+  "extendsElement": "div",
+  "props": {
+    "renderDay": {
+      "type": "((day: Date, events: CalendarEvent[]) => ReactNode)",
+      "detailedType": "| ((day: Date, events: CalendarEvent[]) => ReactNode)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "day",
+                "value": {
+                  "type": "identifier",
+                  "name": "Date"
+                },
+                "optional": false,
+                "rest": false
+              },
+              {
+                "type": "parameter",
+                "name": "events",
+                "value": {
+                  "type": "array",
+                  "elementType": {
+                    "type": "link",
+                    "id": "src/registry/ui/event-calendar/types.ts:CalendarEvent",
+                    "name": "CalendarEvent"
+                  }
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "identifier",
+              "name": "ReactNode"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Render a custom day cell in place of the default one."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  },
+  "typeLinks": {
+    "src/registry/ui/event-calendar/types.ts:CalendarEvent": {
+      "type": "interface",
+      "name": "CalendarEvent",
+      "properties": {
+        "color": {
+          "type": "property",
+          "name": "color",
+          "value": {
+            "type": "identifier",
+            "name": "EventColor | undefined"
+          },
+          "optional": true,
+          "readonly": false,
+          "description": "The semantic color of the event chip."
+        },
+        "date": {
+          "type": "property",
+          "name": "date",
+          "value": {
+            "type": "identifier",
+            "name": "Date"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The day the event falls on. Only the date portion is compared."
+        },
+        "id": {
+          "type": "property",
+          "name": "id",
+          "value": {
+            "type": "string"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Stable unique identifier, used as the React key."
+        },
+        "title": {
+          "type": "property",
+          "name": "title",
+          "value": {
+            "type": "string"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The text shown on the event chip."
+        }
+      }
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/event-calendar-header.json
+++ b/www/src/modules/docs/references/generated/event-calendar-header.json
@@ -1,0 +1,14 @@
+{
+  "name": "EventCalendarHeaderProps",
+  "description": "The calendar header. Renders the month heading and navigation controls by default.",
+  "extendsElement": "header",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/event-calendar-heading.json
+++ b/www/src/modules/docs/references/generated/event-calendar-heading.json
@@ -1,0 +1,14 @@
+{
+  "name": "EventCalendarHeadingProps",
+  "description": "The month/year heading. Falls back to the formatted visible month.",
+  "extendsElement": "h2",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/event-calendar-nav.json
+++ b/www/src/modules/docs/references/generated/event-calendar-nav.json
@@ -1,0 +1,14 @@
+{
+  "name": "EventCalendarNavProps",
+  "description": "The navigation controls: Today, Previous month, and Next month buttons.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/event-calendar.json
+++ b/www/src/modules/docs/references/generated/event-calendar.json
@@ -1,0 +1,196 @@
+{
+  "name": "EventCalendarProps",
+  "description": "A month-grid calendar that renders events as colored chips. Composed of a header\n(heading + navigation) and a 7-column grid of day cells.",
+  "extendsElement": "div",
+  "props": {
+    "events": {
+      "type": "CalendarEvent[]",
+      "detailedType": "CalendarEvent[] | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "array",
+            "elementType": {
+              "type": "link",
+              "id": "src/registry/ui/event-calendar/types.ts:CalendarEvent",
+              "name": "CalendarEvent"
+            }
+          }
+        ]
+      },
+      "description": "Events to render across the visible month."
+    },
+    "month": {
+      "type": "Date",
+      "detailedType": "Date | undefined",
+      "typeAst": {
+        "type": "identifier",
+        "name": "Date"
+      },
+      "description": "The controlled visible month — any `Date` within the month to display."
+    },
+    "defaultMonth": {
+      "type": "Date",
+      "detailedType": "Date | undefined",
+      "typeAst": {
+        "type": "identifier",
+        "name": "Date"
+      },
+      "description": "The initial visible month for uncontrolled usage.",
+      "default": "the current month"
+    },
+    "onMonthChange": {
+      "type": "((date: Date) => void)",
+      "detailedType": "((date: Date) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "date",
+            "value": {
+              "type": "link",
+              "id": "Date",
+              "name": "Date"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Called with the new month whenever navigation changes the visible month."
+    },
+    "weekStartsOn": {
+      "type": "0 | 1",
+      "detailedType": "0 | 1 | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "numberLiteral",
+            "value": 0
+          },
+          {
+            "type": "numberLiteral",
+            "value": 1
+          },
+          {
+            "type": "undefined"
+          }
+        ]
+      },
+      "description": "The first day of the week: `0` for Sunday, `1` for Monday.",
+      "default": "1"
+    },
+    "maxEventsPerDay": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "The maximum number of event chips shown in a day cell before a\n\"+N more\" overflow indicator is rendered.",
+      "default": "3"
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  },
+  "typeLinks": {
+    "src/registry/ui/event-calendar/types.ts:CalendarEvent": {
+      "type": "interface",
+      "id": "src/registry/ui/event-calendar/types.ts:CalendarEvent",
+      "name": "CalendarEvent",
+      "extends": [],
+      "properties": {
+        "color": {
+          "type": "property",
+          "name": "color",
+          "value": {
+            "type": "union",
+            "elements": [
+              {
+                "type": "stringLiteral",
+                "value": "accent"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "danger"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "info"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "neutral"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "primary"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "success"
+              },
+              {
+                "type": "stringLiteral",
+                "value": "warning"
+              },
+              {
+                "type": "undefined"
+              }
+            ]
+          },
+          "optional": true,
+          "readonly": false,
+          "description": "The semantic color of the event chip."
+        },
+        "date": {
+          "type": "property",
+          "name": "date",
+          "value": {
+            "type": "identifier",
+            "name": "Date"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The day the event falls on. Only the date portion is compared."
+        },
+        "id": {
+          "type": "property",
+          "name": "id",
+          "value": {
+            "type": "string"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Stable unique identifier, used as the React key."
+        },
+        "title": {
+          "type": "property",
+          "name": "title",
+          "value": {
+            "type": "string"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The text shown on the event chip."
+        }
+      },
+      "typeParameters": [],
+      "description": "A single event rendered on the calendar grid."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -1333,6 +1333,10 @@ export const DemosIndex: Record<
 		files: ["ui/empty/demos/with-muted-background.tsx"],
 		component: React.lazy(() => import("@/registry/ui/empty/demos/with-muted-background")),
 	},
+	"event-calendar/demos/default": {
+		files: ["ui/event-calendar/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/event-calendar/demos/default")),
+	},
 	"field/demos/login-form": {
 		files: ["ui/field/demos/login-form.tsx"],
 		component: React.lazy(() => import("@/registry/ui/field/demos/login-form")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -40,6 +40,7 @@ import UiDisclosure from "@/registry/ui/disclosure/meta";
 import UiDrawer from "@/registry/ui/drawer/meta";
 import UiDropZone from "@/registry/ui/drop-zone/meta";
 import UiEmpty from "@/registry/ui/empty/meta";
+import UiEventCalendar from "@/registry/ui/event-calendar/meta";
 import UiField from "@/registry/ui/field/meta";
 import UiFileTrigger from "@/registry/ui/file-trigger/meta";
 import UiGroup from "@/registry/ui/group/meta";
@@ -114,6 +115,7 @@ export const registryUi: RegistryItem[] = [
 	UiDrawer,
 	UiDropZone,
 	UiEmpty,
+	UiEventCalendar,
 	UiField,
 	UiFileTrigger,
 	UiGroup,

--- a/www/src/registry/ui/event-calendar/base.tsx
+++ b/www/src/registry/ui/event-calendar/base.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import * as React from 'react'
+import {
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameDay,
+  isSameMonth,
+  isToday,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+} from 'date-fns'
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+
+import { useStyles } from './styles'
+
+// MARK: eventCalendarStyles
+
+// MARK: Types
+
+type EventColor =
+  | 'primary'
+  | 'accent'
+  | 'danger'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'neutral'
+
+interface CalendarEvent {
+  id: string
+  title: string
+  date: Date
+  color?: EventColor
+}
+
+interface EventCalendarContextValue {
+  month: Date
+  setMonth: (date: Date) => void
+  goToPrevious: () => void
+  goToNext: () => void
+  goToToday: () => void
+  weekStartsOn: 0 | 1
+  maxEventsPerDay: number
+  getEventsForDay: (day: Date) => CalendarEvent[]
+}
+
+const EventCalendarContext =
+  React.createContext<EventCalendarContextValue | null>(null)
+
+function useEventCalendar(): EventCalendarContextValue {
+  const context = React.useContext(EventCalendarContext)
+  if (!context) {
+    throw new Error(
+      'useEventCalendar must be used within an <EventCalendar> provider.',
+    )
+  }
+  return context
+}
+
+// MARK: EventCalendar
+
+interface EventCalendarProps extends React.ComponentProps<'div'> {
+  /** Events to render across the month grid. */
+  events?: CalendarEvent[]
+  /** Controlled visible month (any day within it). */
+  month?: Date
+  /** Initial visible month for uncontrolled usage. @default current month */
+  defaultMonth?: Date
+  /** Called when the visible month changes. */
+  onMonthChange?: (date: Date) => void
+  /** First day of the week: 0 = Sunday, 1 = Monday. @default 1 */
+  weekStartsOn?: 0 | 1
+  /** Maximum event chips shown per day before a "+N more" overflow. @default 3 */
+  maxEventsPerDay?: number
+}
+
+const EventCalendar = ({
+  events = [],
+  month: monthProp,
+  defaultMonth,
+  onMonthChange,
+  weekStartsOn = 1,
+  maxEventsPerDay = 3,
+  className,
+  children,
+  ...props
+}: EventCalendarProps) => {
+  const { root } = useStyles()()
+
+  const [internalMonth, setInternalMonth] = React.useState<Date>(
+    () => defaultMonth ?? new Date(),
+  )
+  const month = monthProp ?? internalMonth
+
+  const setMonth = React.useCallback(
+    (date: Date) => {
+      if (monthProp === undefined) {
+        setInternalMonth(date)
+      }
+      onMonthChange?.(date)
+    },
+    [monthProp, onMonthChange],
+  )
+
+  const goToPrevious = React.useCallback(
+    () => setMonth(subMonths(month, 1)),
+    [month, setMonth],
+  )
+  const goToNext = React.useCallback(
+    () => setMonth(addMonths(month, 1)),
+    [month, setMonth],
+  )
+  const goToToday = React.useCallback(() => setMonth(new Date()), [setMonth])
+
+  const getEventsForDay = React.useCallback(
+    (day: Date) => events.filter((event) => isSameDay(event.date, day)),
+    [events],
+  )
+
+  const value = React.useMemo<EventCalendarContextValue>(
+    () => ({
+      month,
+      setMonth,
+      goToPrevious,
+      goToNext,
+      goToToday,
+      weekStartsOn,
+      maxEventsPerDay,
+      getEventsForDay,
+    }),
+    [
+      month,
+      setMonth,
+      goToPrevious,
+      goToNext,
+      goToToday,
+      weekStartsOn,
+      maxEventsPerDay,
+      getEventsForDay,
+    ],
+  )
+
+  return (
+    <EventCalendarContext.Provider value={value}>
+      <div data-event-calendar="" className={root({ className })} {...props}>
+        {children ?? (
+          <>
+            <EventCalendarHeader />
+            <EventCalendarGrid />
+          </>
+        )}
+      </div>
+    </EventCalendarContext.Provider>
+  )
+}
+
+// MARK: EventCalendarHeader
+
+interface EventCalendarHeaderProps extends React.ComponentProps<'header'> {}
+
+const EventCalendarHeader = ({
+  className,
+  children,
+  ...props
+}: EventCalendarHeaderProps) => {
+  const { header } = useStyles()()
+  return (
+    <header
+      data-event-calendar-header=""
+      className={header({ className })}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <EventCalendarHeading />
+          <EventCalendarNav />
+        </>
+      )}
+    </header>
+  )
+}
+
+// MARK: EventCalendarHeading
+
+interface EventCalendarHeadingProps extends React.ComponentProps<'h2'> {}
+
+const EventCalendarHeading = ({
+  className,
+  children,
+  ...props
+}: EventCalendarHeadingProps) => {
+  const { heading } = useStyles()()
+  const { month } = useEventCalendar()
+  return (
+    <h2
+      data-event-calendar-heading=""
+      className={heading({ className })}
+      {...props}
+    >
+      {children ?? format(month, 'MMMM yyyy')}
+    </h2>
+  )
+}
+
+// MARK: EventCalendarNav
+
+interface EventCalendarNavProps extends React.ComponentProps<'div'> {}
+
+const EventCalendarNav = ({
+  className,
+  children,
+  ...props
+}: EventCalendarNavProps) => {
+  const { nav } = useStyles()()
+  const { goToPrevious, goToNext, goToToday } = useEventCalendar()
+  return (
+    <div data-event-calendar-nav="" className={nav({ className })} {...props}>
+      {children ?? (
+        <>
+          <Button variant="quiet" size="sm" onPress={goToToday}>
+            Today
+          </Button>
+          <Button
+            variant="quiet"
+            isIconOnly
+            aria-label="Previous month"
+            onPress={goToPrevious}
+          >
+            <ChevronLeftIcon />
+          </Button>
+          <Button
+            variant="quiet"
+            isIconOnly
+            aria-label="Next month"
+            onPress={goToNext}
+          >
+            <ChevronRightIcon />
+          </Button>
+        </>
+      )}
+    </div>
+  )
+}
+
+// MARK: EventCalendarGrid
+
+interface EventCalendarGridProps extends React.ComponentProps<'div'> {
+  /** Render a custom day cell. */
+  renderDay?: (day: Date, events: CalendarEvent[]) => React.ReactNode
+}
+
+const EventCalendarGrid = ({
+  className,
+  renderDay,
+  ...props
+}: EventCalendarGridProps) => {
+  const { grid, weekday } = useStyles()()
+  const { month, weekStartsOn, getEventsForDay } = useEventCalendar()
+
+  const days = React.useMemo(() => {
+    const gridStart = startOfWeek(startOfMonth(month), { weekStartsOn })
+    const gridEnd = endOfWeek(endOfMonth(month), { weekStartsOn })
+    return eachDayOfInterval({ start: gridStart, end: gridEnd })
+  }, [month, weekStartsOn])
+
+  const weekdayLabels = React.useMemo(() => {
+    // Build labels from the first rendered week so they honor `weekStartsOn`.
+    return days.slice(0, 7).map((day) => format(day, 'EEE'))
+  }, [days])
+
+  return (
+    <div data-event-calendar-grid="" className={grid({ className })} {...props}>
+      {weekdayLabels.map((label) => (
+        <div key={label} data-event-calendar-weekday="" className={weekday()}>
+          {label}
+        </div>
+      ))}
+      {days.map((day) => {
+        const dayEvents = getEventsForDay(day)
+        return (
+          <React.Fragment key={day.toISOString()}>
+            {renderDay ? (
+              renderDay(day, dayEvents)
+            ) : (
+              <EventCalendarDay day={day} events={dayEvents} />
+            )}
+          </React.Fragment>
+        )
+      })}
+    </div>
+  )
+}
+
+// MARK: EventCalendarDay
+
+interface EventCalendarDayProps extends Omit<
+  React.ComponentProps<'div'>,
+  'children'
+> {
+  day: Date
+  events: CalendarEvent[]
+}
+
+const EventCalendarDay = ({
+  day,
+  events,
+  className,
+  ...props
+}: EventCalendarDayProps) => {
+  const { cell, dayNumber, events: eventsList, more } = useStyles()()
+  const { month, maxEventsPerDay } = useEventCalendar()
+
+  const isOutside = !isSameMonth(day, month)
+  const visible = events.slice(0, maxEventsPerDay)
+  const overflow = events.length - visible.length
+
+  return (
+    <div
+      data-event-calendar-day=""
+      data-outside={isOutside ? 'true' : undefined}
+      data-today={isToday(day) ? 'true' : undefined}
+      className={cell({ className })}
+      {...props}
+    >
+      <span
+        data-today={isToday(day) ? 'true' : undefined}
+        className={dayNumber()}
+      >
+        {format(day, 'd')}
+      </span>
+      <div className={eventsList()}>
+        {visible.map((event) => (
+          <EventCalendarChip key={event.id} event={event} />
+        ))}
+        {overflow > 0 && <span className={more()}>+{overflow} more</span>}
+      </div>
+    </div>
+  )
+}
+
+// MARK: EventCalendarChip
+
+interface EventCalendarChipProps extends Omit<
+  React.ComponentProps<'span'>,
+  'color'
+> {
+  event: CalendarEvent
+}
+
+const EventCalendarChip = ({
+  event,
+  className,
+  children,
+  ...props
+}: EventCalendarChipProps) => {
+  const { chip, chipDot, chipLabel } = useStyles()()
+  return (
+    <span
+      data-event-calendar-chip=""
+      className={chip({ color: event.color ?? 'primary', className })}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <span className={chipDot({ color: event.color ?? 'primary' })} />
+          <span className={chipLabel()}>{event.title}</span>
+        </>
+      )}
+    </span>
+  )
+}
+
+// MARK: Separator
+
+export type {
+  CalendarEvent,
+  EventColor,
+  EventCalendarChipProps,
+  EventCalendarDayProps,
+  EventCalendarGridProps,
+  EventCalendarHeaderProps,
+  EventCalendarHeadingProps,
+  EventCalendarNavProps,
+  EventCalendarProps,
+}
+export {
+  EventCalendar,
+  EventCalendarChip,
+  EventCalendarDay,
+  EventCalendarGrid,
+  EventCalendarHeader,
+  EventCalendarHeading,
+  EventCalendarNav,
+  useEventCalendar,
+}

--- a/www/src/registry/ui/event-calendar/demos/default.tsx
+++ b/www/src/registry/ui/event-calendar/demos/default.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { EventCalendar } from '@/registry/ui/event-calendar'
+import type { CalendarEvent } from '@/registry/ui/event-calendar'
+
+const now = new Date()
+const day = (offset: number) =>
+  new Date(now.getFullYear(), now.getMonth(), offset)
+
+const events: CalendarEvent[] = [
+  { id: '1', title: 'Team standup', date: day(4), color: 'primary' },
+  { id: '2', title: 'Design review', date: day(12), color: 'accent' },
+  { id: '3', title: 'Release v2.0', date: day(12), color: 'success' },
+  { id: '4', title: 'On-call rotation', date: day(12), color: 'warning' },
+  { id: '5', title: 'Roadmap sync', date: day(12), color: 'info' },
+  { id: '6', title: 'Incident retro', date: day(21), color: 'danger' },
+]
+
+export default function Demo() {
+  return (
+    <div className="w-full max-w-2xl">
+      <EventCalendar events={events} defaultMonth={now} />
+    </div>
+  )
+}

--- a/www/src/registry/ui/event-calendar/examples.tsx
+++ b/www/src/registry/ui/event-calendar/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import DefaultDemo from './demos/default'
+
+export default function EventCalendarExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <DefaultDemo />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/event-calendar/index.tsx
+++ b/www/src/registry/ui/event-calendar/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/event-calendar/meta.ts
+++ b/www/src/registry/ui/event-calendar/meta.ts
@@ -1,0 +1,26 @@
+import type { RegistryItem } from '@/registry/types'
+
+const eventCalendarMeta = {
+  name: 'event-calendar',
+  type: 'registry:ui',
+  group: 'calendar',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/event-calendar/base.tsx',
+      target: 'ui/event-calendar.tsx',
+    },
+  ],
+  registryDependencies: ['button', 'focus-styles'],
+  dependencies: ['date-fns'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--event-calendar-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default eventCalendarMeta

--- a/www/src/registry/ui/event-calendar/styles.css
+++ b/www/src/registry/ui/event-calendar/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --event-calendar-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/event-calendar/styles.ts
+++ b/www/src/registry/ui/event-calendar/styles.ts
@@ -1,0 +1,56 @@
+import { createStyles } from '@/lib/styles'
+
+import eventCalendarMeta from './meta'
+
+const { useStyles, styles } = createStyles(eventCalendarMeta, {
+  base: {
+    slots: {
+      root: 'flex w-full flex-col gap-4 text-fg',
+      header: 'flex items-center gap-2',
+      heading: 'flex-1 text-sm font-medium',
+      nav: 'flex items-center gap-1',
+      grid: 'grid grid-cols-7 overflow-hidden rounded-(--event-calendar-radius) border',
+      weekday:
+        'border-b bg-muted px-2 py-1.5 text-center text-xs font-medium text-fg-muted',
+      cell: [
+        'flex min-h-24 flex-col gap-1 border-r border-b p-1.5 text-left align-top',
+        '[&:nth-child(7n)]:border-r-0',
+        '[&:nth-last-child(-n+7)]:border-b-0',
+        'data-[outside=true]:bg-muted/40 data-[outside=true]:text-fg-muted',
+      ],
+      dayNumber:
+        'inline-flex size-6 items-center justify-center self-start rounded-full text-xs font-medium tabular-nums data-[today=true]:bg-primary data-[today=true]:text-fg-on-primary',
+      events: 'flex min-w-0 flex-col gap-0.5',
+      chip: [
+        'flex min-w-0 items-center gap-1 rounded-sm px-1.5 py-0.5 text-left text-xs font-medium',
+        'bg-[color-mix(in_srgb,var(--chip-color)_18%,var(--color-bg))] text-[color-mix(in_srgb,var(--chip-color)_75%,var(--color-fg))]',
+      ],
+      chipDot: 'size-1.5 shrink-0 rounded-full bg-(--chip-color)',
+      chipLabel: 'truncate',
+      more: 'px-1.5 text-xs font-medium text-fg-muted',
+    },
+    variants: {
+      color: {
+        primary: { chip: '[--chip-color:var(--color-primary)]' },
+        accent: { chip: '[--chip-color:var(--color-accent)]' },
+        danger: { chip: '[--chip-color:var(--color-danger)]' },
+        success: { chip: '[--chip-color:var(--color-success)]' },
+        warning: { chip: '[--chip-color:var(--color-warning)]' },
+        info: { chip: '[--chip-color:var(--color-info)]' },
+        neutral: { chip: '[--chip-color:var(--color-neutral)]' },
+      },
+    },
+    defaultVariants: {
+      color: 'primary',
+    },
+  },
+  density: {
+    compact: {},
+    default: {},
+    comfortable: {},
+  },
+})
+
+export type EventCalendarStyles = typeof styles
+
+export { styles as eventCalendarStyles, useStyles }

--- a/www/src/registry/ui/event-calendar/types.ts
+++ b/www/src/registry/ui/event-calendar/types.ts
@@ -1,0 +1,106 @@
+import type React from 'react'
+
+/**
+ * The token-based color of an event chip. Maps to a semantic design-system color.
+ */
+export type EventColor =
+  | 'primary'
+  | 'accent'
+  | 'danger'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'neutral'
+
+/**
+ * A single event rendered on the calendar grid.
+ */
+export interface CalendarEvent {
+  /** Stable unique identifier, used as the React key. */
+  id: string
+  /** The text shown on the event chip. */
+  title: string
+  /** The day the event falls on. Only the date portion is compared. */
+  date: Date
+  /**
+   * The semantic color of the event chip.
+   * @default 'primary'
+   */
+  color?: EventColor
+}
+
+/**
+ * A month-grid calendar that renders events as colored chips. Composed of a header
+ * (heading + navigation) and a 7-column grid of day cells.
+ */
+export interface EventCalendarProps extends React.ComponentProps<'div'> {
+  /** Events to render across the visible month. */
+  events?: CalendarEvent[]
+  /** The controlled visible month — any `Date` within the month to display. */
+  month?: Date
+  /**
+   * The initial visible month for uncontrolled usage.
+   * @default the current month
+   */
+  defaultMonth?: Date
+  /** Called with the new month whenever navigation changes the visible month. */
+  onMonthChange?: (date: Date) => void
+  /**
+   * The first day of the week: `0` for Sunday, `1` for Monday.
+   * @default 1
+   */
+  weekStartsOn?: 0 | 1
+  /**
+   * The maximum number of event chips shown in a day cell before a
+   * "+N more" overflow indicator is rendered.
+   * @default 3
+   */
+  maxEventsPerDay?: number
+}
+
+/**
+ * The calendar header. Renders the month heading and navigation controls by default.
+ */
+export interface EventCalendarHeaderProps extends React.ComponentProps<'header'> {}
+
+/**
+ * The month/year heading. Falls back to the formatted visible month.
+ */
+export interface EventCalendarHeadingProps extends React.ComponentProps<'h2'> {}
+
+/**
+ * The navigation controls: Today, Previous month, and Next month buttons.
+ */
+export interface EventCalendarNavProps extends React.ComponentProps<'div'> {}
+
+/**
+ * The 7-column month grid: a row of weekday headers followed by day cells.
+ */
+export interface EventCalendarGridProps extends React.ComponentProps<'div'> {
+  /** Render a custom day cell in place of the default one. */
+  renderDay?: (day: Date, events: CalendarEvent[]) => React.ReactNode
+}
+
+/**
+ * A single day cell, showing the day number and its event chips with overflow.
+ */
+export interface EventCalendarDayProps extends Omit<
+  React.ComponentProps<'div'>,
+  'children'
+> {
+  /** The day this cell represents. */
+  day: Date
+  /** The events that fall on this day. */
+  events: CalendarEvent[]
+}
+
+/**
+ * A colored event chip rendered inside a day cell.
+ */
+export interface EventCalendarChipProps extends Omit<
+  React.ComponentProps<'span'>,
+  'color'
+> {
+  /** The event to render. */
+  event: CalendarEvent
+}


### PR DESCRIPTION
## Summary

Adds an **Event Calendar** (scheduler) to the registry — a month grid that lays out events per day. Distinct from the date *picker*. Part of the real-world-component-blocks batch (Tier 3).

- Engine: **date-fns** (installed as a dependency); month math + rendering only — no heavy scheduler SDK (FullCalendar's scheduler views are commercial, per the research doc).
- Month header with Prev/Next/Today (dotUI `Button`s), a 7-column day grid, event chips per day with a "+N more" overflow, today + outside-month styling.
- Props: `events` (id, title, date, color?) and `month`/`onMonthChange`.
- Themeable axis: `--event-calendar-radius`. Group `calendar`. `dependencies: ['date-fns']`.

## Notes

- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.