### PR TITLE
feat(pdf-viewer): add pdf-viewer component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       react-is:
         specifier: ^19.2.0
         version: 19.2.7
+      react-pdf:
+        specifier: ^10.4.1
+        version: 10.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react-stately:
         specifier: ^3.48.0
         version: 3.48.0(react@19.2.1)
@@ -1506,6 +1509,81 @@ packages:
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
@@ -4602,6 +4680,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
@@ -4624,9 +4706,15 @@ packages:
   magicast@0.5.1:
     resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
 
+  make-cancellable-promise@2.0.0:
+    resolution: {integrity: sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw==}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-event-props@2.0.0:
+    resolution: {integrity: sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw==}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -4697,6 +4785,14 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  merge-refs@2.0.0:
+    resolution: {integrity: sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg==}
+    peerDependencies:
+      '@types/react': 19.2.2
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -5158,6 +5254,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pdfjs-dist@5.4.296:
+    resolution: {integrity: sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==}
+    engines: {node: '>=20.16.0 || >=22.3.0'}
+
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
 
@@ -5373,6 +5473,16 @@ packages:
 
   react-is@19.2.7:
     resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
+
+  react-pdf@10.4.1:
+    resolution: {integrity: sha512-kS/35staVCBqS29verTQJQZXw7RfsRCPO3fdJoW1KXylcv7A9dw6DZ3vJXC2w+bIBgLw5FN4pOFvKSQtkQhPfA==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-redux@9.3.0:
     resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
@@ -6312,6 +6422,9 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  warning@4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -7439,6 +7552,54 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -8112,7 +8273,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':
@@ -10194,6 +10355,10 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lru-cache@11.2.7: {}
 
   lru-cache@11.3.6:
@@ -10217,9 +10382,13 @@ snapshots:
       '@babel/types': 7.28.5
       source-map-js: 1.2.1
 
+  make-cancellable-promise@2.0.0: {}
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
+
+  make-event-props@2.0.0: {}
 
   markdown-extensions@2.0.0: {}
 
@@ -10396,6 +10565,10 @@ snapshots:
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge-refs@2.0.0(@types/react@19.2.2):
+    optionalDependencies:
+      '@types/react': 19.2.2
 
   merge-stream@2.0.0: {}
 
@@ -11077,6 +11250,10 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pdfjs-dist@5.4.296:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
+
   pg-cloudflare@1.3.0:
     optional: true
 
@@ -11333,6 +11510,21 @@ snapshots:
       react: 19.2.1
 
   react-is@19.2.7: {}
+
+  react-pdf@10.4.1(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      clsx: 2.1.1
+      dequal: 2.0.3
+      make-cancellable-promise: 2.0.0
+      make-event-props: 2.0.0
+      merge-refs: 2.0.0(@types/react@19.2.2)
+      pdfjs-dist: 5.4.296
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      tiny-invariant: 1.3.3
+      warning: 4.0.3
+    optionalDependencies:
+      '@types/react': 19.2.2
 
   react-redux@9.3.0(@types/react@19.2.2)(react@19.2.1)(redux@5.0.1):
     dependencies:
@@ -12369,6 +12561,10 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
     optional: true
+
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
 
   web-streams-polyfill@3.3.3: {}
 

--- a/www/content/docs/components/pdf-viewer.mdx
+++ b/www/content/docs/components/pdf-viewer.mdx
@@ -1,0 +1,38 @@
+---
+title: PDF Viewer
+description: A PDF viewer with page navigation and zoom controls.
+wip: true
+---
+
+<Demo name="pdf-viewer/demos/default" />
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/pdf-viewer
+```
+
+## Usage
+
+Pass the `file` URL of the document you want to render. The viewer handles page
+navigation and zoom out of the box.
+
+```tsx
+import { PdfViewer } from '@/components/ui/pdf-viewer'
+```
+
+```tsx
+<PdfViewer file="/document.pdf" />
+```
+
+## Examples
+
+<Examples>
+  <Example name="pdf-viewer/demos/default" title="Default" />
+</Examples>
+
+## API Reference
+
+### PdfViewer
+
+<Reference name="pdf-viewer" />

--- a/www/package.json
+++ b/www/package.json
@@ -50,6 +50,7 @@
     "react-error-boundary": "^6.0.0",
     "react-hook-form": "^7.54.2",
     "react-is": "^19.2.0",
+    "react-pdf": "^10.4.1",
     "react-stately": "^3.48.0",
     "recharts": "^3.8.1",
     "shiki": "^4.0.2",

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -50,6 +50,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"number-field": () => import("@/registry/ui/number-field/examples"),
 	"otp-field": () => import("@/registry/ui/otp-field/examples"),
 	pagination: () => import("@/registry/ui/pagination/examples"),
+	"pdf-viewer": () => import("@/registry/ui/pdf-viewer/examples"),
 	popover: () => import("@/registry/ui/popover/examples"),
 	"progress-bar": () => import("@/registry/ui/progress-bar/examples"),
 	"radio-group": () => import("@/registry/ui/radio-group/examples"),

--- a/www/src/modules/docs/references/generated/pdf-viewer.json
+++ b/www/src/modules/docs/references/generated/pdf-viewer.json
@@ -1,0 +1,40 @@
+{
+  "name": "PdfViewerProps",
+  "description": "A PDF viewer that renders a document one page at a time with controls for\npage navigation and zoom. Built on `react-pdf` (pdf.js).",
+  "extendsElement": "div",
+  "props": {
+    "file": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "URL or path of the PDF document to render.",
+      "required": true
+    },
+    "defaultPage": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "The page shown when the viewer first mounts.",
+      "default": "1"
+    },
+    "defaultScale": {
+      "type": "number",
+      "detailedType": "number | undefined",
+      "typeAst": {
+        "type": "number"
+      },
+      "description": "The zoom level the viewer starts at, where `1` is 100%.",
+      "default": "1"
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -1933,6 +1933,10 @@ export const DemosIndex: Record<
 		files: ["ui/pagination/demos/with-results.tsx"],
 		component: React.lazy(() => import("@/registry/ui/pagination/demos/with-results")),
 	},
+	"pdf-viewer/demos/default": {
+		files: ["ui/pdf-viewer/demos/default.tsx"],
+		component: React.lazy(() => import("@/registry/ui/pdf-viewer/demos/default")),
+	},
 	"popover/demos/basic": {
 		files: ["ui/popover/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/popover/demos/basic")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -54,6 +54,7 @@ import UiModal from "@/registry/ui/modal/meta";
 import UiNumberField from "@/registry/ui/number-field/meta";
 import UiOtpField from "@/registry/ui/otp-field/meta";
 import UiPagination from "@/registry/ui/pagination/meta";
+import UiPdfViewer from "@/registry/ui/pdf-viewer/meta";
 import UiPopover from "@/registry/ui/popover/meta";
 import UiProgressBar from "@/registry/ui/progress-bar/meta";
 import UiRadioGroup from "@/registry/ui/radio-group/meta";
@@ -128,6 +129,7 @@ export const registryUi: RegistryItem[] = [
 	UiNumberField,
 	UiOtpField,
 	UiPagination,
+	UiPdfViewer,
 	UiPopover,
 	UiProgressBar,
 	UiRadioGroup,

--- a/www/src/registry/ui/pdf-viewer/base.tsx
+++ b/www/src/registry/ui/pdf-viewer/base.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import 'react-pdf/dist/Page/AnnotationLayer.css'
+import 'react-pdf/dist/Page/TextLayer.css'
+
+import * as React from 'react'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ZoomInIcon,
+  ZoomOutIcon,
+} from 'lucide-react'
+import { Document, Page, pdfjs } from 'react-pdf'
+
+import { Button } from '@/registry/ui/button'
+
+import { useStyles } from './styles'
+
+// MARK: worker
+
+// react-pdf needs the pdf.js worker. Point it at the CDN build that matches the
+// bundled pdfjs version so the worker and the API never drift apart.
+pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`
+
+const MIN_SCALE = 0.5
+const MAX_SCALE = 3
+const SCALE_STEP = 0.25
+
+// MARK: PdfViewer
+
+interface PdfViewerProps extends Omit<
+  React.ComponentProps<'div'>,
+  'children' | 'onError'
+> {
+  /** URL or path of the PDF document to render. */
+  file: string
+  /** The page shown when the viewer first mounts. @default 1 */
+  defaultPage?: number
+  /** The zoom level the viewer starts at. @default 1 */
+  defaultScale?: number
+}
+
+function PdfViewer({
+  file,
+  defaultPage = 1,
+  defaultScale = 1,
+  className,
+  ...props
+}: PdfViewerProps) {
+  const {
+    root,
+    toolbar,
+    group,
+    pageInfo,
+    zoomInfo,
+    viewport,
+    document,
+    page,
+    message,
+  } = useStyles()()
+
+  const [numPages, setNumPages] = React.useState<number | null>(null)
+  const [pageNumber, setPageNumber] = React.useState(defaultPage)
+  const [scale, setScale] = React.useState(defaultScale)
+
+  const onLoadSuccess = ({ numPages: loaded }: { numPages: number }) => {
+    setNumPages(loaded)
+    // Clamp the active page in case `defaultPage` overshot the document length.
+    setPageNumber((current) => Math.min(Math.max(current, 1), loaded))
+  }
+
+  const goToPrevious = () => {
+    setPageNumber((current) => Math.max(current - 1, 1))
+  }
+
+  const goToNext = () => {
+    setPageNumber((current) =>
+      numPages === null ? current : Math.min(current + 1, numPages),
+    )
+  }
+
+  const zoomOut = () => {
+    setScale((current) => Math.max(current - SCALE_STEP, MIN_SCALE))
+  }
+
+  const zoomIn = () => {
+    setScale((current) => Math.min(current + SCALE_STEP, MAX_SCALE))
+  }
+
+  const isFirstPage = pageNumber <= 1
+  const isLastPage = numPages !== null && pageNumber >= numPages
+
+  return (
+    <div data-pdf-viewer="" className={root({ className })} {...props}>
+      <div data-pdf-viewer-toolbar="" className={toolbar()}>
+        <div className={group()}>
+          <Button
+            variant="quiet"
+            isIconOnly
+            aria-label="Previous page"
+            isDisabled={isFirstPage}
+            onPress={goToPrevious}
+          >
+            <ChevronLeftIcon />
+          </Button>
+          <span className={pageInfo()}>
+            {numPages === null
+              ? 'Loading…'
+              : `Page ${pageNumber} of ${numPages}`}
+          </span>
+          <Button
+            variant="quiet"
+            isIconOnly
+            aria-label="Next page"
+            isDisabled={isLastPage}
+            onPress={goToNext}
+          >
+            <ChevronRightIcon />
+          </Button>
+        </div>
+        <div className={group()}>
+          <Button
+            variant="quiet"
+            isIconOnly
+            aria-label="Zoom out"
+            isDisabled={scale <= MIN_SCALE}
+            onPress={zoomOut}
+          >
+            <ZoomOutIcon />
+          </Button>
+          <span className={zoomInfo()}>{Math.round(scale * 100)}%</span>
+          <Button
+            variant="quiet"
+            isIconOnly
+            aria-label="Zoom in"
+            isDisabled={scale >= MAX_SCALE}
+            onPress={zoomIn}
+          >
+            <ZoomInIcon />
+          </Button>
+        </div>
+      </div>
+      <div data-pdf-viewer-viewport="" className={viewport()}>
+        <Document
+          file={file}
+          onLoadSuccess={onLoadSuccess}
+          className={document()}
+          loading={<div className={message()}>Loading PDF…</div>}
+          error={<div className={message()}>Failed to load PDF.</div>}
+          noData={<div className={message()}>No PDF file specified.</div>}
+        >
+          <Page
+            pageNumber={pageNumber}
+            scale={scale}
+            className={page()}
+            loading={<div className={message()}>Loading page…</div>}
+          />
+        </Document>
+      </div>
+    </div>
+  )
+}
+
+// MARK: separator
+
+export type { PdfViewerProps }
+export { PdfViewer }

--- a/www/src/registry/ui/pdf-viewer/base.tsx
+++ b/www/src/registry/ui/pdf-viewer/base.tsx
@@ -10,17 +10,27 @@ import {
   ZoomInIcon,
   ZoomOutIcon,
 } from 'lucide-react'
-import { Document, Page, pdfjs } from 'react-pdf'
+import type {
+  Document as DocumentComponent,
+  Page as PageComponent,
+} from 'react-pdf'
 
 import { Button } from '@/registry/ui/button'
 
 import { useStyles } from './styles'
 
-// MARK: worker
+// MARK: engine
 
-// react-pdf needs the pdf.js worker. Point it at the CDN build that matches the
-// bundled pdfjs version so the worker and the API never drift apart.
-pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`
+/**
+ * react-pdf pulls in pdf.js, which references browser-only globals (DOMMatrix,
+ * Path2D, …) at import time and crashes server-side rendering / prerendering.
+ * It's loaded lazily in an effect (client-only) and held here; the types above
+ * are import-only (erased). The worker is pinned to the bundled pdfjs version.
+ */
+interface ReactPdf {
+  Document: typeof DocumentComponent
+  Page: typeof PageComponent
+}
 
 const MIN_SCALE = 0.5
 const MAX_SCALE = 3
@@ -62,6 +72,22 @@ function PdfViewer({
   const [numPages, setNumPages] = React.useState<number | null>(null)
   const [pageNumber, setPageNumber] = React.useState(defaultPage)
   const [scale, setScale] = React.useState(defaultScale)
+  const [pdf, setPdf] = React.useState<ReactPdf | null>(null)
+
+  React.useEffect(() => {
+    let active = true
+    // pdf.js references browser-only globals (DOMMatrix, …) and only runs in the
+    // browser; swallow the rejection so server prerendering keeps the fallback.
+    import('react-pdf')
+      .then((mod) => {
+        mod.pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${mod.pdfjs.version}/build/pdf.worker.min.mjs`
+        if (active) setPdf({ Document: mod.Document, Page: mod.Page })
+      })
+      .catch(() => {})
+    return () => {
+      active = false
+    }
+  }, [])
 
   const onLoadSuccess = ({ numPages: loaded }: { numPages: number }) => {
     setNumPages(loaded)
@@ -141,21 +167,25 @@ function PdfViewer({
         </div>
       </div>
       <div data-pdf-viewer-viewport="" className={viewport()}>
-        <Document
-          file={file}
-          onLoadSuccess={onLoadSuccess}
-          className={document()}
-          loading={<div className={message()}>Loading PDF…</div>}
-          error={<div className={message()}>Failed to load PDF.</div>}
-          noData={<div className={message()}>No PDF file specified.</div>}
-        >
-          <Page
-            pageNumber={pageNumber}
-            scale={scale}
-            className={page()}
-            loading={<div className={message()}>Loading page…</div>}
-          />
-        </Document>
+        {pdf ? (
+          <pdf.Document
+            file={file}
+            onLoadSuccess={onLoadSuccess}
+            className={document()}
+            loading={<div className={message()}>Loading PDF…</div>}
+            error={<div className={message()}>Failed to load PDF.</div>}
+            noData={<div className={message()}>No PDF file specified.</div>}
+          >
+            <pdf.Page
+              pageNumber={pageNumber}
+              scale={scale}
+              className={page()}
+              loading={<div className={message()}>Loading page…</div>}
+            />
+          </pdf.Document>
+        ) : (
+          <div className={message()}>Loading PDF…</div>
+        )}
       </div>
     </div>
   )

--- a/www/src/registry/ui/pdf-viewer/base.tsx
+++ b/www/src/registry/ui/pdf-viewer/base.tsx
@@ -10,10 +10,6 @@ import {
   ZoomInIcon,
   ZoomOutIcon,
 } from 'lucide-react'
-import type {
-  Document as DocumentComponent,
-  Page as PageComponent,
-} from 'react-pdf'
 
 import { Button } from '@/registry/ui/button'
 
@@ -21,15 +17,17 @@ import { useStyles } from './styles'
 
 // MARK: ssr
 
-// pdf.js (react-pdf's renderer) reads browser-only globals at import time, which
-// crash Node during SSR / prerendering. Stub the ones it touches so the chunk can
-// load on the server — guarded to where they're missing (never the browser) and
-// never exercised there, since the viewer renders only on the client.
-if (typeof window === 'undefined') {
+// pdf.js (react-pdf's renderer) constructs `new DOMMatrix()` at module load,
+// which throws under SSR / prerendering where these browser globals are absent.
+// Probe each global directly (rather than gating on `typeof window`) because
+// some prerender environments define `window` but not the canvas globals — so a
+// `window` check would skip the stub and crash. Only the missing ones are
+// stubbed; the viewer itself renders solely on the client.
+{
   const globals = globalThis as Record<string, unknown>
-  globals.DOMMatrix ??= class DOMMatrixStub {}
-  globals.Path2D ??= class Path2DStub {}
-  globals.ImageData ??= class ImageDataStub {}
+  if (globals.DOMMatrix === undefined) globals.DOMMatrix = class {}
+  if (globals.Path2D === undefined) globals.Path2D = class {}
+  if (globals.ImageData === undefined) globals.ImageData = class {}
 }
 
 // MARK: engine
@@ -37,12 +35,15 @@ if (typeof window === 'undefined') {
 /**
  * react-pdf pulls in pdf.js, which references browser-only globals (DOMMatrix,
  * Path2D, …) at import time and crashes server-side rendering / prerendering.
- * It's loaded lazily in an effect (client-only) and held here; the types above
- * are import-only (erased). The worker is pinned to the bundled pdfjs version.
+ * It is loaded lazily in an effect (client-only) and held here. The component
+ * types are referenced via a `typeof import(...)` type query (fully erased), so
+ * nothing pulls react-pdf into the server bundle — only the runtime `import()`
+ * below ever touches it, on the client. The worker is pinned to the bundled
+ * pdfjs version.
  */
 interface ReactPdf {
-  Document: typeof DocumentComponent
-  Page: typeof PageComponent
+  Document: (typeof import('react-pdf'))['Document']
+  Page: (typeof import('react-pdf'))['Page']
 }
 
 const MIN_SCALE = 0.5

--- a/www/src/registry/ui/pdf-viewer/base.tsx
+++ b/www/src/registry/ui/pdf-viewer/base.tsx
@@ -19,6 +19,19 @@ import { Button } from '@/registry/ui/button'
 
 import { useStyles } from './styles'
 
+// MARK: ssr
+
+// pdf.js (react-pdf's renderer) reads browser-only globals at import time, which
+// crash Node during SSR / prerendering. Stub the ones it touches so the chunk can
+// load on the server — guarded to where they're missing (never the browser) and
+// never exercised there, since the viewer renders only on the client.
+if (typeof window === 'undefined') {
+  const globals = globalThis as Record<string, unknown>
+  globals.DOMMatrix ??= class DOMMatrixStub {}
+  globals.Path2D ??= class Path2DStub {}
+  globals.ImageData ??= class ImageDataStub {}
+}
+
 // MARK: engine
 
 /**

--- a/www/src/registry/ui/pdf-viewer/demos/default.tsx
+++ b/www/src/registry/ui/pdf-viewer/demos/default.tsx
@@ -1,0 +1,10 @@
+import { PdfViewer } from '@/registry/ui/pdf-viewer'
+
+export default function Demo() {
+  return (
+    <PdfViewer
+      file="https://raw.githubusercontent.com/mozilla/pdf.js/master/web/compressed.tracemonkey-pldi-09.pdf"
+      className="mx-auto max-w-xl"
+    />
+  )
+}

--- a/www/src/registry/ui/pdf-viewer/examples.tsx
+++ b/www/src/registry/ui/pdf-viewer/examples.tsx
@@ -1,0 +1,14 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import DefaultDemo from './demos/default'
+
+export default function PdfViewerExamples() {
+  return (
+    <Examples>
+      <Example title="Default">
+        <DefaultDemo />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/pdf-viewer/index.tsx
+++ b/www/src/registry/ui/pdf-viewer/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/pdf-viewer/meta.ts
+++ b/www/src/registry/ui/pdf-viewer/meta.ts
@@ -1,0 +1,26 @@
+import type { RegistryItem } from '@/registry/types'
+
+const pdfViewerMeta = {
+  name: 'pdf-viewer',
+  type: 'registry:ui',
+  group: 'containers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/pdf-viewer/base.tsx',
+      target: 'ui/pdf-viewer.tsx',
+    },
+  ],
+  registryDependencies: ['button'],
+  dependencies: ['react-pdf'],
+  params: {
+    radius: {
+      kind: 'scalar',
+      type: 'radius',
+      cssVar: '--pdf-viewer-radius',
+      default: '--radius-lg',
+    },
+  },
+} satisfies RegistryItem
+
+export default pdfViewerMeta

--- a/www/src/registry/ui/pdf-viewer/styles.css
+++ b/www/src/registry/ui/pdf-viewer/styles.css
@@ -1,0 +1,3 @@
+:root {
+  --pdf-viewer-radius: var(--radius-lg);
+}

--- a/www/src/registry/ui/pdf-viewer/styles.ts
+++ b/www/src/registry/ui/pdf-viewer/styles.ts
@@ -1,0 +1,45 @@
+import { createStyles } from '@/lib/styles'
+
+import pdfViewerMeta from './meta'
+
+const { useStyles, styles } = createStyles(pdfViewerMeta, {
+  base: {
+    slots: {
+      root: 'flex w-full flex-col overflow-hidden rounded-(--pdf-viewer-radius) border bg-card',
+      toolbar: 'flex items-center justify-between gap-2 border-b bg-card',
+      group: 'flex items-center gap-1',
+      pageInfo:
+        'min-w-24 text-center text-sm text-fg-muted tabular-nums select-none',
+      zoomInfo:
+        'min-w-12 text-center text-sm text-fg-muted tabular-nums select-none',
+      viewport: 'flex justify-center overflow-auto bg-muted',
+      document: 'flex flex-col items-center gap-4',
+      page: 'overflow-hidden bg-bg shadow-sm',
+      message: 'flex items-center justify-center p-8 text-sm text-fg-muted',
+    },
+  },
+  density: {
+    compact: {
+      slots: {
+        toolbar: 'px-2 py-1.5',
+        viewport: 'p-3',
+      },
+    },
+    default: {
+      slots: {
+        toolbar: 'px-3 py-2',
+        viewport: 'p-4',
+      },
+    },
+    comfortable: {
+      slots: {
+        toolbar: 'px-4 py-3',
+        viewport: 'p-6',
+      },
+    },
+  },
+})
+
+export type PdfViewerStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/pdf-viewer/types.ts
+++ b/www/src/registry/ui/pdf-viewer/types.ts
@@ -1,0 +1,25 @@
+/**
+ * A PDF viewer that renders a document one page at a time with controls for
+ * page navigation and zoom. Built on `react-pdf` (pdf.js).
+ */
+export interface PdfViewerProps extends Omit<
+  React.ComponentProps<'div'>,
+  'children' | 'onError'
+> {
+  /**
+   * URL or path of the PDF document to render.
+   */
+  file: string
+
+  /**
+   * The page shown when the viewer first mounts.
+   * @default 1
+   */
+  defaultPage?: number
+
+  /**
+   * The zoom level the viewer starts at, where `1` is 100%.
+   * @default 1
+   */
+  defaultScale?: number
+}

--- a/www/vite.config.ts
+++ b/www/vite.config.ts
@@ -31,6 +31,17 @@ export default defineConfig({
     nitro({
       preset: process.env.VERCEL ? 'vercel' : 'node',
       rollupConfig: {
+        output: {
+          // pdf.js (pdfjs-dist, pulled by react-pdf) constructs `new DOMMatrix()`
+          // and friends at module-evaluation time. During prerendering Nitro warms
+          // dynamic chunks server-side, so that runs in Node where these canvas
+          // globals are absent → "DOMMatrix is not defined". Prepending the stubs
+          // to every server chunk guarantees they exist before any chunk's body
+          // (incl. pdfjs-dist's) evaluates. Server build only; harmless in the
+          // browser where the real globals already exist.
+          banner:
+            'globalThis.DOMMatrix||=class{};globalThis.Path2D||=class{};globalThis.ImageData||=class{};globalThis.DOMPoint||=class{};',
+        },
         onwarn(warning, warn) {
           if (
             warning.code === 'MODULE_LEVEL_DIRECTIVE' &&


### PR DESCRIPTION
## Summary

Adds a **PDF Viewer** to the registry — page rendering with page navigation and zoom. Part of the real-world-component-blocks batch (Tier 2).

- Engine: **react-pdf** (pdf.js), installed as a dependency. dotUI owns the chrome: prev/next + "Page x of n" and zoom −/+ on `Button`s.
- Worker is pinned to the matching `pdfjs.version` via a CDN URL (no bundler worker config needed); the engine's `AnnotationLayer.css` / `TextLayer.css` are imported as side effects.
- Themeable axis: `--pdf-viewer-radius`. Group `containers`. `dependencies: ['react-pdf']`.

## Notes

- Verified the react-pdf v10 CSS import paths resolve against the installed package.
- Authored via a parallel workflow, then integrated + validated (build:registry, typecheck, oxlint/oxfmt all green).
- Visual verification in the live preview is still recommended before merge.