### PR TITLE
feat(dev): add tweaker panel for live design exploration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,15 @@ After modifying `www/src/registry/`, run `pnpm build:registry` and commit the re
 - `pnpm typecheck`; `pnpm test` if you touched `packages/colors`.
 - Touched the registry? Regenerate first (see Registry changes).
 
+## Dev tweaker (design exploration)
+
+`www/src/dev/tweaker` is a **dev-only** floating panel (gated on `import.meta.env.DEV`, dead-code-eliminated from production) for exploring designs/layouts live: you add `useTweak()` calls to a feature component, the user flips the options in the panel and picks one. Full API + workflow: [`www/src/dev/tweaker/README.md`](www/src/dev/tweaker/README.md).
+
+- **When (strict):** only during active PR/feature-branch work, and only when the user explicitly asks for tweaks/options on a specific feature. Never unprompted, never on `main`, never as a way to add real config.
+- **How:** add `useTweak('Label', { type, default, group? })` in the relevant **www** feature component and branch the JSX/styles on the returned value. Keep each `default` equal to the current look (nothing changes until a control moves); offer a small set (≤~5) of meaningful named variants per axis; `group` related controls. Types: `select`, `boolean`, `number`, `color`, `text`.
+- **Boundaries:** never author `useTweak` in `www/src/registry/` — the product source stays clean (the panel reuses registry UI, but the calls live only in site/feature/module code). It's throwaway scaffolding, **not** a `/create` axis: adding a real axis/variant/token is still a product decision (propose-and-approve, below).
+- **Cleanup:** once the user picks (their "Copy for AI" output or a verbal choice), bake the values into the code and **remove the `useTweak` scaffolding** before finalizing the PR — unless they want to keep iterating. Don't merge `useTweak` calls into feature code.
+
 ## Conventions & gotchas
 
 - Issues and PRDs are tracked in GitHub Issues for `mehdibha/dotUI`.

--- a/www/src/dev/tweaker/README.md
+++ b/www/src/dev/tweaker/README.md
@@ -79,15 +79,15 @@ Every config needs a `default` — and it **must match the current design** so n
 
 ## The panel
 
-Docked bottom-center, collapsed to a pill by default (a count badge shows how many controls are registered).
+A small **trigger** is always docked to a screen edge (default: centre-right; a count badge shows how many controls are registered). Drag it to reposition — it follows the cursor and **snaps to the nearest edge** (left/right) when you let go, keeping the height you dropped it at.
 
-- **Pill** → click to expand.
-- **Minimize** (–) → back to the pill.
-- **Hide** (×) → dismiss. Press **⌘ .** (or **Ctrl .**) anywhere to bring it back.
+- **Click the trigger** → opens the panel as a popover beside it (the trigger stays put).
+- **Close** (×), click outside, or press **Escape** → closes the popover.
+- **⌘ .** (or **Ctrl .**) → toggles the popover from anywhere.
 - **Reset** (↺) → all controls back to their defaults.
 - **Copy for AI** (⧉) → copies a summary of the current selections to paste back to the agent.
 
-State (values, collapsed/hidden, control order) persists in `localStorage` under `dotui:tweaker`, so a choice survives reloads and HMR edits to the feature file.
+State (open, side, vertical position, control values + order) persists in `localStorage` under `dotui:tweaker`, so it survives reloads and HMR edits to the feature file.
 
 ## How it stays out of production
 

--- a/www/src/dev/tweaker/README.md
+++ b/www/src/dev/tweaker/README.md
@@ -1,0 +1,102 @@
+# Dev tweaker
+
+A **dev-only** floating panel for live design/layout exploration. While working a PR, an AI agent adds `useTweak()` calls to the feature being explored; the panel (docked bottom-center, Vercel-toolbar style) lets you flip between the options live and pick one. None of it ships — `useTweak` compiles to a no-op in production and the panel + store are dead-code-eliminated.
+
+It is **not** a product feature and **not** a `/create` design-system axis. It's throwaway scaffolding for one exploration. Adding a real axis/variant/token is still a product decision (propose-and-approve — see the root `CLAUDE.md`).
+
+## The loop
+
+1. You're on a feature branch and ask for tweaks/options on a specific feature.
+2. The agent adds `useTweak(...)` in the relevant **www** component and branches the JSX/styles on the returned value. Defaults equal the current look.
+3. The control auto-appears in the panel. You open it, flip variants, see live re-renders, and pick.
+4. You hit **Copy for AI** (or just say the choice). The agent bakes the values into the code and **removes the `useTweak` scaffolding** before finalizing — unless you want to keep iterating.
+
+## API
+
+```tsx
+import { useTweak } from '@/dev/tweaker'
+
+function Hero() {
+  const layout = useTweak('Layout', {
+    type: 'select',
+    options: ['centered', 'split', 'fullbleed'],
+    default: 'centered',
+    group: 'Hero',
+  }) // typed: 'centered' | 'split' | 'fullbleed'
+
+  const gap = useTweak('Gap', {
+    type: 'number',
+    min: 0,
+    max: 64,
+    step: 4,
+    default: 16,
+    group: 'Hero',
+  })
+
+  return layout === 'split' ? (
+    <SplitHero style={{ gap }} />
+  ) : (
+    <CenteredHero style={{ gap }} />
+  )
+}
+```
+
+`useTweak(label, config)` returns the live value. `label` is the control's name in the panel; `config.group` buckets related controls under a heading (defaults to an ungrouped section).
+
+### Control types
+
+| `type`    | renders as                                   | value      | extra fields            |
+| --------- | -------------------------------------------- | ---------- | ----------------------- |
+| `select`  | segmented (≤4 short options) or a dropdown   | option str | `options: string[]`     |
+| `boolean` | switch                                       | `boolean`  | —                       |
+| `number`  | slider (when `min` **and** `max`) or a field | `number`   | `min?`, `max?`, `step?` |
+| `color`   | swatch + hex field                           | string     | —                       |
+| `text`    | text field                                   | string     | —                       |
+
+Every config needs a `default` — and it **must match the current design** so nothing changes until you actually move a control.
+
+### Structural vs. style tweaks
+
+- **Structural** (the main use): branch JSX on a `select`/`boolean`.
+  ```tsx
+  const density = useTweak('Density', {
+    type: 'select',
+    options: ['compact', 'cozy'],
+    default: 'cozy',
+  })
+  return <List density={density} />
+  ```
+- **Style values**: feed a `number`/`color` straight into `style`, a class, or a CSS variable.
+  ```tsx
+  const radius = useTweak('Radius', {
+    type: 'number',
+    min: 0,
+    max: 24,
+    default: 8,
+  })
+  return <Card style={{ borderRadius: radius }} />
+  ```
+
+## The panel
+
+Docked bottom-center, collapsed to a pill by default (a count badge shows how many controls are registered).
+
+- **Pill** → click to expand.
+- **Minimize** (–) → back to the pill.
+- **Hide** (×) → dismiss. Press **⌘ .** (or **Ctrl .**) anywhere to bring it back.
+- **Reset** (↺) → all controls back to their defaults.
+- **Copy for AI** (⧉) → copies a summary of the current selections to paste back to the agent.
+
+State (values, collapsed/hidden, control order) persists in `localStorage` under `dotui:tweaker`, so a choice survives reloads and HMR edits to the feature file.
+
+## How it stays out of production
+
+`useTweak` is `import.meta.env.DEV ? useTweakDev : useTweakNoop` (see `use-tweak.ts`). In a prod build `DEV` is the constant `false`, so the dev arm — and its import of the store — is dead-code-eliminated. The panel is `lazy()`-imported behind the same constant in `__root.tsx`, so its chunk never enters the prod graph. `store.ts` is side-effect-free at module scope so it tree-shakes cleanly.
+
+## Files
+
+- `use-tweak.ts` — the `useTweak` hook (dev/no-op split).
+- `store.ts` — framework-free singleton (values vs. controls, persistence, coercion). Unit-tested in `store.test.ts`.
+- `controls.tsx` — one control row per type.
+- `tweaker.tsx` — the floating panel.
+- `types.ts` — `TweakConfig` and friends.

--- a/www/src/dev/tweaker/controls.tsx
+++ b/www/src/dev/tweaker/controls.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { type Color, parseColor } from 'react-aria-components/ColorField'
+
+import { ColorField } from '@/registry/ui/color-field'
+import { Input } from '@/registry/ui/input'
+import { NumberField } from '@/registry/ui/number-field'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from '@/registry/ui/select'
+import { Slider, SliderControl, SliderOutput } from '@/registry/ui/slider'
+import { Switch } from '@/registry/ui/switch'
+import { TextField } from '@/registry/ui/text-field'
+import { ToggleButton } from '@/registry/ui/toggle-button'
+import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
+
+import { getValue, setValue, subscribe } from './store'
+import type {
+  BooleanTweakConfig,
+  ColorTweakConfig,
+  NumberTweakConfig,
+  RegisteredControl,
+  SelectTweakConfig,
+  TextTweakConfig,
+} from './types'
+
+/** Subscribe a single row to its own value (only the changed row re-renders). */
+function useControlValue<T>(id: string, fallback: T): T {
+  return useSyncExternalStore(
+    subscribe,
+    () => {
+      const v = getValue(id)
+      return (v === undefined ? fallback : v) as T
+    },
+    () => fallback,
+  )
+}
+
+function FieldLabel({ children }: { children: string }) {
+  return (
+    <span className="block truncate text-xs font-medium text-fg-muted">
+      {children}
+    </span>
+  )
+}
+
+/** A small enum (a few short options) renders as a segmented control; bigger sets fall back to a Select. */
+function isSegmented(options: readonly string[]): boolean {
+  return (
+    options.length > 1 &&
+    options.length <= 4 &&
+    options.every((o) => o.length <= 8)
+  )
+}
+
+export function ControlRow({ control }: { control: RegisteredControl }) {
+  const { config } = control
+  switch (config.type) {
+    case 'boolean':
+      return <BooleanRow control={control} config={config} />
+    case 'select':
+      return <SelectRow control={control} config={config} />
+    case 'number':
+      return <NumberRow control={control} config={config} />
+    case 'color':
+      return <ColorRow control={control} config={config} />
+    case 'text':
+      return <TextRow control={control} config={config} />
+    default:
+      return null
+  }
+}
+
+function BooleanRow({
+  control,
+  config,
+}: {
+  control: RegisteredControl
+  config: BooleanTweakConfig
+}) {
+  const value = useControlValue(control.id, config.default)
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <FieldLabel>{control.label}</FieldLabel>
+      <Switch
+        aria-label={control.label}
+        isSelected={value}
+        onChange={(v) => setValue(control.id, v)}
+        size="sm"
+        className="shrink-0"
+      />
+    </div>
+  )
+}
+
+function SelectRow({
+  control,
+  config,
+}: {
+  control: RegisteredControl
+  config: SelectTweakConfig
+}) {
+  const value = useControlValue(control.id, config.default)
+
+  if (isSegmented(config.options)) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <FieldLabel>{control.label}</FieldLabel>
+        <ToggleButtonGroup
+          aria-label={control.label}
+          size="sm"
+          selectionMode="single"
+          disallowEmptySelection
+          selectedKeys={[value]}
+          onSelectionChange={(keys) => {
+            const next = keys.values().next().value
+            if (next != null) setValue(control.id, String(next))
+          }}
+          className="w-full"
+        >
+          {config.options.map((option) => (
+            <ToggleButton key={option} id={option} className="flex-1">
+              {option}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <FieldLabel>{control.label}</FieldLabel>
+      <Select
+        aria-label={control.label}
+        selectedKey={value}
+        onSelectionChange={(key) => setValue(control.id, String(key))}
+        className="w-full"
+      >
+        <SelectTrigger size="sm" />
+        <SelectContent>
+          {config.options.map((option) => (
+            <SelectItem key={option} id={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function NumberRow({
+  control,
+  config,
+}: {
+  control: RegisteredControl
+  config: NumberTweakConfig
+}) {
+  const value = useControlValue(control.id, config.default)
+  const bounded = config.min !== undefined && config.max !== undefined
+
+  if (bounded) {
+    return (
+      <Slider
+        aria-label={control.label}
+        value={value}
+        minValue={config.min}
+        maxValue={config.max}
+        step={config.step}
+        onChange={(v) => setValue(control.id, Array.isArray(v) ? v[0] : v)}
+        className="flex w-full flex-col gap-1.5"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <FieldLabel>{control.label}</FieldLabel>
+          <SliderOutput className="text-xs text-fg-muted tabular-nums" />
+        </div>
+        <SliderControl />
+      </Slider>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <FieldLabel>{control.label}</FieldLabel>
+      <NumberField
+        aria-label={control.label}
+        value={value}
+        minValue={config.min}
+        maxValue={config.max}
+        step={config.step}
+        onChange={(v) =>
+          setValue(control.id, Number.isNaN(v) ? config.default : v)
+        }
+        className="w-full"
+      />
+    </div>
+  )
+}
+
+function ColorRow({
+  control,
+  config,
+}: {
+  control: RegisteredControl
+  config: ColorTweakConfig
+}) {
+  const value = useControlValue(control.id, config.default)
+  let color: Color | null = null
+  try {
+    color = parseColor(value)
+  } catch {
+    color = null
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <FieldLabel>{control.label}</FieldLabel>
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden
+          className="size-6 shrink-0 rounded-md border border-border"
+          style={{ backgroundColor: value }}
+        />
+        <ColorField
+          aria-label={control.label}
+          value={color}
+          onChange={(c) => c && setValue(control.id, c.toString('hex'))}
+          className="w-full"
+        >
+          <Input size="sm" />
+        </ColorField>
+      </div>
+    </div>
+  )
+}
+
+function TextRow({
+  control,
+  config,
+}: {
+  control: RegisteredControl
+  config: TextTweakConfig
+}) {
+  const value = useControlValue(control.id, config.default)
+  return (
+    <div className="flex flex-col gap-1.5">
+      <FieldLabel>{control.label}</FieldLabel>
+      <TextField
+        aria-label={control.label}
+        value={value}
+        onChange={(v) => setValue(control.id, v)}
+        className="w-full"
+      >
+        <Input size="sm" />
+      </TextField>
+    </div>
+  )
+}

--- a/www/src/dev/tweaker/index.ts
+++ b/www/src/dev/tweaker/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Dev tweaker — a dev-only floating panel for live design/layout exploration.
+ * See ./README.md for the AI workflow and the full API.
+ *
+ * Public surface:
+ * - `useTweak(label, config)` — call inside a feature component you're exploring.
+ *   No-op in production (returns `config.default`), and the panel tree-shakes away.
+ * - `DevTweaker` — the floating panel; mounted once, dev-gated, in `__root.tsx`.
+ */
+
+export { useTweak } from './use-tweak'
+export { DevTweaker } from './tweaker'
+export type { TweakConfig } from './types'

--- a/www/src/dev/tweaker/store.test.ts
+++ b/www/src/dev/tweaker/store.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  __resetStoreForTests,
+  coerceTweakValue,
+  getValue,
+  registerControl,
+  setValue,
+  subscribe,
+  unregisterControl,
+} from './store'
+
+afterEach(() => {
+  __resetStoreForTests()
+})
+
+describe('coerceTweakValue', () => {
+  test('boolean type-guards', () => {
+    expect(coerceTweakValue({ type: 'boolean', default: true }, 'nope')).toBe(
+      true,
+    )
+    expect(coerceTweakValue({ type: 'boolean', default: true }, false)).toBe(
+      false,
+    )
+  })
+
+  test('number rejects NaN/non-numbers and clamps into range', () => {
+    const cfg = { type: 'number', default: 10, min: 0, max: 20 } as const
+    expect(coerceTweakValue(cfg, 50)).toBe(20)
+    expect(coerceTweakValue(cfg, -5)).toBe(0)
+    expect(coerceTweakValue(cfg, 7)).toBe(7)
+    expect(coerceTweakValue(cfg, Number.NaN)).toBe(10)
+    expect(coerceTweakValue(cfg, 'x')).toBe(10)
+  })
+
+  test('select falls back to default when the option is gone', () => {
+    const cfg = { type: 'select', options: ['a', 'b'], default: 'a' } as const
+    expect(coerceTweakValue(cfg, 'b')).toBe('b')
+    expect(coerceTweakValue(cfg, 'gone')).toBe('a')
+  })
+
+  test('color/text guard strings', () => {
+    expect(coerceTweakValue({ type: 'color', default: '#000' }, 5)).toBe('#000')
+    expect(coerceTweakValue({ type: 'color', default: '#000' }, '#fff')).toBe(
+      '#fff',
+    )
+    expect(coerceTweakValue({ type: 'text', default: 'hi' }, 9)).toBe('hi')
+    expect(coerceTweakValue({ type: 'text', default: 'hi' }, 'yo')).toBe('yo')
+  })
+})
+
+describe('register / value lifetime', () => {
+  test('register seeds the default', () => {
+    const id = registerControl(
+      'Layout',
+      { type: 'select', options: ['a', 'b'], default: 'a' },
+      'owner-1',
+    )
+    expect(getValue(id)).toBe('a')
+  })
+
+  test('a chosen value survives unregister + re-register (StrictMode / HMR)', () => {
+    const cfg = { type: 'select', options: ['a', 'b'], default: 'a' } as const
+    const id = registerControl('Layout', cfg, 'owner-1')
+    setValue(id, 'b')
+    expect(getValue(id)).toBe('b')
+
+    unregisterControl(id)
+    expect(getValue(id)).toBe('b') // value is NOT cleared on unmount
+
+    const id2 = registerControl('Layout', cfg, 'owner-1')
+    expect(id2).toBe(id)
+    expect(getValue(id)).toBe('b')
+  })
+
+  test('re-register re-coerces a now-invalid value to the default', () => {
+    const id = registerControl(
+      'Size',
+      { type: 'select', options: ['sm', 'lg'], default: 'sm' },
+      'owner-1',
+    )
+    setValue(id, 'lg')
+    unregisterControl(id)
+
+    // The agent edited the config: 'lg' is no longer a valid option.
+    registerControl(
+      'Size',
+      { type: 'select', options: ['sm', 'md'], default: 'sm' },
+      'owner-1',
+    )
+    expect(getValue(id)).toBe('sm')
+  })
+
+  test('group + label form the id', () => {
+    const id = registerControl(
+      'Padding',
+      { type: 'number', default: 8, group: 'Header' },
+      'owner-1',
+    )
+    expect(id).toBe('Header::Padding')
+  })
+})
+
+describe('setValue', () => {
+  test('no-ops (no notify) on an equal value', () => {
+    const id = registerControl(
+      'On',
+      { type: 'boolean', default: false },
+      'owner-1',
+    )
+    const listener = vi.fn<() => void>()
+    const unsub = subscribe(listener)
+
+    setValue(id, true)
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    setValue(id, true) // equal → no-op, no notification
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    unsub()
+  })
+
+  test('coerces against the registered config', () => {
+    const id = registerControl(
+      'Gap',
+      { type: 'number', default: 8, min: 0, max: 16 },
+      'owner-1',
+    )
+    setValue(id, 999)
+    expect(getValue(id)).toBe(16) // clamped to max
+  })
+})

--- a/www/src/dev/tweaker/store.ts
+++ b/www/src/dev/tweaker/store.ts
@@ -1,0 +1,286 @@
+/**
+ * Dev tweaker — the store.
+ *
+ * A framework-free singleton (so it's unit-testable without React and tree-shakes
+ * out of production via the `useTweak` build-constant split in ./use-tweak.ts).
+ * Mirrors the localStorage + useSyncExternalStore pattern of
+ * `@/modules/create/preset/storage.ts`, with two deliberate twists:
+ *
+ *   1. Value lifetime ≠ control lifetime. `values` (live, chosen values) is NEVER
+ *      cleared when a control unmounts — only `controls` (the mounted set the panel
+ *      renders) is ref-counted in/out. That's what makes a choice survive React
+ *      StrictMode's double-invoke, an HMR edit to the feature file, and route
+ *      remounts.
+ *
+ *   2. On-disk snapshot (`persisted`) is kept separate from `values`, and a value
+ *      only moves into `values` when its control *registers* (in a mount effect).
+ *      So `getValue` returns `undefined` (→ the hook falls back to the default)
+ *      during SSR and the first client render, and the stored choice is applied
+ *      only after mount — no hydration mismatch when a tweak changes the DOM.
+ *
+ * Keep this module side-effect-free at the top level (all `window`/`localStorage`
+ * access lives inside `typeof window`-guarded functions) so production DCE can drop
+ * it entirely.
+ */
+
+import type {
+  PersistedTweakerState,
+  RegisteredControl,
+  TweakConfig,
+  TweakerUiState,
+} from './types'
+
+const STORAGE_KEY = 'dotui:tweaker'
+
+const DEFAULT_UI: TweakerUiState = {
+  collapsed: true,
+  hidden: false,
+}
+
+/* ------------------------------ module state ------------------------------ */
+
+const controls = new Map<string, RegisteredControl>()
+const values = new Map<string, unknown>() // live, chosen this session
+const persisted = new Map<string, unknown>() // last on-disk snapshot (seed source)
+const order = new Map<string, number>()
+let ui: TweakerUiState = DEFAULT_UI
+let nextOrder = 0
+let loaded = false
+
+const listeners = new Set<() => void>()
+
+// useSyncExternalStore demands referentially-stable snapshots: rebuild the sorted
+// control list only when the set actually changes, and hand back the cached array
+// otherwise. The `ui` object is likewise replaced (never mutated) on change.
+let controlListSnapshot: RegisteredControl[] = []
+let controlListDirty = true
+const EMPTY_CONTROLS: RegisteredControl[] = []
+
+/* -------------------------------- helpers --------------------------------- */
+
+function idFor(label: string, group: string): string {
+  return `${group}::${label}`
+}
+
+/** Validate/repair a stored value against the control's *current* config. */
+export function coerceTweakValue(config: TweakConfig, raw: unknown): unknown {
+  switch (config.type) {
+    case 'boolean':
+      return typeof raw === 'boolean' ? raw : config.default
+    case 'number': {
+      if (typeof raw !== 'number' || Number.isNaN(raw)) return config.default
+      const min = config.min ?? Number.NEGATIVE_INFINITY
+      const max = config.max ?? Number.POSITIVE_INFINITY
+      return Math.min(Math.max(raw, min), max) // snap into the current range
+    }
+    case 'select':
+      return typeof raw === 'string' && config.options.includes(raw)
+        ? raw
+        : config.default
+    case 'color':
+      return typeof raw === 'string' && raw.length > 0 ? raw : config.default
+    case 'text':
+      return typeof raw === 'string' ? raw : config.default
+    default:
+      return (config as TweakConfig).default
+  }
+}
+
+function ensureLoaded(): void {
+  if (loaded || typeof window === 'undefined') return
+  loaded = true
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return
+    const parsed = JSON.parse(raw) as PersistedTweakerState
+    if (parsed?.v !== 1) return
+    for (const [k, val] of Object.entries(parsed.values ?? {}))
+      persisted.set(k, val)
+    for (const [k, o] of Object.entries(parsed.order ?? {})) {
+      order.set(k, o)
+      nextOrder = Math.max(nextOrder, o + 1)
+    }
+    if (parsed.ui) ui = { ...DEFAULT_UI, ...parsed.ui }
+  } catch {
+    // Corrupt/disabled storage — start clean. Non-fatal for a dev tool.
+  }
+}
+
+function persist(): void {
+  if (typeof window === 'undefined') return
+  try {
+    // Live values win over the on-disk snapshot; orphans (persisted but not mounted
+    // this session) are preserved so a choice isn't lost by navigating away.
+    const merged: Record<string, unknown> = {
+      ...Object.fromEntries(persisted),
+      ...Object.fromEntries(values),
+    }
+    const data: PersistedTweakerState = {
+      v: 1,
+      values: merged,
+      order: Object.fromEntries(order),
+      ui,
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  } catch {
+    // Private mode / quota — the tweaker just won't persist this session.
+  }
+}
+
+function notify(): void {
+  for (const l of listeners) l()
+}
+
+/* ------------------------------ registration ------------------------------ */
+
+/** Register (or re-register) a control. Idempotent and ref-counted. Returns its id. */
+export function registerControl(
+  label: string,
+  config: TweakConfig,
+  ownerToken: string,
+): string {
+  ensureLoaded()
+  const group = config.group ?? 'default'
+  const id = idFor(label, group)
+  const existing = controls.get(id)
+
+  if (existing) {
+    existing.refCount += 1
+    existing.config = config
+    // HMR may have changed options/min/max — re-validate the held value.
+    values.set(id, coerceTweakValue(config, values.get(id)))
+    if (existing.ownerToken !== ownerToken && import.meta.env.DEV) {
+      console.warn(
+        `[tweaker] duplicate control id "${id}". Give one a different \`group\` or \`label\`; last writer wins and the value is shared.`,
+      )
+    }
+  } else {
+    let o = order.get(id)
+    if (o === undefined) {
+      o = nextOrder++
+      order.set(id, o)
+    }
+    // Seed from the on-disk value (if any) coerced to this config, else default.
+    const seed = values.has(id) ? values.get(id) : persisted.get(id)
+    values.set(id, coerceTweakValue(config, seed))
+    controls.set(id, {
+      id,
+      label,
+      group,
+      order: o,
+      refCount: 1,
+      ownerToken,
+      config,
+    })
+    controlListDirty = true
+  }
+
+  persist()
+  notify()
+  return id
+}
+
+/** Drop one mount's reference. Removes the control from the panel at zero refs; never clears its value. */
+export function unregisterControl(id: string): void {
+  const control = controls.get(id)
+  if (!control) return
+  control.refCount -= 1
+  if (control.refCount <= 0) {
+    controls.delete(id)
+    controlListDirty = true
+    notify()
+  }
+}
+
+/** Write a value (coerced against the control's config when registered). No-ops on an equal value. */
+export function setValue(id: string, raw: unknown): void {
+  ensureLoaded()
+  const control = controls.get(id)
+  const next = control ? coerceTweakValue(control.config, raw) : raw
+  if (Object.is(values.get(id), next)) return // prevent controlled-input ping-pong
+  values.set(id, next)
+  persist()
+  notify()
+}
+
+/** Reset one control to its config default. */
+export function resetControl(id: string): void {
+  const control = controls.get(id)
+  if (!control) return
+  setValue(id, control.config.default)
+}
+
+/** Reset every currently-mounted control to its default. */
+export function resetAll(): void {
+  for (const control of controls.values()) {
+    values.set(control.id, control.config.default)
+  }
+  persist()
+  notify()
+}
+
+/* -------------------------------- reads ----------------------------------- */
+
+/**
+ * The live value for an id, or `undefined` if no control has registered it yet
+ * this session. The hook treats `undefined` as "use the default", which keeps the
+ * stored choice from being applied until after mount (SSR-safe).
+ */
+export function getValue(id: string): unknown {
+  return values.get(id)
+}
+
+/** Stable, sorted (group, then source order) snapshot of mounted controls. */
+export function getControls(): RegisteredControl[] {
+  ensureLoaded()
+  if (controlListDirty) {
+    controlListSnapshot = [...controls.values()].sort(
+      (a, b) => a.group.localeCompare(b.group) || a.order - b.order,
+    )
+    controlListDirty = false
+  }
+  return controlListSnapshot
+}
+
+export function getServerControls(): RegisteredControl[] {
+  return EMPTY_CONTROLS
+}
+
+export function getUiState(): TweakerUiState {
+  ensureLoaded()
+  return ui
+}
+
+export function getServerUiState(): TweakerUiState {
+  return DEFAULT_UI
+}
+
+export function setUiState(patch: Partial<TweakerUiState>): void {
+  ensureLoaded()
+  ui = { ...ui, ...patch }
+  persist()
+  notify()
+}
+
+/* ----------------------------- subscription ------------------------------- */
+
+export function subscribe(onChange: () => void): () => void {
+  listeners.add(onChange)
+  return () => {
+    listeners.delete(onChange)
+  }
+}
+
+/** Test-only: wipe all state and skip localStorage. */
+export function __resetStoreForTests(): void {
+  controls.clear()
+  values.clear()
+  persisted.clear()
+  order.clear()
+  ui = DEFAULT_UI
+  nextOrder = 0
+  loaded = true // skip localStorage in tests
+  controlListSnapshot = []
+  controlListDirty = true
+  listeners.clear()
+}

--- a/www/src/dev/tweaker/store.ts
+++ b/www/src/dev/tweaker/store.ts
@@ -33,8 +33,9 @@ import type {
 const STORAGE_KEY = 'dotui:tweaker'
 
 const DEFAULT_UI: TweakerUiState = {
-  collapsed: true,
-  hidden: false,
+  open: false,
+  side: 'right',
+  y: 0.5,
 }
 
 /* ------------------------------ module state ------------------------------ */

--- a/www/src/dev/tweaker/tweaker.tsx
+++ b/www/src/dev/tweaker/tweaker.tsx
@@ -1,16 +1,16 @@
 'use client'
 
-import { useEffect, useSyncExternalStore } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import {
   CheckIcon,
   CopyIcon,
-  MinusIcon,
   RotateCcwIcon,
   SlidersHorizontalIcon,
   XIcon,
 } from 'lucide-react'
 
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
+import { cn } from '@/registry/lib/utils'
 import { Button } from '@/registry/ui/button'
 import { Kbd } from '@/registry/ui/kbd'
 
@@ -26,6 +26,10 @@ import {
   subscribe,
 } from './store'
 import type { RegisteredControl } from './types'
+
+const TRIGGER_SIZE = 40 // px (size-10)
+const EDGE_GAP = 12 // px between the trigger and the screen edge
+const PANEL_OFFSET = EDGE_GAP + TRIGGER_SIZE + 8 // edge → panel's near side
 
 const noopSubscribe = () => () => {}
 
@@ -46,6 +50,10 @@ function useUiState() {
   return useSyncExternalStore(subscribe, getUiState, getServerUiState)
 }
 
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(Math.max(n, lo), hi)
+}
+
 /** A compact summary of the current selections the user can paste back to the agent. */
 function buildCopyText(): string {
   const lines = getControls().map((c) => {
@@ -63,43 +71,148 @@ export function DevTweaker() {
   const controls = useControls()
   const { isCopied, copyToClipboard } = useCopyToClipboard()
 
-  // ⌘. / Ctrl+. toggles the panel (and un-collapses when bringing it back).
+  const [viewport, setViewport] = useState(() =>
+    typeof window === 'undefined'
+      ? { w: 1280, h: 800 }
+      : { w: window.innerWidth, h: window.innerHeight },
+  )
+  // While dragging, the trigger follows the cursor (px); on release it snaps to a side.
+  const [drag, setDrag] = useState<{ x: number; y: number } | null>(null)
+  const dragStart = useRef<{ x: number; y: number } | null>(null)
+  const moved = useRef(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const onResize = () =>
+      setViewport({ w: window.innerWidth, h: window.innerHeight })
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  // ⌘. / Ctrl+. toggles the popover; Escape closes it.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === '.') {
         e.preventDefault()
-        const next = !getUiState().hidden
-        setUiState({ hidden: next, collapsed: next ? true : false })
+        setUiState({ open: !getUiState().open })
+      } else if (e.key === 'Escape' && getUiState().open) {
+        setUiState({ open: false })
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [])
 
-  if (!mounted || ui.hidden) return null
+  // Dismiss the popover on an outside click (it stays anchored to the trigger otherwise).
+  useEffect(() => {
+    if (!ui.open) return
+    const onDown = (e: PointerEvent) => {
+      const target = e.target as Node
+      if (
+        panelRef.current?.contains(target) ||
+        triggerRef.current?.contains(target)
+      ) {
+        return
+      }
+      setUiState({ open: false })
+    }
+    window.addEventListener('pointerdown', onDown)
+    return () => window.removeEventListener('pointerdown', onDown)
+  }, [ui.open])
+
+  if (!mounted) return null
+
+  /* --------------------------- trigger drag --------------------------- */
+
+  const onPointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+    // Capture so move/up keep firing if the cursor leaves the button mid-drag.
+    // Can throw InvalidPointerId on stray/synthetic pointers — non-fatal.
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId)
+    } catch {
+      /* ignore */
+    }
+    dragStart.current = { x: e.clientX, y: e.clientY }
+    moved.current = false
+  }
+
+  const onPointerMove = (e: React.PointerEvent<HTMLButtonElement>) => {
+    if (!dragStart.current) return
+    const dx = e.clientX - dragStart.current.x
+    const dy = e.clientY - dragStart.current.y
+    if (!moved.current && Math.hypot(dx, dy) > 5) {
+      moved.current = true
+      if (getUiState().open) setUiState({ open: false }) // dragging closes the popover
+    }
+    if (moved.current) setDrag({ x: e.clientX, y: e.clientY })
+  }
+
+  const onPointerUp = (e: React.PointerEvent<HTMLButtonElement>) => {
+    if (!dragStart.current) return
+    dragStart.current = null
+    setDrag(null)
+    if (moved.current) {
+      // Snap to the nearest edge, keeping the vertical position it was dropped at.
+      const side = e.clientX < window.innerWidth / 2 ? 'left' : 'right'
+      const y = clamp(e.clientY / window.innerHeight, 0.06, 0.94)
+      setUiState({ side, y })
+    } else {
+      setUiState({ open: !getUiState().open }) // a tap toggles the popover
+    }
+  }
+
+  /* ----------------------------- geometry ----------------------------- */
+
+  const dockedCx =
+    ui.side === 'left'
+      ? EDGE_GAP + TRIGGER_SIZE / 2
+      : viewport.w - EDGE_GAP - TRIGGER_SIZE / 2
+  const triggerStyle: React.CSSProperties = drag
+    ? { left: drag.x, top: drag.y }
+    : { left: dockedCx, top: ui.y * viewport.h }
+
+  const panelSideStyle: React.CSSProperties =
+    ui.side === 'left' ? { left: PANEL_OFFSET } : { right: PANEL_OFFSET }
+  // Centre the panel on the trigger, but clamp so it always stays fully on screen.
+  const panelTop = clamp(ui.y, 0.36, 0.64) * viewport.h
 
   const count = controls.length
 
-  // z-40: above page content, but below the popover layer (z-50) so the panel's own
-  // Select/ColorField dropdowns render above it, and below modals (z-100).
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-40 flex justify-center px-4">
-      {ui.collapsed ? (
-        <button
-          type="button"
-          onClick={() => setUiState({ collapsed: false })}
-          className="hover:bg-bg-muted pointer-events-auto flex items-center gap-2 rounded-full border border-border bg-bg/95 px-3 py-2 text-fg shadow-lg backdrop-blur-sm transition-colors"
+    <>
+      {/* Trigger — always visible, docked to a side, draggable (snaps to an edge). z-40 keeps
+          it above page content but below the popover layer (z-50) and modals (z-100). */}
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="Open tweaker"
+        aria-expanded={ui.open}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        style={triggerStyle}
+        className={cn(
+          'hover:bg-bg-muted fixed z-40 flex size-10 -translate-x-1/2 -translate-y-1/2 cursor-pointer touch-none items-center justify-center rounded-full border border-border bg-bg text-fg shadow-lg',
+          !drag && 'transition-[left,top] duration-200 ease-out',
+          ui.open && 'bg-bg-muted',
+        )}
+      >
+        <SlidersHorizontalIcon className="size-4 text-fg-muted" />
+        {count > 0 && (
+          <span className="absolute -top-1 -right-1 flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-fg-on-primary">
+            {count}
+          </span>
+        )}
+      </button>
+
+      {/* Popover panel — anchored beside the trigger; the trigger stays visible. */}
+      {ui.open && !drag && (
+        <div
+          ref={panelRef}
+          style={{ ...panelSideStyle, top: panelTop }}
+          className="fixed z-40 flex max-h-[70vh] w-75 max-w-[calc(100vw-5rem)] -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-border bg-bg shadow-2xl"
         >
-          <SlidersHorizontalIcon className="size-4 text-fg-muted" />
-          <span className="text-xs font-medium">Tweaker</span>
-          {count > 0 && (
-            <span className="flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-fg-on-primary">
-              {count}
-            </span>
-          )}
-        </button>
-      ) : (
-        <div className="pointer-events-auto flex max-h-[70vh] w-75 flex-col overflow-hidden rounded-xl border border-border bg-bg shadow-2xl">
           <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
             <div className="flex items-center gap-2">
               <SlidersHorizontalIcon className="size-4 text-fg-muted" />
@@ -133,17 +246,8 @@ export function DevTweaker() {
                 size="sm"
                 variant="quiet"
                 isIconOnly
-                aria-label="Minimize"
-                onPress={() => setUiState({ collapsed: true })}
-              >
-                <MinusIcon />
-              </Button>
-              <Button
-                size="sm"
-                variant="quiet"
-                isIconOnly
-                aria-label="Hide (⌘.)"
-                onPress={() => setUiState({ hidden: true })}
+                aria-label="Close"
+                onPress={() => setUiState({ open: false })}
               >
                 <XIcon />
               </Button>
@@ -161,12 +265,12 @@ export function DevTweaker() {
           <div className="flex items-center justify-between border-t border-border px-3 py-1.5 text-[10px] text-fg-muted">
             <span>dev only · not shipped</span>
             <span className="flex items-center gap-1">
-              <Kbd>⌘ .</Kbd> to hide
+              <Kbd>⌘ .</Kbd> to toggle
             </span>
           </div>
         </div>
       )}
-    </div>
+    </>
   )
 }
 

--- a/www/src/dev/tweaker/tweaker.tsx
+++ b/www/src/dev/tweaker/tweaker.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { useEffect, useSyncExternalStore } from 'react'
+import {
+  CheckIcon,
+  CopyIcon,
+  MinusIcon,
+  RotateCcwIcon,
+  SlidersHorizontalIcon,
+  XIcon,
+} from 'lucide-react'
+
+import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
+import { Button } from '@/registry/ui/button'
+import { Kbd } from '@/registry/ui/kbd'
+
+import { ControlRow } from './controls'
+import {
+  getControls,
+  getServerControls,
+  getServerUiState,
+  getUiState,
+  getValue,
+  resetAll,
+  setUiState,
+  subscribe,
+} from './store'
+import type { RegisteredControl } from './types'
+
+const noopSubscribe = () => () => {}
+
+/** SSR-safe "are we on the client yet?" — false on the server + first paint, true after. */
+function useMounted(): boolean {
+  return useSyncExternalStore(
+    noopSubscribe,
+    () => true,
+    () => false,
+  )
+}
+
+function useControls(): RegisteredControl[] {
+  return useSyncExternalStore(subscribe, getControls, getServerControls)
+}
+
+function useUiState() {
+  return useSyncExternalStore(subscribe, getUiState, getServerUiState)
+}
+
+/** A compact summary of the current selections the user can paste back to the agent. */
+function buildCopyText(): string {
+  const lines = getControls().map((c) => {
+    const raw = getValue(c.id)
+    const chosen = raw === undefined ? c.config.default : raw
+    const prefix = c.group === 'default' ? '' : `${c.group} / `
+    return `- ${prefix}${c.label} (${c.config.type}): ${JSON.stringify(chosen)}  [default ${JSON.stringify(c.config.default)}]`
+  })
+  return `Tweaker selections:\n${lines.join('\n') || '(none)'}`
+}
+
+export function DevTweaker() {
+  const mounted = useMounted()
+  const ui = useUiState()
+  const controls = useControls()
+  const { isCopied, copyToClipboard } = useCopyToClipboard()
+
+  // ⌘. / Ctrl+. toggles the panel (and un-collapses when bringing it back).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === '.') {
+        e.preventDefault()
+        const next = !getUiState().hidden
+        setUiState({ hidden: next, collapsed: next ? true : false })
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  if (!mounted || ui.hidden) return null
+
+  const count = controls.length
+
+  // z-40: above page content, but below the popover layer (z-50) so the panel's own
+  // Select/ColorField dropdowns render above it, and below modals (z-100).
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-40 flex justify-center px-4">
+      {ui.collapsed ? (
+        <button
+          type="button"
+          onClick={() => setUiState({ collapsed: false })}
+          className="hover:bg-bg-muted pointer-events-auto flex items-center gap-2 rounded-full border border-border bg-bg/95 px-3 py-2 text-fg shadow-lg backdrop-blur-sm transition-colors"
+        >
+          <SlidersHorizontalIcon className="size-4 text-fg-muted" />
+          <span className="text-xs font-medium">Tweaker</span>
+          {count > 0 && (
+            <span className="flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-fg-on-primary">
+              {count}
+            </span>
+          )}
+        </button>
+      ) : (
+        <div className="pointer-events-auto flex max-h-[70vh] w-75 flex-col overflow-hidden rounded-xl border border-border bg-bg shadow-2xl">
+          <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+            <div className="flex items-center gap-2">
+              <SlidersHorizontalIcon className="size-4 text-fg-muted" />
+              <span className="text-sm font-medium">Tweaker</span>
+              {count > 0 && (
+                <span className="flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-fg-on-primary">
+                  {count}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-0.5">
+              <Button
+                size="sm"
+                variant="quiet"
+                isIconOnly
+                aria-label="Copy selections for the agent"
+                onPress={() => copyToClipboard(buildCopyText())}
+              >
+                {isCopied ? <CheckIcon /> : <CopyIcon />}
+              </Button>
+              <Button
+                size="sm"
+                variant="quiet"
+                isIconOnly
+                aria-label="Reset all to defaults"
+                onPress={() => resetAll()}
+              >
+                <RotateCcwIcon />
+              </Button>
+              <Button
+                size="sm"
+                variant="quiet"
+                isIconOnly
+                aria-label="Minimize"
+                onPress={() => setUiState({ collapsed: true })}
+              >
+                <MinusIcon />
+              </Button>
+              <Button
+                size="sm"
+                variant="quiet"
+                isIconOnly
+                aria-label="Hide (⌘.)"
+                onPress={() => setUiState({ hidden: true })}
+              >
+                <XIcon />
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-3">
+            {count === 0 ? (
+              <EmptyState />
+            ) : (
+              <GroupedControls controls={controls} />
+            )}
+          </div>
+
+          <div className="flex items-center justify-between border-t border-border px-3 py-1.5 text-[10px] text-fg-muted">
+            <span>dev only · not shipped</span>
+            <span className="flex items-center gap-1">
+              <Kbd>⌘ .</Kbd> to hide
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-1.5 px-2 py-6 text-center">
+      <SlidersHorizontalIcon className="size-5 text-fg-muted" />
+      <p className="text-sm font-medium text-fg">No tweaks yet</p>
+      <p className="text-xs text-balance text-fg-muted">
+        Ask the agent to add tweaks for the feature you&rsquo;re exploring.
+      </p>
+    </div>
+  )
+}
+
+function GroupedControls({ controls }: { controls: RegisteredControl[] }) {
+  // `controls` arrives sorted by (group, order), so a single pass groups them.
+  const groups: Array<[string, RegisteredControl[]]> = []
+  for (const control of controls) {
+    const last = groups[groups.length - 1]
+    if (last && last[0] === control.group) last[1].push(control)
+    else groups.push([control.group, [control]])
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {groups.map(([group, items]) => (
+        <div key={group} className="flex flex-col gap-3">
+          {group !== 'default' && (
+            <div className="text-[10px] font-semibold tracking-wide text-fg-muted uppercase">
+              {group}
+            </div>
+          )}
+          {items.map((control) => (
+            <ControlRow key={control.id} control={control} />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/www/src/dev/tweaker/types.ts
+++ b/www/src/dev/tweaker/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Dev tweaker — type definitions.
+ *
+ * The tweaker is dev-only tooling (see ./README.md): an AI agent adds `useTweak`
+ * calls to a feature component while you explore designs/layouts, and the floating
+ * panel lets you flip between the options live. None of this ships to production.
+ */
+
+export interface BaseTweakConfig {
+  /** Heading the control is grouped under in the panel. Defaults to "default". */
+  group?: string
+}
+
+export interface BooleanTweakConfig extends BaseTweakConfig {
+  type: 'boolean'
+  default: boolean
+}
+
+export interface SelectTweakConfig extends BaseTweakConfig {
+  type: 'select'
+  /** The choices. Each string is both the option's label and its value. */
+  options: readonly string[]
+  default: string
+}
+
+export interface NumberTweakConfig extends BaseTweakConfig {
+  type: 'number'
+  default: number
+  /** When both `min` and `max` are set the control renders as a slider. */
+  min?: number
+  max?: number
+  step?: number
+}
+
+export interface ColorTweakConfig extends BaseTweakConfig {
+  type: 'color'
+  /** Any CSS color string (e.g. "#635bff", "hsl(217 91% 60%)"). */
+  default: string
+}
+
+export interface TextTweakConfig extends BaseTweakConfig {
+  type: 'text'
+  default: string
+}
+
+export type TweakConfig =
+  | BooleanTweakConfig
+  | SelectTweakConfig
+  | NumberTweakConfig
+  | ColorTweakConfig
+  | TextTweakConfig
+
+type SelectOptionValue<O> = O extends readonly (infer E)[] ? E : string
+
+/**
+ * The value a given config resolves to. A `select` narrows to the union of its
+ * options (when `useTweak` is called with a `const`-inferred config), so
+ * `useTweak('Layout', { type: 'select', options: ['a', 'b'], default: 'a' })`
+ * is typed `'a' | 'b'`.
+ */
+export type TweakValue<C extends TweakConfig> = C extends BooleanTweakConfig
+  ? boolean
+  : C extends NumberTweakConfig
+    ? number
+    : C extends SelectTweakConfig
+      ? SelectOptionValue<C['options']>
+      : string
+
+/** A control currently mounted in a feature component (lives only while mounted). */
+export interface RegisteredControl {
+  id: string
+  label: string
+  group: string
+  /** Stable source-order index, assigned on first registration and persisted. */
+  order: number
+  /** How many mounted components reference this id (ref-counted register/unregister). */
+  refCount: number
+  /** `useId()` of the first registrant — used to warn on a true id collision. */
+  ownerToken: string
+  config: TweakConfig
+}
+
+/** Floating-panel chrome state. */
+export interface TweakerUiState {
+  /** Collapsed to the pill (true) vs the full expanded panel (false). */
+  collapsed: boolean
+  /** Dismissed entirely; restore with ⌘. */
+  hidden: boolean
+}
+
+/** What we persist to localStorage. Versioned so a schema change can drop it cleanly. */
+export interface PersistedTweakerState {
+  v: 1
+  /** Chosen values, keyed by control id. Outlives any single control's mount. */
+  values: Record<string, unknown>
+  /** Stable order index per id, so the panel doesn't reshuffle across reloads. */
+  order: Record<string, number>
+  ui: TweakerUiState
+}

--- a/www/src/dev/tweaker/types.ts
+++ b/www/src/dev/tweaker/types.ts
@@ -82,10 +82,12 @@ export interface RegisteredControl {
 
 /** Floating-panel chrome state. */
 export interface TweakerUiState {
-  /** Collapsed to the pill (true) vs the full expanded panel (false). */
-  collapsed: boolean
-  /** Dismissed entirely; restore with ⌘. */
-  hidden: boolean
+  /** Whether the popover panel is open (the docked trigger is always visible). */
+  open: boolean
+  /** Which edge the trigger is docked to. */
+  side: 'left' | 'right'
+  /** Vertical position of the trigger as a fraction (0–1) of the viewport height. */
+  y: number
 }
 
 /** What we persist to localStorage. Versioned so a schema change can drop it cleanly. */

--- a/www/src/dev/tweaker/use-tweak.ts
+++ b/www/src/dev/tweaker/use-tweak.ts
@@ -1,0 +1,73 @@
+'use client'
+
+import { useEffect, useId, useSyncExternalStore } from 'react'
+
+import {
+  getValue,
+  registerControl,
+  subscribe,
+  unregisterControl,
+} from './store'
+import type { TweakConfig, TweakValue } from './types'
+
+type UseTweak = <const C extends TweakConfig>(
+  label: string,
+  config: C,
+) => TweakValue<C>
+
+function useTweakDev<const C extends TweakConfig>(
+  label: string,
+  config: C,
+): TweakValue<C> {
+  const ownerToken = useId()
+  const group = config.group ?? 'default'
+  const id = `${group}::${label}`
+  // Inline config literals change identity every render; key the register effect by
+  // a stable hash so it doesn't re-register (and churn the panel) on every render.
+  const hash = JSON.stringify(config)
+
+  const value = useSyncExternalStore(
+    subscribe,
+    () => {
+      const v = getValue(id)
+      return (v === undefined ? config.default : v) as TweakValue<C>
+    },
+    () => config.default as TweakValue<C>,
+  )
+
+  useEffect(() => {
+    registerControl(label, config, ownerToken)
+    return () => unregisterControl(id)
+    // oxlint-disable-next-line react/exhaustive-deps -- keyed by `hash`/`id`, which derive from label+config
+  }, [id, hash, ownerToken])
+
+  return value
+}
+
+function useTweakNoop<const C extends TweakConfig>(
+  _label: string,
+  config: C,
+): TweakValue<C> {
+  return config.default as TweakValue<C>
+}
+
+/**
+ * Read a live, user-tweakable value while exploring a design in dev.
+ *
+ * Dev-only: an AI agent adds these to a feature component while you explore it, and
+ * the floating Tweaker panel (mounted in `__root.tsx`) lets you flip the value live.
+ * In production this compiles to a no-op that returns `config.default`, and the whole
+ * tweaker (store + panel) tree-shakes away. See ./README.md for the full workflow.
+ *
+ * @example
+ * const layout = useTweak('Layout', {
+ *   type: 'select',
+ *   options: ['centered', 'split', 'fullbleed'],
+ *   default: 'centered',
+ *   group: 'Hero',
+ * })
+ * // → typed 'centered' | 'split' | 'fullbleed'
+ */
+export const useTweak: UseTweak = import.meta.env.DEV
+  ? useTweakDev
+  : useTweakNoop

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import { useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import {
   createRootRoute,
   HeadContent,
@@ -23,6 +23,13 @@ import { ToastProvider } from '@/registry/ui/toast'
 import { usePreviewForcedTheme } from '@/modules/create/preset'
 
 import appCss from '@/styles.css?url'
+
+// Dev-only floating panel for live design/layout exploration (see src/dev/tweaker).
+// Lazily imported behind the DEV constant so the whole tweaker is dead-code-eliminated
+// from production builds.
+const DevTweaker = import.meta.env.DEV
+  ? lazy(() => import('@/dev/tweaker').then((m) => ({ default: m.DevTweaker })))
+  : null
 
 export const Route = createRootRoute({
   head: ({ matches }) => {
@@ -166,6 +173,11 @@ function RootComponent() {
         <ToastProvider>
           <Outlet />
         </ToastProvider>
+        {DevTweaker && (
+          <Suspense fallback={null}>
+            <DevTweaker />
+          </Suspense>
+        )}
       </RootDocument>
     </ThemeProvider>
   )


### PR DESCRIPTION
## Summary

A **dev-only** floating "Tweaker" panel (Vercel-toolbar style) that gives AI agents a clear, repeatable workflow for surfacing live design/layout tweaks during PR exploration — instead of code-edit → reload round-trips.

**The loop:** while exploring a feature, an agent adds `useTweak()` calls to the component → controls auto-appear in the panel → you flip options live and pick → **Copy for AI** (or just say it) → the agent bakes the choice in and removes the scaffolding.

It's internal tooling only — never in the registry product source, and **fully stripped from production**: `useTweak` compiles to a no-op and the panel + store tree-shake away (verified: the prod client and server bundles contain zero tweaker code).

### What's here

- `www/src/dev/tweaker/`
  - `use-tweak.ts` — colocated `useTweak(label, config)` hook; 5 control types (`select` / `boolean` / `number` / `color` / `text`). `import.meta.env.DEV ? useTweakDev : useTweakNoop` build-constant split keeps prod a no-op.
  - `store.ts` — framework-free `useSyncExternalStore` singleton (mirrors `modules/create/preset/storage.ts`). Value lifetime is decoupled from control lifetime, so a choice survives React StrictMode, HMR edits, and route remounts; on-disk state seeds only after mount → no SSR hydration mismatch.
  - `controls.tsx` / `tweaker.tsx` — the panel (pill ↔ expand, minimize, hide + **⌘.** restore, reset, copy-for-AI), reusing registry UI.
  - `store.test.ts` — 10 unit tests.
  - `README.md` — full API + workflow.
- `__root.tsx` — mounts `DevTweaker` lazily + DEV-gated.
- `CLAUDE.md` — a **Dev tweaker (design exploration)** section: the strict *when* (PR work + explicit ask only), *how*, the registry-source boundary, and the *cleanup* rule.

### Reviewer notes

- This is **not** a `/create` axis — it's throwaway exploration scaffolding, not a product tweak (those still follow propose-and-approve).
- No animation on the pill ↔ panel swap: `AnimatePresence mode="wait"` stalled the swap under headless/SSR-dev (state flipped but the DOM didn't), so it's an instant conditional render. Easy to re-add with a CSS transition later.
- Panel uses `z-40` deliberately, so its own Select/ColorField dropdowns (popover layer `z-50`) render above it and modals (`z-100`) sit above it.

### Verification

- `pnpm typecheck`, `pnpm check`, and the 10 store tests pass.
- Live on the dev server: pill / expand / minimize / hide, control registration, live re-render of the consuming component on flip, and persistence across reload.
- Production build: client + server bundles free of tweaker code (`dotui:tweaker`, `coerceTweakValue`, `useTweakDev`, "No tweaks yet" all absent).
