### PR TITLE
fix(www): keep native scroll restoration to stop reload flash

### DIFF
--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -187,6 +187,24 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Keep the browser's NATIVE scroll restoration on for full-page loads.
+            The router runs `scrollRestoration: true`, which sets
+            `history.scrollRestoration = "manual"` and restores scroll from JS —
+            but our pages are server-rendered, so the browser paints the content
+            at the top before that JS runs and a reload partway down flashes to
+            the top then jumps. The browser's own restoration runs as part of
+            layout, before paint (this is what shadcn/Next.js rely on). We force
+            it back to "auto" AND lock the property, because the router re-sets
+            "manual" during hydration — without the lock that flip lands right
+            when the browser is about to restore and disables it. In-app
+            navigation is unaffected: the router's `onRendered` handler scrolls
+            to top / restores from its cache in JS regardless of this mode. */}
+        <script
+          // oxlint-disable-next-line react/no-danger -- static, hardcoded inline script (no user input)
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{history.scrollRestoration="auto";var d=Object.getOwnPropertyDescriptor(History.prototype,"scrollRestoration");Object.defineProperty(history,"scrollRestoration",{configurable:true,get:function(){return d.get.call(history)},set:function(){}})}catch(_){}})()`,
+          }}
+        />
         {/* <script src="https://unpkg.com/react-scan/dist/auto.global.js" /> */}
         <HeadContent />
       </head>


### PR DESCRIPTION
**Alternative to #340** — same bug, cleaner fix. Open both so you can compare; merge one.

## The bug

Reload a page while scrolled down → it flashes at the top for a frame, then jumps to where you were. (Full investigation, measurements, and a dotUI/TanStack/shadcn perf comparison are in #340's `docs/research/2026-06-30-scroll-restoration-and-perf.md`.)

**Root cause:** the router's `scrollRestoration: true` sets `history.scrollRestoration = "manual"` and restores scroll in JavaScript. Our pages are server-rendered, so the browser paints the content at the top *before* that JS runs — and the restore lands after. It's a known TanStack issue ([#2601](https://github.com/TanStack/router/issues/2601), closed but unsolved for heavy SSR).

## Why this approach

shadcn (also SSR) doesn't have the flash because it leaves full-page reloads to the **browser's native** scroll restoration, which runs during layout — before paint. I measured it: shadcn restores at 48ms, paints at 264ms; zero JS scrollTo. dotUI flashes only because TanStack turns native restoration *off*.

This PR does what shadcn/Next.js do — a **hybrid**:
- **reload** → browser native restoration (before paint)
- **in-app navigation** → the router's existing `onRendered` (scroll-to-top on link nav, restore on back/forward)

A head script forces `history.scrollRestoration = "auto"` and **locks** the property. The lock matters: the router re-sets `"manual"` during hydration, which would disable native restoration at exactly the wrong moment. Locking the value doesn't disturb the router's JS scroll logic (it runs regardless of the browser mode), so in-app nav is unchanged.

## vs #340

| | #340 (hide-until-restored) | this PR (native) |
|---|---|---|
| flash | gone | gone |
| blank on reload-at-scroll | ~0.2–0.4s | **none** — paints already restored |
| couples to | router's sessionStorage cache | a property lock on `history` |
| in-app nav | untouched | untouched |

This is the better result (no blank); the trade-off is it relies on the browser's native restoration + a small property lock, and back/forward is now handled by both native and the router (verified harmless).

## Verification (real browser)

Headless can't show this flash, so verified **headful** (real Chrome, frame-by-frame), local build, 3 runs — all green:

- **reload partway down** → restores to the saved offset, **no top frame is ever painted** (first visible frame is already at `y=1456`), `history.scrollRestoration` = `auto`
- **link nav** (`/` → `/docs`) → scrolls to top (`scrollY=0`)
- **back** → home scroll restored (500); **forward** → `/docs` scroll restored (1681)

`pnpm check` (0 errors) + `pnpm typecheck` pass.

> Please also confirm with a manual reload-at-bottom + some link/back-forward clicking on the preview, since this leans on real-browser timing.