### PR TITLE
feat(voice-message): add voice-message component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
+      wavesurfer.js:
+        specifier: ^7.12.8
+        version: 7.12.8
       zod:
         specifier: ^4.2.1
         version: 4.3.6
@@ -6313,6 +6316,9 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  wavesurfer.js@7.12.8:
+    resolution: {integrity: sha512-G3nxzcC4X+ZWrLtcIV17kCWHVq3ysJCS4dS0YkGKILrQ2esAb8cScw965zKNKYxUvpiZsPK93KLWgWTYdIBQiw==}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -8112,7 +8118,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':
@@ -12369,6 +12375,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
     optional: true
+
+  wavesurfer.js@7.12.8: {}
 
   web-streams-polyfill@3.3.3: {}
 

--- a/www/content/docs/components/voice-message.mdx
+++ b/www/content/docs/components/voice-message.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="voice-message/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/voice-message.mdx
+++ b/www/content/docs/components/voice-message.mdx
@@ -1,0 +1,44 @@
+---
+title: Voice message
+description: A chat-style voice message bubble with a play control, a waveform, and an elapsed/total duration readout.
+links:
+  - label: wavesurfer.js
+    href: https://wavesurfer.xyz
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/voice-message
+```
+
+## Usage
+
+`VoiceMessage` wraps [wavesurfer.js](https://wavesurfer.xyz) to render a chat-style bubble: a play/pause [Button](/docs/components/button), the audio waveform, and an elapsed/total duration. Click or drag the waveform to seek. Wave and progress colors are resolved from your design system tokens at runtime, so the bubble follows your theme.
+
+```tsx
+import { VoiceMessage } from '@/components/ui/voice-message'
+```
+
+```tsx
+<VoiceMessage src="/audio/message.mp3" />
+```
+
+Pass `duration` (in seconds) to show the total length before the audio metadata loads.
+
+```tsx
+<VoiceMessage src="/audio/message.mp3" duration={12} />
+```
+
+## Examples
+
+<Examples>
+  <Example name="voice-message/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### VoiceMessage
+
+<Reference name="voice-message" />

--- a/www/package.json
+++ b/www/package.json
@@ -63,6 +63,7 @@
     "ts-morph": "^28.0.0",
     "tw-animate-css": "^1.3.5",
     "unist-util-visit": "^5.0.0",
+    "wavesurfer.js": "^7.12.8",
     "zod": "^4.2.1"
   },
   "devDependencies": {

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -72,6 +72,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"toggle-button-group": () => import("@/registry/ui/toggle-button-group/examples"),
 	tooltip: () => import("@/registry/ui/tooltip/examples"),
 	tree: () => import("@/registry/ui/tree/examples"),
+	"voice-message": () => import("@/registry/ui/voice-message/examples"),
 };
 
 export const GroupExamplesIndex: Record<string, () => Promise<{ default: React.ComponentType }>> = {

--- a/www/src/modules/docs/references/generated/voice-message.json
+++ b/www/src/modules/docs/references/generated/voice-message.json
@@ -1,0 +1,30 @@
+{
+  "name": "VoiceMessageProps",
+  "description": "A chat-style voice message bubble: a play/pause control, a `wavesurfer.js`\nwaveform, and an elapsed/total duration readout. Click or drag the waveform\nto seek. Theming (wave and progress colors) is resolved from dotUI tokens at\nruntime.",
+  "extendsElement": "div",
+  "props": {
+    "src": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The audio source URL to play.",
+      "required": true
+    },
+    "duration": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "Total duration in seconds, shown before the audio metadata loads. Once the\nwaveform is ready the real duration replaces it."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -2829,4 +2829,8 @@ export const DemosIndex: Record<
 		files: ["ui/tree/demos/with-icons.tsx"],
 		component: React.lazy(() => import("@/registry/ui/tree/demos/with-icons")),
 	},
+	"voice-message/demos/default": {
+		files: ["ui/voice-message/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/voice-message/demos/default")),
+	},
 };

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -75,6 +75,7 @@ import UiToggleButtonGroup from "@/registry/ui/toggle-button-group/meta";
 import UiToggleButton from "@/registry/ui/toggle-button/meta";
 import UiTooltip from "@/registry/ui/tooltip/meta";
 import UiTree from "@/registry/ui/tree/meta";
+import UiVoiceMessage from "@/registry/ui/voice-message/meta";
 
 import type { RegistryItem } from "@/registry/types";
 
@@ -149,6 +150,7 @@ export const registryUi: RegistryItem[] = [
 	UiToggleButtonGroup,
 	UiTooltip,
 	UiTree,
+	UiVoiceMessage,
 ];
 
 export const registryLib: RegistryItem[] = [LibFocusStyles, LibResponsive, LibTextareaCaret, LibUtils];

--- a/www/src/registry/ui/voice-message/base.tsx
+++ b/www/src/registry/ui/voice-message/base.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import * as React from 'react'
+import { PauseIcon, PlayIcon } from 'lucide-react'
+import WaveSurfer from 'wavesurfer.js'
+
+import { Button } from '@/registry/ui/button'
+
+import { useStyles } from './styles'
+
+// MARK: voiceMessageStyles
+
+// MARK: helpers
+
+/**
+ * wavesurfer needs concrete colors, not CSS variables, so resolve dotUI tokens
+ * off a live element. Falls back to a sensible value when the var is unset
+ * (e.g. during SSR or before the element is attached).
+ */
+function resolveColor(
+  el: HTMLElement,
+  token: string,
+  fallback: string,
+): string {
+  const value = getComputedStyle(el).getPropertyValue(token).trim()
+  return value.length > 0 ? value : fallback
+}
+
+function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00'
+  const total = Math.floor(seconds)
+  const mins = Math.floor(total / 60)
+  const secs = total % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+// MARK: VoiceMessage
+
+interface VoiceMessageProps extends Omit<
+  React.ComponentProps<'div'>,
+  'children'
+> {
+  /** The audio source URL to play. */
+  src: string
+  /**
+   * Total duration in seconds, shown before the audio metadata loads. Once the
+   * waveform is ready the real duration replaces it.
+   */
+  duration?: number
+}
+
+function VoiceMessage({
+  src,
+  duration,
+  className,
+  ...props
+}: VoiceMessageProps) {
+  const { root, waveform, time } = useStyles()()
+  const waveformRef = React.useRef<HTMLDivElement>(null)
+  const wavesurferRef = React.useRef<WaveSurfer | null>(null)
+
+  const [isPlaying, setIsPlaying] = React.useState(false)
+  const [isReady, setIsReady] = React.useState(false)
+  const [totalDuration, setTotalDuration] = React.useState(duration ?? 0)
+  const [elapsed, setElapsed] = React.useState(0)
+
+  React.useEffect(() => {
+    const container = waveformRef.current
+    if (!container) return
+
+    const ws = WaveSurfer.create({
+      container,
+      url: src,
+      height: 32,
+      barWidth: 2,
+      barGap: 2,
+      barRadius: 2,
+      cursorWidth: 0,
+      waveColor: resolveColor(container, '--color-fg-muted', '#a1a1aa'),
+      progressColor: resolveColor(container, '--color-primary', '#6366f1'),
+    })
+    wavesurferRef.current = ws
+
+    const subscriptions = [
+      ws.on('ready', (dur) => {
+        setIsReady(true)
+        setTotalDuration(dur)
+      }),
+      ws.on('timeupdate', (current) => setElapsed(current)),
+      ws.on('play', () => setIsPlaying(true)),
+      ws.on('pause', () => setIsPlaying(false)),
+      ws.on('finish', () => {
+        setIsPlaying(false)
+        setElapsed(0)
+      }),
+    ]
+
+    return () => {
+      for (const unsubscribe of subscriptions) unsubscribe()
+      ws.destroy()
+      wavesurferRef.current = null
+    }
+  }, [src])
+
+  const togglePlay = () => {
+    wavesurferRef.current?.playPause()
+  }
+
+  // Before playback the bubble shows the total length; once the user starts, it
+  // counts the elapsed time like a typical voice message.
+  const shownTime = isPlaying || elapsed > 0 ? elapsed : totalDuration
+
+  return (
+    <div data-voice-message="" className={root({ className })} {...props}>
+      <Button
+        variant="primary"
+        aria-label={isPlaying ? 'Pause' : 'Play'}
+        isDisabled={!isReady}
+        onPress={togglePlay}
+        isIconOnly
+      >
+        {isPlaying ? <PauseIcon /> : <PlayIcon />}
+      </Button>
+      <div ref={waveformRef} data-waveform="" className={waveform()} />
+      <span data-time="" className={time()}>
+        {formatTime(shownTime)}
+      </span>
+    </div>
+  )
+}
+
+// MARK: exports
+
+export type { VoiceMessageProps }
+export { VoiceMessage }

--- a/www/src/registry/ui/voice-message/demos/default.tsx
+++ b/www/src/registry/ui/voice-message/demos/default.tsx
@@ -1,0 +1,17 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/registry/ui/avatar'
+import { VoiceMessage } from '@/registry/ui/voice-message'
+
+export default function Demo() {
+  return (
+    <div className="flex w-full max-w-md items-end gap-2">
+      <Avatar>
+        <AvatarImage src="https://i.pravatar.cc/80?img=12" alt="Olivia" />
+        <AvatarFallback>OL</AvatarFallback>
+      </Avatar>
+      <VoiceMessage
+        src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3"
+        className="w-full"
+      />
+    </div>
+  )
+}

--- a/www/src/registry/ui/voice-message/examples.tsx
+++ b/www/src/registry/ui/voice-message/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function VoiceMessageExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/voice-message/index.tsx
+++ b/www/src/registry/ui/voice-message/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/voice-message/meta.ts
+++ b/www/src/registry/ui/voice-message/meta.ts
@@ -1,0 +1,26 @@
+import type { RegistryItem } from '@/registry/types'
+
+const voiceMessageMeta = {
+  name: 'voice-message',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/voice-message/base.tsx',
+      target: 'ui/voice-message.tsx',
+    },
+  ],
+  registryDependencies: ['button'],
+  dependencies: ['wavesurfer.js'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--voice-message-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default voiceMessageMeta

--- a/www/src/registry/ui/voice-message/styles.css
+++ b/www/src/registry/ui/voice-message/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --voice-message-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/voice-message/styles.ts
+++ b/www/src/registry/ui/voice-message/styles.ts
@@ -1,0 +1,24 @@
+import { createStyles } from '@/lib/styles'
+
+import voiceMessageMeta from './meta'
+
+const { useStyles, styles } = createStyles(voiceMessageMeta, {
+  base: {
+    slots: {
+      root: [
+        'group/voice-message flex w-fit max-w-full items-center gap-3 rounded-(--voice-message-radius) bg-muted p-2 pr-3',
+      ],
+      waveform: ['min-w-0 flex-1 cursor-pointer'],
+      time: ['shrink-0 text-xs text-fg-muted tabular-nums select-none'],
+    },
+  },
+  density: {
+    compact: {},
+    default: {},
+    comfortable: {},
+  },
+})
+
+export type VoiceMessageStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/voice-message/types.ts
+++ b/www/src/registry/ui/voice-message/types.ts
@@ -1,0 +1,18 @@
+/**
+ * A chat-style voice message bubble: a play/pause control, a `wavesurfer.js`
+ * waveform, and an elapsed/total duration readout. Click or drag the waveform
+ * to seek. Theming (wave and progress colors) is resolved from dotUI tokens at
+ * runtime.
+ */
+export interface VoiceMessageProps extends Omit<
+  React.ComponentProps<'div'>,
+  'children'
+> {
+  /** The audio source URL to play. */
+  src: string
+  /**
+   * Total duration in seconds, shown before the audio metadata loads. Once the
+   * waveform is ready the real duration replaces it.
+   */
+  duration?: number
+}


### PR DESCRIPTION
## Summary

Adds a **Voice Message** bubble to the registry — a play/pause control + waveform scrubber + duration, styled like a chat bubble. Part of the real-world-component-blocks batch (Tier 2 media cluster).

- Engine: **wavesurfer.js v7** (BSD-3, the uncontested waveform lib), installed as a dependency. Chrome is dotUI's: a `Button` play/pause + a themed waveform; colors resolve from the design-system tokens.
- Pairs with the chat / AI-assistant layer.
- Themeable axis: `--voice-message-radius`. Group `containers`. `dependencies: ['wavesurfer.js']`.

## Notes

- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.