### PR TITLE
fix(www): tighten header progressive blur height

### DIFF
--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -75,7 +75,7 @@ export function Header({ className, items = [] }: HeaderProps) {
       <div
         key={pathname}
         aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[180%] header-blur-reveal"
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] header-blur-reveal"
       >
         {BLUR_LAYERS.map(({ blur, mask }) => (
           <div


### PR DESCRIPTION
## What changed

Reduced the header's progressive-blur overlay from `h-[180%]` to `h-[140%]` of the header height in `www/src/components/layout/header.tsx`.

## Why

With the header at 56px, the 180% overlay extended its blur feather ~45px below the bar, smearing visibly into page content. At 140% the ramp fades out ~20px below the bar — same smooth iOS-style dissolve, contained to the header's zone.

## Notes for review

The seven layer masks are percentage-based, so they compress proportionally with the container — no mask stops needed adjusting. The dark tint gradient and dither ride the same container and tighten to match automatically.