### PR TITLE
feat(registry): add time-picker component

### DIFF
--- a/www/content/docs/components/time-picker.mdx
+++ b/www/content/docs/components/time-picker.mdx
@@ -1,0 +1,68 @@
+---
+title: Time Picker
+description: A time picker combines a time field and a scrollable column popover to allow users to select a time.
+links:
+  - label: Docs
+    href: https://react-spectrum.adobe.com/react-aria/TimeField.html
+wip: true
+---
+
+<Demo name="time-picker/demos/basic" />
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/time-picker
+```
+
+## Usage
+
+Use time pickers to allow users to select a time using a field and a scrollable column popover.
+
+```tsx
+import { ClockIcon } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { DialogContent } from '@/components/ui/dialog'
+import { Label } from '@/components/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/components/ui/input'
+import { Popover } from '@/components/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/components/ui/time-picker'
+```
+
+```tsx
+<TimePicker>
+  <Label>Time</Label>
+  <InputGroup>
+    <DateInput />
+    <InputGroupAddon>
+      <Button variant="default" size="sm" isIconOnly aria-label="Choose time">
+        <ClockIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Popover>
+    <DialogContent>
+      <TimePickerColumns />
+    </DialogContent>
+  </Popover>
+</TimePicker>
+```
+
+## Examples
+
+<Examples className="sm:grid-cols-2">
+  <Example name="time-picker/demos/basic" title="Basic" />
+  <Example
+    name="time-picker/demos/composition"
+    title="With Label & Description"
+  />
+  <Example name="time-picker/demos/granularity" title="Granularity" />
+  <Example name="time-picker/demos/hour-cycle" title="Hour Cycle" />
+</Examples>
+
+## API Reference
+
+### TimePicker
+
+<Reference name="time-picker" />

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -67,6 +67,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"text-area": () => import("@/registry/ui/text-area/examples"),
 	"text-field": () => import("@/registry/ui/text-field/examples"),
 	"time-field": () => import("@/registry/ui/time-field/examples"),
+	"time-picker": () => import("@/registry/ui/time-picker/examples"),
 	toast: () => import("@/registry/ui/toast/examples"),
 	"toggle-button": () => import("@/registry/ui/toggle-button/examples"),
 	"toggle-button-group": () => import("@/registry/ui/toggle-button-group/examples"),

--- a/www/src/modules/docs/references/generated/time-picker-columns.json
+++ b/www/src/modules/docs/references/generated/time-picker-columns.json
@@ -1,0 +1,14 @@
+{
+  "name": "TimePickerColumnsProps",
+  "description": "The scrollable hour / minute / second / day-period columns rendered inside a\nTimePicker popover. Reads and writes the value from the enclosing TimePicker.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/time-picker.json
+++ b/www/src/modules/docs/references/generated/time-picker.json
@@ -1,0 +1,816 @@
+{
+  "name": "TimePickerProps",
+  "description": "A time picker combines a TimeField and a scrollable time-column popover to\nallow users to enter or select a time value.",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    },
+    "defaultOpen": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the popover is open by default (uncontrolled)."
+    },
+    "isOpen": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the popover is open (controlled)."
+    },
+    "onOpenChange": {
+      "type": "((isOpen: boolean) => void)",
+      "detailedType": "((isOpen: boolean) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "isOpen",
+            "value": {
+              "type": "link",
+              "id": "boolean",
+              "name": "boolean"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when the popover's open state changes."
+    },
+    "onFocus": {
+      "type": "((e: FocusEvent<Element, Element>) => void)",
+      "detailedType": "| ((e: FocusEvent<Element, Element>) => void)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "e",
+                "value": {
+                  "type": "identifier",
+                  "name": "FocusEvent"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Handler that is called when the element receives focus."
+    },
+    "onBlur": {
+      "type": "((e: FocusEvent<Element, Element>) => void)",
+      "detailedType": "| ((e: FocusEvent<Element, Element>) => void)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "e",
+                "value": {
+                  "type": "identifier",
+                  "name": "FocusEvent"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Handler that is called when the element loses focus."
+    },
+    "onFocusChange": {
+      "type": "((isFocused: boolean) => void)",
+      "detailedType": "((isFocused: boolean) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "isFocused",
+            "value": {
+              "type": "link",
+              "id": "boolean",
+              "name": "boolean"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when the element's focus status changes."
+    },
+    "onKeyDown": {
+      "type": "((e: KeyboardEvent) => void)",
+      "detailedType": "((e: KeyboardEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "KeyboardEvent",
+              "name": "KeyboardEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a key is pressed."
+    },
+    "onKeyUp": {
+      "type": "((e: KeyboardEvent) => void)",
+      "detailedType": "((e: KeyboardEvent) => void) | undefined",
+      "typeAst": {
+        "type": "function",
+        "parameters": [
+          {
+            "type": "parameter",
+            "name": "e",
+            "value": {
+              "type": "link",
+              "id": "KeyboardEvent",
+              "name": "KeyboardEvent"
+            },
+            "optional": false,
+            "rest": false
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "typeParameters": []
+      },
+      "description": "Handler that is called when a key is released."
+    },
+    "aria-describedby": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that describes the object."
+    },
+    "aria-details": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that provide a detailed, extended description for the\nobject."
+    },
+    "aria-label": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Defines a string value that labels the current element."
+    },
+    "aria-labelledby": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Identifies the element (or elements) that labels the current element."
+    },
+    "autoFocus": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the element should receive focus on render."
+    },
+    "defaultValue": {
+      "type": "T | null",
+      "detailedType": "T | null | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "typeParameter",
+            "name": "T",
+            "constraint": {
+              "type": "identifier",
+              "name": "TimeValue"
+            },
+            "default": null
+          }
+        ]
+      },
+      "description": "The default value (uncontrolled)."
+    },
+    "form": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The `<form>` element to associate the input with.\nThe value of this attribute must be the id of a `<form>` in the same document.\nSee [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#form)."
+    },
+    "granularity": {
+      "type": "\"hour\" | \"minute\" | \"second\"",
+      "detailedType": "'hour' | 'minute' | 'second' | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "hour"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "minute"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "second"
+          }
+        ]
+      },
+      "description": "Determines the smallest unit that is displayed in the time picker.",
+      "default": "'minute'"
+    },
+    "hideTimeZone": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether to hide the time zone abbreviation."
+    },
+    "hourCycle": {
+      "type": "12 | 24",
+      "detailedType": "12 | 24 | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "numberLiteral",
+            "value": 12
+          },
+          {
+            "type": "numberLiteral",
+            "value": 24
+          },
+          {
+            "type": "undefined"
+          }
+        ]
+      },
+      "description": "Whether to display the time in 12 or 24 hour format. By default, this is determined by the\nuser's locale."
+    },
+    "id": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The element's unique identifier. See\n[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)."
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the input is disabled."
+    },
+    "isInvalid": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the input value is invalid."
+    },
+    "isReadOnly": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether the input can be selected but not changed by the user."
+    },
+    "isRequired": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether user input is required on the input before form submission."
+    },
+    "maxValue": {
+      "type": "TimeValue | null",
+      "detailedType": "TimeValue | null | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "link",
+            "id": "@internationalized/date/dist/types/src/CalendarDate.d.ts:CalendarDateTime",
+            "name": "CalendarDateTime"
+          },
+          {
+            "type": "link",
+            "id": "@internationalized/date/dist/types/src/CalendarDate.d.ts:Time",
+            "name": "Time"
+          },
+          {
+            "type": "link",
+            "id": "@internationalized/date/dist/types/src/CalendarDate.d.ts:ZonedDateTime",
+            "name": "ZonedDateTime"
+          }
+        ]
+      },
+      "description": "The maximum allowed time that a user may select."
+    },
+    "minValue": {
+      "type": "TimeValue | null",
+      "detailedType": "TimeValue | null | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "link",
+            "id": "@internationalized/date/dist/types/src/CalendarDate.d.ts:CalendarDateTime",
+            "name": "CalendarDateTime"
+          },
+          {
+            "type": "link",
+            "id": "@internationalized/date/dist/types/src/CalendarDate.d.ts:Time",
+            "name": "Time"
+          },
+          {
+            "type": "link",
+            "id": "@internationalized/date/dist/types/src/CalendarDate.d.ts:ZonedDateTime",
+            "name": "ZonedDateTime"
+          }
+        ]
+      },
+      "description": "The minimum allowed time that a user may select."
+    },
+    "name": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The name of the input element, used when submitting an HTML form. See\n[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname)."
+    },
+    "onChange": {
+      "type": "((value: MappedTimeValue<T> | null) => void)",
+      "detailedType": "| ((value: MappedTimeValue<T> | null) => void)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "value",
+                "value": {
+                  "type": "union",
+                  "elements": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "application",
+                      "base": {
+                        "type": "identifier",
+                        "name": "MappedTimeValue"
+                      },
+                      "typeParameters": [
+                        {
+                          "type": "typeParameter",
+                          "name": "T",
+                          "constraint": {
+                            "type": "identifier",
+                            "name": "TimeValue"
+                          },
+                          "default": null
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "void"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "Handler that is called when the value changes."
+    },
+    "placeholderValue": {
+      "type": "T",
+      "detailedType": "T | undefined",
+      "typeAst": {
+        "type": "identifier",
+        "name": "T"
+      },
+      "description": "A placeholder time that influences the format of the placeholder shown when no value is\nselected. Defaults to 12:00 AM or 00:00 depending on the hour cycle."
+    },
+    "render": {
+      "type": "DOMRenderFunction<\"div\", DateFieldRenderProps>",
+      "detailedType": "| DOMRenderFunction<'div', DateFieldRenderProps>\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "application",
+            "base": {
+              "type": "identifier",
+              "name": "DOMRenderFunction"
+            },
+            "typeParameters": [
+              {
+                "type": "stringLiteral",
+                "value": "div"
+              },
+              {
+                "type": "link",
+                "id": "react-aria-components/dist/types/src/DateField.d.ts:DateFieldRenderProps",
+                "name": "DateFieldRenderProps"
+              }
+            ]
+          }
+        ]
+      },
+      "description": "Overrides the default DOM element with a custom render function.\nThis allows rendering existing components with built-in styles and behaviors\nsuch as router links, animation libraries, and pre-styled components.\n\nRequirements:\n\n- You must render the expected element type (e.g. if `<button>` is expected, you cannot render an\n  `<a>`).\n- Only a single root DOM element can be rendered (no fragments).\n- You must pass through props and ref to the underlying DOM element, merging with your own prop\n  as appropriate."
+    },
+    "shouldForceLeadingZeros": {
+      "type": "boolean",
+      "detailedType": "boolean | undefined",
+      "typeAst": {
+        "type": "boolean"
+      },
+      "description": "Whether to always show leading zeros in the hour field.\nBy default, this is determined by the user's locale."
+    },
+    "slot": {
+      "type": "null | string",
+      "detailedType": "null | string | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "description": "A slot name for the component. Slots allow the component to receive props from a parent\ncomponent. An explicit `null` value indicates that the local props completely override all\nprops received from a parent."
+    },
+    "style": {
+      "type": "CSSProperties | (values: DateFieldRenderProps) => CSSProperties",
+      "detailedType": "CSSProperties | (values: DateFieldRenderProps) => CSSProperties | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "identifier",
+            "name": "CSSProperties"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "values",
+                "value": {
+                  "type": "link",
+                  "id": "DateFieldRenderProps",
+                  "name": "DateFieldRenderProps"
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "identifier",
+              "name": "CSSProperties"
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the\nelement. A function may be provided to compute the style based on component state."
+    },
+    "validate": {
+      "type": "((value: MappedTimeValue<T>) => true | ValidationError | null | undefined)",
+      "detailedType": "| ((\n    value: MappedTimeValue<T>,\n  ) => true | ValidationError | null | undefined)\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "function",
+            "parameters": [
+              {
+                "type": "parameter",
+                "name": "value",
+                "value": {
+                  "type": "application",
+                  "base": {
+                    "type": "identifier",
+                    "name": "MappedTimeValue"
+                  },
+                  "typeParameters": [
+                    {
+                      "type": "typeParameter",
+                      "name": "T",
+                      "constraint": {
+                        "type": "identifier",
+                        "name": "TimeValue"
+                      },
+                      "default": null
+                    }
+                  ]
+                },
+                "optional": false,
+                "rest": false
+              }
+            ],
+            "return": {
+              "type": "union",
+              "elements": [
+                {
+                  "type": "booleanLiteral",
+                  "value": true
+                },
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "undefined"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "elementType": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "typeParameters": []
+          }
+        ]
+      },
+      "description": "A function that returns an error message if a given value is invalid.\nValidation errors are displayed to the user when the form is submitted\nif `validationBehavior=\"native\"`. For realtime validation, use the `isInvalid`\nprop instead."
+    },
+    "validationBehavior": {
+      "type": "\"aria\" | \"native\"",
+      "detailedType": "'aria' | 'native' | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "aria"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "native"
+          }
+        ]
+      },
+      "description": "Whether to use native HTML form validation to prevent form submission\nwhen the value is missing or invalid, or mark the field as required\nor invalid via ARIA.",
+      "default": "'native'"
+    },
+    "value": {
+      "type": "T | null",
+      "detailedType": "T | null | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "typeParameter",
+            "name": "T",
+            "constraint": {
+              "type": "identifier",
+              "name": "TimeValue"
+            },
+            "default": null
+          }
+        ]
+      },
+      "description": "The current value (controlled)."
+    }
+  },
+  "typeLinks": {
+    "DateFieldRenderProps": {
+      "type": "interface",
+      "name": "DateFieldRenderProps",
+      "properties": {
+        "isDisabled": {
+          "type": "property",
+          "name": "isDisabled",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the date field is disabled."
+        },
+        "isInvalid": {
+          "type": "property",
+          "name": "isInvalid",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the date field is invalid."
+        },
+        "isReadOnly": {
+          "type": "property",
+          "name": "isReadOnly",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the date field is read only."
+        },
+        "isRequired": {
+          "type": "property",
+          "name": "isRequired",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the date field is required."
+        },
+        "state": {
+          "type": "property",
+          "name": "state",
+          "value": {
+            "type": "identifier",
+            "name": "DateFieldState"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "State of the date field."
+        }
+      }
+    },
+    "react-aria-components/dist/types/src/DateField.d.ts:DateFieldRenderProps": {
+      "type": "interface",
+      "id": "react-aria-components/dist/types/src/DateField.d.ts:DateFieldRenderProps",
+      "name": "DateFieldRenderProps",
+      "extends": [],
+      "properties": {
+        "isDisabled": {
+          "type": "property",
+          "name": "isDisabled",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the date field is disabled."
+        },
+        "isInvalid": {
+          "type": "property",
+          "name": "isInvalid",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the date field is invalid."
+        },
+        "isReadOnly": {
+          "type": "property",
+          "name": "isReadOnly",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the date field is read only."
+        },
+        "isRequired": {
+          "type": "property",
+          "name": "isRequired",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "Whether the date field is required."
+        },
+        "state": {
+          "type": "property",
+          "name": "state",
+          "value": {
+            "type": "link",
+            "id": "react-stately/dist/types/src/datepicker/useDateFieldState.d.ts:DateFieldState",
+            "name": "DateFieldState"
+          },
+          "optional": false,
+          "readonly": false,
+          "description": "State of the date field."
+        }
+      },
+      "typeParameters": [],
+      "description": ""
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -2701,6 +2701,58 @@ export const DemosIndex: Record<
 		files: ["ui/time-field/demos/uncontrolled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/time-field/demos/uncontrolled")),
 	},
+	"time-picker/demos/basic": {
+		files: ["ui/time-picker/demos/basic.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/basic")),
+	},
+	"time-picker/demos/composition": {
+		files: ["ui/time-picker/demos/composition.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/composition")),
+	},
+	"time-picker/demos/controlled": {
+		files: ["ui/time-picker/demos/controlled.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/controlled")),
+	},
+	"time-picker/demos/description": {
+		files: ["ui/time-picker/demos/description.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/description")),
+	},
+	"time-picker/demos/disabled": {
+		files: ["ui/time-picker/demos/disabled.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/disabled")),
+	},
+	"time-picker/demos/error-message": {
+		files: ["ui/time-picker/demos/error-message.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/error-message")),
+	},
+	"time-picker/demos/granularity": {
+		files: ["ui/time-picker/demos/granularity.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/granularity")),
+	},
+	"time-picker/demos/hour-cycle": {
+		files: ["ui/time-picker/demos/hour-cycle.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/hour-cycle")),
+	},
+	"time-picker/demos/label": {
+		files: ["ui/time-picker/demos/label.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/label")),
+	},
+	"time-picker/demos/placeholder": {
+		files: ["ui/time-picker/demos/placeholder.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/placeholder")),
+	},
+	"time-picker/demos/read-only": {
+		files: ["ui/time-picker/demos/read-only.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/read-only")),
+	},
+	"time-picker/demos/required": {
+		files: ["ui/time-picker/demos/required.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/required")),
+	},
+	"time-picker/demos/uncontrolled": {
+		files: ["ui/time-picker/demos/uncontrolled.tsx"],
+		component: React.lazy(() => import("@/registry/ui/time-picker/demos/uncontrolled")),
+	},
 	"toggle-button/demos/controlled": {
 		files: ["ui/toggle-button/demos/controlled.tsx"],
 		component: React.lazy(() => import("@/registry/ui/toggle-button/demos/controlled")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -70,6 +70,7 @@ import UiTagGroup from "@/registry/ui/tag-group/meta";
 import UiTextField from "@/registry/ui/text-field/meta";
 import UiText from "@/registry/ui/text/meta";
 import UiTimeField from "@/registry/ui/time-field/meta";
+import UiTimePicker from "@/registry/ui/time-picker/meta";
 import UiToast from "@/registry/ui/toast/meta";
 import UiToggleButtonGroup from "@/registry/ui/toggle-button-group/meta";
 import UiToggleButton from "@/registry/ui/toggle-button/meta";
@@ -144,6 +145,7 @@ export const registryUi: RegistryItem[] = [
 	UiText,
 	UiTextField,
 	UiTimeField,
+	UiTimePicker,
 	UiToast,
 	UiToggleButton,
 	UiToggleButtonGroup,

--- a/www/src/registry/ui/time-picker/base.tsx
+++ b/www/src/registry/ui/time-picker/base.tsx
@@ -1,0 +1,328 @@
+'use client'
+
+import React from 'react'
+import type { Time } from '@internationalized/date'
+import { ButtonContext } from 'react-aria-components/Button'
+import {
+  DialogContext,
+  OverlayTriggerStateContext,
+} from 'react-aria-components/Dialog'
+import { FieldErrorContext } from 'react-aria-components/FieldError'
+import { GroupContext } from 'react-aria-components/Group'
+import { useLocale } from 'react-aria-components/I18nProvider'
+import { InputContext } from 'react-aria-components/Input'
+import { LabelContext } from 'react-aria-components/Label'
+import * as ListBoxPrimitive from 'react-aria-components/ListBox'
+import { PopoverContext } from 'react-aria-components/Popover'
+import { Provider } from 'react-aria-components/slots'
+import { TextContext } from 'react-aria-components/Text'
+import { TimeFieldStateContext } from 'react-aria-components/TimeField'
+import type * as TimeFieldPrimitive from 'react-aria-components/TimeField'
+import { useFocusRing } from 'react-aria/useFocusRing'
+import { useOverlayTrigger } from 'react-aria/useOverlayTrigger'
+import { useTimeField } from 'react-aria/useTimeField'
+import { useOverlayTriggerState } from 'react-stately/useOverlayTriggerState'
+import { useTimeFieldState } from 'react-stately/useTimeFieldState'
+
+import { useStyles as useFieldStyles } from '@/registry/ui/field/styles'
+
+import { useStyles } from './styles'
+import type { TimePickerColumnsProps, TimePickerProps } from './types'
+
+// MARK: timePickerStyles
+
+// Contexts the trigger provides that must NOT leak into the popover content
+// (otherwise a button/label inside the columns would inherit the trigger's props).
+const CLEAR_CONTEXTS = [GroupContext, ButtonContext, LabelContext, TextContext]
+
+// A callback ref + boolean flag: lets the field detect whether a <Label> was
+// rendered so the a11y wiring can fall back to aria-label when it wasn't.
+const useSlot = (
+  initialState: boolean,
+): [(el: Element | null) => void, boolean] => {
+  const [hasSlot, setHasSlot] = React.useState(initialState)
+  const ref = React.useCallback((el: Element | null) => setHasSlot(!!el), [])
+  return [ref, hasSlot]
+}
+
+// MARK: TimePicker
+
+// There is no React Aria `TimePicker` primitive, so we compose one from the
+// same building blocks its `DatePicker` uses: a shared `TimeFieldState` drives
+// the editable segments (`DateInput`) and the popover columns, while an overlay
+// trigger state drives the popover. Both are exposed to children through the
+// same contexts `DatePicker` provides, so the composition reads identically.
+const TimePicker = <T extends TimeFieldPrimitive.TimeValue>({
+  className,
+  children,
+  isOpen,
+  defaultOpen,
+  onOpenChange,
+  ...props
+}: TimePickerProps<T>) => {
+  const fieldStyles = useFieldStyles()
+  const { locale } = useLocale()
+
+  const state = useTimeFieldState<T>({ ...props, locale })
+  const overlayState = useOverlayTriggerState({
+    isOpen,
+    defaultOpen,
+    onOpenChange,
+  })
+
+  const groupRef = React.useRef<HTMLDivElement>(null)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const [labelRef, label] = useSlot(
+    !props['aria-label'] && !props['aria-labelledby'],
+  )
+
+  const {
+    labelProps,
+    fieldProps,
+    inputProps,
+    descriptionProps,
+    errorMessageProps,
+    ...validation
+  } = useTimeField({ ...props, label, inputRef }, state, groupRef)
+
+  const { triggerProps, overlayProps } = useOverlayTrigger(
+    { type: 'dialog' },
+    overlayState,
+    groupRef,
+  )
+
+  const { isFocused, isFocusVisible, focusProps } = useFocusRing({
+    within: true,
+  })
+
+  return (
+    <Provider
+      values={[
+        [TimeFieldStateContext, state],
+        [
+          GroupContext,
+          {
+            ...fieldProps,
+            ref: groupRef,
+            isInvalid: state.isInvalid,
+            isDisabled: state.isDisabled,
+          },
+        ],
+        [InputContext, { ...inputProps, ref: inputRef }],
+        [
+          ButtonContext,
+          {
+            ...triggerProps,
+            isDisabled: state.isDisabled,
+            isPressed: overlayState.isOpen,
+          },
+        ],
+        [LabelContext, { ...labelProps, ref: labelRef, elementType: 'span' }],
+        [OverlayTriggerStateContext, overlayState],
+        [
+          PopoverContext,
+          {
+            trigger: 'TimePicker',
+            triggerRef: groupRef,
+            placement: 'bottom start',
+            clearContexts: CLEAR_CONTEXTS,
+          },
+        ],
+        [DialogContext, overlayProps],
+        [
+          TextContext,
+          {
+            slots: {
+              description: descriptionProps,
+              errorMessage: errorMessageProps,
+            },
+          },
+        ],
+        [FieldErrorContext, validation],
+      ]}
+    >
+      <div
+        {...focusProps}
+        data-time-picker=""
+        data-focus-within={isFocused || undefined}
+        data-focus-visible={isFocusVisible || undefined}
+        data-open={overlayState.isOpen || undefined}
+        data-disabled={state.isDisabled || undefined}
+        data-invalid={state.isInvalid || undefined}
+        data-readonly={state.isReadOnly || undefined}
+        data-required={state.isRequired || undefined}
+        className={fieldStyles().field({ className })}
+      >
+        {children}
+      </div>
+    </Provider>
+  )
+}
+
+// MARK: TimePickerColumns
+
+interface TimeColumnOption {
+  id: string
+  label: string
+}
+
+const range = (length: number, offset = 0): number[] =>
+  Array.from({ length }, (_, i) => i + offset)
+
+const pad = (value: number): string => String(value).padStart(2, '0')
+
+const TimePickerColumns = ({ className, ...props }: TimePickerColumnsProps) => {
+  const state = React.useContext(TimeFieldStateContext)
+  const { columns } = useStyles()()
+
+  if (!state) return null
+
+  const time = state.timeValue
+  const use12Hour = state.segments.some((s) => s.type === 'dayPeriod')
+  const showMinutes =
+    state.granularity === 'minute' || state.granularity === 'second'
+  const showSeconds = state.granularity === 'second'
+
+  const isImmutable = state.isDisabled || state.isReadOnly
+  const update = (fields: {
+    hour?: number
+    minute?: number
+    second?: number
+  }) => {
+    if (isImmutable) return
+    // Every TimeValue member (Time / CalendarDateTime / ZonedDateTime) implements
+    // `.set`; the `as Time` cast satisfies the union-method call while the real
+    // object handles the update, preserving date/zone for non-Time values.
+    const base = (state.value ?? state.timeValue) as Time
+    state.setValue(base.set(fields) as never)
+  }
+
+  const period = time.hour >= 12 ? 'PM' : 'AM'
+  const displayHour = time.hour % 12 === 0 ? 12 : time.hour % 12
+
+  const hourOptions: TimeColumnOption[] = use12Hour
+    ? range(12, 1).map((h) => ({ id: String(h), label: String(h) }))
+    : range(24).map((h) => ({ id: String(h), label: pad(h) }))
+  const minuteOptions = range(60).map((m) => ({ id: String(m), label: pad(m) }))
+  const secondOptions = range(60).map((s) => ({ id: String(s), label: pad(s) }))
+
+  return (
+    <div
+      data-time-picker-columns=""
+      className={columns({ className })}
+      {...props}
+    >
+      <TimeColumn
+        label="Hour"
+        options={hourOptions}
+        selectedKey={use12Hour ? String(displayHour) : String(time.hour)}
+        onSelect={(id) => {
+          const value = Number(id)
+          update({
+            hour: use12Hour ? (value % 12) + (period === 'PM' ? 12 : 0) : value,
+          })
+        }}
+      />
+      {showMinutes && (
+        <TimeColumn
+          label="Minute"
+          options={minuteOptions}
+          selectedKey={String(time.minute)}
+          onSelect={(id) => update({ minute: Number(id) })}
+        />
+      )}
+      {showSeconds && (
+        <TimeColumn
+          label="Second"
+          options={secondOptions}
+          selectedKey={String(time.second)}
+          onSelect={(id) => update({ second: Number(id) })}
+        />
+      )}
+      {use12Hour && (
+        <TimeColumn
+          label="AM/PM"
+          options={[
+            { id: 'AM', label: 'AM' },
+            { id: 'PM', label: 'PM' },
+          ]}
+          selectedKey={period}
+          onSelect={(id) => {
+            if (id === 'AM' && time.hour >= 12) update({ hour: time.hour - 12 })
+            if (id === 'PM' && time.hour < 12) update({ hour: time.hour + 12 })
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+// MARK: TimeColumn
+
+interface TimeColumnProps {
+  label: string
+  options: TimeColumnOption[]
+  selectedKey: string
+  onSelect: (id: string) => void
+}
+
+const TimeColumn = ({
+  label,
+  options,
+  selectedKey,
+  onSelect,
+}: TimeColumnProps) => {
+  const { column, item } = useStyles()()
+  const ref = React.useRef<HTMLDivElement>(null)
+
+  // Center the selected value when the popover opens.
+  React.useEffect(() => {
+    const container = ref.current
+    const selected = container?.querySelector<HTMLElement>(
+      '[data-selected="true"]',
+    )
+    if (!container || !selected) return
+    const containerRect = container.getBoundingClientRect()
+    const selectedRect = selected.getBoundingClientRect()
+    container.scrollTop +=
+      selectedRect.top -
+      containerRect.top -
+      (container.clientHeight - selected.clientHeight) / 2
+  }, [])
+
+  return (
+    <ListBoxPrimitive.ListBox
+      ref={ref}
+      data-time-picker-column=""
+      aria-label={label}
+      className={column()}
+      selectionMode="single"
+      selectionBehavior="replace"
+      disallowEmptySelection
+      shouldFocusWrap
+      selectedKeys={[selectedKey]}
+      onSelectionChange={(keys) => {
+        if (keys === 'all') return
+        const id = [...keys][0]
+        if (id != null) onSelect(String(id))
+      }}
+    >
+      {options.map((option) => (
+        <ListBoxPrimitive.ListBoxItem
+          key={option.id}
+          id={option.id}
+          data-time-picker-item=""
+          textValue={option.label}
+          className={item()}
+        >
+          {option.label}
+        </ListBoxPrimitive.ListBoxItem>
+      ))}
+    </ListBoxPrimitive.ListBox>
+  )
+}
+
+// MARK: exports
+
+export type { TimePickerColumnsProps, TimePickerProps }
+export { TimePicker, TimePickerColumns }

--- a/www/src/registry/ui/time-picker/demos/basic.tsx
+++ b/www/src/registry/ui/time-picker/demos/basic.tsx
@@ -1,0 +1,37 @@
+import { Time } from '@internationalized/date'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <TimePicker
+      className="w-40"
+      aria-label="Event time"
+      defaultValue={new Time(9, 30)}
+    >
+      <InputGroup>
+        <DateInput />
+        <InputGroupAddon>
+          <Button
+            variant="default"
+            size="sm"
+            isIconOnly
+            aria-label="Choose time"
+          >
+            <ClockIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+      <Popover>
+        <DialogContent>
+          <TimePickerColumns />
+        </DialogContent>
+      </Popover>
+    </TimePicker>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/composition.tsx
+++ b/www/src/registry/ui/time-picker/demos/composition.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Description, FieldError, Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <TimePicker className="w-40">
+      <Label>Event time</Label>
+      <InputGroup>
+        <DateInput />
+        <InputGroupAddon>
+          <Button
+            variant="default"
+            size="sm"
+            isIconOnly
+            aria-label="Choose time"
+          >
+            <ClockIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+      <Description>Please select a time.</Description>
+      <FieldError />
+      <Popover>
+        <DialogContent>
+          <TimePickerColumns />
+        </DialogContent>
+      </Popover>
+    </TimePicker>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/controlled.tsx
+++ b/www/src/registry/ui/time-picker/demos/controlled.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import React from 'react'
+import { Time } from '@internationalized/date'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  const [value, setValue] = React.useState<Time | null>(new Time(9, 30))
+  return (
+    <div className="flex w-40 flex-col gap-6">
+      <TimePicker value={value} onChange={setValue}>
+        <Label>Event time</Label>
+        <InputGroup>
+          <DateInput />
+          <InputGroupAddon>
+            <Button
+              variant="default"
+              size="sm"
+              isIconOnly
+              aria-label="Choose time"
+            >
+              <ClockIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <DialogContent>
+            <TimePickerColumns />
+          </DialogContent>
+        </Popover>
+      </TimePicker>
+      <p className="text-sm text-fg-muted">
+        selected time: {value?.toString() ?? '—'}
+      </p>
+    </div>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/description.tsx
+++ b/www/src/registry/ui/time-picker/demos/description.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Description, Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <TimePicker className="w-40">
+      <Label>Reminder</Label>
+      <InputGroup>
+        <DateInput />
+        <InputGroupAddon>
+          <Button
+            variant="default"
+            size="sm"
+            isIconOnly
+            aria-label="Choose time"
+          >
+            <ClockIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+      <Description>We'll notify you at this time.</Description>
+      <Popover>
+        <DialogContent>
+          <TimePickerColumns />
+        </DialogContent>
+      </Popover>
+    </TimePicker>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/disabled.tsx
+++ b/www/src/registry/ui/time-picker/demos/disabled.tsx
@@ -1,0 +1,35 @@
+import { Time } from '@internationalized/date'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <TimePicker className="w-40" defaultValue={new Time(9, 30)} isDisabled>
+      <Label>Event time</Label>
+      <InputGroup>
+        <DateInput />
+        <InputGroupAddon>
+          <Button
+            variant="default"
+            size="sm"
+            isIconOnly
+            aria-label="Choose time"
+          >
+            <ClockIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+      <Popover>
+        <DialogContent>
+          <TimePickerColumns />
+        </DialogContent>
+      </Popover>
+    </TimePicker>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/error-message.tsx
+++ b/www/src/registry/ui/time-picker/demos/error-message.tsx
@@ -1,0 +1,34 @@
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { FieldError, Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <TimePicker className="w-40" aria-label="Event time" isInvalid>
+      <Label>Event time</Label>
+      <InputGroup>
+        <DateInput />
+        <InputGroupAddon>
+          <Button
+            variant="default"
+            size="sm"
+            isIconOnly
+            aria-label="Choose time"
+          >
+            <ClockIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+      <FieldError>Please choose a time during business hours.</FieldError>
+      <Popover>
+        <DialogContent>
+          <TimePickerColumns />
+        </DialogContent>
+      </Popover>
+    </TimePicker>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/granularity.tsx
+++ b/www/src/registry/ui/time-picker/demos/granularity.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { Time } from '@internationalized/date'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+const granularities = ['hour', 'minute', 'second'] as const
+
+export default function Demo() {
+  return (
+    <div className="flex w-40 flex-col gap-6">
+      {granularities.map((granularity) => (
+        <TimePicker
+          key={granularity}
+          granularity={granularity}
+          defaultValue={new Time(11, 45, 30)}
+        >
+          <Label className="capitalize">{granularity}</Label>
+          <InputGroup>
+            <DateInput />
+            <InputGroupAddon>
+              <Button
+                variant="default"
+                size="sm"
+                isIconOnly
+                aria-label="Choose time"
+              >
+                <ClockIcon />
+              </Button>
+            </InputGroupAddon>
+          </InputGroup>
+          <Popover>
+            <DialogContent>
+              <TimePickerColumns />
+            </DialogContent>
+          </Popover>
+        </TimePicker>
+      ))}
+    </div>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/hour-cycle.tsx
+++ b/www/src/registry/ui/time-picker/demos/hour-cycle.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { Time } from '@internationalized/date'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <div className="flex w-40 flex-col gap-6">
+      <TimePicker defaultValue={new Time(14, 30)} hourCycle={12}>
+        <Label>12-hour</Label>
+        <InputGroup>
+          <DateInput />
+          <InputGroupAddon>
+            <Button
+              variant="default"
+              size="sm"
+              isIconOnly
+              aria-label="Choose time"
+            >
+              <ClockIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <DialogContent>
+            <TimePickerColumns />
+          </DialogContent>
+        </Popover>
+      </TimePicker>
+      <TimePicker defaultValue={new Time(14, 30)} hourCycle={24}>
+        <Label>24-hour</Label>
+        <InputGroup>
+          <DateInput />
+          <InputGroupAddon>
+            <Button
+              variant="default"
+              size="sm"
+              isIconOnly
+              aria-label="Choose time"
+            >
+              <ClockIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <DialogContent>
+            <TimePickerColumns />
+          </DialogContent>
+        </Popover>
+      </TimePicker>
+    </div>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/label.tsx
+++ b/www/src/registry/ui/time-picker/demos/label.tsx
@@ -1,0 +1,55 @@
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <div className="flex w-40 flex-col gap-6">
+      <TimePicker>
+        <Label>Event time</Label>
+        <InputGroup>
+          <DateInput />
+          <InputGroupAddon>
+            <Button
+              variant="default"
+              size="sm"
+              isIconOnly
+              aria-label="Choose time"
+            >
+              <ClockIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <DialogContent>
+            <TimePickerColumns />
+          </DialogContent>
+        </Popover>
+      </TimePicker>
+      <TimePicker aria-label="Event time">
+        <InputGroup>
+          <DateInput />
+          <InputGroupAddon>
+            <Button
+              variant="default"
+              size="sm"
+              isIconOnly
+              aria-label="Choose time"
+            >
+              <ClockIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <DialogContent>
+            <TimePickerColumns />
+          </DialogContent>
+        </Popover>
+      </TimePicker>
+    </div>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/placeholder.tsx
+++ b/www/src/registry/ui/time-picker/demos/placeholder.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Time } from '@internationalized/date'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <TimePicker className="w-40" placeholderValue={new Time(9)}>
+      <Label>Event time</Label>
+      <InputGroup>
+        <DateInput />
+        <InputGroupAddon>
+          <Button
+            variant="default"
+            size="sm"
+            isIconOnly
+            aria-label="Choose time"
+          >
+            <ClockIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+      <Popover>
+        <DialogContent>
+          <TimePickerColumns />
+        </DialogContent>
+      </Popover>
+    </TimePicker>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/playground.tsx
+++ b/www/src/registry/ui/time-picker/demos/playground.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+interface TimePickerPlaygroundProps {
+  label?: string
+  isDisabled?: boolean
+  isReadOnly?: boolean
+}
+
+export function TimePickerPlayground({
+  label = 'Time',
+  isDisabled = false,
+  isReadOnly = false,
+}: TimePickerPlaygroundProps) {
+  return (
+    <TimePicker
+      className="w-40"
+      isDisabled={isDisabled}
+      isReadOnly={isReadOnly}
+    >
+      {label && <Label>{label}</Label>}
+      <InputGroup>
+        <DateInput />
+        <InputGroupAddon>
+          <Button
+            variant="default"
+            size="sm"
+            isIconOnly
+            aria-label="Choose time"
+          >
+            <ClockIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+      <Popover>
+        <DialogContent>
+          <TimePickerColumns />
+        </DialogContent>
+      </Popover>
+    </TimePicker>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/read-only.tsx
+++ b/www/src/registry/ui/time-picker/demos/read-only.tsx
@@ -1,0 +1,35 @@
+import { Time } from '@internationalized/date'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <TimePicker className="w-40" defaultValue={new Time(9, 30)} isReadOnly>
+      <Label>Event time</Label>
+      <InputGroup>
+        <DateInput />
+        <InputGroupAddon>
+          <Button
+            variant="default"
+            size="sm"
+            isIconOnly
+            aria-label="Choose time"
+          >
+            <ClockIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+      <Popover>
+        <DialogContent>
+          <TimePickerColumns />
+        </DialogContent>
+      </Popover>
+    </TimePicker>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/required.tsx
+++ b/www/src/registry/ui/time-picker/demos/required.tsx
@@ -1,0 +1,33 @@
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <TimePicker className="w-40" isRequired>
+      <Label>Event time</Label>
+      <InputGroup>
+        <DateInput />
+        <InputGroupAddon>
+          <Button
+            variant="default"
+            size="sm"
+            isIconOnly
+            aria-label="Choose time"
+          >
+            <ClockIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+      <Popover>
+        <DialogContent>
+          <TimePickerColumns />
+        </DialogContent>
+      </Popover>
+    </TimePicker>
+  )
+}

--- a/www/src/registry/ui/time-picker/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/time-picker/demos/uncontrolled.tsx
@@ -1,0 +1,37 @@
+import { Time } from '@internationalized/date'
+
+import { ClockIcon } from '@/registry/__generated__/icons'
+import { Button } from '@/registry/ui/button'
+import { DialogContent } from '@/registry/ui/dialog'
+import { DateInput, InputGroup, InputGroupAddon } from '@/registry/ui/input'
+import { Popover } from '@/registry/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/registry/ui/time-picker'
+
+export default function Demo() {
+  return (
+    <TimePicker
+      className="w-40"
+      aria-label="Event time"
+      defaultValue={new Time(14, 15)}
+    >
+      <InputGroup>
+        <DateInput />
+        <InputGroupAddon>
+          <Button
+            variant="default"
+            size="sm"
+            isIconOnly
+            aria-label="Choose time"
+          >
+            <ClockIcon />
+          </Button>
+        </InputGroupAddon>
+      </InputGroup>
+      <Popover>
+        <DialogContent>
+          <TimePickerColumns />
+        </DialogContent>
+      </Popover>
+    </TimePicker>
+  )
+}

--- a/www/src/registry/ui/time-picker/examples.tsx
+++ b/www/src/registry/ui/time-picker/examples.tsx
@@ -1,0 +1,62 @@
+import { Example } from '@/modules/create/preview/example'
+import { Examples } from '@/modules/create/preview/examples'
+
+import Basic from './demos/basic'
+import Composition from './demos/composition'
+import Controlled from './demos/controlled'
+import Description from './demos/description'
+import Disabled from './demos/disabled'
+import ErrorMessage from './demos/error-message'
+import Granularity from './demos/granularity'
+import HourCycle from './demos/hour-cycle'
+import Label from './demos/label'
+import Placeholder from './demos/placeholder'
+import ReadOnly from './demos/read-only'
+import Required from './demos/required'
+import Uncontrolled from './demos/uncontrolled'
+
+export default function TimePickerExamples() {
+  return (
+    <Examples className="md:grid-cols-2">
+      <Example title="basic">
+        <Basic />
+      </Example>
+      <Example title="composition">
+        <Composition />
+      </Example>
+      <Example title="description">
+        <Description />
+      </Example>
+      <Example title="disabled">
+        <Disabled />
+      </Example>
+      <Example title="error message">
+        <ErrorMessage />
+      </Example>
+      <Example title="granularity">
+        <Granularity />
+      </Example>
+      <Example title="hour cycle">
+        <HourCycle />
+      </Example>
+      <Example title="label">
+        <Label />
+      </Example>
+      <Example title="placeholder">
+        <Placeholder />
+      </Example>
+      <Example title="read only">
+        <ReadOnly />
+      </Example>
+      <Example title="required">
+        <Required />
+      </Example>
+      <Example title="uncontrolled">
+        <Uncontrolled />
+      </Example>
+      <Example title="controlled">
+        <Controlled />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/time-picker/index.tsx
+++ b/www/src/registry/ui/time-picker/index.tsx
@@ -1,0 +1,1 @@
+export * from './base'

--- a/www/src/registry/ui/time-picker/meta.ts
+++ b/www/src/registry/ui/time-picker/meta.ts
@@ -1,0 +1,17 @@
+import type { RegistryItem } from '@/registry/types'
+
+const timePickerMeta = {
+  name: 'time-picker',
+  type: 'registry:ui',
+  group: 'pickers',
+  files: [
+    {
+      type: 'registry:ui',
+      path: 'ui/time-picker/base.tsx',
+      target: 'ui/time-picker.tsx',
+    },
+  ],
+  registryDependencies: ['button', 'dialog', 'field', 'input', 'popover'],
+} satisfies RegistryItem
+
+export default timePickerMeta

--- a/www/src/registry/ui/time-picker/styles.ts
+++ b/www/src/registry/ui/time-picker/styles.ts
@@ -1,0 +1,32 @@
+import { createStyles } from '@/lib/styles'
+
+import timePickerMeta from './meta'
+
+const { useStyles, styles } = createStyles(timePickerMeta, {
+  base: {
+    slots: {
+      columns: 'flex h-56 gap-1 p-1',
+      column: [
+        'flex w-14 scroll-py-1 flex-col gap-0.5 overflow-y-auto outline-hidden',
+        '[scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+      ],
+      item: [
+        'flex h-8 w-full shrink-0 items-center justify-center rounded-md text-sm tabular-nums no-highlight',
+        'cursor-interactive outline-hidden transition-colors',
+        'hover:bg-[color-mix(in_srgb,var(--color-accent)_20%,var(--color-bg))]',
+        'focus-visible:focus-ring',
+        'selected:bg-accent selected:text-fg-on-accent',
+        'disabled:pointer-events-none disabled:text-fg-disabled',
+      ],
+    },
+  },
+  density: {
+    compact: {},
+    default: {},
+    comfortable: {},
+  },
+})
+
+export type TimePickerStyles = typeof styles
+
+export { styles as timePickerStyles, useStyles }

--- a/www/src/registry/ui/time-picker/types.ts
+++ b/www/src/registry/ui/time-picker/types.ts
@@ -1,0 +1,25 @@
+import type React from 'react'
+import type * as TimeFieldPrimitive from 'react-aria-components/TimeField'
+
+/**
+ * A time picker combines a TimeField and a scrollable time-column popover to
+ * allow users to enter or select a time value.
+ */
+export interface TimePickerProps<
+  T extends TimeFieldPrimitive.TimeValue,
+> extends Omit<TimeFieldPrimitive.TimeFieldProps<T>, 'className' | 'children'> {
+  className?: string
+  children?: React.ReactNode
+  /** Whether the popover is open by default (uncontrolled). */
+  defaultOpen?: boolean
+  /** Whether the popover is open (controlled). */
+  isOpen?: boolean
+  /** Handler that is called when the popover's open state changes. */
+  onOpenChange?: (isOpen: boolean) => void
+}
+
+/**
+ * The scrollable hour / minute / second / day-period columns rendered inside a
+ * TimePicker popover. Reads and writes the value from the enclosing TimePicker.
+ */
+export interface TimePickerColumnsProps extends React.ComponentProps<'div'> {}


### PR DESCRIPTION
## What

Adds a new `time-picker` registry component — a `TimeField` paired with a scrollable time-column popover — following the same composition-first pattern as `date-picker`.

## Why it stays true to React Aria

React Aria ships **no `TimePicker` primitive** (only `DatePicker`/`DateRangePicker`). So instead of inventing a foreign API, the root mirrors RAC's `DatePicker` internals exactly: a `<Provider>` (from `react-aria-components/slots`) wiring the **same context set** DatePicker provides — `TimeFieldStateContext`, `GroupContext`, `ButtonContext`, `PopoverContext`, `DialogContext`, `LabelContext`, `TextContext`, `FieldErrorContext` — backed by `useTimeFieldState` + `useTimeField` + `useOverlayTriggerState` + `useOverlayTrigger`.

Because RAC's `DateInput`/`DateSegment` already consume `TimeFieldStateContext`, the composition reads **identically to `date-picker`**:

```tsx
<TimePicker>
  <Label>Time</Label>
  <InputGroup>
    <DateInput />
    <InputGroupAddon>
      <Button isIconOnly aria-label="Choose time"><ClockIcon /></Button>
    </InputGroupAddon>
  </InputGroup>
  <Popover><DialogContent><TimePickerColumns /></DialogContent></Popover>
</TimePicker>
```

Segment editing, form submission, validation, and overlay behavior all come from RAC.

## Popover UI

`TimePickerColumns` renders scrollable, keyboard-navigable `ListBox` columns (Hour / Minute / Second / AM·PM). They share the field's single `TimeFieldState`, so editing segments and picking columns stay in sync. Granularity- and hour-cycle-aware; auto-scrolls to the current value on open.

## Included

- `base.tsx`, `styles.ts`, `types.ts`, `meta.ts`, `index.tsx`, `examples.tsx` + 14 demos
- Docs page `content/docs/components/time-picker.mdx`
- Regenerated registry manifests (`registry-items.ts`, `demos.tsx`, create `examples.tsx`) + API references

## Verification

- `pnpm typecheck` ✅ · `pnpm check` ✅ (only pre-existing warnings elsewhere)
- `pnpm test` — **248/248 pass** (incl. 47 playground-fidelity)
- Live browser (verified via DOM/computed styles — headless screenshots render black, a known repo quirk): popover opens with correct columns (12/60/2), `Time(9,30)` pre-selects 9 / 30 / AM, selecting hour 11 updates the field to 11:30 PM, accent styling resolves.

## Reviewer notes

- Scope is a single time picker (no range yet). A `TimeRangePicker` would extend this same Provider approach with two field slots, mirroring `DateRangePicker`.
- v1 simplification: individual out-of-range options aren't greyed per `minValue`/`maxValue` (the field still flags `isInvalid`).
- The popover column/item styling lives as fixed values in `styles.ts` — not exposed as a `/create` axis (that would be a separate propose-and-approve step).