### PR TITLE
fix(www): move chart replay button into each demo card

### DIFF
--- a/www/src/modules/charts/chart-card.tsx
+++ b/www/src/modules/charts/chart-card.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { Suspense } from 'react'
+import { Suspense, useState } from 'react'
+import { RotateCcwIcon } from 'lucide-react'
 
 import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
 import { ShowcaseCard } from '@/components/showcase-card'
 
 import { ChartCodeModal } from './chart-code-modal'
@@ -15,13 +17,11 @@ interface ChartCardProps {
   demoKey: string
   /** Human label for the card, e.g. `multiple`. */
   label: string
-  /** Bump to replay the chart's entry animation (remounts the chart). */
-  replayKey?: number
 }
 
 /**
- * One variant in the gallery: a subtle title and a "Show code" link sit in a
- * header row above a card that holds nothing but the live chart. The chart is
+ * One variant in the gallery: a subtle title, a replay action and a "Show code"
+ * link sit in a header row above a card that holds nothing but the live chart. The chart is
  * decorative (`inert` + `aria-hidden`) so it never traps focus across the grid —
  * the real, interactive component (with its source) lives in the docs, which
  * "Show code" links to.
@@ -31,12 +31,9 @@ interface ChartCardProps {
  * frame width, polar charts (pie/radar/radial) stay square and are capped at
  * 250px (shadcn's size) so they don't balloon, centered in the frame.
  */
-export function ChartCard({
-  familyId,
-  demoKey,
-  label,
-  replayKey,
-}: ChartCardProps) {
+export function ChartCard({ familyId, demoKey, label }: ChartCardProps) {
+  // Bumping this key remounts the chart, replaying its entry animation.
+  const [replayKey, setReplayKey] = useState(0)
   const Component = getDemoComponent(demoKey)
   if (!Component) return null
 
@@ -45,7 +42,21 @@ export function ChartCard({
   return (
     <ShowcaseCard
       label={label}
-      action={<ChartCodeModal demoKey={demoKey} label={label} />}
+      action={
+        <div className="flex items-center">
+          <Button
+            variant="quiet"
+            size="sm"
+            isIconOnly
+            aria-label="Replay animation"
+            className="text-fg-muted hover:text-fg"
+            onPress={() => setReplayKey((k) => k + 1)}
+          >
+            <RotateCcwIcon />
+          </Button>
+          <ChartCodeModal demoKey={demoKey} label={label} />
+        </div>
+      }
       className="h-80"
       inert
       aria-hidden="true"

--- a/www/src/modules/charts/chart-showcase.tsx
+++ b/www/src/modules/charts/chart-showcase.tsx
@@ -1,9 +1,5 @@
 'use client'
 
-import { useState } from 'react'
-import { RotateCcwIcon } from 'lucide-react'
-
-import { Button } from '@/registry/ui/button'
 import { Tab, TabList, TabPanel, Tabs } from '@/registry/ui/tabs'
 
 import { ChartCard } from './chart-card'
@@ -16,40 +12,26 @@ import { CHART_FAMILIES, variantsFor } from './data'
  * the design system as usual.
  */
 export function ChartShowcase() {
-  // Bumping this key remounts the charts in the active tab, replaying their
-  // entry animation on demand.
-  const [replayKey, setReplayKey] = useState(0)
-
   return (
     <Tabs
       defaultSelectedKey={CHART_FAMILIES[0].id}
       className="gap-8 [--tabs-list-height:2.75rem]"
     >
-      <div className="flex flex-wrap items-center justify-center gap-3">
-        <TabList
-          aria-label="Chart families"
-          variant="default"
-          className="flex-wrap justify-center gap-2 bg-transparent [&_[data-tab-indicator]]:rounded-full [&_[data-tab-indicator]]:bg-muted [&_[data-tab-indicator]]:shadow-none"
-        >
-          {CHART_FAMILIES.map((f) => (
-            <Tab
-              key={f.id}
-              id={f.id}
-              className="rounded-full px-4 text-base selected:text-fg"
-            >
-              {f.name} chart
-            </Tab>
-          ))}
-        </TabList>
-        <Button
-          size="sm"
-          className="rounded-full"
-          onPress={() => setReplayKey((k) => k + 1)}
-        >
-          <RotateCcwIcon />
-          Replay
-        </Button>
-      </div>
+      <TabList
+        aria-label="Chart families"
+        variant="default"
+        className="flex-wrap justify-center gap-2 self-center bg-transparent [&_[data-tab-indicator]]:rounded-full [&_[data-tab-indicator]]:bg-muted [&_[data-tab-indicator]]:shadow-none"
+      >
+        {CHART_FAMILIES.map((f) => (
+          <Tab
+            key={f.id}
+            id={f.id}
+            className="rounded-full px-4 text-base selected:text-fg"
+          >
+            {f.name} chart
+          </Tab>
+        ))}
+      </TabList>
       {CHART_FAMILIES.map((f) => {
         const variants = variantsFor(f.id)
         return (
@@ -64,7 +46,6 @@ export function ChartShowcase() {
                 familyId={f.id}
                 demoKey={v.key}
                 label={v.label}
-                replayKey={replayKey}
               />
             ))}
           </TabPanel>


### PR DESCRIPTION
## Summary
- Replaces the single global "Replay" button above the charts tabs with a per-card, icon-only, quiet replay button placed next to "Show code" in each demo's header row.
- Replaying now remounts only the clicked card's chart (bumping a per-card `replayKey`) instead of remounting every chart in the active tab.

## Test plan
- [x] `pnpm build:registry`, `pnpm check`, `pnpm typecheck` all pass.
- [x] Verified in browser preview at `/charts`: 9 replay buttons render (one per card), no global Replay button remains, clicking a card's button remounts only that chart while siblings stay untouched.