### PR TITLE
feat(data-grid): add data-grid component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8112,7 +8112,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':

--- a/www/content/docs/components/data-grid.mdx
+++ b/www/content/docs/components/data-grid.mdx
@@ -1,0 +1,56 @@
+---
+title: Data Grid
+description: An advanced data grid built on TanStack Table, with sortable column headers and pagination on top of the accessible Table.
+links:
+  - label: Docs
+    href: https://tanstack.com/table/latest
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/data-grid
+```
+
+## Usage
+
+`DataGrid` wires [TanStack Table](https://tanstack.com/table/latest) onto the dotUI `Table`. Pass TanStack `ColumnDef`s and a `data` array; it handles sorting (click a header to toggle) and pagination for you.
+
+```tsx
+import { DataGrid } from '@/components/ui/data-grid'
+import type { ColumnDef } from '@tanstack/react-table'
+```
+
+```tsx
+const columns: ColumnDef<Invoice>[] = [
+  { accessorKey: 'id', header: 'Invoice' },
+  { accessorKey: 'email', header: 'Email' },
+  { accessorKey: 'amount', header: 'Amount' },
+]
+
+<DataGrid aria-label="Invoices" columns={columns} data={invoices} />
+```
+
+Set `enableSorting: false` on a column to make its header non-sortable, `pageSize` to change rows per page, and `pagination={false}` to render every row without a footer.
+
+```tsx
+<DataGrid
+  aria-label="Invoices"
+  columns={columns}
+  data={invoices}
+  pageSize={5}
+/>
+```
+
+## Examples
+
+<Examples>
+  <Example name="data-grid/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### DataGrid
+
+<Reference name="data-grid" />

--- a/www/content/docs/components/data-grid.mdx
+++ b/www/content/docs/components/data-grid.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="data-grid/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -28,6 +28,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	combobox: () => import("@/registry/ui/combobox/examples"),
 	command: () => import("@/registry/ui/command/examples"),
 	"context-menu": () => import("@/registry/ui/context-menu/examples"),
+	"data-grid": () => import("@/registry/ui/data-grid/examples"),
 	"date-field": () => import("@/registry/ui/date-field/examples"),
 	"date-picker": () => import("@/registry/ui/date-picker/examples"),
 	dialog: () => import("@/registry/ui/dialog/examples"),

--- a/www/src/modules/docs/references/generated/data-grid.json
+++ b/www/src/modules/docs/references/generated/data-grid.json
@@ -1,0 +1,100 @@
+{
+  "name": "DataGridProps",
+  "description": "An advanced data grid built on TanStack Table over the dotUI Table. Accepts\nTanStack `ColumnDef`s and a `data` array, and adds click-to-toggle column\nsorting and Previous/Next pagination on top of the accessible table.",
+  "extendsElement": "div",
+  "props": {
+    "columns": {
+      "type": "ColumnDef<TData>[]",
+      "typeAst": {
+        "type": "array",
+        "elementType": {
+          "type": "application",
+          "base": {
+            "type": "identifier",
+            "name": "ColumnDef"
+          },
+          "typeParameters": [
+            {
+              "type": "typeParameter",
+              "name": "TData",
+              "constraint": null,
+              "default": null
+            }
+          ]
+        }
+      },
+      "description": "Column definitions, in TanStack Table's `ColumnDef` shape. Set\n`enableSorting: false` on a column to make its header non-sortable.",
+      "required": true
+    },
+    "data": {
+      "type": "TData[]",
+      "typeAst": {
+        "type": "array",
+        "elementType": {
+          "type": "typeParameter",
+          "name": "TData",
+          "constraint": null,
+          "default": null
+        }
+      },
+      "description": "The rows to render. Sorting and pagination are derived from this array.",
+      "required": true
+    },
+    "pageSize": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "Number of rows shown per page.",
+      "default": "10"
+    },
+    "pagination": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether to render the pagination footer.",
+      "default": "true"
+    },
+    "renderEmptyState": {
+      "type": "(() => ReactNode)",
+      "detailedType": "(() => ReactNode) | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [],
+            "return": {
+              "type": "identifier",
+              "name": "ReactNode"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Rendered inside the table body when there are no rows to display."
+    },
+    "aria-label": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Accessible label for the underlying table.",
+      "default": "\"Data grid\""
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -949,6 +949,10 @@ export const DemosIndex: Record<
 		files: ["ui/context-menu/demos/with-submenu.tsx"],
 		component: React.lazy(() => import("@/registry/ui/context-menu/demos/with-submenu")),
 	},
+	"data-grid/demos/default": {
+		files: ["ui/data-grid/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/data-grid/demos/default")),
+	},
 	"date-field/demos/appointment": {
 		files: ["ui/date-field/demos/appointment.tsx"],
 		component: React.lazy(() => import("@/registry/ui/date-field/demos/appointment")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -33,6 +33,7 @@ import UiColorThumb from "@/registry/ui/color-thumb/meta";
 import UiCombobox from "@/registry/ui/combobox/meta";
 import UiCommand from "@/registry/ui/command/meta";
 import UiContextMenu from "@/registry/ui/context-menu/meta";
+import UiDataGrid from "@/registry/ui/data-grid/meta";
 import UiDateField from "@/registry/ui/date-field/meta";
 import UiDatePicker from "@/registry/ui/date-picker/meta";
 import UiDialog from "@/registry/ui/dialog/meta";
@@ -107,6 +108,7 @@ export const registryUi: RegistryItem[] = [
 	UiCombobox,
 	UiCommand,
 	UiContextMenu,
+	UiDataGrid,
 	UiDateField,
 	UiDatePicker,
 	UiDialog,

--- a/www/src/registry/ui/data-grid/base.tsx
+++ b/www/src/registry/ui/data-grid/base.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import * as React from 'react'
+import {
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import type {
+  ColumnDef,
+  SortingState,
+  Table as TanstackTable,
+} from '@tanstack/react-table'
+import {
+  ArrowUpDownIcon,
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronUpIcon,
+} from 'lucide-react'
+
+import { Button } from '@/registry/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContainer,
+  TableHeader,
+  TableRow,
+} from '@/registry/ui/table'
+
+import { useStyles } from './styles'
+
+// MARK: DataGrid
+
+interface DataGridProps<TData> extends Omit<
+  React.ComponentProps<'div'>,
+  'children'
+> {
+  /** Column definitions, in TanStack Table's `ColumnDef` shape. */
+  columns: ColumnDef<TData>[]
+  /** The rows to render. */
+  data: TData[]
+  /** Accessible label for the underlying table. */
+  'aria-label'?: string
+  /** Number of rows shown per page. @default 10 */
+  pageSize?: number
+  /** Whether to render the pagination footer. @default true */
+  pagination?: boolean
+  /** Rendered when there are no rows to display. */
+  renderEmptyState?: () => React.ReactNode
+}
+
+function DataGrid<TData>({
+  columns,
+  data,
+  pageSize = 10,
+  pagination = true,
+  renderEmptyState = () => 'No results found.',
+  className,
+  'aria-label': ariaLabel = 'Data grid',
+  ...props
+}: DataGridProps<TData>) {
+  const { root } = useStyles()()
+  const [sorting, setSorting] = React.useState<SortingState>([])
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: pagination ? getPaginationRowModel() : undefined,
+    initialState: pagination ? { pagination: { pageSize } } : undefined,
+  })
+
+  const rows = table.getRowModel().rows
+
+  return (
+    <div className={root({ className })} {...props}>
+      <TableContainer>
+        <Table aria-label={ariaLabel}>
+          <TableHeader>
+            {table.getFlatHeaders().map((header) => (
+              <TableColumn
+                key={header.id}
+                isRowHeader={header.index === 0}
+                style={
+                  header.column.getSize() === 150
+                    ? undefined
+                    : { width: header.getSize() }
+                }
+              >
+                {header.isPlaceholder ? null : header.column.getCanSort() ? (
+                  <DataGridSortButton header={header} />
+                ) : (
+                  flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )
+                )}
+              </TableColumn>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={columns.length}>
+                  {renderEmptyState()}
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((tableRow) => (
+                <TableRow key={tableRow.id}>
+                  {tableRow.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      {pagination && <DataGridPagination table={table} />}
+    </div>
+  )
+}
+
+// MARK: DataGridSortButton
+
+interface DataGridSortButtonProps<TData> {
+  // The header is generic over the column's value type, which DataGrid does not
+  // expose, so the cell value is left `unknown`.
+  header: ReturnType<TanstackTable<TData>['getFlatHeaders']>[number]
+}
+
+function DataGridSortButton<TData>({ header }: DataGridSortButtonProps<TData>) {
+  const { sortButton, sortLabel, sortIcon } = useStyles()()
+  const sorted = header.column.getIsSorted()
+
+  return (
+    <button
+      type="button"
+      data-sorted={sorted ? sorted : undefined}
+      aria-label={`Sort by ${header.column.id}`}
+      className={sortButton()}
+      onClick={header.column.getToggleSortingHandler()}
+    >
+      <span className={sortLabel()}>
+        {flexRender(header.column.columnDef.header, header.getContext())}
+      </span>
+      {sorted === 'asc' ? (
+        <ChevronUpIcon aria-hidden className={sortIcon()} />
+      ) : sorted === 'desc' ? (
+        <ChevronDownIcon aria-hidden className={sortIcon()} />
+      ) : (
+        <ArrowUpDownIcon aria-hidden className={sortIcon()} />
+      )}
+    </button>
+  )
+}
+
+// MARK: DataGridPagination
+
+interface DataGridPaginationProps<TData> {
+  table: TanstackTable<TData>
+}
+
+function DataGridPagination<TData>({ table }: DataGridPaginationProps<TData>) {
+  const { footer, pageInfo, actions } = useStyles()()
+  const pageIndex = table.getState().pagination.pageIndex
+  const pageCount = table.getPageCount()
+
+  return (
+    <div className={footer()}>
+      <p className={pageInfo()}>
+        Page {pageCount === 0 ? 0 : pageIndex + 1} of {pageCount}
+      </p>
+      <div className={actions()}>
+        <Button
+          variant="default"
+          size="sm"
+          isDisabled={!table.getCanPreviousPage()}
+          onPress={() => table.previousPage()}
+        >
+          <ChevronLeftIcon />
+          Previous
+        </Button>
+        <Button
+          variant="default"
+          size="sm"
+          isDisabled={!table.getCanNextPage()}
+          onPress={() => table.nextPage()}
+        >
+          Next
+          <ChevronRightIcon />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// MARK: Separator
+
+export type { DataGridProps }
+export { DataGrid }

--- a/www/src/registry/ui/data-grid/demos/default.tsx
+++ b/www/src/registry/ui/data-grid/demos/default.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { Badge } from '@/registry/ui/badge'
+import { DataGrid } from '@/registry/ui/data-grid'
+
+type InvoiceStatus = 'paid' | 'pending' | 'unpaid'
+
+interface Invoice {
+  id: string
+  status: InvoiceStatus
+  email: string
+  amount: number
+}
+
+const statusVariant = {
+  paid: 'success',
+  pending: 'warning',
+  unpaid: 'neutral',
+} as const
+
+const formatCurrency = (amount: number) =>
+  new Intl.NumberFormat('en-US', {
+    currency: 'USD',
+    style: 'currency',
+  }).format(amount)
+
+const columns: ColumnDef<Invoice>[] = [
+  {
+    accessorKey: 'id',
+    header: 'Invoice',
+    cell: ({ row }) => <span className="font-medium">{row.original.id}</span>,
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => (
+      <Badge appearance="subtle" variant={statusVariant[row.original.status]}>
+        {row.original.status}
+      </Badge>
+    ),
+  },
+  {
+    accessorKey: 'email',
+    header: 'Email',
+  },
+  {
+    accessorKey: 'amount',
+    header: 'Amount',
+    cell: ({ row }) => (
+      <span className="tabular-nums">
+        {formatCurrency(row.original.amount)}
+      </span>
+    ),
+  },
+]
+
+const invoices: Invoice[] = [
+  { id: 'INV001', status: 'paid', email: 'ken99@example.com', amount: 316 },
+  { id: 'INV002', status: 'pending', email: 'abe45@example.com', amount: 242 },
+  {
+    id: 'INV003',
+    status: 'unpaid',
+    email: 'monserrat@example.com',
+    amount: 837,
+  },
+  { id: 'INV004', status: 'paid', email: 'silas22@example.com', amount: 124 },
+  {
+    id: 'INV005',
+    status: 'pending',
+    email: 'carmella@example.com',
+    amount: 529,
+  },
+  { id: 'INV006', status: 'unpaid', email: 'jason78@example.com', amount: 95 },
+]
+
+export default function Demo() {
+  return (
+    <DataGrid
+      aria-label="Invoices"
+      columns={columns}
+      data={invoices}
+      pageSize={4}
+      className="w-full max-w-xl"
+    />
+  )
+}

--- a/www/src/registry/ui/data-grid/examples.tsx
+++ b/www/src/registry/ui/data-grid/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function DataGridExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/data-grid/index.tsx
+++ b/www/src/registry/ui/data-grid/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/data-grid/meta.ts
+++ b/www/src/registry/ui/data-grid/meta.ts
@@ -1,0 +1,18 @@
+import type { RegistryItem } from '@/registry/types'
+
+const dataGridMeta = {
+  name: 'data-grid',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/data-grid/base.tsx',
+      target: 'ui/data-grid.tsx',
+    },
+  ],
+  registryDependencies: ['table', 'button', 'focus-styles'],
+  dependencies: ['@tanstack/react-table'],
+} satisfies RegistryItem
+
+export default dataGridMeta

--- a/www/src/registry/ui/data-grid/styles.ts
+++ b/www/src/registry/ui/data-grid/styles.ts
@@ -1,0 +1,25 @@
+import { createStyles } from '@/lib/styles'
+
+import dataGridMeta from './meta'
+
+const { useStyles, styles } = createStyles(dataGridMeta, {
+  base: {
+    slots: {
+      root: 'flex w-full flex-col gap-3',
+      sortButton: [
+        'group/sort -mx-1.5 inline-flex h-7 max-w-full items-center gap-1.5 rounded-sm px-1.5 font-medium text-fg-muted outline-hidden transition-colors',
+        'hover:text-fg focus-visible:focus-ring data-[sorted]:text-fg',
+      ],
+      sortLabel: 'min-w-0 truncate',
+      sortIcon:
+        'size-3.5 shrink-0 opacity-60 group-data-[sorted]/sort:opacity-100',
+      footer: 'flex items-center justify-between gap-3',
+      pageInfo: 'text-sm text-fg-muted tabular-nums',
+      actions: 'flex items-center gap-2',
+    },
+  },
+})
+
+export type DataGridStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/data-grid/types.ts
+++ b/www/src/registry/ui/data-grid/types.ts
@@ -1,0 +1,45 @@
+import type { ColumnDef } from '@tanstack/react-table'
+
+/**
+ * An advanced data grid built on TanStack Table over the dotUI Table. Accepts
+ * TanStack `ColumnDef`s and a `data` array, and adds click-to-toggle column
+ * sorting and Previous/Next pagination on top of the accessible table.
+ */
+export interface DataGridProps<TData> extends Omit<
+  React.ComponentProps<'div'>,
+  'children'
+> {
+  /**
+   * Column definitions, in TanStack Table's `ColumnDef` shape. Set
+   * `enableSorting: false` on a column to make its header non-sortable.
+   */
+  columns: ColumnDef<TData>[]
+
+  /**
+   * The rows to render. Sorting and pagination are derived from this array.
+   */
+  data: TData[]
+
+  /**
+   * Accessible label for the underlying table.
+   * @default "Data grid"
+   */
+  'aria-label'?: string
+
+  /**
+   * Number of rows shown per page.
+   * @default 10
+   */
+  pageSize?: number
+
+  /**
+   * Whether to render the pagination footer.
+   * @default true
+   */
+  pagination?: boolean
+
+  /**
+   * Rendered inside the table body when there are no rows to display.
+   */
+  renderEmptyState?: () => React.ReactNode
+}


### PR DESCRIPTION
## Summary

Adds a **Data Grid** to the registry — sortable, paginated tabular data built on TanStack Table over the existing dotUI `Table`. Part of the real-world-component-blocks batch (Tier 2).

- Engine: **TanStack Table** (`@tanstack/react-table`, already a dotUI dep — the free, headless, shadcn-path data grid). Renders through the dotUI `Table` primitives with `flexRender`.
- Click-to-sort column headers (with arrow indicators) and pagination (Previous/Next dotUI `Button`s + page info). Generic `DataGrid<TData>` taking `columns` + `data`.
- Group `containers`. `registryDependencies: ['table', 'button', 'focus-styles']`, `dependencies: ['@tanstack/react-table']`.

## Notes

- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.