### PR TITLE
fix(www): clip code modal corners and contain code overflow

### DIFF
--- a/www/src/modules/charts/chart-code-modal-content.tsx
+++ b/www/src/modules/charts/chart-code-modal-content.tsx
@@ -45,7 +45,7 @@ export default function ChartCodeModalContent({
   return (
     <div className="flex h-full min-h-0 flex-col md:flex-row">
       {/* LEFT: title, live preview, install command */}
-      <div className="flex min-h-0 flex-col md:w-2/5 md:border-r lg:w-1/2">
+      <div className="flex min-h-0 min-w-0 flex-col md:w-2/5 md:border-r lg:w-1/2">
         <DialogTitle className="shrink-0 px-4 pt-3 text-sm text-fg-muted capitalize">
           {label}
         </DialogTitle>
@@ -84,11 +84,16 @@ export default function ChartCodeModalContent({
       </div>
 
       {/* RIGHT: variant source, filling the full modal height */}
-      <div className="flex min-h-0 flex-1 flex-col border-t bg-card md:border-t-0">
-        <div className="min-h-0 flex-1 overflow-auto">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col border-t bg-card md:border-t-0">
+        <div className="no-scrollbar min-h-0 flex-1 scroll-fade-y overflow-y-auto">
           {source ? (
             <CodeBlock className="rounded-none border-0 bg-transparent">
-              <DynamicPre lang="tsx">{source}</DynamicPre>
+              <DynamicPre
+                lang="tsx"
+                className="no-scrollbar w-full scroll-fade-x overflow-x-auto *:[code]:w-max *:[code]:min-w-full"
+              >
+                {source}
+              </DynamicPre>
             </CodeBlock>
           ) : (
             <p className="p-4 text-sm text-fg-muted">Source unavailable.</p>

--- a/www/src/modules/charts/chart-code-modal-content.tsx
+++ b/www/src/modules/charts/chart-code-modal-content.tsx
@@ -85,20 +85,22 @@ export default function ChartCodeModalContent({
 
       {/* RIGHT: variant source, filling the full modal height */}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col border-t bg-card md:border-t-0">
-        <div className="no-scrollbar min-h-0 flex-1 scroll-fade-y overflow-y-auto">
-          {source ? (
-            <CodeBlock className="rounded-none border-0 bg-transparent">
-              <DynamicPre
-                lang="tsx"
-                className="no-scrollbar w-full scroll-fade-x overflow-x-auto *:[code]:w-max *:[code]:min-w-full"
-              >
-                {source}
-              </DynamicPre>
-            </CodeBlock>
-          ) : (
-            <p className="p-4 text-sm text-fg-muted">Source unavailable.</p>
-          )}
-        </div>
+        {source ? (
+          <CodeBlock
+            title={`${demoKey.split('/').pop()}.tsx`}
+            className="flex min-h-0 flex-1 flex-col rounded-none border-0 bg-transparent"
+            contentClassName="no-scrollbar min-h-0 flex-1 scroll-fade-y overflow-y-auto"
+          >
+            <DynamicPre
+              lang="tsx"
+              className="no-scrollbar w-full scroll-fade-x overflow-x-auto *:[code]:w-max *:[code]:min-w-full"
+            >
+              {source}
+            </DynamicPre>
+          </CodeBlock>
+        ) : (
+          <p className="p-4 text-sm text-fg-muted">Source unavailable.</p>
+        )}
       </div>
     </div>
   )

--- a/www/src/modules/charts/chart-code-modal.tsx
+++ b/www/src/modules/charts/chart-code-modal.tsx
@@ -33,7 +33,7 @@ export function ChartCodeModal({ demoKey, label }: ChartCodeModalProps) {
       <Modal className="h-[80vh] w-full sm:max-w-3xl md:max-w-4xl lg:max-w-5xl xl:max-w-6xl">
         <DialogContent
           aria-label={`${label} chart code`}
-          className="relative flex h-full min-h-0 flex-col p-0"
+          className="relative flex h-full min-h-0 flex-col rounded-[inherit] p-0"
         >
           {/* Close sits just outside the panel's top-right corner. Kept inside
               the dialog (so slot="close" works) but escaping the rounded body. */}
@@ -47,7 +47,7 @@ export function ChartCodeModal({ demoKey, label }: ChartCodeModalProps) {
           >
             <XIcon />
           </Button>
-          <div className="min-h-0 flex-1 overflow-hidden">
+          <div className="min-h-0 flex-1 overflow-hidden rounded-[inherit]">
             <Suspense
               fallback={
                 <div className="flex h-full items-center justify-center">

--- a/www/src/modules/docs/code-block.tsx
+++ b/www/src/modules/docs/code-block.tsx
@@ -136,6 +136,7 @@ function CopyButton() {
     <Button
       variant="quiet"
       size="xs"
+      isIconOnly
       onPress={handleCopy}
       aria-label={isCopied ? 'Copied!' : 'Copy code'}
     >

--- a/www/src/modules/docs/code-block.tsx
+++ b/www/src/modules/docs/code-block.tsx
@@ -12,6 +12,8 @@ export interface CodeBlockProps extends React.ComponentProps<'figure'> {
   title?: string
   actions?: React.ReactNode
   icon?: string | React.ReactNode
+  /** Extra classes for the scrollable code container, e.g. to make it a modal's scroller. */
+  contentClassName?: string
   'data-line-numbers'?: boolean
 }
 
@@ -21,6 +23,7 @@ export function CodeBlock({
   actions: actionsProp,
   children,
   className,
+  contentClassName,
   ...props
 }: CodeBlockProps) {
   const containerRef = useRef<HTMLElement>(null)
@@ -56,7 +59,7 @@ export function CodeBlock({
           </div>
         )}
         <div
-          className="relative overflow-auto"
+          className={cn('relative overflow-auto', contentClassName)}
           style={{
             counterReset: 'line',
           }}

--- a/www/src/modules/docs/dynamic-pre.tsx
+++ b/www/src/modules/docs/dynamic-pre.tsx
@@ -2,12 +2,15 @@ import { useDeferredValue, useMemo } from 'react'
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 
+import { cn } from '@/registry/lib/utils'
+
 import { Pre } from './code-block'
 import { highlightTsx } from './highlight'
 
 export interface DynamicPreProps {
   lang: 'tsx'
   children: string
+  className?: string
 }
 
 /**
@@ -16,7 +19,7 @@ export interface DynamicPreProps {
  * already highlighted — no fallback state. `useDeferredValue` keeps control
  * interactions responsive by letting React defer re-highlights under load.
  */
-export function DynamicPre({ children: code }: DynamicPreProps) {
+export function DynamicPre({ children: code, className }: DynamicPreProps) {
   const deferredCode = useDeferredValue(code)
   return useMemo(
     () =>
@@ -24,8 +27,12 @@ export function DynamicPre({ children: code }: DynamicPreProps) {
         Fragment,
         jsx,
         jsxs,
-        components: { pre: Pre },
+        components: {
+          pre: (props) => (
+            <Pre {...props} className={cn(props.className, className)} />
+          ),
+        },
       }),
-    [deferredCode],
+    [deferredCode, className],
   )
 }

--- a/www/src/modules/docs/example-code-modal.tsx
+++ b/www/src/modules/docs/example-code-modal.tsx
@@ -22,6 +22,8 @@ export interface ExampleCodeModalProps {
   component: React.ComponentType
   /** Pre-highlighted source (the `DemoCode` slot content built at MDX build time). */
   code: React.ReactNode
+  /** Demo file name shown as the code block title, e.g. `disabled.tsx`. */
+  file?: string
   /** Registry items to install, e.g. `["button"]`. */
   install: string[]
 }
@@ -37,6 +39,7 @@ export function ExampleCodeModal({
   title,
   component: Component,
   code,
+  file,
   install,
 }: ExampleCodeModalProps) {
   const commands = buildInstallCommands(install)
@@ -108,13 +111,15 @@ export function ExampleCodeModal({
 
             {/* RIGHT: example source, filling the full modal height */}
             <div className="flex min-h-0 min-w-0 flex-1 flex-col border-t bg-card md:border-t-0">
-              <div className="no-scrollbar min-h-0 flex-1 scroll-fade-y overflow-y-auto">
-                <CodeBlock className="rounded-none border-0 bg-transparent">
-                  <Pre className="no-scrollbar w-full scroll-fade-x overflow-x-auto *:[code]:w-max *:[code]:min-w-full">
-                    {code}
-                  </Pre>
-                </CodeBlock>
-              </div>
+              <CodeBlock
+                title={file}
+                className="flex min-h-0 flex-1 flex-col rounded-none border-0 bg-transparent"
+                contentClassName="no-scrollbar min-h-0 flex-1 scroll-fade-y overflow-y-auto"
+              >
+                <Pre className="no-scrollbar w-full scroll-fade-x overflow-x-auto *:[code]:w-max *:[code]:min-w-full">
+                  {code}
+                </Pre>
+              </CodeBlock>
             </div>
           </div>
         </DialogContent>

--- a/www/src/modules/docs/example-code-modal.tsx
+++ b/www/src/modules/docs/example-code-modal.tsx
@@ -50,7 +50,7 @@ export function ExampleCodeModal({
       <Modal className="h-[80vh] w-full sm:max-w-3xl md:max-w-4xl lg:max-w-5xl xl:max-w-6xl">
         <DialogContent
           aria-label={`${title} code`}
-          className="relative flex h-full min-h-0 flex-col p-0"
+          className="relative flex h-full min-h-0 flex-col rounded-[inherit] p-0"
         >
           {/* Close sits just outside the panel's top-right corner. Kept inside
               the dialog (so slot="close" works) but escaping the rounded body. */}
@@ -64,9 +64,9 @@ export function ExampleCodeModal({
           >
             <XIcon />
           </Button>
-          <div className="flex h-full min-h-0 flex-col md:flex-row">
+          <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-[inherit] md:flex-row">
             {/* LEFT: title, live preview, install command */}
-            <div className="flex min-h-0 flex-col md:w-2/5 md:border-r lg:w-1/2">
+            <div className="flex min-h-0 min-w-0 flex-col md:w-2/5 md:border-r lg:w-1/2">
               <DialogTitle className="shrink-0 px-4 pt-3 text-sm text-fg-muted">
                 {title}
               </DialogTitle>
@@ -107,10 +107,12 @@ export function ExampleCodeModal({
             </div>
 
             {/* RIGHT: example source, filling the full modal height */}
-            <div className="flex min-h-0 flex-1 flex-col border-t bg-card md:border-t-0">
-              <div className="min-h-0 flex-1 overflow-auto">
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col border-t bg-card md:border-t-0">
+              <div className="no-scrollbar min-h-0 flex-1 scroll-fade-y overflow-y-auto">
                 <CodeBlock className="rounded-none border-0 bg-transparent">
-                  <Pre>{code}</Pre>
+                  <Pre className="no-scrollbar w-full scroll-fade-x overflow-x-auto *:[code]:w-max *:[code]:min-w-full">
+                    {code}
+                  </Pre>
                 </CodeBlock>
               </div>
             </div>

--- a/www/src/modules/docs/example.tsx
+++ b/www/src/modules/docs/example.tsx
@@ -11,6 +11,8 @@ export interface ExampleProps extends React.ComponentProps<'div'> {
   title?: string
   /** Registry items to install, injected by the rehype transform. */
   install?: string[]
+  /** Demo file name (e.g. `disabled.tsx`), injected by the rehype transform. */
+  file?: string
   children?: React.ReactNode
 }
 
@@ -18,6 +20,7 @@ export function Example({
   component: Component,
   title,
   install,
+  file,
   children,
   className,
   ...props
@@ -52,6 +55,7 @@ export function Example({
             title={title ?? 'Example'}
             component={Component}
             code={code}
+            file={file}
             install={install ?? []}
           />
         ) : null}

--- a/www/src/modules/docs/mdx-plugins/rehype-transform.ts
+++ b/www/src/modules/docs/mdx-plugins/rehype-transform.ts
@@ -524,8 +524,8 @@ function transformDemoNode(processed: ProcessedDemo): void {
   // The Example card renders the demo live and exposes its source via a "Show
   // code" modal. Inject a real <h3 id="{slug}">{title}</h3> so the title shows
   // up in the TOC (the `title` prop is kept too, for the modal heading), the
-  // install items for the modal, and the highlighted source as a DemoCode slot
-  // the card routes into the modal.
+  // install items and demo file name for the modal, and the highlighted source
+  // as a DemoCode slot the card routes into the modal.
   if (processed.nodeInfo.type === 'Example') {
     const { title, titleId } = processed.nodeInfo
     const existing = (node.children ?? []) as ElementContent[]
@@ -533,6 +533,11 @@ function transformDemoNode(processed: ProcessedDemo): void {
     node.attributes.push(
       makeJsonParseAttr('install', JSON.stringify(processed.install)),
     )
+    node.attributes.push({
+      type: 'mdxJsxAttribute',
+      name: 'file',
+      value: `${processed.nodeInfo.name.split('/').pop()}.tsx`,
+    })
 
     if (title && titleId) {
       const heading: Element = {

--- a/www/src/modules/presets/preset-modal.tsx
+++ b/www/src/modules/presets/preset-modal.tsx
@@ -78,7 +78,7 @@ export function PresetModal({
     >
       <DialogContent
         aria-label={active ? `${active.name} design system` : 'Design system'}
-        className="relative flex h-full min-h-0 flex-col overflow-hidden p-0"
+        className="relative flex h-full min-h-0 flex-col rounded-[inherit] p-0"
       >
         {/* Close sits just outside the panel's top-right corner (kept inside the
             dialog so focus management still scopes to it). */}
@@ -160,7 +160,7 @@ function PresetModalBody({ preset }: { preset: Preset }) {
   ]
 
   return (
-    <div className="flex h-full min-h-0 flex-col md:flex-row">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-[inherit] md:flex-row">
       {/* LEFT: the editorial spec sheet. Capped on mobile (where it stacks above
           the preview) so the live showcase always keeps a usable share. */}
       <div className="flex min-h-0 flex-col gap-6 overflow-auto border-b p-6 max-md:max-h-[55%] md:w-[340px] md:shrink-0 md:border-r md:border-b-0 lg:w-[380px]">


### PR DESCRIPTION
## Summary

Fixes two visual bugs in the docs examples "Show code" modal, and applies the identical fix to its mirror on /charts:

- **Square corners poking past the modal's radius** — the modal panel is rounded but nothing clipped its content, so the code column's `bg-card` painted square corners over the rounded ones. The layout container now carries `overflow-hidden rounded-[inherit]`, with `rounded-[inherit]` chained through `DialogContent` so it picks up the modal's actual radius. The close button stays outside the clipped container.
- **Code overflowing the modal on the right** — the code column was `flex-1` without `min-w-0`, so long lines widened the column past the modal edge instead of scrolling. Both columns now have `min-w-0`.
- **Hidden scrollbars + scroll fades on the code area** — vertical scrolling on the column wrapper (`no-scrollbar scroll-fade-y overflow-y-auto`), horizontal scrolling moved onto the `pre` itself (`no-scrollbar scroll-fade-x overflow-x-auto`). The fade utilities use `scroll(self)` timelines, so each sits on the element that actually scrolls; `*:[code]:w-max *:[code]:min-w-full` keeps line highlights spanning the full scroll width.

To reuse the pre classes on the charts side, `DynamicPre` now accepts an optional `className` forwarded to its rendered `Pre` (merged with the highlighter's own class) — no change for existing callers.

## Reviewer notes

- The chart code modal (`chart-code-modal*.tsx`) is a deliberate mirror of the docs one (its comments say so), and had the exact same defects — landed together to keep them in sync.
- `pnpm check` and `pnpm typecheck` pass.