### PR TITLE
fix(docs): refine TOC font/active-line and layout widths

### DIFF
--- a/www/src/modules/docs/docs-sidebar.tsx
+++ b/www/src/modules/docs/docs-sidebar.tsx
@@ -11,7 +11,7 @@ export function DocsSidebar({ items }: { items: PageTree.Node[] }) {
   return (
     <nav
       aria-label="Docs"
-      className="scrollbar-none flex h-full scroll-fade-y flex-col gap-6 overflow-y-auto scroll-smooth rounded-2xl py-6 pr-3 pl-4 scroll-fade-6"
+      className="scrollbar-none flex h-full scroll-fade-y flex-col gap-6 overflow-y-auto scroll-smooth rounded-2xl pt-10 pr-3 pb-6 pl-4 scroll-fade-6"
     >
       {items.map((item) => {
         if (item.type === 'folder') {

--- a/www/src/modules/docs/toc.tsx
+++ b/www/src/modules/docs/toc.tsx
@@ -4,7 +4,6 @@ import {
   TOCItem as PrimitiveTOCItem,
   ScrollProvider,
   type TOCItemType,
-  useActiveAnchors,
 } from 'fumadocs-core/toc'
 import { mergeRefs } from 'react-aria/mergeRefs'
 
@@ -66,7 +65,7 @@ export function TOCScrollArea({
     <div
       ref={mergeRefs(viewRef, ref)}
       className={cn(
-        'relative ms-px scrollbar-none min-h-0 scroll-fade-y overflow-auto pt-6 pb-3 text-sm scroll-fade-4',
+        'scrollbar-none min-h-0 scroll-fade-y overflow-auto pt-10 pb-3 text-sm scroll-fade-4',
         className,
       )}
       {...props}
@@ -76,110 +75,26 @@ export function TOCScrollArea({
   )
 }
 
-type TocThumb = [top: number, height: number]
-
-interface RefProps {
-  containerRef: React.RefObject<HTMLElement | null>
-}
-
-export function TocThumb({
-  containerRef,
-  ...props
-}: React.ComponentProps<'div'> & RefProps) {
-  const thumbRef = React.useRef<HTMLDivElement>(null)
-
-  return (
-    <>
-      <div ref={thumbRef} role="none" {...props} />
-      <Updater containerRef={containerRef} thumbRef={thumbRef} />
-    </>
-  )
-}
-
-function Updater({
-  containerRef,
-  thumbRef,
-}: RefProps & { thumbRef: React.RefObject<HTMLElement | null> }) {
-  const active = useActiveAnchors()
-  const updateThumb = React.useCallback(() => {
-    if (!containerRef.current || !thumbRef.current) return
-    update(thumbRef.current, calc(containerRef.current, active))
-  }, [active, containerRef, thumbRef])
-
-  React.useEffect(() => {
-    if (!containerRef.current) return
-    const container = containerRef.current
-
-    const observer = new ResizeObserver(updateThumb)
-    observer.observe(container)
-
-    return () => observer.disconnect()
-  }, [containerRef, updateThumb])
-
-  React.useEffect(() => {
-    updateThumb()
-  }, [updateThumb])
-
-  return null
-}
-
-function calc(container: HTMLElement, active: string[]): TocThumb {
-  if (active.length === 0 || container.clientHeight === 0) {
-    return [0, 0]
-  }
-
-  let upper = Number.MAX_VALUE
-  let lower = 0
-
-  for (const item of active) {
-    const element = container.querySelector<HTMLElement>(`a[href="#${item}"]`)
-    if (!element) continue
-
-    const styles = getComputedStyle(element)
-    upper = Math.min(upper, element.offsetTop + parseFloat(styles.paddingTop))
-    lower = Math.max(
-      lower,
-      element.offsetTop +
-        element.clientHeight -
-        parseFloat(styles.paddingBottom),
-    )
-  }
-
-  return [upper, lower - upper]
-}
-
-function update(element: HTMLElement, info: TocThumb): void {
-  element.style.setProperty('--toc-top', `${info[0]}px`)
-  element.style.setProperty('--toc-height', `${info[1]}px`)
-}
-
 export function TOCItems({
   ref,
   className,
   ...props
 }: React.ComponentProps<'div'>) {
-  const containerRef = React.useRef<HTMLDivElement>(null)
   const items = useTOCItems()
 
   if (items.length === 0) return null
 
   return (
-    <>
-      <TocThumb
-        containerRef={containerRef}
-        className="absolute top-(--toc-top) h-(--toc-height) w-px bg-primary transition-[height,top]"
-      />
-      <nav
-        ref={mergeRefs(ref, containerRef)}
-        aria-label="On this page"
-        className={cn('flex flex-col', className)}
-        {...props}
-      >
-        {items.map((item) => (
-          <TOCItem key={item.url} item={item} />
-        ))}
-      </nav>
-    </>
+    <nav
+      ref={ref}
+      aria-label="On this page"
+      className={cn('flex flex-col', className)}
+      {...props}
+    >
+      {items.map((item) => (
+        <TOCItem key={item.url} item={item} />
+      ))}
+    </nav>
   )
 }
 
@@ -188,7 +103,7 @@ function TOCItem({ item }: { item: TOCItemType }) {
     <PrimitiveTOCItem
       href={item.url}
       className={cn(
-        'py-1 text-sm wrap-anywhere text-fg-muted transition-colors first:pt-0 last:pb-0 data-[active=true]:text-fg',
+        'py-1 text-[0.8rem] wrap-anywhere text-fg-muted transition-colors first:pt-0 last:pb-0 data-[active=true]:text-fg',
         item.depth <= 2 && 'pl-3',
         item.depth === 3 && 'pl-6',
         item.depth >= 4 && 'pl-8',

--- a/www/src/routes/_app/docs/$.tsx
+++ b/www/src/routes/_app/docs/$.tsx
@@ -134,7 +134,7 @@ const clientLoader = browserCollections.docs.createClientLoader({
     return (
       <TOCProvider toc={toc}>
         <PageLayout className="mt-4 flex scroll-mt-24 items-stretch pb-8 text-[1.05rem] sm:text-[15px] xl:w-full">
-          <div className="mx-auto flex w-full max-w-3xl min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-0 lg:py-8 dark:text-neutral-300">
+          <div className="mx-auto flex w-full max-w-2xl min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-0 lg:py-8 dark:text-neutral-300">
             <div data-page-header="" className="relative mb-2 space-y-3 pb-4">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div className="flex min-w-0 flex-col gap-2">
@@ -174,7 +174,10 @@ const clientLoader = browserCollections.docs.createClientLoader({
               )}
             </div>
           </div>
-          <div className="sticky top-(--header-height) z-30 hidden h-[90svh] w-(--sidebar-width) flex-col gap-4 overflow-hidden overscroll-none pb-8 xl:flex">
+          {/* -mt-4 cancels PageLayout's mt-4 so the TOC top lines up with the
+              sidebar (which isn't inside PageLayout) at scroll 0, matching the
+              already-aligned scrolled/sticky state. */}
+          <div className="sticky top-(--header-height) z-30 -mt-4 hidden h-[90svh] w-(--sidebar-width) flex-col gap-4 overflow-hidden overscroll-none pb-8 xl:flex">
             {hasToc && <TOC className="pr-12" />}
           </div>
         </PageLayout>

--- a/www/src/routes/_app/docs/route.tsx
+++ b/www/src/routes/_app/docs/route.tsx
@@ -14,7 +14,7 @@ function DocsLayout() {
   const items = pageTree.children as PageTree.Node[]
 
   return (
-    <div className="flex min-h-[calc(100vh-var(--header-height))] [--sidebar-width:240px]">
+    <div className="flex min-h-[calc(100vh-var(--header-height))] [--sidebar-width:228px]">
       <aside className="sticky top-(--header-height) hidden h-[calc(100vh-var(--header-height))] w-(--sidebar-width) shrink-0 md:block">
         <DocsSidebar items={items} />
         <div className="absolute top-0 right-0 bottom-0 hidden h-full w-px bg-linear-to-b from-transparent via-border to-transparent lg:flex" />


### PR DESCRIPTION
## Summary

- **TOC font size** — set docs TOC links to `text-[0.8rem]` (12.8px), down from `text-sm` (14px).
- **Removed the animated TOC highlight line** — deleted the `TocThumb` bar and its `Updater`/`calc`/`update` logic, the now-unused `useActiveAnchors` import, and the `relative ms-px` scaffolding that only existed to host it. The active link's text-color highlight (`data-[active=true]:text-fg`) is kept.
- **Docs column widths** — sidebar and TOC rail share `--sidebar-width`, now **228px** (was 240px); content column max-width drops from `max-w-3xl` (48rem) to **`max-w-2xl`** (42rem).
- **TOC aligned with the sidebar** — the TOC rail sits inside `PageLayout` (`mt-4`) but the sidebar doesn't, so the TOC started 16px below the sidebar's first item until you scrolled. A `-mt-4` on the rail cancels that, so the TOC top lines up with "Overview" at scroll 0 (and stays aligned when scrolled).
- **Navbar breathing room** — bumped the top padding on both the sidebar nav and the TOC scroll area (`pt-10`) so the rails clear the header by the same amount when idle.

## Verification

- Live at `/docs/components/combobox` (1440px): TOC link computed `font-size: 12.8px`; no leftover highlight bar; sidebar 228px; TOC rail 228px; content column 672px (`max-w-2xl`).
- Sidebar "Overview" and the TOC's first link both sit at 96px at scroll 0 (aligned) and stay aligned when scrolled.
- `oxlint` 0 errors · `oxfmt` clean · `pnpm typecheck` passes. No registry source or `types.ts` touched, so no `__generated__`/references regeneration needed.
