### PR TITLE
fix(www): let page scroll below short docs TOC

### DIFF
--- a/www/src/modules/docs/toc.tsx
+++ b/www/src/modules/docs/toc.tsx
@@ -38,7 +38,7 @@ export function TOC({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        'sticky top-10 flex h-[calc(100svh-var(--header-height))] flex-col max-xl:hidden',
+        'sticky top-10 flex max-h-[calc(100svh-var(--header-height))] flex-col max-xl:hidden',
         className,
       )}
       {...props}

--- a/www/src/modules/docs/toc.tsx
+++ b/www/src/modules/docs/toc.tsx
@@ -65,7 +65,7 @@ export function TOCScrollArea({
     <div
       ref={mergeRefs(viewRef, ref)}
       className={cn(
-        'no-scrollbar min-h-0 scroll-fade-y overflow-auto pt-10 pb-3 text-sm scroll-fade-4',
+        'no-scrollbar min-h-0 scroll-fade-y overflow-auto pt-10 pb-3 text-sm scroll-fade-6',
         className,
       )}
       {...props}

--- a/www/src/routes/_app/docs/$.tsx
+++ b/www/src/routes/_app/docs/$.tsx
@@ -177,7 +177,7 @@ const clientLoader = browserCollections.docs.createClientLoader({
           {/* -mt-4 cancels PageLayout's mt-4 so the TOC top lines up with the
               sidebar (which isn't inside PageLayout) at scroll 0, matching the
               already-aligned scrolled/sticky state. */}
-          <div className="sticky top-(--header-height) z-30 -mt-4 hidden h-[90svh] w-(--sidebar-width) flex-col gap-4 overflow-hidden overscroll-none pb-8 xl:flex">
+          <div className="sticky top-(--header-height) z-30 -mt-4 hidden max-h-[90svh] w-(--sidebar-width) flex-col gap-4 self-start overflow-hidden overscroll-none pb-8 xl:flex">
             {hasToc && <TOC className="pr-12" />}
           </div>
         </PageLayout>


### PR DESCRIPTION
## What

On docs pages, wheel-scrolling over the empty area below a short TOC did nothing — the sticky right-rail column had a fixed \`h-[90svh]\` with \`overflow-hidden overscroll-none\`, so it always covered 90% of the viewport and swallowed scroll events.

- \`www/src/routes/_app/docs/$.tsx\` — the sticky column now uses \`max-h-[90svh]\` plus \`self-start\` (the layout's \`items-stretch\` was otherwise stretching it back to full height).
- \`www/src/modules/docs/toc.tsx\` — the inner TOC wrapper's fixed \`h-[calc(100svh-var(--header-height))]\` became \`max-h-[...]\` for the same reason.

## Notes for review

Verified in the browser preview: the column collapses to its content on short-TOC pages (page scrolls normally below it), sticky positioning still pins at the header on scroll, and a long TOC on a short viewport still caps at 90svh and scrolls internally.