### PR TITLE
feat(onboarding-tour): add onboarding-tour component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       cnfast:
         specifier: ^0.0.8
         version: 0.0.8
+      driver.js:
+        specifier: ^1.6.0
+        version: 1.6.0
       fumadocs-core:
         specifier: ^16.8.11
         version: 16.8.11(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.2)(lucide-react@1.16.0(react@19.2.1))(next@16.0.8(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
@@ -3611,6 +3614,9 @@ packages:
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
+
+  driver.js@1.6.0:
+    resolution: {integrity: sha512-gryo9QS7AZhz8J0bmdf42dwaTzcd1BgSJLnaSM7cPJbu8bTW8wIEuiGDy4MoCvB4Sr8wA9g5o2G9EFNVYZGeVQ==}
 
   drizzle-orm@0.44.7:
     resolution: {integrity: sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==}
@@ -8112,7 +8118,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':
@@ -9209,6 +9215,8 @@ snapshots:
       domhandler: 5.0.3
 
   dotenv@17.4.2: {}
+
+  driver.js@1.6.0: {}
 
   drizzle-orm@0.44.7(@types/pg@8.15.6)(@vercel/postgres@0.10.0)(kysely@0.28.8)(pg@8.16.3):
     optionalDependencies:

--- a/www/content/docs/components/onboarding-tour.mdx
+++ b/www/content/docs/components/onboarding-tour.mdx
@@ -1,0 +1,67 @@
+---
+title: Onboarding Tour
+description: A guided product tour that highlights elements with coachmark popovers.
+links:
+  - label: Driver.js
+    href: https://driverjs.com
+wip: true
+---
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/onboarding-tour
+```
+
+## Usage
+
+`OnboardingTour` is a thin wrapper around [driver.js](https://driverjs.com). You give it an ordered list of `steps` — each targets an element by CSS selector and shows a popover — and it renders a `Button` that starts the tour. For full control, use the `useOnboardingTour` hook instead and trigger the tour from your own UI.
+
+```tsx
+import { OnboardingTour } from '@/components/ui/onboarding-tour'
+import type { DriveStep } from 'driver.js'
+```
+
+```tsx
+const steps: DriveStep[] = [
+  {
+    element: '#search',
+    popover: { title: 'Search', description: 'Jump to anything from here.' },
+  },
+  {
+    element: '#settings',
+    popover: { title: 'Settings', description: 'Manage your workspace.' },
+  },
+]
+
+;<OnboardingTour steps={steps}>Start tour</OnboardingTour>
+```
+
+For a custom trigger, call the `useOnboardingTour` hook and wire `start` to any control:
+
+```tsx
+import { useOnboardingTour } from '@/components/ui/onboarding-tour'
+
+function Toolbar() {
+  const tour = useOnboardingTour(steps)
+  return <Button onPress={() => tour.start()}>Take the tour</Button>
+}
+```
+
+## Examples
+
+<Examples>
+  <Example name="onboarding-tour/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### OnboardingTour
+
+<Reference name="onboarding-tour" />
+
+### useOnboardingTour
+
+`useOnboardingTour(steps, options?)` returns an imperative handle for driving the tour.
+
+<Reference name="onboarding-tour-handle" />

--- a/www/content/docs/components/onboarding-tour.mdx
+++ b/www/content/docs/components/onboarding-tour.mdx
@@ -7,6 +7,8 @@ links:
 wip: true
 ---
 
+<Demo name="onboarding-tour/demos/default" />
+
 ## Installation
 
 ```npm

--- a/www/content/docs/components/onboarding-tour.mdx
+++ b/www/content/docs/components/onboarding-tour.mdx
@@ -64,6 +64,4 @@ function Toolbar() {
 
 ### useOnboardingTour
 
-`useOnboardingTour(steps, options?)` returns an imperative handle for driving the tour.
-
-<Reference name="onboarding-tour-handle" />
+`useOnboardingTour(steps, options?)` returns an imperative handle (`{ start }`) for driving the tour.

--- a/www/package.json
+++ b/www/package.json
@@ -36,6 +36,7 @@
     "@tanstack/router-plugin": "^1.168.2",
     "@vercel/og": "^0.11.1",
     "cnfast": "^0.0.8",
+    "driver.js": "^1.6.0",
     "fumadocs-core": "^16.8.11",
     "fumadocs-mdx": "^15.0.5",
     "globals-docs": "^2.4.1",

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -48,6 +48,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	menu: () => import("@/registry/ui/menu/examples"),
 	modal: () => import("@/registry/ui/modal/examples"),
 	"number-field": () => import("@/registry/ui/number-field/examples"),
+	"onboarding-tour": () => import("@/registry/ui/onboarding-tour/examples"),
 	"otp-field": () => import("@/registry/ui/otp-field/examples"),
 	pagination: () => import("@/registry/ui/pagination/examples"),
 	popover: () => import("@/registry/ui/popover/examples"),

--- a/www/src/modules/docs/references/generated/onboarding-tour.json
+++ b/www/src/modules/docs/references/generated/onboarding-tour.json
@@ -1,0 +1,1486 @@
+{
+  "name": "OnboardingTourProps",
+  "description": "A guided product tour built on driver.js. Highlights a sequence of elements\non the page, each with a coachmark popover, advancing on user interaction.\nRenders a `Button` trigger by default; pass a render function for a custom one.",
+  "props": {
+    "steps": {
+      "type": "DriveStep[]",
+      "typeAst": {
+        "type": "array",
+        "elementType": {
+          "type": "identifier",
+          "name": "DriveStep"
+        }
+      },
+      "description": "The ordered steps that make up the tour. Each step targets an element by\nCSS selector and shows a popover with a title and description.",
+      "required": true
+    },
+    "options": {
+      "type": "OnboardingTourOptions",
+      "detailedType": "OnboardingTourOptions | undefined",
+      "typeAst": {
+        "type": "identifier",
+        "name": "OnboardingTourOptions"
+      },
+      "description": "Driver.js configuration, minus `steps` (e.g. `showProgress`, `allowClose`,\n`overlayColor`)."
+    },
+    "children": {
+      "type": "ReactNode | ((tour: OnboardingTourHandle) => ReactNode)",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "bigint"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "identifier",
+            "name": "ReactElement"
+          },
+          {
+            "type": "link",
+            "id": "@types/react/index.d.ts:ReactPortal",
+            "name": "ReactPortal"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "tour",
+                "value": {
+                  "type": "link",
+                  "id": "src/registry/ui/onboarding-tour/types.ts:OnboardingTourHandle",
+                  "name": "OnboardingTourHandle"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "identifier",
+              "name": "ReactNode"
+            },
+            "typeParameters": []
+          },
+          {
+            "type": "application",
+            "base": {
+              "type": "identifier",
+              "name": "Iterable"
+            },
+            "typeParameters": [
+              {
+                "type": "identifier",
+                "name": "ReactNode"
+              }
+            ]
+          },
+          {
+            "type": "application",
+            "base": {
+              "type": "identifier",
+              "name": "Promise"
+            },
+            "typeParameters": [
+              {
+                "type": "identifier",
+                "name": "AwaitedReactNode"
+              }
+            ]
+          }
+        ]
+      },
+      "description": "Trigger content. A function receives the tour handle so you can render a\ncustom control (calling `start`, `next`, etc.); a node renders inside the\ndefault `Button` trigger.",
+      "default": "\"Start tour\""
+    },
+    "onPressStart": {
+      "type": "((e: PressEvent) => void)",
+      "detailedType": "((e: PressEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "PressEvent",
+              "name": "PressEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a press interaction starts."
+    },
+    "onPressEnd": {
+      "type": "((e: PressEvent) => void)",
+      "detailedType": "((e: PressEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "PressEvent",
+              "name": "PressEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a press interaction ends, either\nover the target or when the pointer leaves the target."
+    },
+    "onPressChange": {
+      "type": "((isPressed: boolean) => void)",
+      "detailedType": "((isPressed: boolean) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "isPressed",
+            "value": {
+              "type": "link",
+              "id": "boolean",
+              "name": "boolean"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when the press state changes."
+    },
+    "onPressUp": {
+      "type": "((e: PressEvent) => void)",
+      "detailedType": "((e: PressEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "PressEvent",
+              "name": "PressEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a press is released over the target, regardless of\nwhether it started on the target or not."
+    },
+    "onClick": {
+      "type": "((e: MouseEvent<FocusableElement, MouseEvent>) => void)",
+      "detailedType": "| ((e: MouseEvent<FocusableElement, MouseEvent>) => void)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "e",
+                "value": {
+                  "type": "application",
+                  "base": {
+                    "type": "identifier",
+                    "name": "MouseEvent"
+                  },
+                  "typeParameters": [
+                    {
+                      "type": "identifier",
+                      "name": "FocusableElement"
+                    }
+                  ]
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "**Not recommended – use `onPress` instead.** `onClick` is an alias for `onPress`\nprovided for compatibility with other libraries. `onPress` provides\nadditional event details for non-mouse interactions."
+    },
+    "onFocus": {
+      "type": "((e: FocusEvent<Element, Element>) => void)",
+      "detailedType": "| ((e: FocusEvent<Element, Element>) => void)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "e",
+                "value": {
+                  "type": "identifier",
+                  "name": "FocusEvent"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Handler that is called when the element receives focus."
+    },
+    "onBlur": {
+      "type": "((e: FocusEvent<Element, Element>) => void)",
+      "detailedType": "| ((e: FocusEvent<Element, Element>) => void)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "e",
+                "value": {
+                  "type": "identifier",
+                  "name": "FocusEvent"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Handler that is called when the element loses focus."
+    },
+    "onFocusChange": {
+      "type": "((isFocused: boolean) => void)",
+      "detailedType": "((isFocused: boolean) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "isFocused",
+            "value": {
+              "type": "link",
+              "id": "boolean",
+              "name": "boolean"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when the element's focus status changes."
+    },
+    "onKeyDown": {
+      "type": "((e: KeyboardEvent) => void)",
+      "detailedType": "((e: KeyboardEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "KeyboardEvent",
+              "name": "KeyboardEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a key is pressed."
+    },
+    "onKeyUp": {
+      "type": "((e: KeyboardEvent) => void)",
+      "detailedType": "((e: KeyboardEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "KeyboardEvent",
+              "name": "KeyboardEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a key is released."
+    },
+    "onHoverStart": {
+      "type": "((e: HoverEvent) => void)",
+      "detailedType": "((e: HoverEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "HoverEvent",
+              "name": "HoverEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a hover interaction starts."
+    },
+    "onHoverEnd": {
+      "type": "((e: HoverEvent) => void)",
+      "detailedType": "((e: HoverEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "HoverEvent",
+              "name": "HoverEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a hover interaction ends."
+    },
+    "onHoverChange": {
+      "type": "((isHovering: boolean) => void)",
+      "detailedType": "((isHovering: boolean) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "isHovering",
+            "value": {
+              "type": "link",
+              "id": "boolean",
+              "name": "boolean"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when the hover state changes."
+    },
+    "aria-controls": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) whose contents or presence are controlled by the current\nelement."
+    },
+    "aria-current": {
+      "type": "\"date\" | \"false\" | \"location\" | \"page\" | \"step\" | \"time\" | \"true\" | boolean",
+      "detailedType": "| 'date'\n| 'false'\n| 'location'\n| 'page'\n| 'step'\n| 'time'\n| 'true'\n| boolean\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "date"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "false"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "location"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "page"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "step"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "time"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "true"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "description": "Indicates whether this element represents the current item within a container or set of related\nelements."
+    },
+    "aria-describedby": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that describes the object."
+    },
+    "aria-details": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that provide a detailed, extended description for the\nobject."
+    },
+    "aria-disabled": {
+      "type": "\"false\" | \"true\" | boolean",
+      "detailedType": "'false' | 'true' | boolean | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "false"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "true"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "description": "Indicates whether the element is disabled to users of assistive technology."
+    },
+    "aria-expanded": {
+      "type": "\"false\" | \"true\" | boolean",
+      "detailedType": "'false' | 'true' | boolean | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "false"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "true"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "description": "Indicates whether the element, or another grouping element it controls, is currently expanded\nor collapsed."
+    },
+    "aria-haspopup": {
+      "type": "\"dialog\" | \"false\" | \"grid\" | \"listbox\" | \"menu\" | \"tree\" | \"true\" | boolean",
+      "detailedType": "| 'dialog'\n| 'false'\n| 'grid'\n| 'listbox'\n| 'menu'\n| 'tree'\n| 'true'\n| boolean\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "dialog"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "false"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "grid"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "listbox"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "menu"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "tree"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "true"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that\ncan be triggered by an element."
+    },
+    "aria-label": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Defines a string value that labels the current element."
+    },
+    "aria-labelledby": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that labels the current element."
+    },
+    "aria-pressed": {
+      "type": "\"false\" | \"mixed\" | \"true\" | boolean",
+      "detailedType": "'false' | 'mixed' | 'true' | boolean | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "false"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "mixed"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "true"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "description": "Indicates the current \"pressed\" state of toggle buttons."
+    },
+    "autoFocus": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the element should receive focus on render."
+    },
+    "className": {
+      "type": "string | (values: ButtonRenderProps) => string",
+      "detailedType": "string | (values: ButtonRenderProps) => string | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "ButtonRenderProps",
+                  "name": "ButtonRenderProps"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "string"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the\nelement. A function may be provided to compute the class based on component state."
+    },
+    "excludeFromTabOrder": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether to exclude the element from the sequential tab order. If true,\nthe element will not be focusable via the keyboard by tabbing. This should\nbe avoided except in rare scenarios where an alternative means of accessing\nthe element or its functionality via the keyboard is available."
+    },
+    "form": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The `<form>` element to associate the button with.\nThe value of this attribute must be the id of a `<form>` in the same document.\nSee [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#form)."
+    },
+    "formAction": {
+      "type": "string | ((formData: FormData) => void | Promise<void>)",
+      "detailedType": "| string\n| ((formData: FormData) => void | Promise<void>)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "formData",
+                "value": {
+                  "type": "identifier",
+                  "name": "FormData"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "union",
+              "elements": [
+                {
+                  "type": "void"
+                },
+                {
+                  "type": "application",
+                  "base": {
+                    "type": "identifier",
+                    "name": "Promise"
+                  },
+                  "typeParameters": [
+                    {
+                      "type": "void"
+                    }
+                  ]
+                }
+              ]
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The URL that processes the information submitted by the button.\nOverrides the action attribute of the button's form owner."
+    },
+    "formEncType": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Indicates how to encode the form data that is submitted."
+    },
+    "formMethod": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Indicates the HTTP method used to submit the form."
+    },
+    "formNoValidate": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Indicates that the form is not to be validated when it is submitted."
+    },
+    "formTarget": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Overrides the target attribute of the button's form owner."
+    },
+    "id": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The element's unique identifier. See\n[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)."
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the button is disabled."
+    },
+    "isPending": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the button is in a pending state. This disables press and hover events\nwhile retaining focusability, and announces the pending state to screen readers."
+    },
+    "name": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Submitted as a pair with the button's value as part of the form data."
+    },
+    "preventFocusOnPress": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether to prevent focus from moving to the button when pressing it.\n\nCaution, this can make the button inaccessible and should only be used when alternative\nkeyboard interaction is provided, such as ComboBox's MenuTrigger or a NumberField's\nincrement/decrement control."
+    },
+    "render": {
+      "type": "DOMRenderFunction<\"button\", ButtonRenderProps>",
+      "detailedType": "| DOMRenderFunction<'button', ButtonRenderProps>\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "application",
+            "base": {
+              "type": "identifier",
+              "name": "DOMRenderFunction"
+            },
+            "typeParameters": [
+              {
+                "type": "stringLiteral",
+                "value": "button"
+              },
+              {
+                "type": "link",
+                "id": "react-aria-components/dist/types/src/Button.d.ts:ButtonRenderProps",
+                "name": "ButtonRenderProps"
+              }
+            ]
+          }
+        ]
+      },
+      "description": "Overrides the default DOM element with a custom render function.\nThis allows rendering existing components with built-in styles and behaviors\nsuch as router links, animation libraries, and pre-styled components.\n\nRequirements:\n\n- You must render the expected element type (e.g. if `<button>` is expected, you cannot render an\n  `<a>`).\n- Only a single root DOM element can be rendered (no fragments).\n- You must pass through props and ref to the underlying DOM element, merging with your own prop\n  as appropriate."
+    },
+    "slot": {
+      "type": "null | string",
+      "detailedType": "null | string | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "description": "A slot name for the component. Slots allow the component to receive props from a parent\ncomponent. An explicit `null` value indicates that the local props completely override all\nprops received from a parent."
+    },
+    "style": {
+      "type": "CSSProperties | (values: ButtonRenderProps) => CSSProperties",
+      "detailedType": "CSSProperties | (values: ButtonRenderProps) => CSSProperties | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "identifier",
+            "name": "CSSProperties"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "ButtonRenderProps",
+                  "name": "ButtonRenderProps"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "identifier",
+              "name": "CSSProperties"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
+    },
+    "type": {
+      "type": "\"button\" | \"reset\" | \"submit\"",
+      "detailedType": "'button' | 'reset' | 'submit' | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "button"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "reset"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "submit"
+          }
+        ]
+      },
+      "description": "The behavior of the button when used in an HTML form.",
+      "default": "'button'"
+    },
+    "value": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The value associated with the button's name when it's submitted with the form data."
+    }
+  },
+  "typeLinks": {
+    "@types/react/index.d.ts:ReactPortal": {
+      "type": "interface",
+      "id": "@types/react/index.d.ts:ReactPortal",
+      "name": "ReactPortal",
+      "extends": [
+        {
+          "type": "identifier",
+          "name": "ReactElement"
+        }
+      ],
+      "properties": {
+        "children": {
+          "type": "property",
+          "name": "children",
+          "value": {
+            "type": "identifier",
+            "name": "ReactNode"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": ""
+        },
+        "key": {
+          "type": "property",
+          "name": "key",
+          "value": {
+            "type": "union",
+            "elements": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "optional": false,
+          "readonly": false,
+          "description": ""
+        },
+        "props": {
+          "type": "property",
+          "name": "props",
+          "value": {
+            "type": "unknown"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": ""
+        },
+        "type": {
+          "type": "property",
+          "name": "type",
+          "value": {
+            "type": "union",
+            "elements": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "identifier",
+                "name": "new (props: any, context: any) => Component<any, any, any>"
+              },
+              {
+                "type": "function",
+                "parameters": [
+                  {
+                    "type": "parameter",
+                    "name": "props",
+                    "value": {
+                      "type": "any"
+                    },
+                    "optional": false,
+                    "rest": false
+                  }
+                ],
+                "return": {
+                  "type": "union",
+                  "elements": [
+                    {
+                      "type": "identifier",
+                      "name": "bigint"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "false"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "Iterable<ReactNode>"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "null"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "number"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "Promise<AwaitedReactNode>"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "Promise<ReactNode>"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "ReactElement<unknown, string | JSXElementConstructor<any>>"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "ReactPortal"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "string"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "true"
+                    },
+                    {
+                      "type": "identifier",
+                      "name": "undefined"
+                    }
+                  ]
+                },
+                "typeParameters": []
+              }
+            ]
+          },
+          "optional": false,
+          "readonly": false,
+          "description": ""
+        }
+      },
+      "typeParameters": [],
+      "description": ""
+    },
+    "ButtonRenderProps": {
+      "type": "interface",
+      "name": "ButtonRenderProps",
+      "properties": {
+        "isDisabled": {
+          "type": "property",
+          "name": "isDisabled",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is disabled."
+        },
+        "isFocused": {
+          "type": "property",
+          "name": "isFocused",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is focused, either via a mouse or keyboard."
+        },
+        "isFocusVisible": {
+          "type": "property",
+          "name": "isFocusVisible",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is keyboard focused."
+        },
+        "isHovered": {
+          "type": "property",
+          "name": "isHovered",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is currently hovered with a mouse."
+        },
+        "isPending": {
+          "type": "property",
+          "name": "isPending",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is currently in a pending state."
+        },
+        "isPressed": {
+          "type": "property",
+          "name": "isPressed",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is currently in a pressed state."
+        }
+      }
+    },
+    "HoverEvent": {
+      "type": "interface",
+      "name": "HoverEvent",
+      "properties": {
+        "pointerType": {
+          "type": "property",
+          "name": "pointerType",
+          "value": {
+            "type": "identifier",
+            "name": "\"mouse\" | \"pen\""
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The pointer type that triggered the hover event."
+        },
+        "target": {
+          "type": "property",
+          "name": "target",
+          "value": {
+            "type": "identifier",
+            "name": "HTMLElement"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The target element of the hover event."
+        },
+        "type": {
+          "type": "property",
+          "name": "type",
+          "value": {
+            "type": "identifier",
+            "name": "\"hoverstart\" | \"hoverend\""
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The type of hover event being fired."
+        }
+      }
+    },
+    "PressEvent": {
+      "type": "interface",
+      "name": "PressEvent",
+      "properties": {
+        "altKey": {
+          "type": "property",
+          "name": "altKey",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the alt keyboard modifier was held during the press event."
+        },
+        "continuePropagation": {
+          "type": "property",
+          "name": "continuePropagation",
+          "value": {
+            "type": "identifier",
+            "name": "() => void"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "By default, press events stop propagation to parent elements.\nIn cases where a handler decides not to handle a specific event,\nit can call `continuePropagation()` to allow a parent to handle it."
+        },
+        "ctrlKey": {
+          "type": "property",
+          "name": "ctrlKey",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the ctrl keyboard modifier was held during the press event."
+        },
+        "key": {
+          "type": "property",
+          "name": "key",
+          "value": {
+            "type": "identifier",
+            "name": "string | undefined"
+          },
+          "optional": true,
+          "readonly": false,
+          "description": "The key that triggered the press event, if it was triggered by a keyboard interaction.\nThis is useful for differentiating between Space and Enter key presses."
+        },
+        "metaKey": {
+          "type": "property",
+          "name": "metaKey",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the meta keyboard modifier was held during the press event."
+        },
+        "pointerType": {
+          "type": "property",
+          "name": "pointerType",
+          "value": {
+            "type": "identifier",
+            "name": "PointerType"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The pointer type that triggered the press event."
+        },
+        "shiftKey": {
+          "type": "property",
+          "name": "shiftKey",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the shift keyboard modifier was held during the press event."
+        },
+        "target": {
+          "type": "property",
+          "name": "target",
+          "value": {
+            "type": "identifier",
+            "name": "Element"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The target element of the press event."
+        },
+        "type": {
+          "type": "property",
+          "name": "type",
+          "value": {
+            "type": "identifier",
+            "name": "\"pressstart\" | \"pressend\" | \"pressup\" | \"press\""
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "The type of press event being fired."
+        },
+        "x": {
+          "type": "property",
+          "name": "x",
+          "value": {
+            "type": "number"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "X position relative to the target."
+        },
+        "y": {
+          "type": "property",
+          "name": "y",
+          "value": {
+            "type": "number"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Y position relative to the target."
+        }
+      }
+    },
+    "react-aria-components/dist/types/src/Button.d.ts:ButtonRenderProps": {
+      "type": "interface",
+      "id": "react-aria-components/dist/types/src/Button.d.ts:ButtonRenderProps",
+      "name": "ButtonRenderProps",
+      "extends": [],
+      "properties": {
+        "isDisabled": {
+          "type": "property",
+          "name": "isDisabled",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is disabled."
+        },
+        "isFocused": {
+          "type": "property",
+          "name": "isFocused",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is focused, either via a mouse or keyboard."
+        },
+        "isFocusVisible": {
+          "type": "property",
+          "name": "isFocusVisible",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is keyboard focused."
+        },
+        "isHovered": {
+          "type": "property",
+          "name": "isHovered",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is currently hovered with a mouse."
+        },
+        "isPending": {
+          "type": "property",
+          "name": "isPending",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is currently in a pending state."
+        },
+        "isPressed": {
+          "type": "property",
+          "name": "isPressed",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the button is currently in a pressed state."
+        }
+      },
+      "typeParameters": [],
+      "description": ""
+    },
+    "src/registry/ui/onboarding-tour/types.ts:OnboardingTourHandle": {
+      "type": "interface",
+      "id": "src/registry/ui/onboarding-tour/types.ts:OnboardingTourHandle",
+      "name": "OnboardingTourHandle",
+      "extends": [],
+      "properties": {
+        "isActive": {
+          "type": "method",
+          "name": "isActive",
+          "value": {
+            "type": "function",
+            "parameters": [],
+            "return": {
+              "type": "boolean"
+            },
+            "typeParameters": []
+          },
+          "optional": false,
+          "description": "Whether the tour is currently running."
+        },
+        "next": {
+          "type": "method",
+          "name": "next",
+          "value": {
+            "type": "function",
+            "parameters": [],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          },
+          "optional": false,
+          "description": "Move to the next step. No-op when the tour is not running."
+        },
+        "previous": {
+          "type": "method",
+          "name": "previous",
+          "value": {
+            "type": "function",
+            "parameters": [],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          },
+          "optional": false,
+          "description": "Move to the previous step. No-op when the tour is not running."
+        },
+        "start": {
+          "type": "method",
+          "name": "start",
+          "value": {
+            "type": "function",
+            "parameters": [],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          },
+          "optional": false,
+          "description": "Build the driver instance (if needed) and start the tour from the first step."
+        },
+        "stop": {
+          "type": "method",
+          "name": "stop",
+          "value": {
+            "type": "function",
+            "parameters": [],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          },
+          "optional": false,
+          "description": "Stop the tour and clear the highlight overlay."
+        }
+      },
+      "typeParameters": [],
+      "description": "Imperative handle returned by `useOnboardingTour`, used to drive the tour\nfrom your own controls."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -1865,6 +1865,10 @@ export const DemosIndex: Record<
 		files: ["ui/number-field/demos/with-input-group.tsx"],
 		component: React.lazy(() => import("@/registry/ui/number-field/demos/with-input-group")),
 	},
+	"onboarding-tour/demos/default": {
+		files: ["ui/onboarding-tour/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/onboarding-tour/demos/default")),
+	},
 	"otp-field/demos/alphanumeric": {
 		files: ["ui/otp-field/demos/alphanumeric.tsx"],
 		component: React.lazy(() => import("@/registry/ui/otp-field/demos/alphanumeric")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -52,6 +52,7 @@ import UiMention from "@/registry/ui/mention/meta";
 import UiMenu from "@/registry/ui/menu/meta";
 import UiModal from "@/registry/ui/modal/meta";
 import UiNumberField from "@/registry/ui/number-field/meta";
+import UiOnboardingTour from "@/registry/ui/onboarding-tour/meta";
 import UiOtpField from "@/registry/ui/otp-field/meta";
 import UiPagination from "@/registry/ui/pagination/meta";
 import UiPopover from "@/registry/ui/popover/meta";
@@ -126,6 +127,7 @@ export const registryUi: RegistryItem[] = [
 	UiMenu,
 	UiModal,
 	UiNumberField,
+	UiOnboardingTour,
 	UiOtpField,
 	UiPagination,
 	UiPopover,

--- a/www/src/registry/ui/onboarding-tour/base.tsx
+++ b/www/src/registry/ui/onboarding-tour/base.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import 'driver.js/dist/driver.css'
+
+import * as React from 'react'
+import { driver } from 'driver.js'
+import type { Config, Driver, DriveStep } from 'driver.js'
+
+import { Button } from '@/registry/ui/button'
+
+import { useStyles } from './styles'
+
+// MARK: useOnboardingTour
+
+type OnboardingTourOptions = Omit<Config, 'steps'>
+
+interface OnboardingTourHandle {
+  /** Build the driver instance (if needed) and start the tour from the first step. */
+  start: () => void
+  /** Move to the next step. No-op when the tour is not running. */
+  next: () => void
+  /** Move to the previous step. No-op when the tour is not running. */
+  previous: () => void
+  /** Stop the tour and clear the highlight overlay. */
+  stop: () => void
+  /** Whether the tour is currently running. */
+  isActive: () => boolean
+}
+
+function useOnboardingTour(
+  steps: DriveStep[],
+  options?: OnboardingTourOptions,
+): OnboardingTourHandle {
+  const { popover } = useStyles()()
+  const driverRef = React.useRef<Driver | null>(null)
+
+  // Keep the latest steps/options without rebuilding the driver on every render.
+  const stepsRef = React.useRef(steps)
+  stepsRef.current = steps
+  const optionsRef = React.useRef(options)
+  optionsRef.current = options
+
+  const popoverClass = popover()
+
+  const getDriver = React.useCallback(() => {
+    if (!driverRef.current) {
+      driverRef.current = driver({
+        showProgress: true,
+        popoverClass,
+        ...optionsRef.current,
+        steps: stepsRef.current,
+      })
+    }
+    return driverRef.current
+  }, [popoverClass])
+
+  // Tear down the overlay if the component unmounts mid-tour.
+  React.useEffect(() => {
+    return () => {
+      driverRef.current?.destroy()
+      driverRef.current = null
+    }
+  }, [])
+
+  return React.useMemo<OnboardingTourHandle>(
+    () => ({
+      start: () => {
+        getDriver().drive()
+      },
+      next: () => {
+        driverRef.current?.moveNext()
+      },
+      previous: () => {
+        driverRef.current?.movePrevious()
+      },
+      stop: () => {
+        driverRef.current?.destroy()
+      },
+      isActive: () => driverRef.current?.isActive() ?? false,
+    }),
+    [getDriver],
+  )
+}
+
+// MARK: OnboardingTour
+
+interface OnboardingTourProps extends Omit<
+  React.ComponentProps<typeof Button>,
+  'onPress' | 'children'
+> {
+  /** The ordered steps that make up the tour. */
+  steps: DriveStep[]
+  /** Driver.js configuration, minus `steps`. */
+  options?: OnboardingTourOptions
+  /**
+   * Trigger content. A function receives the tour handle so you can render a
+   * custom control; a node renders inside the default `Button` trigger.
+   */
+  children?: React.ReactNode | ((tour: OnboardingTourHandle) => React.ReactNode)
+}
+
+function OnboardingTour({
+  steps,
+  options,
+  children = 'Start tour',
+  ...props
+}: OnboardingTourProps) {
+  const tour = useOnboardingTour(steps, options)
+
+  if (typeof children === 'function') {
+    return <>{children(tour)}</>
+  }
+
+  return (
+    <Button data-onboarding-tour="" onPress={() => tour.start()} {...props}>
+      {children}
+    </Button>
+  )
+}
+
+// MARK: Separator
+
+export type { OnboardingTourHandle, OnboardingTourOptions, OnboardingTourProps }
+export { OnboardingTour, useOnboardingTour }

--- a/www/src/registry/ui/onboarding-tour/demos/default.tsx
+++ b/www/src/registry/ui/onboarding-tour/demos/default.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import type { DriveStep } from 'driver.js'
+import { BellIcon, SearchIcon, SettingsIcon } from 'lucide-react'
+
+import { OnboardingTour } from '@/registry/ui/onboarding-tour'
+
+const steps: DriveStep[] = [
+  {
+    element: '#tour-search',
+    popover: {
+      title: 'Search',
+      description: 'Jump to anything from here. Try typing a project name.',
+    },
+  },
+  {
+    element: '#tour-notifications',
+    popover: {
+      title: 'Notifications',
+      description: 'New activity and mentions show up here.',
+    },
+  },
+  {
+    element: '#tour-settings',
+    popover: {
+      title: 'Settings',
+      description: 'Manage your workspace and preferences.',
+    },
+  },
+]
+
+export default function Demo() {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-4">
+      <div className="flex items-center justify-between rounded-lg border bg-card p-2">
+        <div className="flex items-center gap-1">
+          <div
+            id="tour-search"
+            className="flex size-9 items-center justify-center rounded-md text-fg-muted hover:bg-muted"
+          >
+            <SearchIcon className="size-4" />
+          </div>
+          <div
+            id="tour-notifications"
+            className="flex size-9 items-center justify-center rounded-md text-fg-muted hover:bg-muted"
+          >
+            <BellIcon className="size-4" />
+          </div>
+          <div
+            id="tour-settings"
+            className="flex size-9 items-center justify-center rounded-md text-fg-muted hover:bg-muted"
+          >
+            <SettingsIcon className="size-4" />
+          </div>
+        </div>
+        <OnboardingTour steps={steps} variant="primary" size="sm">
+          Start tour
+        </OnboardingTour>
+      </div>
+      <p className="text-sm text-fg-muted">
+        Click <span className="font-medium text-fg">Start tour</span> to walk
+        through the toolbar above.
+      </p>
+    </div>
+  )
+}

--- a/www/src/registry/ui/onboarding-tour/examples.tsx
+++ b/www/src/registry/ui/onboarding-tour/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function OnboardingTourExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/onboarding-tour/index.tsx
+++ b/www/src/registry/ui/onboarding-tour/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/onboarding-tour/meta.ts
+++ b/www/src/registry/ui/onboarding-tour/meta.ts
@@ -1,0 +1,18 @@
+import type { RegistryItem } from '@/registry/types'
+
+const onboardingTourMeta = {
+  name: 'onboarding-tour',
+  type: 'registry:ui',
+  group: 'overlays',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/onboarding-tour/base.tsx',
+      target: 'ui/onboarding-tour.tsx',
+    },
+  ],
+  registryDependencies: ['button'],
+  dependencies: ['driver.js'],
+} satisfies RegistryItem
+
+export default onboardingTourMeta

--- a/www/src/registry/ui/onboarding-tour/styles.css
+++ b/www/src/registry/ui/onboarding-tour/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --onboarding-tour-radius: var(--radius-md);
+}

--- a/www/src/registry/ui/onboarding-tour/styles.ts
+++ b/www/src/registry/ui/onboarding-tour/styles.ts
@@ -1,0 +1,32 @@
+import { createStyles } from '@/lib/styles'
+
+import onboardingTourMeta from './meta'
+
+const { useStyles, styles } = createStyles(onboardingTourMeta, {
+  base: {
+    slots: {
+      // Applied to driver.js' `.driver-popover` via the `popoverClass` option so
+      // the coachmark bubble inherits the design system's surface, text and radius
+      // tokens. The selectors reach into driver.js' own popover DOM (title,
+      // description, footer, nav buttons) which it renders inside `.driver-popover`.
+      popover: [
+        'rounded-(--onboarding-tour-radius) border bg-popover text-fg shadow-lg',
+        '[&_.driver-popover-title]:font-medium [&_.driver-popover-title]:text-fg',
+        '[&_.driver-popover-description]:text-fg-muted',
+        '[&_.driver-popover-progress-text]:text-fg-muted',
+        '[&_.driver-popover-arrow]:hidden',
+        '[&_.driver-popover-close-btn]:text-fg-muted [&_.driver-popover-close-btn]:hover:text-fg',
+        '[&_.driver-popover-footer_button]:rounded-(--btn-radius) [&_.driver-popover-footer_button]:border [&_.driver-popover-footer_button]:bg-bg [&_.driver-popover-footer_button]:text-fg [&_.driver-popover-footer_button]:shadow-none [&_.driver-popover-footer_button]:hover:bg-muted',
+      ],
+    },
+  },
+  density: {
+    compact: {},
+    default: {},
+    comfortable: {},
+  },
+})
+
+export type OnboardingTourStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/onboarding-tour/types.ts
+++ b/www/src/registry/ui/onboarding-tour/types.ts
@@ -1,0 +1,59 @@
+import type { Config, DriveStep } from 'driver.js'
+
+import type { ButtonProps } from '@/registry/ui/button'
+
+/**
+ * Driver.js configuration shared by the hook and component, minus the `steps`
+ * array, which is passed separately.
+ *
+ * @see https://driverjs.com/docs/configuration
+ */
+export type OnboardingTourOptions = Omit<Config, 'steps'>
+
+/**
+ * Imperative handle returned by `useOnboardingTour`, used to drive the tour
+ * from your own controls.
+ */
+export interface OnboardingTourHandle {
+  /** Build the driver instance (if needed) and start the tour from the first step. */
+  start: () => void
+  /** Move to the next step. No-op when the tour is not running. */
+  next: () => void
+  /** Move to the previous step. No-op when the tour is not running. */
+  previous: () => void
+  /** Stop the tour and clear the highlight overlay. */
+  stop: () => void
+  /** Whether the tour is currently running. */
+  isActive: () => boolean
+}
+
+/**
+ * A guided product tour built on driver.js. Highlights a sequence of elements
+ * on the page, each with a coachmark popover, advancing on user interaction.
+ * Renders a `Button` trigger by default; pass a render function for a custom one.
+ */
+export interface OnboardingTourProps extends Omit<
+  ButtonProps,
+  'onPress' | 'children'
+> {
+  /**
+   * The ordered steps that make up the tour. Each step targets an element by
+   * CSS selector and shows a popover with a title and description.
+   */
+  steps: DriveStep[]
+
+  /**
+   * Driver.js configuration, minus `steps` (e.g. `showProgress`, `allowClose`,
+   * `overlayColor`).
+   */
+  options?: OnboardingTourOptions
+
+  /**
+   * Trigger content. A function receives the tour handle so you can render a
+   * custom control (calling `start`, `next`, etc.); a node renders inside the
+   * default `Button` trigger.
+   *
+   * @default "Start tour"
+   */
+  children?: React.ReactNode | ((tour: OnboardingTourHandle) => React.ReactNode)
+}


### PR DESCRIPTION
## Summary

Adds an **Onboarding Tour** / coachmarks component to the registry — spotlight + step popovers. Part of the real-world-component-blocks batch (Tier 2).

- Engine: **driver.js** (MIT, ~5KB), installed as a dependency — deliberately chosen over the AGPL Shepherd.js/intro.js (the licensing landmine flagged in the research doc).
- Exposes a `useOnboardingTour(steps, options)` hook + component; the coachmark popover is themed with dotUI tokens via driver's `popoverClass` (surface, text, radius, footer buttons).
- Themeable axis: `--onboarding-tour-radius`. Group `overlays`. `dependencies: ['driver.js']`.

## Notes

- Fixed a `useStyles()()` call + verified the `driver.js/dist/driver.css` side-effect import builds through the registry pipeline.
- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.