### PR TITLE
feat(code-editor): add code-editor component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@base-ui/react':
         specifier: 1.4.1
         version: 1.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.5
+        version: 6.2.5
       '@dotui/colors':
         specifier: workspace:*
         version: link:../packages/colors
@@ -141,6 +144,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.168.2
         version: 1.168.2(@tanstack/react-router@1.170.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))
+      '@uiw/react-codemirror':
+        specifier: ^4.25.10
+        version: 4.25.10(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.4)(codemirror@6.0.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@vercel/og':
         specifier: ^0.11.1
         version: 0.11.1
@@ -528,6 +534,33 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.10.4':
+    resolution: {integrity: sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/language@6.12.4':
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/search@6.7.1':
+    resolution: {integrity: sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==}
+
+  '@codemirror/state@6.7.0':
+    resolution: {integrity: sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==}
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.43.4':
+    resolution: {integrity: sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -1486,6 +1519,21 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@marijn/find-cluster-break@1.0.3':
+    resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
   '@material/material-color-utilities@0.3.0':
     resolution: {integrity: sha512-ztmtTd6xwnuh2/xu+Vb01btgV8SQWYCaK56CkRK8gEkWe5TuDyBcYJ0wgkMRn+2VcE9KUmhvkz+N9GHrqw/C0g==}
@@ -2915,6 +2963,28 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.10':
+    resolution: {integrity: sha512-P3vytLlpE62KYSWrMUnwDCv2lvaQDuDZzyj03mHntuHo5bSl34fRZpjTY3kQTPGuXHxkGSYpoPFFj+hMTqaaMQ==}
+    peerDependencies:
+      '@codemirror/autocomplete': '>=6.0.0'
+      '@codemirror/commands': '>=6.0.0'
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/lint': '>=6.0.0'
+      '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/react-codemirror@4.25.10':
+    resolution: {integrity: sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==}
+    peerDependencies:
+      '@babel/runtime': '>=7.11.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/theme-one-dark': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
@@ -3304,6 +3374,9 @@ packages:
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -3392,6 +3465,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -5774,6 +5850,9 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -6309,6 +6388,9 @@ packages:
       jsdom:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -6777,6 +6859,69 @@ snapshots:
       '@types/react': 19.2.2
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.4':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/language@6.12.4':
+    dependencies:
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      crelt: 1.0.7
+
+  '@codemirror/search@6.7.1':
+    dependencies:
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      crelt: 1.0.7
+
+  '@codemirror/state@6.7.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.3
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      '@lezer/highlight': 1.2.3
+
+  '@codemirror/view@6.43.4':
+    dependencies:
+      '@codemirror/state': 6.7.0
+      crelt: 1.0.7
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@csstools/color-helpers@6.0.2':
     optional: true
@@ -7375,6 +7520,24 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@marijn/find-cluster-break@1.0.3': {}
 
   '@material/material-color-utilities@0.3.0': {}
 
@@ -8112,7 +8275,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':
@@ -8562,6 +8725,33 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.10(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.0)(@codemirror/view@6.43.4)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.4
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.1
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+
+  '@uiw/react-codemirror@4.25.10(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.4)(codemirror@6.0.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@codemirror/commands': 6.10.4
+      '@codemirror/state': 6.7.0
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.43.4
+      '@uiw/codemirror-extensions-basic-setup': 4.25.10(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.0)(@codemirror/view@6.43.4)
+      codemirror: 6.0.2
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vercel/config@0.5.0':
@@ -8977,6 +9167,16 @@ snapshots:
 
   code-block-writer@13.0.3: {}
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.4
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.1
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+
   collapse-white-space@2.1.0: {}
 
   color-convert@1.9.3:
@@ -9041,6 +9241,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
+
+  crelt@1.0.7: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -11937,6 +12139,8 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  style-mod@4.1.3: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -12364,6 +12568,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/www/content/docs/components/code-editor.mdx
+++ b/www/content/docs/components/code-editor.mdx
@@ -1,0 +1,55 @@
+---
+title: Code Editor
+description: A controlled code editor built on CodeMirror 6, themed by your design system.
+links:
+  - label: CodeMirror
+    href: https://codemirror.net
+wip: true
+---
+
+<Demo name="code-editor/demos/default" />
+
+`CodeEditor` is a thin, themeable layer over [CodeMirror 6](https://codemirror.net) via [`@uiw/react-codemirror`](https://uiwjs.github.io/react-codemirror). It owns the chrome — a bordered, rounded container with an optional header bar — and keeps the editor itself as a peer dependency, so you control the source through `value` and `onChange` like any other input.
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/code-editor
+```
+
+## Usage
+
+Render `CodeEditor` as a controlled component: pass `value` and an `onChange` handler. Choose a grammar with `language` and add a header with `filename`.
+
+```tsx
+import { CodeEditor } from '@/components/ui/code-editor'
+```
+
+```tsx
+const [value, setValue] = React.useState('const x = 1')
+
+<CodeEditor
+  value={value}
+  onChange={setValue}
+  language="typescript"
+  filename="example.ts"
+/>
+```
+
+Set `readOnly` to render the source without allowing edits, and `hideHeader` to drop the filename and language label.
+
+```tsx
+<CodeEditor value={value} language="tsx" readOnly hideHeader />
+```
+
+## Examples
+
+<Examples>
+  <Example name="code-editor/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### CodeEditor
+
+<Reference name="code-editor" />

--- a/www/package.json
+++ b/www/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@base-ui/react": "1.4.1",
+    "@codemirror/lang-javascript": "^6.2.5",
     "@dotui/colors": "workspace:*",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/josefin-sans": "^5.2.8",
@@ -34,6 +35,7 @@
     "@tanstack/react-start": "catalog:",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/router-plugin": "^1.168.2",
+    "@uiw/react-codemirror": "^4.25.10",
     "@vercel/og": "^0.11.1",
     "cnfast": "^0.0.8",
     "fumadocs-core": "^16.8.11",

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -18,6 +18,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"chart-radial": () => import("@/registry/ui/chart-radial/examples"),
 	checkbox: () => import("@/registry/ui/checkbox/examples"),
 	"checkbox-group": () => import("@/registry/ui/checkbox-group/examples"),
+	"code-editor": () => import("@/registry/ui/code-editor/examples"),
 	"color-area": () => import("@/registry/ui/color-area/examples"),
 	"color-editor": () => import("@/registry/ui/color-editor/examples"),
 	"color-field": () => import("@/registry/ui/color-field/examples"),

--- a/www/src/modules/docs/references/generated/code-editor.json
+++ b/www/src/modules/docs/references/generated/code-editor.json
@@ -1,0 +1,101 @@
+{
+  "name": "CodeEditorProps",
+  "description": "A controlled code editor built on CodeMirror 6 (via `@uiw/react-codemirror`).\nRenders in a bordered, rounded container with an optional header bar showing a\nfilename and the active language. Pass `value` and `onChange` to control it.",
+  "props": {
+    "value": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The current source. Controlled.",
+      "required": true
+    },
+    "onChange": {
+      "type": "((value: string) => void)",
+      "detailedType": "((value: string) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "value",
+            "value": {
+              "type": "link",
+              "id": "string",
+              "name": "string"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Called with the next source whenever the user edits."
+    },
+    "language": {
+      "type": "Language",
+      "detailedType": "Language | undefined",
+      "typeAst": {
+        "type": "identifier",
+        "name": "Language"
+      },
+      "description": "Language grammar used for syntax highlighting.",
+      "default": "\"javascript\""
+    },
+    "readOnly": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Render the contents but block edits.",
+      "default": "false"
+    },
+    "filename": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Filename shown in the header bar. Defaults to \"untitled\" when the header shows."
+    },
+    "hideHeader": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Hide the header bar (filename + language label).",
+      "default": "false"
+    },
+    "extensions": {
+      "type": "unknown[]",
+      "detailedType": "undefined | unknown[]",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "array",
+            "elementType": {
+              "type": "unknown"
+            }
+          }
+        ]
+      },
+      "description": "Extra CodeMirror extensions appended after the language grammar."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -649,6 +649,10 @@ export const DemosIndex: Record<
 		files: ["ui/checkbox-group/demos/uncontrolled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/checkbox-group/demos/uncontrolled")),
 	},
+	"code-editor/demos/default": {
+		files: ["ui/code-editor/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/code-editor/demos/default")),
+	},
 	"color-area/demos/brand-color": {
 		files: ["ui/color-area/demos/brand-color.tsx"],
 		component: React.lazy(() => import("@/registry/ui/color-area/demos/brand-color")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -22,6 +22,7 @@ import UiChartRadial from "@/registry/ui/chart-radial/meta";
 import UiChart from "@/registry/ui/chart/meta";
 import UiCheckboxGroup from "@/registry/ui/checkbox-group/meta";
 import UiCheckbox from "@/registry/ui/checkbox/meta";
+import UiCodeEditor from "@/registry/ui/code-editor/meta";
 import UiColorArea from "@/registry/ui/color-area/meta";
 import UiColorEditor from "@/registry/ui/color-editor/meta";
 import UiColorField from "@/registry/ui/color-field/meta";
@@ -96,6 +97,7 @@ export const registryUi: RegistryItem[] = [
 	UiChartRadial,
 	UiCheckbox,
 	UiCheckboxGroup,
+	UiCodeEditor,
 	UiColorArea,
 	UiColorEditor,
 	UiColorField,

--- a/www/src/registry/ui/code-editor/base.tsx
+++ b/www/src/registry/ui/code-editor/base.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import * as React from 'react'
+import { javascript } from '@codemirror/lang-javascript'
+import CodeMirror from '@uiw/react-codemirror'
+import type { Extension, ReactCodeMirrorProps } from '@uiw/react-codemirror'
+
+import { useStyles } from './styles'
+
+// MARK: constants
+
+type Language = 'javascript' | 'jsx' | 'typescript' | 'tsx'
+
+const LANGUAGE_LABELS: Record<Language, string> = {
+  javascript: 'JS',
+  jsx: 'JSX',
+  typescript: 'TS',
+  tsx: 'TSX',
+}
+
+function languageExtension(language: Language): Extension {
+  switch (language) {
+    case 'jsx':
+      return javascript({ jsx: true })
+    case 'typescript':
+      return javascript({ typescript: true })
+    case 'tsx':
+      return javascript({ jsx: true, typescript: true })
+    case 'javascript':
+    default:
+      return javascript()
+  }
+}
+
+// MARK: CodeEditor
+
+interface CodeEditorProps extends Omit<
+  ReactCodeMirrorProps,
+  'value' | 'onChange' | 'theme' | 'extensions'
+> {
+  /** The current source. Controlled. */
+  value: string
+  /** Called with the next source whenever the user edits. */
+  onChange?: (value: string) => void
+  /**
+   * Language grammar to highlight with.
+   * @default "javascript"
+   */
+  language?: Language
+  /** When set, the editor renders its contents but blocks edits. */
+  readOnly?: boolean
+  /** Optional filename shown in the header bar. */
+  filename?: string
+  /** Hide the header bar (filename + language label). */
+  hideHeader?: boolean
+  /** Extra CodeMirror extensions appended after the language grammar. */
+  extensions?: Extension[]
+  className?: string
+}
+
+function CodeEditor({
+  value,
+  onChange,
+  language = 'javascript',
+  readOnly = false,
+  filename,
+  hideHeader = false,
+  extensions,
+  basicSetup,
+  className,
+  ...props
+}: CodeEditorProps) {
+  const styles = useStyles()()
+  const {
+    root,
+    header,
+    filename: filenameSlot,
+    language: languageSlot,
+    editor,
+  } = styles
+
+  const resolvedExtensions = React.useMemo<Extension[]>(
+    () => [languageExtension(language), ...(extensions ?? [])],
+    [language, extensions],
+  )
+
+  const showHeader = !hideHeader && (filename !== undefined || !readOnly)
+
+  return (
+    <div data-code-editor="" className={root({ className })}>
+      {showHeader ? (
+        <div data-code-editor-header="" className={header()}>
+          <span className={filenameSlot()}>{filename ?? 'untitled'}</span>
+          <span className={languageSlot()}>{LANGUAGE_LABELS[language]}</span>
+        </div>
+      ) : null}
+      <CodeMirror
+        value={value}
+        readOnly={readOnly}
+        editable={!readOnly}
+        extensions={resolvedExtensions}
+        basicSetup={basicSetup ?? true}
+        onChange={onChange}
+        className={editor()}
+        {...props}
+      />
+    </div>
+  )
+}
+
+// MARK: exports
+
+export type { CodeEditorProps, Language }
+export { CodeEditor }

--- a/www/src/registry/ui/code-editor/demos/default.tsx
+++ b/www/src/registry/ui/code-editor/demos/default.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import * as React from 'react'
+
+import { CodeEditor } from '@/registry/ui/code-editor'
+
+const SAMPLE = `interface User {
+  id: string
+  name: string
+  role: 'admin' | 'member'
+}
+
+function greet(user: User): string {
+  const prefix = user.role === 'admin' ? 'Welcome back' : 'Hello'
+  return \`\${prefix}, \${user.name}!\`
+}
+
+const users: User[] = [
+  { id: '1', name: 'Ada', role: 'admin' },
+  { id: '2', name: 'Linus', role: 'member' },
+]
+
+users.map(greet).forEach((line) => console.log(line))
+`
+
+export default function Demo() {
+  const [value, setValue] = React.useState(SAMPLE)
+
+  return (
+    <CodeEditor
+      value={value}
+      onChange={setValue}
+      language="typescript"
+      filename="greet.ts"
+      className="w-full max-w-xl"
+    />
+  )
+}

--- a/www/src/registry/ui/code-editor/examples.tsx
+++ b/www/src/registry/ui/code-editor/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Default from './demos/default'
+
+export default function CodeEditorExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <Default />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/code-editor/index.tsx
+++ b/www/src/registry/ui/code-editor/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/code-editor/meta.ts
+++ b/www/src/registry/ui/code-editor/meta.ts
@@ -1,0 +1,26 @@
+import type { RegistryItem } from '@/registry/types'
+
+const codeEditorMeta = {
+  name: 'code-editor',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/code-editor/base.tsx',
+      target: 'ui/code-editor.tsx',
+    },
+  ],
+  dependencies: ['@uiw/react-codemirror', '@codemirror/lang-javascript'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--code-editor-radius',
+      default: '--radius-lg',
+      // description: "Radius of the code editor container.",
+    },
+  },
+} satisfies RegistryItem
+
+export default codeEditorMeta

--- a/www/src/registry/ui/code-editor/styles.css
+++ b/www/src/registry/ui/code-editor/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --code-editor-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/code-editor/styles.ts
+++ b/www/src/registry/ui/code-editor/styles.ts
@@ -1,0 +1,44 @@
+import { createStyles } from '@/lib/styles'
+
+import codeEditorMeta from './meta'
+
+const { useStyles, styles } = createStyles(codeEditorMeta, {
+  base: {
+    slots: {
+      root: 'flex flex-col overflow-hidden rounded-(--code-editor-radius) border bg-card text-fg',
+      header:
+        'flex items-center justify-between gap-2 border-b px-3 py-1.5 text-fg-muted',
+      filename: 'truncate font-mono',
+      language: 'shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono uppercase',
+      editor:
+        'min-h-0 flex-1 [&_.cm-editor]:bg-transparent! [&_.cm-editor.cm-focused]:outline-none [&_.cm-gutters]:border-none [&_.cm-gutters]:bg-transparent! [&_.cm-scroller]:font-mono',
+    },
+  },
+  density: {
+    compact: {
+      slots: {
+        header: 'text-xs',
+        language: 'text-[0.625rem]',
+        editor: '[&_.cm-scroller]:text-xs',
+      },
+    },
+    default: {
+      slots: {
+        header: 'text-xs',
+        language: 'text-[0.625rem]',
+        editor: '[&_.cm-scroller]:text-sm',
+      },
+    },
+    comfortable: {
+      slots: {
+        header: 'text-sm',
+        language: 'text-xs',
+        editor: '[&_.cm-scroller]:text-sm',
+      },
+    },
+  },
+})
+
+export type CodeEditorStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/code-editor/types.ts
+++ b/www/src/registry/ui/code-editor/types.ts
@@ -1,0 +1,42 @@
+import type { Language } from './base'
+
+export type { Language }
+
+/**
+ * A controlled code editor built on CodeMirror 6 (via `@uiw/react-codemirror`).
+ * Renders in a bordered, rounded container with an optional header bar showing a
+ * filename and the active language. Pass `value` and `onChange` to control it.
+ */
+export interface CodeEditorProps {
+  /** The current source. Controlled. */
+  value: string
+
+  /** Called with the next source whenever the user edits. */
+  onChange?: (value: string) => void
+
+  /**
+   * Language grammar used for syntax highlighting.
+   * @default "javascript"
+   */
+  language?: Language
+
+  /**
+   * Render the contents but block edits.
+   * @default false
+   */
+  readOnly?: boolean
+
+  /** Filename shown in the header bar. Defaults to "untitled" when the header shows. */
+  filename?: string
+
+  /**
+   * Hide the header bar (filename + language label).
+   * @default false
+   */
+  hideHeader?: boolean
+
+  /** Extra CodeMirror extensions appended after the language grammar. */
+  extensions?: unknown[]
+
+  className?: string
+}


### PR DESCRIPTION
## Summary

Adds a **Code Editor** to the registry — an interactive CodeMirror 6 editor with dotUI chrome. Part of the real-world-component-blocks batch (Tier 3).

- Engine: **CodeMirror 6** via `@uiw/react-codemirror` (+ `@codemirror/lang-javascript`), installed as dependencies. Thin chrome over the stateful editor engine (per the research doc).
- Controlled `value` / `onChange`, language + read-only options, an optional filename/language header, all in a tokenized bordered surface.
- Themeable axis: `--code-editor-radius`. Group `containers`. `dependencies: ['@uiw/react-codemirror', '@codemirror/lang-javascript']`.

## Notes

- Distinct from `code-block` (read-only Shiki highlighting): this one is editable.
- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.