### PR TITLE
fix(www): reset header blur when scroll timeline goes inactive

### DIFF
--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -66,7 +66,14 @@ export function Header({ className, items = [] }: HeaderProps) {
         className,
       )}
     >
+      {/* Keyed by pathname: navigating to a page with no root overflow (/create
+          fills the viewport exactly) turns the scroll timeline inactive, and a
+          newly inactive timeline HOLDS the animation's last progress — arriving
+          from a scrolled page would freeze the blur fully on. Remounting restarts
+          the animation; on an inactive timeline its time is unresolved, so no fill
+          applies and --blur-progress falls back to its initial 0. */}
       <div
+        key={pathname}
         aria-hidden
         className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[180%] header-blur-reveal"
       >


### PR DESCRIPTION
## Summary
- The header's progressive blur (`header-blur-reveal`, `--blur-progress`) is driven by a `scroll(root y)` timeline. On pages that fill the viewport exactly (e.g. `/create`), the root has no scrollable overflow, so the timeline goes inactive after a client-side navigation.
- Per spec, a newly-inactive timeline holds the animation's last progress — so navigating to `/create` from a page scrolled past ~56px left the blur frozen fully on, even at the top of the new page.
- Fix: key the blur wrapper by `pathname` in `header.tsx` so it remounts on navigation. A fresh animation on an inactive timeline has unresolved time, so no fill applies and `--blur-progress` falls back to its initial `0`.

## Notes for reviewers
- Only reproducible in a real headful browser — headless Chromium (Puppeteer) and Playwright WebKit both clear the effect instead of holding it, so there's no automated regression seam for this. Verified manually against the running dev server via the Chrome extension: scrolled home → click Create → blur is now off at scroll top; scrolling still ramps the blur normally on scrollable pages (e.g. `/presets`).
- `pnpm check` and `pnpm typecheck` pass.

## Test plan
- [x] Scroll down on a scrollable page (home), navigate to `/create`, confirm blur is off at the top
- [x] Scroll down on `/presets`, confirm blur still ramps in normally
- [x] `pnpm check`
- [x] `pnpm typecheck`