### PR TITLE
fix(www): prevent scroll-restoration flash on reload

### DIFF
--- a/docs/research/2026-06-30-scroll-restoration-and-perf.md
+++ b/docs/research/2026-06-30-scroll-restoration-and-perf.md
@@ -1,6 +1,6 @@
 # Scroll-restoration flash + performance comparison (dotUI vs TanStack vs shadcn)
 
-> Status: investigated and fixed 2026-06-30. Fix = a one-line head script that re-enables native scroll restoration (`www/src/routes/__root.tsx`). Benchmark numbers are a point-in-time snapshot of the live production sites; do not treat them as kept-current.
+> Status: investigated and fixed 2026-06-30. Fix = a head script that defers the first paint until scroll restoration has landed, but only when reloading at a saved non-zero scroll (`www/src/routes/__root.tsx`). An earlier attempt (re-enabling native restoration) was proven insufficient on a real browser — see Root cause. Benchmark numbers are a point-in-time snapshot of the live production sites; do not treat them as kept-current.
 
 ## 1. The scroll-restoration flash
 
@@ -10,45 +10,47 @@ Reload any dotUI page while scrolled down (e.g. scrolled to the bottom). For one
 
 ### Root cause
 
-dotUI runs `scrollRestoration: true` on the router (`www/src/router.tsx`). TanStack implements that by setting `history.scrollRestoration = "manual"` — turning off the browser's native restoration — and restoring scroll from JavaScript instead, via two paths: a small inline script near `</body>`, and a post-hydration `onRendered` handler.
+dotUI runs `scrollRestoration: true` on the router (`www/src/router.tsx`); TanStack restores scroll from JavaScript after hydration. But the real cause is more fundamental than the restore mechanism: **our pages are server-rendered, so the browser paints the content at the top before the scroll can be restored.** On a heavy page the browser can't reach the saved offset until the document is parsed and tall enough — which is *after* first paint.
 
-Our pages are server-rendered, so the browser has paintable content immediately and paints it at the top early. The JavaScript restore then lands after that first paint, and you see the jump. Measured on the live site (instrumented headless Chrome, scroll to bottom then reload):
+Crucially this is true of the browser's own **native** scroll restoration too, not just TanStack's JS. Measured in a real (headful) browser, forcing native restoration on and blocking all JS scroll:
 
-- `onRendered` restore consistently fires **~100 ms after** first contentful paint (e.g. FCP 1384 ms, restore 1487 ms).
-- The before-paint inline script only wins by a razor-thin **~40–45 ms** in headless — and headless paints once at end-of-parse. A real browser progressively paints a heavy (~440 KB / ~2000-node) document and shows the top before that end-of-body script runs, so the visible restore becomes the post-paint `onRendered`. That is the flash.
+- first paint at **184 ms** with the page still at the top (scrollY 0),
+- native restore lands at **239 ms** — **55 ms after** first paint → the flash.
+
+So you cannot fix this by switching the restore mechanism (native vs JS); both lose to the early paint. Headless Chrome hides the bug entirely — it paints once, at end-of-parse, after restoration — which is why a native-restoration-only attempt (my first commit) looked clean in headless yet still flashed on a real browser.
 
 ### Why tanstack.com looks fine despite the same config
 
-tanstack.com also sets `scrollRestoration: true`, on near-identical versions (router 1.170.x, start 1.168.x). The difference is **timing, not configuration**. Measured the same way on a long tanstack docs page (scrolled to 19140 px, reloaded): the restore fires at **548 ms, before first paint at 656 ms** — 108 ms early. Their restore wins the race against paint; ours loses it on heavier pages. So this is not something tanstack does differently in code; it is an emergent property of page weight and hydration timing.
+tanstack.com also sets `scrollRestoration: true`, on near-identical versions (router 1.170.x, start 1.168.x). The difference is **what gets painted when, not configuration.** Its docs content is largely client-rendered — the document is short until JS builds it — so the browser has nothing to paint until *after* hydration runs and scroll is restored. It paints late, already in the right place. dotUI's SSR content is paintable immediately, so it paints early, before restore. The fix makes dotUI behave the same way: paint after restoration.
 
 ### The fix
 
-Re-enable the browser's **native** scroll restoration for full-page loads. Native restoration runs as part of the browser's layout pipeline, before any paint — it cannot lose the race the way a script can. A blocking inline script in `<head>`, which runs before first paint, flips the mode back:
+Defer the first paint until the scroll has actually landed — but only when it matters. When (and only when) we're reloading at a saved non-zero scroll, the head script hides `<html>` and reveals it the moment `scrollY` reaches the saved offset, so the first paint the user sees is already in the right place. First visits and reloads at the top read no saved offset, so they never hide and pay nothing.
 
-```html
-<script>try{history.scrollRestoration="auto"}catch(e){}</script>
+```js
+// runs before first paint, inline in <head>
+var target = savedScrollForThisEntry()        // the router's sessionStorage scroll cache
+if (target > 0) {
+  document.documentElement.style.visibility = "hidden"
+  // reveal as soon as scroll lands: scroll event + rAF loop, 1.5s safety net
+  reveal when window.scrollY >= target
+}
 ```
 
-The router re-arms `"manual"` during hydration (verified), so in-app client-side navigation restoration — the reason `scrollRestoration: true` is enabled — is untouched. The head script only governs the brief window of the initial document load, where native restoration is strictly better for our SSR'd content.
+It also flips `history.scrollRestoration` back to `"auto"` so native restoration helps the scroll land sooner (shorter hidden window); TanStack re-arms `"manual"` during hydration, so in-app navigation restoration is untouched.
 
-### Verification
+Trade-off: on a reload partway down the page, the user now sees a brief blank (~0.2–0.4 s in dev, less in prod) instead of a flash-and-jump — scoped to that case only. Normal navigations, first loads and reloads at the top are unchanged, so Core Web Vitals (measured cold, at scroll 0) are unaffected. The deeper fix is to make dotUI paint less eagerly / hydrate faster (see §3) so paint and restore coincide the way tanstack's do; the head script is the pragmatic stopgap.
 
-- **Mechanism (live site):** with `history.scrollRestoration="auto"` set at document start and *every* JS `window.scrollTo` blocked, the page still restored to the saved position, at t≈31 ms, before FCP (156 ms). The browser records scroll even in manual mode and restores it natively before paint.
-- **Emission:** React 19 SSR emits the inline `<script>` inside `<head>`; confirmed in the dev server's served HTML (script present before `</head>`).
-- **End-to-end (local build with the fix):** with all JS `scrollTo` blocked, scroll still restored to the saved position — purely native — and `history.scrollRestoration` ended as `"manual"`, i.e. TanStack's in-app restoration re-armed.
+### Verification (real browser)
 
-Caveat: the visible flash is a real-browser progressive-paint effect that headless Chrome (single paint at end-of-parse) does not reproduce, so the final confirmation is the timing/native-restore evidence above plus a manual reload on a real browser.
+Headless can't reproduce the flash, so this was verified headful (real Chrome, instrumented frame-by-frame) on a local production build, fix toggled on/off:
 
-### Before / after on dotUI (same local build)
+| dotUI, real browser, reload at the bottom | what the user sees |
+|---|---|
+| **Before** (no fix / native-only attempt) | first paint at the top (scrollY 0), restore ~55 ms later → **flash** |
+| **After** (this PR) | every frame while `scrollY < target` is `visibility: hidden`; first *visible* frame is already at the restored offset (`y = 1456 = target`) → **no flash** |
 
-The fix changes *when* scroll is restored, not page-load weight — it's a ~30-byte head script, so FCP/LCP/bytes/requests are unchanged. To isolate its effect, the test below blocks every JS `window.scrollTo` on reload, so only the browser's native restoration can act. Same local production build, fix toggled on/off:
-
-| dotUI | JS `scrollTo` blocked | final scroll | restored before paint? |
-|---|---|---|---|
-| **Before** (no head script) | yes (2×) | **0 px** — stuck at top | ❌ no — the only restore is the after-paint JS one → this is the flash |
-| **After** (this PR) | yes (2×) | **1343 px** | ✅ yes — native, ~100 ms before first paint (restore t≈216 ms, FCP ≈316 ms) |
-
-Without the fix, nothing restores the scroll before paint (JS is the only mechanism and it lands ~100 ms after first paint → the flash). With the fix, the browser restores natively, before paint, so there is no after-paint jump. `history.scrollRestoration` ends `"manual"` in both cases — i.e. the fix doesn't disturb TanStack's in-app navigation restoration.
+A screenshot 400 ms post-reload shows the restored (bottom) content, not the top. `history.scrollRestoration` still ends `"manual"`, so TanStack's in-app restoration is untouched. The script is gated on the router's scroll cache; if that cache's shape ever changes it no-ops back to the previous behavior.
 
 ## 2. Performance comparison
 

--- a/docs/research/2026-06-30-scroll-restoration-and-perf.md
+++ b/docs/research/2026-06-30-scroll-restoration-and-perf.md
@@ -1,0 +1,92 @@
+# Scroll-restoration flash + performance comparison (dotUI vs TanStack vs shadcn)
+
+> Status: investigated and fixed 2026-06-30. Fix = a one-line head script that re-enables native scroll restoration (`www/src/routes/__root.tsx`). Benchmark numbers are a point-in-time snapshot of the live production sites; do not treat them as kept-current.
+
+## 1. The scroll-restoration flash
+
+### Symptom
+
+Reload any dotUI page while scrolled down (e.g. scrolled to the bottom). For one frame the page appears at the top, then jumps to the restored scroll position. tanstack.com — same framework (TanStack Start) — does not visibly do this.
+
+### Root cause
+
+dotUI runs `scrollRestoration: true` on the router (`www/src/router.tsx`). TanStack implements that by setting `history.scrollRestoration = "manual"` — turning off the browser's native restoration — and restoring scroll from JavaScript instead, via two paths: a small inline script near `</body>`, and a post-hydration `onRendered` handler.
+
+Our pages are server-rendered, so the browser has paintable content immediately and paints it at the top early. The JavaScript restore then lands after that first paint, and you see the jump. Measured on the live site (instrumented headless Chrome, scroll to bottom then reload):
+
+- `onRendered` restore consistently fires **~100 ms after** first contentful paint (e.g. FCP 1384 ms, restore 1487 ms).
+- The before-paint inline script only wins by a razor-thin **~40–45 ms** in headless — and headless paints once at end-of-parse. A real browser progressively paints a heavy (~440 KB / ~2000-node) document and shows the top before that end-of-body script runs, so the visible restore becomes the post-paint `onRendered`. That is the flash.
+
+### Why tanstack.com looks fine despite the same config
+
+tanstack.com also sets `scrollRestoration: true`, on near-identical versions (router 1.170.x, start 1.168.x). The difference is **timing, not configuration**. Measured the same way on a long tanstack docs page (scrolled to 19140 px, reloaded): the restore fires at **548 ms, before first paint at 656 ms** — 108 ms early. Their restore wins the race against paint; ours loses it on heavier pages. So this is not something tanstack does differently in code; it is an emergent property of page weight and hydration timing.
+
+### The fix
+
+Re-enable the browser's **native** scroll restoration for full-page loads. Native restoration runs as part of the browser's layout pipeline, before any paint — it cannot lose the race the way a script can. A blocking inline script in `<head>`, which runs before first paint, flips the mode back:
+
+```html
+<script>try{history.scrollRestoration="auto"}catch(e){}</script>
+```
+
+The router re-arms `"manual"` during hydration (verified), so in-app client-side navigation restoration — the reason `scrollRestoration: true` is enabled — is untouched. The head script only governs the brief window of the initial document load, where native restoration is strictly better for our SSR'd content.
+
+### Verification
+
+- **Mechanism (live site):** with `history.scrollRestoration="auto"` set at document start and *every* JS `window.scrollTo` blocked, the page still restored to the saved position, at t≈31 ms, before FCP (156 ms). The browser records scroll even in manual mode and restores it natively before paint.
+- **Emission:** React 19 SSR emits the inline `<script>` inside `<head>`; confirmed in the dev server's served HTML (script present before `</head>`).
+- **End-to-end (local build with the fix):** with all JS `scrollTo` blocked, scroll still restored to the saved position — purely native — and `history.scrollRestoration` ended as `"manual"`, i.e. TanStack's in-app restoration re-armed.
+
+Caveat: the visible flash is a real-browser progressive-paint effect that headless Chrome (single paint at end-of-parse) does not reproduce, so the final confirmation is the timing/native-restore evidence above plus a manual reload on a real browser.
+
+## 2. Performance comparison
+
+### Methodology
+
+Headless Chrome 141, cold cache, desktop viewport 1366×900, a fixed network pipe (~20 Mbps down / 5 Mbps up / 40 ms RTT) applied equally to all sites so the comparison reflects site weight rather than connection jitter. Median of the best 5 of 6 runs (slowest run by FCP dropped). Live production sites, 2026-06-30. Bytes are CDP `encodedDataLength` (over-the-wire), counting all resource types. Cells below are `median (best)`.
+
+TTFB is the noisiest metric — it depends on CDN cache and serverless cold-start state, not just the app. dotUI's TTFB swung 145–999 ms across runs as the Vercel function warmed up; read it loosely.
+
+### Landing pages — dotui.org · tanstack.com · ui.shadcn.com
+
+| Metric | dotUI | TanStack | shadcn |
+|---|---|---|---|
+| TTFB ms | **187 (145)** | 1255 (947) | 419 (135) |
+| FCP ms | **520 (412)** | 1644 (1340) | 964 (608) |
+| LCP ms | **520 (412)** | 1704 (1340) | 964 (608) |
+| load ms | **1858** | 1949 | 2148 |
+| TBT ms | 26 | 1 | **0** |
+| long-task ms | 76 | 51 | **0** |
+| total KB | 1771 | **999** | 3055 |
+| JS KB | 817 | **763** | 2370 |
+| requests | 162 | **36** | 119 |
+| DOM nodes | 2040 | 2024 | **1752** |
+| JS heap MB | 23 | **16** | 68 |
+
+### Docs / component pages — /docs/components/button (dotUI, shadcn) · router docs overview (TanStack)
+
+| Metric | dotUI | shadcn | TanStack |
+|---|---|---|---|
+| TTFB ms | **180** | 434 | 252 |
+| FCP ms | 588 | 1584 | **556** |
+| LCP ms | 588 | 1584 | **556** |
+| load ms | 2284 | 6793 | **1027** |
+| TBT ms | 2 | **0** | 18 |
+| total KB | **893** | 3807 | 1280 |
+| JS KB | **744** | 2566 | 969 |
+| requests | 148 | 202 | **89** |
+| DOM nodes | **966** | 1541 | 1639 |
+| JS heap MB | **24** | 47 | 26 |
+
+### Reading
+
+- **dotUI renders fast.** Fastest FCP/LCP on the landing (520 ms) and essentially tied with TanStack on docs (588 vs 556 ms); both beat shadcn by ~1 s. Lean DOM and JS heap.
+- **dotUI ships lean JavaScript.** 817 KB (landing) / 744 KB (docs) over the wire — comparable to TanStack and roughly a third of shadcn (2.4–2.6 MB). shadcn is the heavy one across bytes, JS, heap, and load time (its docs pull a ~460 KB data payload — the registry JSON).
+- **dotUI's one real weakness is request fan-out.** 162 requests on the landing vs TanStack's 36 — ~4.5× more, mostly small JS chunks (the live-component showcase pulls in many modules). dotUI also has the highest main-thread blocking on the landing (TBT 26 ms, long-tasks 76 ms).
+- That request/hydration overhead is exactly what made the JS scroll-restore land after first paint. The native-restoration fix sidesteps it entirely (restoration no longer depends on hydration timing), but the fan-out is worth reducing on its own merits.
+
+## 3. Follow-up opportunities (not in this PR)
+
+- **Cut landing request count.** ~160 requests to render the landing is the standout regression vs TanStack's ~36. The component showcase appears to load many per-component chunks eagerly. Bundling the above-the-fold showcase and lazy-loading the rest would cut requests and landing hydration time.
+- **Trim landing hydration main-thread time** (TBT 26 ms / 76 ms long-tasks) — same root as the request fan-out.
+- **TTFB on cold Vercel functions.** The landing's first-byte time spikes on cold start; if it isn't already, the marketing routes are good candidates for prerender/ISR so first-byte is CDN-served like shadcn's.

--- a/docs/research/2026-06-30-scroll-restoration-and-perf.md
+++ b/docs/research/2026-06-30-scroll-restoration-and-perf.md
@@ -39,6 +39,17 @@ The router re-arms `"manual"` during hydration (verified), so in-app client-side
 
 Caveat: the visible flash is a real-browser progressive-paint effect that headless Chrome (single paint at end-of-parse) does not reproduce, so the final confirmation is the timing/native-restore evidence above plus a manual reload on a real browser.
 
+### Before / after on dotUI (same local build)
+
+The fix changes *when* scroll is restored, not page-load weight — it's a ~30-byte head script, so FCP/LCP/bytes/requests are unchanged. To isolate its effect, the test below blocks every JS `window.scrollTo` on reload, so only the browser's native restoration can act. Same local production build, fix toggled on/off:
+
+| dotUI | JS `scrollTo` blocked | final scroll | restored before paint? |
+|---|---|---|---|
+| **Before** (no head script) | yes (2×) | **0 px** — stuck at top | ❌ no — the only restore is the after-paint JS one → this is the flash |
+| **After** (this PR) | yes (2×) | **1343 px** | ✅ yes — native, ~100 ms before first paint (restore t≈216 ms, FCP ≈316 ms) |
+
+Without the fix, nothing restores the scroll before paint (JS is the only mechanism and it lands ~100 ms after first paint → the flash). With the fix, the browser restores natively, before paint, so there is no after-paint jump. `history.scrollRestoration` ends `"manual"` in both cases — i.e. the fix doesn't disturb TanStack's in-app navigation restoration.
+
 ## 2. Performance comparison
 
 ### Methodology

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -175,6 +175,22 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Re-enable the browser's native scroll restoration for full-page
+            loads. The router runs `scrollRestoration: true`, which sets
+            `history.scrollRestoration = "manual"` and restores scroll from JS —
+            but our pages are server-rendered, so the browser paints the content
+            at the top before that JS runs. A reload at a non-zero scroll then
+            flashes at the top and jumps down. This blocking head script runs
+            before first paint and flips the mode back to "auto", so the browser
+            restores the scroll as part of layout (no flash). The router re-arms
+            "manual" during hydration, leaving in-app navigation restoration —
+            the reason it's enabled — untouched. */}
+        <script
+          // oxlint-disable-next-line react/no-danger -- static, hardcoded inline script (no user input)
+          dangerouslySetInnerHTML={{
+            __html: `try{history.scrollRestoration="auto"}catch(e){}`,
+          }}
+        />
         {/* <script src="https://unpkg.com/react-scan/dist/auto.global.js" /> */}
         <HeadContent />
       </head>

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -175,20 +175,23 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        {/* Re-enable the browser's native scroll restoration for full-page
-            loads. The router runs `scrollRestoration: true`, which sets
-            `history.scrollRestoration = "manual"` and restores scroll from JS —
-            but our pages are server-rendered, so the browser paints the content
-            at the top before that JS runs. A reload at a non-zero scroll then
-            flashes at the top and jumps down. This blocking head script runs
-            before first paint and flips the mode back to "auto", so the browser
-            restores the scroll as part of layout (no flash). The router re-arms
-            "manual" during hydration, leaving in-app navigation restoration —
-            the reason it's enabled — untouched. */}
+        {/* Reload-at-scroll flash fix. The router runs `scrollRestoration:
+            true`, restoring scroll from JS. Our pages are server-rendered, so on
+            a heavy page the browser paints the content at the top *before* the
+            scroll is restored (this is true of the browser's own native restore
+            too — it can't reach the saved offset until the document is tall
+            enough, which is after first paint). A reload partway down then
+            flashes at the top and jumps. Fix: when — and only when — we're
+            reloading at a saved non-zero scroll, hide the document until the
+            scroll has actually landed, so the first paint the user sees is
+            already at the right place. First visits and reloads at the top read
+            no saved offset, so they never hide and pay no cost. Reads the
+            router's scroll cache; if its shape ever changes this no-ops back to
+            the previous behavior. */}
         <script
           // oxlint-disable-next-line react/no-danger -- static, hardcoded inline script (no user input)
           dangerouslySetInnerHTML={{
-            __html: `try{history.scrollRestoration="auto"}catch(e){}`,
+            __html: `(function(){try{history.scrollRestoration="auto";var c=JSON.parse(sessionStorage.getItem("tsr-scroll-restoration-v1_3")||"{}");var k=(history.state&&history.state.__TSR_key)||location.href;var w=c[k]&&c[k].window;var y=w&&w.scrollY;if(!(y>0))return;var e=document.documentElement;e.style.visibility="hidden";var shown=false;function show(){if(shown)return;shown=true;e.style.visibility="";removeEventListener("scroll",chk,true)}function chk(){if(window.scrollY>=y-4)show()}addEventListener("scroll",chk,true);setTimeout(show,1500);function loop(){chk();if(!shown)requestAnimationFrame(loop)}requestAnimationFrame(loop)}catch(_){}})()`,
           }}
         />
         {/* <script src="https://unpkg.com/react-scan/dist/auto.global.js" /> */}


### PR DESCRIPTION
## Problem

Reload a dotUI page while scrolled down — for one frame it shows the top, then jumps to the restored position. tanstack.com (same framework) doesn't.

**Root cause (corrected after real-browser testing).** dotUI is server-rendered, so the browser paints the content at the top **before** the scroll can be restored — on a heavy page the browser can't reach the saved offset until the document is parsed and tall enough, which is *after* first paint. This is true of the browser's **native** scroll restoration too, not just TanStack's JS. Headful (real Chrome), native restoration forced on, all JS scroll blocked:

```
first paint = 184ms  (page still at the top, scrollY 0)
native restore = 239ms   → 55ms AFTER first paint → flash
```

So you can't fix it by switching restore mechanism — both native and JS lose to the early paint. (Headless paints once, after restore, so it never shows the flash — which is why my first commit, re-enabling native restoration, looked clean in headless but still flashed live.)

tanstack.com escapes this because its docs content is **client-rendered** — there's nothing to paint until JS builds the page, so it paints late, already restored.

## Fix

Make dotUI paint *after* restoration, the way tanstack's pages already do — but only when it matters. When reloading at a saved non-zero scroll, a `<head>` script hides `<html>` and reveals it the instant `scrollY` reaches the saved offset:

```js
var target = savedScrollForThisEntry()          // router's sessionStorage cache
if (target > 0) {
  document.documentElement.style.visibility = "hidden"
  reveal when window.scrollY >= target          // scroll event + rAF, 1.5s safety
}
```

First visits and reloads at the top read no saved offset → never hide, zero cost. It also re-enables `history.scrollRestoration = "auto"` so the scroll lands sooner (shorter hidden window); TanStack re-arms `"manual"` during hydration, so **in-app navigation restoration is untouched**.

**Trade-off:** on a reload partway down, the user sees a brief blank (~0.2–0.4s in dev, less in prod) instead of a flash-and-jump — scoped to that case only. Core Web Vitals (measured cold, at scroll 0) are unaffected. The deeper fix is to reduce the landing's paint/hydration weight (see below) so paint and restore coincide; this is the pragmatic stopgap.

## Verification (real browser)

Headless can't reproduce the flash, so verified **headful** (real Chrome, frame-by-frame), local production build:

| dotUI, real browser, reload at bottom | result |
|---|---|
| **Before** | first paint at top (scrollY 0), restore ~55ms later → **flash** |
| **After** | every frame while `scrollY < target` is `visibility:hidden`; first *visible* frame is already at `y=1456=target` → **no flash** |

Screenshot 400ms post-reload shows the restored (bottom) content, not the top. `history.scrollRestoration` still ends `"manual"`. `pnpm check` (0 errors) + `pnpm typecheck` pass.

## Performance comparison

Full writeup in `docs/research/2026-06-30-scroll-restoration-and-perf.md`. Headlines (cold cache, fixed network, median of best 5/6 runs, live sites):

- **dotUI renders fast:** fastest FCP/LCP on the landing (520ms), tied with TanStack on docs, both ~1s ahead of shadcn.
- **dotUI ships lean JS:** ~817KB landing / 744KB docs — comparable to TanStack, ~⅓ of shadcn (2.4–2.6MB).
- **dotUI's weakness is request fan-out:** **162** requests on the landing vs TanStack's **36** (small showcase chunks) + highest hydration main-thread time. That early-paint-then-slow-hydrate gap is the same root as the flash.

## Suggested follow-ups

- Cut the landing's ~160 requests (bundle the above-the-fold showcase, lazy-load the rest) — also shrinks the flash's hidden window.
- Trim landing hydration main-thread time (TBT 26ms / long-tasks 76ms).
- Consider prerender/ISR for marketing routes (TTFB spikes on cold Vercel functions).