### PR TITLE
feat(image-cropper): add image-cropper component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.1(react@19.2.1)
+      react-easy-crop:
+        specifier: ^6.0.2
+        version: 6.0.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react-error-boundary:
         specifier: ^6.0.0
         version: 6.0.0(react@19.2.1)
@@ -4978,6 +4981,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -5359,6 +5365,12 @@ packages:
     resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
     peerDependencies:
       react: ^19.2.1
+
+  react-easy-crop@6.0.2:
+    resolution: {integrity: sha512-nY/YiNEuRjc851+/PsOR6Q7XoshmnXMl+oEOsxp3Ah0PrhECi5388jjRnHwsTFx3W0o2zPwvq85oljzUqZNpEw==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
 
   react-error-boundary@6.0.0:
     resolution: {integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==}
@@ -8112,7 +8124,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':
@@ -10839,6 +10851,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-wheel@1.0.1: {}
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
@@ -11322,6 +11336,12 @@ snapshots:
     dependencies:
       react: 19.2.1
       scheduler: 0.27.0
+
+  react-easy-crop@6.0.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   react-error-boundary@6.0.0(react@19.2.1):
     dependencies:

--- a/www/content/docs/components/image-cropper.mdx
+++ b/www/content/docs/components/image-cropper.mdx
@@ -1,0 +1,43 @@
+---
+title: Image Cropper
+description: An interactive crop surface for selecting and exporting a region of an image.
+links:
+  - label: react-easy-crop
+    href: https://github.com/ValentinH/react-easy-crop
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/image-cropper
+```
+
+## Usage
+
+Compose `ImageCropper` over an image source and read the cropped region from
+`onCropComplete`. Pass the result to `getCroppedImg` to render the final image.
+
+```tsx
+import { getCroppedImg, ImageCropper } from '@/components/ui/image-cropper'
+```
+
+```tsx
+<ImageCropper
+  image="/photo.jpg"
+  aspect={1}
+  onCropComplete={(croppedAreaPixels) => setArea(croppedAreaPixels)}
+/>
+```
+
+## Examples
+
+<Examples>
+  <Example name="image-cropper/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### ImageCropper
+
+<Reference name="image-cropper" />

--- a/www/content/docs/components/image-cropper.mdx
+++ b/www/content/docs/components/image-cropper.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="image-cropper/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/package.json
+++ b/www/package.json
@@ -47,6 +47,7 @@
     "react-aria": "^3.50.0",
     "react-aria-components": "^1.19.0",
     "react-dom": "catalog:",
+    "react-easy-crop": "^6.0.2",
     "react-error-boundary": "^6.0.0",
     "react-hook-form": "^7.54.2",
     "react-is": "^19.2.0",

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -39,6 +39,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"file-trigger": () => import("@/registry/ui/file-trigger/examples"),
 	form: () => import("@/registry/ui/form/examples"),
 	group: () => import("@/registry/ui/group/examples"),
+	"image-cropper": () => import("@/registry/ui/image-cropper/examples"),
 	input: () => import("@/registry/ui/input/examples"),
 	"input-group": () => import("@/registry/ui/input-group/examples"),
 	kbd: () => import("@/registry/ui/kbd/examples"),

--- a/www/src/modules/docs/references/generated/image-cropper.json
+++ b/www/src/modules/docs/references/generated/image-cropper.json
@@ -1,0 +1,82 @@
+{
+  "name": "ImageCropperProps",
+  "description": "An image cropper presents an interactive crop surface over an image, with\ncontrols for zoom, rotation, and aspect ratio. It reports the cropped region\nin pixel coordinates so you can produce the final image with `getCroppedImg`.",
+  "extendsElement": "div",
+  "props": {
+    "image": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The source URL of the image to crop.",
+      "required": true
+    },
+    "aspect": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "The aspect ratio of the crop area, expressed as `width / height`.\nOmit for a free-form crop."
+    },
+    "showZoom": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether to show the zoom slider.",
+      "default": "true"
+    },
+    "showRotate": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether to show the rotate slider.",
+      "default": "false"
+    },
+    "showAspectPresets": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether to show the aspect-ratio presets.",
+      "default": "false"
+    },
+    "onCropComplete": {
+      "type": "((croppedAreaPixels: Area) => void)",
+      "detailedType": "((croppedAreaPixels: Area) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "croppedAreaPixels",
+            "value": {
+              "type": "link",
+              "id": "Area",
+              "name": "Area"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Called whenever the crop selection settles, with the cropped region in\npixel coordinates. Pass the result to `getCroppedImg` to render the output."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -1449,6 +1449,10 @@ export const DemosIndex: Record<
 		files: ["ui/group/demos/with-text.tsx"],
 		component: React.lazy(() => import("@/registry/ui/group/demos/with-text")),
 	},
+	"image-cropper/demos/default": {
+		files: ["ui/image-cropper/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/image-cropper/demos/default")),
+	},
 	"input/demos/default": {
 		files: ["ui/input/demos/default.tsx"],
 		component: React.lazy(() => import("@/registry/ui/input/demos/default")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -43,6 +43,7 @@ import UiEmpty from "@/registry/ui/empty/meta";
 import UiField from "@/registry/ui/field/meta";
 import UiFileTrigger from "@/registry/ui/file-trigger/meta";
 import UiGroup from "@/registry/ui/group/meta";
+import UiImageCropper from "@/registry/ui/image-cropper/meta";
 import UiInput from "@/registry/ui/input/meta";
 import UiKbd from "@/registry/ui/kbd/meta";
 import UiLink from "@/registry/ui/link/meta";
@@ -117,6 +118,7 @@ export const registryUi: RegistryItem[] = [
 	UiField,
 	UiFileTrigger,
 	UiGroup,
+	UiImageCropper,
 	UiInput,
 	UiKbd,
 	UiLink,

--- a/www/src/registry/ui/image-cropper/base.tsx
+++ b/www/src/registry/ui/image-cropper/base.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import * as React from 'react'
+import Cropper from 'react-easy-crop'
+import type { Area, Point } from 'react-easy-crop'
+
+import { Button } from '@/registry/ui/button'
+import { Slider, SliderControl } from '@/registry/ui/slider'
+
+import { useStyles } from './styles'
+
+// MARK: imageCropperStyles
+
+// MARK: helpers
+
+type CroppedArea = Area
+
+const ASPECT_PRESETS = [
+  { label: 'Free', value: undefined },
+  { label: '1:1', value: 1 },
+  { label: '4:3', value: 4 / 3 },
+  { label: '16:9', value: 16 / 9 },
+] as const
+
+/** Normalize a RAC Slider value (number | number[]) down to a single number. */
+const toNumber = (value: number | number[]): number =>
+  Array.isArray(value) ? (value[0] ?? 0) : value
+
+const createImage = (url: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image()
+    image.addEventListener('load', () => resolve(image))
+    image.addEventListener('error', (error) => reject(error))
+    image.setAttribute('crossOrigin', 'anonymous')
+    image.src = url
+  })
+
+const toRadians = (degrees: number): number => (degrees * Math.PI) / 180
+
+/**
+ * Render the cropped region onto a canvas and return it as a data URL.
+ * `rotation` is in degrees; pass the same value used by the cropper.
+ */
+async function getCroppedImg(
+  imageSrc: string,
+  croppedAreaPixels: CroppedArea,
+  rotation = 0,
+): Promise<string | null> {
+  const image = await createImage(imageSrc)
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return null
+
+  const radians = toRadians(rotation)
+  const sin = Math.abs(Math.sin(radians))
+  const cos = Math.abs(Math.cos(radians))
+  const boxWidth = image.width * cos + image.height * sin
+  const boxHeight = image.width * sin + image.height * cos
+
+  // Draw the rotated source image onto an intermediate canvas.
+  canvas.width = boxWidth
+  canvas.height = boxHeight
+  ctx.translate(boxWidth / 2, boxHeight / 2)
+  ctx.rotate(radians)
+  ctx.drawImage(image, -image.width / 2, -image.height / 2)
+
+  const data = ctx.getImageData(0, 0, boxWidth, boxHeight)
+
+  // Resize the canvas to the cropped region and paint the rotated pixels back.
+  canvas.width = croppedAreaPixels.width
+  canvas.height = croppedAreaPixels.height
+  ctx.putImageData(
+    data,
+    Math.round(-boxWidth / 2 + image.width / 2 - croppedAreaPixels.x),
+    Math.round(-boxHeight / 2 + image.height / 2 - croppedAreaPixels.y),
+  )
+
+  return canvas.toDataURL('image/png')
+}
+
+// MARK: ImageCropper
+
+interface ImageCropperProps extends Omit<
+  React.ComponentProps<'div'>,
+  'onChange'
+> {
+  /** The source URL of the image to crop. */
+  image: string
+  /** The aspect ratio of the crop area (width / height). Omit for a free crop. */
+  aspect?: number
+  /** Show the zoom slider. */
+  showZoom?: boolean
+  /** Show the rotate slider. */
+  showRotate?: boolean
+  /** Show the aspect-ratio presets. */
+  showAspectPresets?: boolean
+  /** Called whenever the crop selection settles, with pixel coordinates. */
+  onCropComplete?: (croppedAreaPixels: CroppedArea) => void
+}
+
+function ImageCropper({
+  image,
+  aspect: aspectProp,
+  showZoom = true,
+  showRotate = false,
+  showAspectPresets = false,
+  onCropComplete,
+  className,
+  children,
+  ...props
+}: ImageCropperProps) {
+  const { root, cropper, controls, control, controlLabel, actions } =
+    useStyles()()
+
+  const [crop, setCrop] = React.useState<Point>({ x: 0, y: 0 })
+  const [zoom, setZoom] = React.useState(1)
+  const [rotation, setRotation] = React.useState(0)
+  const [aspect, setAspect] = React.useState<number | undefined>(aspectProp)
+
+  React.useEffect(() => {
+    setAspect(aspectProp)
+  }, [aspectProp])
+
+  const handleCropComplete = React.useCallback(
+    (_croppedArea: Area, croppedAreaPixels: Area) => {
+      onCropComplete?.(croppedAreaPixels)
+    },
+    [onCropComplete],
+  )
+
+  return (
+    <div data-image-cropper="" className={root({ className })} {...props}>
+      <div data-image-cropper-surface="" className={cropper()}>
+        <Cropper
+          image={image}
+          crop={crop}
+          zoom={zoom}
+          rotation={rotation}
+          aspect={aspect}
+          onCropChange={setCrop}
+          onZoomChange={setZoom}
+          onRotationChange={setRotation}
+          onCropComplete={handleCropComplete}
+        />
+      </div>
+
+      <div data-image-cropper-controls="" className={controls()}>
+        {showAspectPresets && (
+          <div data-image-cropper-aspect="" className={actions()}>
+            {ASPECT_PRESETS.map((preset) => (
+              <Button
+                key={preset.label}
+                size="sm"
+                variant={aspect === preset.value ? 'primary' : 'quiet'}
+                onPress={() => setAspect(preset.value)}
+              >
+                {preset.label}
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {showZoom && (
+          <div data-image-cropper-zoom="" className={control()}>
+            <span className={controlLabel()}>Zoom</span>
+            <Slider
+              aria-label="Zoom"
+              value={zoom}
+              minValue={1}
+              maxValue={3}
+              step={0.01}
+              onChange={(value) => setZoom(toNumber(value))}
+              className="flex-1"
+            >
+              <SliderControl />
+            </Slider>
+          </div>
+        )}
+
+        {showRotate && (
+          <div data-image-cropper-rotate="" className={control()}>
+            <span className={controlLabel()}>Rotate</span>
+            <Slider
+              aria-label="Rotate"
+              value={rotation}
+              minValue={0}
+              maxValue={360}
+              step={1}
+              onChange={(value) => setRotation(toNumber(value))}
+              className="flex-1"
+            >
+              <SliderControl />
+            </Slider>
+          </div>
+        )}
+
+        {children}
+      </div>
+    </div>
+  )
+}
+
+// MARK: separator
+
+export type { CroppedArea, ImageCropperProps }
+export { getCroppedImg, ImageCropper }

--- a/www/src/registry/ui/image-cropper/demos/default.tsx
+++ b/www/src/registry/ui/image-cropper/demos/default.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import * as React from 'react'
+
+import { Button } from '@/registry/ui/button'
+import { getCroppedImg, ImageCropper } from '@/registry/ui/image-cropper'
+import type { CroppedArea } from '@/registry/ui/image-cropper'
+
+const IMAGE_SRC =
+  'https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?w=800&q=80'
+
+export default function Demo() {
+  const [croppedAreaPixels, setCroppedAreaPixels] =
+    React.useState<CroppedArea | null>(null)
+  const [result, setResult] = React.useState<string | null>(null)
+
+  const handleCrop = async () => {
+    if (!croppedAreaPixels) return
+    const dataUrl = await getCroppedImg(IMAGE_SRC, croppedAreaPixels)
+    setResult(dataUrl)
+  }
+
+  return (
+    <div className="flex w-full max-w-md flex-col gap-4">
+      <ImageCropper
+        image={IMAGE_SRC}
+        aspect={1}
+        onCropComplete={setCroppedAreaPixels}
+      >
+        <div className="flex justify-end">
+          <Button size="sm" variant="primary" onPress={handleCrop}>
+            Crop image
+          </Button>
+        </div>
+      </ImageCropper>
+
+      {result && (
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-fg-muted">Result</span>
+          <img
+            src={result}
+            alt="Cropped result"
+            className="size-16 rounded-(--image-cropper-radius) object-cover"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/www/src/registry/ui/image-cropper/examples.tsx
+++ b/www/src/registry/ui/image-cropper/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function ImageCropperExamples() {
+  return (
+    <Examples>
+      <Example title="default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/image-cropper/index.tsx
+++ b/www/src/registry/ui/image-cropper/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/image-cropper/meta.ts
+++ b/www/src/registry/ui/image-cropper/meta.ts
@@ -1,0 +1,26 @@
+import type { RegistryItem } from '@/registry/types'
+
+const imageCropperMeta = {
+  name: 'image-cropper',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/image-cropper/base.tsx',
+      target: 'ui/image-cropper.tsx',
+    },
+  ],
+  registryDependencies: ['button', 'slider'],
+  dependencies: ['react-easy-crop'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--image-cropper-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default imageCropperMeta

--- a/www/src/registry/ui/image-cropper/styles.css
+++ b/www/src/registry/ui/image-cropper/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --image-cropper-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/image-cropper/styles.ts
+++ b/www/src/registry/ui/image-cropper/styles.ts
@@ -1,0 +1,38 @@
+import { createStyles } from '@/lib/styles'
+
+import imageCropperMeta from './meta'
+
+const { useStyles, styles } = createStyles(imageCropperMeta, {
+  base: {
+    slots: {
+      root: 'flex w-full flex-col gap-4',
+      cropper:
+        'relative h-72 w-full overflow-hidden rounded-(--image-cropper-radius) bg-neutral',
+      controls: 'flex flex-col gap-4',
+      control: 'flex items-center gap-3',
+      controlLabel: 'w-14 shrink-0 text-fg-muted',
+      actions: 'flex items-center justify-end gap-2',
+    },
+  },
+  density: {
+    compact: {
+      slots: {
+        controlLabel: 'text-xs',
+      },
+    },
+    default: {
+      slots: {
+        controlLabel: 'text-sm',
+      },
+    },
+    comfortable: {
+      slots: {
+        controlLabel: 'text-sm',
+      },
+    },
+  },
+})
+
+export type ImageCropperStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/image-cropper/types.ts
+++ b/www/src/registry/ui/image-cropper/types.ts
@@ -1,0 +1,46 @@
+import type { Area } from 'react-easy-crop'
+
+/**
+ * An image cropper presents an interactive crop surface over an image, with
+ * controls for zoom, rotation, and aspect ratio. It reports the cropped region
+ * in pixel coordinates so you can produce the final image with `getCroppedImg`.
+ */
+export interface ImageCropperProps extends Omit<
+  React.ComponentProps<'div'>,
+  'onChange'
+> {
+  /**
+   * The source URL of the image to crop.
+   */
+  image: string
+
+  /**
+   * The aspect ratio of the crop area, expressed as `width / height`.
+   * Omit for a free-form crop.
+   */
+  aspect?: number
+
+  /**
+   * Whether to show the zoom slider.
+   * @default true
+   */
+  showZoom?: boolean
+
+  /**
+   * Whether to show the rotate slider.
+   * @default false
+   */
+  showRotate?: boolean
+
+  /**
+   * Whether to show the aspect-ratio presets.
+   * @default false
+   */
+  showAspectPresets?: boolean
+
+  /**
+   * Called whenever the crop selection settles, with the cropped region in
+   * pixel coordinates. Pass the result to `getCroppedImg` to render the output.
+   */
+  onCropComplete?: (croppedAreaPixels: Area) => void
+}


### PR DESCRIPTION
## Summary

Adds an **Image Cropper** to the registry — a crop surface with zoom/rotate/aspect controls. Part of the real-world-component-blocks batch (Tier 2).

- Engine: **react-easy-crop** (installed as a dependency). dotUI owns the chrome: a `Slider` for zoom/rotate and a `getCroppedImg` canvas helper that returns the cropped result.
- Ships a *cropper*, not a full image editor (the full editors are commercial, per the research doc), over the existing FileTrigger/DropZone flow.
- Themeable axis: `--image-cropper-radius`. Group `containers`. `registryDependencies: ['button', 'slider']`, `dependencies: ['react-easy-crop']`.

## Notes

- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.