### PR TITLE
fix(www): align header logo with docs sidebar text on md+

### DIFF
--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -62,7 +62,7 @@ export function Header({ className, items = [] }: HeaderProps) {
   return (
     <header
       className={cn(
-        'sticky top-0 z-30 flex h-(--header-height) w-full items-center justify-between header-blur-fallback pr-3 pl-4',
+        'sticky top-0 z-30 flex h-(--header-height) w-full items-center justify-between header-blur-fallback pr-3 pl-4 md:pl-6',
         className,
       )}
     >

--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -62,7 +62,7 @@ export function Header({ className, items = [] }: HeaderProps) {
   return (
     <header
       className={cn(
-        'sticky top-0 z-30 flex h-(--header-height) w-full items-center justify-between header-blur-fallback pr-3 pl-4 md:pl-6',
+        'sticky top-0 z-30 flex h-(--header-height) w-full items-center justify-between header-blur-fallback pr-3 pl-4 md:pr-4 md:pl-6',
         className,
       )}
     >

--- a/www/src/routes/_app/docs/route.tsx
+++ b/www/src/routes/_app/docs/route.tsx
@@ -17,7 +17,6 @@ function DocsLayout() {
     <div className="flex min-h-[calc(100vh-var(--header-height))] [--sidebar-width:228px]">
       <aside className="sticky top-(--header-height) hidden h-[calc(100vh-var(--header-height))] w-(--sidebar-width) shrink-0 md:block">
         <DocsSidebar items={items} />
-        <div className="absolute top-0 right-0 bottom-0 hidden h-full w-px bg-linear-to-b from-transparent via-border to-transparent lg:flex" />
       </aside>
       <div className="min-w-0 flex-1">
         <Outlet />


### PR DESCRIPTION
## What

- Adds `md:pl-6` to the header so the logo's left edge (24px) lines up with the docs sidebar text on screens where the sidebar is visible.
- Adds `md:pr-4` to keep the header optically balanced: the right-side icon glyphs sit ~9px inside their 32px hitboxes, so 16px of padding puts the glyph ink at ~25px — matching the logo's 24px within a pixel.
- Removes the docs sidebar's right separator hairline.

## Why

The header used `pl-4` (16px) while sidebar text sits at 24px (`pl-4` on the nav + `px-2` on each item), leaving the logo visibly outdented from the sidebar column.

## Notes for review

- Mobile (< md) keeps the original `pl-4 pr-3` — the sidebar is hidden there, so there's nothing to align with.
- Verified in the browser at 1280px: logo, sidebar section headings, and link text all measure 24px from the left, and the last icon glyph 25px from the right; at 375px everything keeps its original inset.