### PR TITLE
docs(plans): add ds.dotui.org research-site design plan

### DIFF
--- a/docs/plans/2026-07-03-ds-research-site/001-roster-selection.md
+++ b/docs/plans/2026-07-03-ds-research-site/001-roster-selection.md
@@ -1,0 +1,55 @@
+# 001 — Roster selection research
+
+Planned at `9c86ac02`. Gates 002/004. Read [README.md](README.md) Phase 0 first.
+
+## Goal
+
+Decide **which 8–12 design systems get deep analysis** in v1, with documented criteria and scores — and make the selection itself publishable content ("how we chose what to study"). Quality over popularity is the founding editorial rule: the maintainer explicitly wants "a list of the design systems we should really follow, not shitty ones — popular doesn't mean good."
+
+## Deliverables
+
+1. `docs/research/2026-MM-DD-ds-roster-selection.md` — the research report: longlist, criteria, scores, shortlist, rejections with reasons. (Follows the existing `docs/research/` convention; it later becomes the site's "methodology / how we chose" page.)
+2. A machine-readable roster: `ds/data/roster.json` (or, if 003 hasn't landed, park it next to the report and move it later) — `[{ slug, name, org, type, status: 'tier1' | 'watchlist' | 'rejected', sources: {...}, rationale }]`.
+
+## Method
+
+Run as maintainer-driven agent research sessions (Phase-0 decision 7). For each candidate, agents must actually open the docs/repo/shipped CSS — no scoring from memory or reputation.
+
+### Longlist (start here, expand during research)
+
+Confirmed maintainer interest: **Vercel Geist, Linear** (no public repo — inspect shipped CSS variables), **Adobe Spectrum 2, GitHub Primer, Material 3 (M3/HCT), Radix (Colors + Themes), shadcn/ui** (it has a real color system, not just a CLI — evaluate the thing itself, not the distribution model). Maintainer also named **"Astryx by Meta"** — ⚠️ unverified name; first task is to identify what Meta system this refers to (could be an internal DS; verify existence and inspectability before scoring; if it can't be confirmed, record that and drop it).
+
+Additional candidates to score: IBM Carbon, Shopify Polaris, Atlassian Design System, Microsoft Fluent 2, Salesforce Lightning, Uber Base, Mantine, Chakra v3 / Park UI (Panda ecosystem), Hero UI, Once UI, Nord (Provet), Orbit (Kiwi), Ant Design, Arco, Tailwind (Catalyst + the Tailwind palette as a token system), Stripe (shipped-CSS inspection; no public DS), Airbnb DLS (likely uninspectable — verify), Untitled UI (maintainer: "check if it's slop; if so forget it"), Atlassian, GOV.UK Design System, USWDS. Also consider **pure token/color systems** that aren't full DSs but are canonical for the v1 dimension: Open Props, Tailwind colors, Radix Colors standalone, Adobe Leonardo.
+
+### Scoring criteria (draft — refine in the report, then freeze)
+
+Score each candidate 0–3 per criterion, **for the v1 dimension (color & tokens)** specifically:
+
+- **Technical depth of the color/token system** — real architecture (layers, generation, contrast strategy) vs a flat palette.
+- **Originality / lessons** — does studying it teach something the others don't? (e.g. M3's HCT, Spectrum's Leonardo-based contrast targets, Radix's 12-step scale semantics.)
+- **Inspectability** — public repo > public docs > shipped CSS only > closed. Closed + shallow = drop; closed + excellent (Linear, Stripe) = keep, tagged `reverse-engineered`.
+- **Documentation quality** — can facts be cited to stable URLs?
+- **Influence on the field** — tiebreaker only, never the lead criterion.
+
+### Entity typing (from Phase 0 — typed entities, correctly classified)
+
+Assign each entry a `type` (`corporate-design-system` / `component-library` / `primitives-library` / `token-or-color-system` / `figma-kit`) and optional `upstream` links (shadcn→Radix/Base UI, Park→Ark/Panda, dotUI→React Aria). Get the classification *right* — the maintainer flagged that lazy typing (e.g. "Radix = just primitives", "shadcn = just a CLI") is exactly the error to avoid. Comparisons on the site will only span comparable types.
+
+## Steps
+
+1. Verify/resolve the "Astryx by Meta" reference (web research; check Meta's public design resources).
+2. Fan out agent research: one pass per longlist candidate producing a filled scorecard with evidence links.
+3. Score, rank, cut to 8–12 tier-1 + a watchlist. Write rejections down (binding for future roster debates, like audit rejected-findings).
+4. Maintainer sign-off on the final roster (this is a product decision — do not proceed to 004 without it).
+5. Write the report + `roster.json`.
+
+## Done criteria
+
+- Report exists in `docs/research/` with per-candidate scorecards and evidence links (no candidate scored without opened sources).
+- `roster.json` validates against the shape above; 8–12 `tier1` entries; every rejection has a reason.
+- Maintainer has explicitly approved the tier-1 list.
+
+## STOP conditions
+
+- If scoring produces >12 strong tier-1 candidates, STOP and present the tradeoff to the maintainer rather than silently widening v1.
+- If a maintainer-named system (Linear, "Astryx") turns out to be effectively uninspectable even via shipped CSS, STOP and report before dropping it.

--- a/docs/plans/2026-07-03-ds-research-site/002-schema-and-question-bank.md
+++ b/docs/plans/2026-07-03-ds-research-site/002-schema-and-question-bank.md
@@ -1,0 +1,70 @@
+# 002 — Fact schema, question bank, and 2-system pilot
+
+Planned at `9c86ac02`. Depends on [001](001-roster-selection.md) (roster + entity types). Gates [004](004-research-execution.md). Read [README.md](README.md) Phase 0 first.
+
+## Goal
+
+Design the data model that everything else is a view over, and **stabilize it against two real systems before fanning out**. Schema churn after 10 systems are researched means 10 rewrites; churn after 2 is cheap. The schema is the product — topic pages, profiles, and matrices are all renderers over it.
+
+## Core ideas (binding)
+
+1. **The question bank IS the taxonomy.** A canonical, versioned list of research questions per dimension. V1 ships only the `color-tokens` dimension. Topic pages = one question (or cluster) across systems; profiles = one system across questions; matrices = generated from structured answers. Adding a dimension later (focus, density, typography…) = adding questions, not reshaping the schema.
+2. **Independent taxonomy** (Phase-0 decision): questions are phrased as a neutral researcher would, never in dotUI-builder vocabulary.
+3. **Every fact carries evidence** (Phase-0 decision 4): source URL(s), retrieval date, method (`documented` / `source-read` / `reverse-engineered`), and a `verifiedAt` date. A fact without evidence fails CI.
+4. **Structured answers where comparison needs them, prose where nuance needs it.** Each question declares an answer shape (enum / number / structured object / free-form). Matrices only render questions with structured shapes.
+
+## Question bank v1 — `color-tokens` (draft; finalize during pilot)
+
+The maintainer's own questions, made canonical (IDs are permanent once published):
+
+- `palette.structure` — Base palettes? How many ramps, steps per ramp, step semantics (Radix-style 1–12 with defined roles? Tailwind 50–950? custom)?
+- `palette.generation` — How are colors generated? Algorithm (HCT, Leonardo/contrast-targeted, OKLCH interpolation, hand-picked), inputs (seed/brand color? lightness curve?), open-source implementation?
+- `palette.colorspace` — Working color space(s) and output formats (OKLCH, HCT, LAB, sRGB hex; P3 support?).
+- `contrast.strategy` — Contrast guarantees: enforced by construction (per-step targets), checked in tooling, or convention only? WCAG 2.x vs APCA? Guaranteed pairings (text-on-bg tokens)?
+- `tokens.layers` — Token architecture: primitive → semantic → component layers? Which layers exist, what are they called, examples of each?
+- `tokens.scope` — What is tokenized beyond color: spacing, radius, typography, elevation, motion, breakpoints…? (Structured checklist.)
+- `tokens.naming` — Naming convention and grammar (`--color-bg-accent-emphasis` style analysis), theming mechanism (CSS vars? build-time? data attributes?).
+- `modes.support` — Light/dark/HC modes: separate palettes, transformed palettes, or same tokens re-pointed? System sync?
+- `focus.construction` — How the focus highlight is built (outline vs ring vs shadow, offset, color source token, :focus-visible discipline). Included in v1 as maintainer-requested color-adjacent mechanics.
+- `component.color-usage` — spot-check: how a Button consumes the system (which token layer does it touch, how many color variants exist).
+
+## Schema sketch (implement as zod in `ds/src/data/schema.ts`, TS types inferred)
+
+```
+system.json    { slug, name, org, type, upstream[], sources{docs,repo,figma,site}, status, addedAt }
+facts.json     [{ questionId, answer: <shape per question>, summary: string,
+                  evidence: [{ url, kind: 'docs'|'source'|'shipped-css'|'changelog'|'talk',
+                               retrievedAt, excerpt?, note? }],
+                  method, verifiedAt, confidence: 'verified'|'inferred', notes? }]
+analysis/*.mdx prose deep-dive per system, may embed facts by questionId (never restate values by hand)
+question-bank.ts  [{ id, dimension, prompt, answerShape (zod), matrixable: boolean, rationale }]
+```
+
+Location: `ds/data/systems/<slug>/` + `ds/src/data/` for schema/bank. If 003 hasn't landed yet, develop under `docs/research/ds-pilot/` and move.
+
+## The pilot (the actual work of this plan)
+
+Research **two systems end-to-end** through every question, chosen to stress opposite methods:
+
+- **Radix (Colors + Themes)** — fully open: docs + source citations, tests `documented`/`source-read` flows.
+- **Linear** — closed: shipped-CSS inspection only, tests the `reverse-engineered` flow (CSS variable extraction from the live site, dated observations, minimal excerpts).
+
+For each: fill `facts.json` completely, write a short `analysis.mdx`, and note every place the schema fought you. Then revise the question bank/schema **once**, and freeze v1 (additive changes allowed after; breaking changes need a migration note).
+
+## Reverse-engineering rules (binding for 004 too)
+
+- Facts from shipped CSS are observations: record retrieval date and page inspected; phrase as "as shipped on linear.app, 2026-07-XX", never as official documentation.
+- Quote minimal excerpts (variable names, values) — never republish whole files or embed proprietary assets.
+- Prefer corroboration (blog posts, talks by the system's team) when it exists; cite both.
+
+## Done criteria
+
+- `question-bank` v1 frozen with ≥10 questions, each with an answer shape and matrixable flag.
+- zod schema validates both pilot systems' data in CI (`pnpm --filter=ds check:data` or equivalent vitest).
+- Both pilot systems: 100% of questions answered or explicitly marked `not-applicable`/`unknown` with a reason; every fact has evidence + dates.
+- A short schema-retro note appended to this plan (what churned during the pilot).
+
+## STOP conditions
+
+- If the pilot shows a question can't be answered for a closed system even via CSS inspection, STOP and decide with the maintainer: mark `unknown` (honest) vs drop the question — don't guess.
+- If answer shapes turn out to need per-system special-casing (schema fighting reality), STOP and redesign before fan-out; do not bolt on `anyOf` escape hatches.

--- a/docs/plans/2026-07-03-ds-research-site/003-app-scaffold.md
+++ b/docs/plans/2026-07-03-ds-research-site/003-app-scaffold.md
@@ -1,0 +1,36 @@
+# 003 — `ds/` app scaffold, dogfooded UI, data build pipeline
+
+Planned at `9c86ac02`. Independent of 001/002 (needs only the schema's rough shape from [002](002-schema-and-question-bank.md)); runs in parallel. Read [README.md](README.md) Phase 0 first.
+
+## Goal
+
+A deployable, near-empty but real site: new TanStack Start app `ds/` in the workspace, its own Vercel project on **ds.dotui.org**, UI installed from the dotUI registry (dogfooding), and the data build pipeline (validate → index) wired into the monorepo's turbo/CI conventions.
+
+## Decisions baked in
+
+- **Folder `ds/` at repo root**, sibling of `www/` (matches the existing `www` naming-by-host convention). Package name `ds`, private.
+- Same stack as `www`: TanStack Start + Vite, Tailwind v4, React 19 — all via `catalog:` versions so the two apps can't drift.
+- **Own Vercel project** (`dotui-ds` or similar) rooted at `ds/`, domain `ds.dotui.org`. Independent deploys from `www` — that isolation is the reason it's a separate app.
+- **Dogfooding**: components come from the dotUI registry via the shadcn CLI (`shadcn add`) against the production registry (or a local registry build during dev) into `ds/src/components/ui/`. This is deliberate end-to-end product testing: **every friction point is a product bug — fix it in the registry/publisher (as its own PR), don't work around it in `ds/`** (maintainer-approved). Do NOT import from `www/src/registry/*` across workspaces; that bypasses exactly the pipeline we want to test.
+- No fumadocs for v1 unless a concrete need appears — content is data-driven pages + plain MDX, not a docs tree.
+
+## Steps
+
+1. **Workspace wiring**: add `- ds` to `pnpm-workspace.yaml` `packages`; create `ds/package.json` (scripts mirroring `www`: `dev`, `build`, `typecheck`), extend `turbo.json` only if task shapes differ; add root convenience scripts `dev:ds`, `build:ds`.
+2. **App skeleton**: TanStack Start entry, root route with the **"ds." wordmark** header, footer disclosure line ("Built by dotUI. The builder follows this research — not the reverse."), 404, base theme. Keep the shell spartan; content carries the site.
+3. **Dogfood install**: `shadcn` init against the dotUI registry; install the initial kit (button, link, tabs, table, tooltip, popover, kbd, badge…). Log every rough edge into a running list; file/fix registry bugs separately.
+4. **Data pipeline**: `ds/src/data/schema.ts` (zod, from 002), `ds/data/` content tree, and a build step that (a) validates every `systems/<slug>/` against the schema — CI-fatal on violation, missing evidence, or unknown `questionId` — and (b) emits a static index (one JSON: all systems × all facts + question bank) consumed by routes at build time. Client-side search over the same index (orama/fuse) — no server, no service.
+5. **Routes (empty-state versions)**: `/` (mission + roster grid with published/planned status), `/systems/$slug` (profile shell), `/topics/$slug` (topic shell), `/methodology` (from 001's report). Prerender everything prerenderable; the site is static-first.
+6. **CI/conventions**: `pnpm check`, `typecheck` green across the workspace; data validation runs in `test` or a dedicated turbo task; Vercel project + domain configured and a hello-world deploy live on ds.dotui.org.
+
+## Done criteria
+
+- `pnpm dev:ds` serves the shell locally; `pnpm build` (turbo) builds both apps; `check` + `typecheck` green.
+- ds.dotui.org serves the deployed shell over the real domain.
+- Pilot data from 002 (once merged) renders on a profile shell page with citations + verified-dates visible — proving the data→index→UI path end-to-end.
+- A "dogfood friction log" exists (in the PR description or `docs/research/`) with each registry/CLI issue found, and fixes filed or landed separately.
+
+## STOP conditions
+
+- If dogfood installation is blocked by a registry/publisher bug that can't be fixed in a reasonable side PR, STOP and surface it — do not vendor/hand-copy components as a workaround (that silently kills the dogfood value).
+- If sharing code with `www` becomes tempting (layouts, utils), STOP and prefer duplication or a small `packages/` extraction — never `ds` → `www/src/*` imports.

--- a/docs/plans/2026-07-03-ds-research-site/004-research-execution.md
+++ b/docs/plans/2026-07-03-ds-research-site/004-research-execution.md
@@ -1,0 +1,50 @@
+# 004 — Per-system research execution across the roster
+
+Planned at `9c86ac02`. Depends on [001](001-roster-selection.md) (approved roster) and [002](002-schema-and-question-bank.md) (frozen schema + pilot). Read [README.md](README.md) Phase 0 first.
+
+## Goal
+
+Fill `ds/data/systems/<slug>/` for every tier-1 roster system to the citation standard, via maintainer-driven agent sessions. One system = one session (or a few) = **one PR**, reviewed by the maintainer. This is the long middle of the project; the playbook below keeps quality uniform across sessions run weeks apart.
+
+## The playbook (per system)
+
+1. **Recon** — locate all inspectable sources: docs site, public repo(s), npm packages, design blog posts / conference talks by the team, Figma community files, and the shipped product/site for CSS inspection. Record them in `system.json.sources`.
+2. **Answer the question bank** — for each question in the `color-tokens` bank, in order:
+   - Find the answer in the *most authoritative* source available (docs > source code > shipped CSS > secondary writing).
+   - Record the structured answer per the question's shape, a one-line `summary`, and full `evidence` (URL, kind, retrieval date, minimal excerpt).
+   - Unknown or not-applicable is a valid, honest answer — with a reason. Never infer silently; if you infer, mark `confidence: 'inferred'` and say from what.
+3. **Reverse-engineering pass** (closed systems, or verification for open ones) — inspect shipped CSS: enumerate custom properties, map ramps/steps, sample computed colors, measure text/background contrast pairs. Follow 002's binding rules (dated observations, minimal excerpts, observed-not-official phrasing).
+4. **Analysis MDX** — a readable per-system deep-dive of the color/token architecture: what's distinctive, what the numbers show, one or two genuinely interesting findings. Embed facts by `questionId`; never restate values by hand (they'd rot independently).
+5. **Cross-check** — a second agent pass that attempts to *refute* each recorded fact against the cited source (adversarial verify). Facts that fail get fixed or downgraded to `inferred`/`unknown`.
+6. **PR** — data + MDX + any question-bank clarifications (additive only). Maintainer reviews like any code PR; CI validates schema/evidence.
+
+## Order of execution
+
+Pilot systems (Radix, Linear) are done in 002. Suggested next order — alternate open and closed to keep both muscles exercised, and front-load the systems whose findings most inform `/create`'s color engine: Material 3 (HCT — richest algorithm), Spectrum 2 (Leonardo/contrast-targeted), Geist, Primer, shadcn/ui, then the rest of the approved roster.
+
+## Publishing cadence
+
+Per Phase-0 decision 10 (progressive launch): systems go live as they're merged once the site (003/005/006) is up. The roster grid shows `published` vs `planned` — visible momentum is a feature, not an embarrassment.
+
+## Refresh discipline (v1 = manual, minimal)
+
+No automation in v1 (deferred, Phase-0 decision 7). Two cheap habits instead:
+
+- Every fact already has `verifiedAt`; the UI (006) surfaces staleness honestly.
+- When touching a system for any reason, re-verify its most volatile facts (versions, package names, step counts) and bump dates.
+
+## Done criteria (per system)
+
+- 100% of the question bank answered / explicitly unknown-with-reason; CI green.
+- Cross-check pass ran; no `verified` fact lacks a working citation.
+- Analysis MDX exists and renders with embedded facts.
+- Merged via a maintainer-reviewed PR.
+
+## Done criteria (plan)
+
+- All approved tier-1 systems merged; status table in [README.md](README.md) updated with per-system checkmarks (add a roster-progress table to this file as systems land).
+
+## STOP conditions
+
+- If the frozen question bank/schema proves inadequate mid-roster (not just a missing question — a shape problem), STOP the fan-out and route back to 002 for a versioned schema change; don't fork per-system conventions.
+- If a system turns out to be dramatically shallower than its 001 score suggested, STOP and ask the maintainer whether to demote it to the watchlist rather than padding thin facts to fill the bank.

--- a/docs/plans/2026-07-03-ds-research-site/005-topic-showpieces.md
+++ b/docs/plans/2026-07-03-ds-research-site/005-topic-showpieces.md
@@ -1,0 +1,46 @@
+# 005 — Topic deep-dive pages + interactive widget kit
+
+Planned at `9c86ac02`. Depends on [003](003-app-scaffold.md) (app + index) and ≥3 systems of data from [002](002-schema-and-question-bank.md)/[004](004-research-execution.md). Read [README.md](README.md) Phase 0 first.
+
+## Goal
+
+The crown jewels: **interactive-first topic pages** (maintainer's explicit choice — showpieces, not static tables) that answer one canonical question across all researched systems, with explorable widgets no other publication can build — because we own an OKLCH engine and can run every system's palette algorithm live.
+
+## Guardrails (binding — this is where the month-eating risk lives)
+
+- **Widget kit first, showpieces second.** Build shared primitives once (below); every topic page composes them. A topic page may add at most ONE bespoke widget.
+- **Timebox per topic page: ~1 week equivalent.** If a page wants more, cut the widget, ship prose+tables+existing widgets, file the idea.
+- **Widgets are renderers over `facts` data + algorithm functions.** No widget owns hand-entered data; if a widget needs data the schema lacks, that's a 002/004 change first.
+- **Static fallback always**: every widget SSRs/prerenders a meaningful static state (SEO + no-JS + link previews). No blank-div-until-hydration pages.
+
+## The widget kit (`ds/src/components/widgets/`)
+
+1. **`PaletteRamp`** — render any system's ramp(s) with step labels, hover→OKLCH/hex/contrast readouts, light/dark toggle. Data: facts + sampled palettes stored per system.
+2. **`AlgorithmPlayground`** — the flagship: pick a seed color, watch each system's generation algorithm produce its palette side by side. Backed by a common interface, `packages/`-worthy if it grows: `PaletteAlgorithm { id, systemSlug, generate(seed, options) → ramps }`, with adapters: `@dotui/colors` (ours), `@material/material-color-utilities` (HCT), `@adobe/leonardo-contrast-colors` (Spectrum), static-scale adapters (Radix, Tailwind — no algorithm, shown as fixed references), plus faithful reimplementations only when a system documents its math and no package exists (cite the doc in the adapter).
+3. **`ContrastMatrix`** — for a system's guaranteed pairings: measured WCAG 2.x + APCA values against the claimed guarantees. "Claimed vs measured" is exactly the truth-seeking flex the site exists for.
+4. **`TokenLayerDiagram`** — primitive→semantic→component layer visualization from `tokens.layers` facts, per system, with real token names.
+5. **`FactTable` / `Matrix`** — the generated comparison table over any `matrixable` question; every cell carries its citation popover + verified-date. (Shared with 006.)
+
+## Topic pages for v1 (one per question-cluster; each ends with "Implications for builders" → feeds 006's issues pipeline)
+
+1. **How the best design systems generate color** (`palette.generation` + `palette.colorspace`) — flagship, uses AlgorithmPlayground.
+2. **The anatomy of a palette** (`palette.structure`) — ramps/steps/semantics compared; PaletteRamp gallery.
+3. **Contrast: guaranteed, checked, or vibes** (`contrast.strategy`) — ContrastMatrix; claimed-vs-measured.
+4. **Semantic tokens, component tokens, and who actually uses them** (`tokens.layers` + `tokens.naming`) — TokenLayerDiagram.
+5. **What gets tokenized** (`tokens.scope`) — matrix-led, lightest page.
+6. **Dark mode architectures** (`modes.support`).
+7. (v1-optional, maintainer interest) **How focus rings are built** (`focus.construction`) — only if roster data for it lands in 004.
+
+Fun awards (Phase-0 decision 5) live inside relevant topic pages as small evidence-backed callouts, not standalone leaderboard pages.
+
+## Done criteria
+
+- Widget kit primitives 1–5 exist, SSR a static state, and are data/algorithm-driven end-to-end.
+- Topic pages 1–5 published to citation standard, each with an implications section.
+- Each page's widgets render correctly with *partial* data (systems not yet researched simply absent — progressive launch).
+- `pnpm check`/`typecheck` green; pages prerender.
+
+## STOP conditions
+
+- If an algorithm adapter requires reverse-engineering *undocumented* math (vs documented math without a package), STOP — present the fidelity risk to the maintainer; a mislabeled approximation would violate the truth standard. Approximations must be labeled as such in the UI.
+- If any single topic page exceeds its timebox by 2×, STOP, ship the static version, and log the widget as follow-up.

--- a/docs/plans/2026-07-03-ds-research-site/006-profiles-matrices-launch.md
+++ b/docs/plans/2026-07-03-ds-research-site/006-profiles-matrices-launch.md
@@ -1,0 +1,46 @@
+# 006 — System profiles, generated matrices, research→create pipeline, launch
+
+Planned at `9c86ac02`. Depends on [003](003-app-scaffold.md), [005](005-topic-showpieces.md), and ≥3 systems from [004](004-research-execution.md). Read [README.md](README.md) Phase 0 first.
+
+## Goal
+
+The second entry point (per Phase-0 decision 3: topics AND profiles co-equal from day one), the generated comparison views, the pipeline that makes findings change `/create`, and the actual go-live.
+
+## Profiles (`/systems/$slug`)
+
+One rich page per system, entirely rendered from the data layer:
+
+- Header: name, org, entity type, upstream links ("builds on React Aria"), sources, overall `verifiedAt` freshness.
+- The system's answers to every question in the bank, grouped by cluster — each fact with its citation popover, method badge (`documented`/`source-read`/`reverse-engineered`), and date. Reverse-engineered profiles (Linear) open with the observed-not-official disclosure.
+- The `analysis.mdx` deep-dive inline.
+- Its palette rendered live (`PaletteRamp` from 005).
+- Cross-links into every topic page that features it.
+
+## Matrices (`/compare`, and embedded per-topic)
+
+Generated from `matrixable` questions — never hand-maintained (Phase-0 decision 3). Filter by entity type so comparisons stay apples-to-apples (typed-entities decision). Cells link to evidence. An empty/sparse column (system not yet researched) renders as "planned", not blank — progressive-launch honesty.
+
+## Research→create pipeline (Phase-0 decision 11)
+
+- Every topic page's "Implications for builders" section is neutral and public (no dotUI pitch — decision 1's direction-of-truth).
+- For each implication that `/create` should act on: file a GitHub issue on `mehdibha/dotUI`, label **`research-finding`** (create the label), title as an axis/behavior proposal, body links the topic page + specific facts. Per CLAUDE.md, these are proposals awaiting maintainer approval — the pipeline feeds product decisions, it doesn't make them.
+- Add a short section to the site's `/methodology` page explaining this pipeline publicly (it's part of the credibility story).
+
+## Launch checklist
+
+1. **Open data**: license the `ds/data/` content clearly (data/prose CC BY 4.0, code stays MIT — confirm with maintainer at PR time); a `/data` page or README section explains how to consume the JSON and how to submit corrections (PRs welcome).
+2. **SEO/meta**: per-page titles/descriptions/OG images (static generation fine for v1), sitemap, canonical URLs on ds.dotui.org. The matrices and topic pages are the linkable assets — make their URLs stable and their headings anchor-linkable.
+3. **Freshness UI**: site-wide "last verified" surfacing; a `/changelog` (or just the GitHub history link) showing the data is alive.
+4. **Cross-site**: one quiet link from www's footer/nav to ds.dotui.org and back — no aggressive funnel (decision on funnel direction).
+5. **Go-live gate**: schema frozen, ≥3 systems published to citation standard, topic pages 1–3 live, profiles live, methodology page live, lighthouse/a11y sanity pass (the site dogfoods an accessibility-first registry — it should ace this), maintainer sign-off, announce.
+
+## Done criteria
+
+- Profiles + `/compare` render fully from the index for every published system; zero hand-duplicated facts anywhere in the app.
+- `research-finding` label exists with ≥1 real issue filed through the pipeline end-to-end.
+- Launch checklist items all checked; ds.dotui.org public and announced.
+
+## STOP conditions
+
+- Do not launch with any `verified`-marked fact lacking a working citation — run a link-check over all evidence URLs as part of the gate; downgrade or fix failures first.
+- If licensing questions arise beyond the simple CC-BY/MIT split (e.g. quoting limits for reverse-engineered material), STOP and resolve with the maintainer before publishing the affected pages.

--- a/docs/plans/2026-07-03-ds-research-site/README.md
+++ b/docs/plans/2026-07-03-ds-research-site/README.md
@@ -1,0 +1,67 @@
+# ds.dotui.org — design-systems research site
+
+Feature-design plan (not an audit; follows the folder/index/`NNN-slug.md` convention). Planned at `9c86ac02`, decisions resolved with the maintainer on 2026-07-03 in a structured Q&A session.
+
+**What this is:** a new site at **ds.dotui.org** (header wordmark: **"ds."**) — a rigorous, citation-backed research property about how the best design systems actually work, starting with the deepest possible treatment of **color & token systems** across a curated roster of ~8–12 genuinely excellent systems (Geist, Linear, Spectrum 2, Primer, Material 3, Radix, shadcn/ui, …). Every fact is cited and dated. The site is the upstream truth; **dotui.org/create follows the research, never the reverse**.
+
+Start from this index, never from an individual plan. Read the whole plan you pick up, honor its STOP conditions, and update its status row here when done.
+
+## Phase 0 — product decisions (RESOLVED 2026-07-03)
+
+All resolved with the maintainer; these are binding for every plan in this folder.
+
+1. **Purpose — the full flywheel, with a fixed direction of truth.** The research feeds the builder (cataloging real systems reveals which axes `/create` is missing), publishing it earns authority, authority feeds the product. But causality is one-way: **research findings drive `/create`; `/create`'s needs never bend the published research.** If the research disagrees with how `/create` does something today, the research publishes the disagreement and `/create` gets an issue to follow it.
+2. **Scope of v1 — narrow & deep, one dimension.** V1 covers **color & token systems only** — palette structure, generation algorithm, base palettes, semantic vs component tokens, what exactly is tokenized (colors only? spacing? …), contrast guarantees, plus adjacent color-mechanics like focus-highlight construction. Focus rings in full, density, typography, component variants etc. become v1.1+, reusing the same schema/machinery. Roster: **8–12 systems**, selected by [001](001-roster-selection.md) — quality over popularity ("popular doesn't mean good").
+3. **Content shape — topics AND profiles from day one, over one dataset.** Two co-equal entry points: **topic deep-dives** ("how 10 systems generate color", "semantic vs component tokens: who does what") and **system profiles** (the Geist page, the Linear page). Both are views over the same structured fact data; comparison matrices are generated, never hand-maintained.
+4. **Truth standard — every fact cited + dated.** Each data point carries evidence (source URL / repo file / shipped-CSS observation), a retrieval date, and a method tag (`documented` / `source-read` / `reverse-engineered`). Reverse-engineered facts (e.g. Linear's CSS variables read from the shipped site) are first-class but always labeled as observed-not-official. This is the moat.
+5. **Editorial line — describe, don't rank; fun awards allowed.** No leaderboards or scored verdicts. Occasional light-hearted awards (e.g. "most obsessive focus ring") are fine; they must still be evidence-backed.
+6. **Data — hybrid, git-source, zero new paid services.** Structured facts as schema-validated JSON + MDX analysis in the repo (open data); a build step compiles them into a static index the site queries. Vercel is the only paid service; no database.
+7. **Ops — maintainer-driven agent sessions.** The maintainer kicks off Claude Code research sessions per system; agents produce schema-valid facts + citations; every merge is a reviewed PR. Scheduled autonomous re-verification is deferred until the dataset and schema are stable (explicitly phase-2).
+8. **Tech — new TanStack Start app `ds/` in this monorepo,** own Vercel project on ds.dotui.org. Same stack as `www` (TanStack Start, Tailwind v4). The site **dogfoods dotUI**: its UI is installed from the dotUI registry via the shadcn CLI, exactly as a user would; installation problems found along the way get fixed as product bugs (maintainer: "if you find issues installing, you can fix them").
+9. **Interactivity — interactive-first showpieces.** Topic pages are explorable: live palette ramps per system, "same seed color through each system's algorithm", contrast-guarantee checkers — powered by `@dotui/colors` plus each system's own open algorithm packages where they exist (`@material/material-color-utilities`, Adobe Leonardo, Radix scales…). Guardrails in [005](005-topic-showpieces.md) keep any single page from eating a month.
+10. **Launch — progressive + open data.** Publish when the schema is stable and ~3 systems meet the citation bar; grow in the open ("12 planned, 3 published"). Data/content openly licensed; corrections arrive as PRs.
+11. **Research→create pipeline — implications → GitHub issues.** Every topic page ends with a neutral "implications for builders" section; each finding `/create` should adopt becomes a GitHub issue on `mehdibha/dotUI` labeled `research-finding`, linking the evidence. Traceable: page → issue → axis.
+12. **Name & voice — "ds." on ds.dotui.org.** Plain disclosure in the footer: built by dotUI; the builder follows this research, not the reverse. Voice: rigorous, human, cited; occasional fun.
+
+## Execution order
+
+```
+001 roster selection ──►  002 schema + question bank (pilot: 2 systems) ──►  004 research execution (roster fan-out)
+                                        │                                            │
+                    003 app scaffold ───┴──────────►  005 topic showpieces  ◄────────┤
+                    (parallel with 002)                                              │
+                                                      006 profiles + matrices + launch
+```
+
+- [001](001-roster-selection.md) gates everything: it decides *what* we study and produces the first publishable artifact ("how we chose").
+- [002](002-schema-and-question-bank.md) is the intellectual core — the fact schema and the canonical question bank. It pilots on 2 systems (one documented, one reverse-engineered) so schema churn happens before the fan-out, not after.
+- [003](003-app-scaffold.md) is independent of 001/002 (needs only the schema's rough shape) and can run in parallel.
+- [004](004-research-execution.md) fans out across the roster once the pilot has frozen the schema. One PR per system.
+- [005](005-topic-showpieces.md) needs ≥3 systems' facts to be worth building against real data.
+- [006](006-profiles-matrices-launch.md) is the launch gate: profiles, generated matrices, implications→issues pipeline, licensing, SEO, go-live.
+
+## Status
+
+| Plan | Title | Status |
+|---|---|---|
+| 000 | Phase 0 product decisions | DONE — resolved 2026-07-03 (grill session; 12 decisions above) |
+| [001](001-roster-selection.md) | Roster selection research | TODO |
+| [002](002-schema-and-question-bank.md) | Fact schema + canonical question bank + 2-system pilot | TODO |
+| [003](003-app-scaffold.md) | `ds/` app scaffold, Vercel project, dogfooded UI, data build pipeline | TODO |
+| [004](004-research-execution.md) | Per-system research execution across the roster | TODO |
+| [005](005-topic-showpieces.md) | Topic deep-dive pages + interactive widget kit | TODO |
+| [006](006-profiles-matrices-launch.md) | Profiles, generated matrices, research→create pipeline, launch | TODO |
+
+## Architecture in one paragraph
+
+A second TanStack Start app, `ds/`, sibling of `www/` in the pnpm workspace, deployed as its own Vercel project on ds.dotui.org. Its source of truth is `ds/data/`: one directory per rostered system holding schema-validated `facts` JSON (zod-checked in CI) plus MDX analysis, and a shared `question-bank` that defines the canonical research questions for each dimension. A build step compiles all facts into a static, client-queryable index — topic pages, system profiles, and comparison matrices are all views over that one index, so nothing is hand-duplicated and every rendered fact carries its citation + verified-date from the data layer. The site's own components are installed from the dotUI registry via the shadcn CLI (dogfooding); interactive showpieces implement each system's color algorithm behind one common `PaletteAlgorithm` interface (own engine `@dotui/colors`, plus published packages like material-color-utilities and Leonardo, plus static scales like Radix). No database, no new services.
+
+## Rejected / deferred (binding until revisited)
+
+- **Wide-and-shallow catalog (60–100+ systems)** — rejected for v1. Quality-curated roster instead; count is not the product.
+- **Rankings/leaderboards** — rejected. Describe, don't rank (fun awards excepted).
+- **Untitled UI on the roster by default** — not assumed; 001 evaluates it on merit ("check if it's slop; if so, forget it").
+- **Scheduled autonomous refresh agents** — deferred to phase 2, after schema stability. Do not build refresh automation in v1.
+- **Real database / CMS / any new paid service** — rejected. Git + build-time index only.
+- **dotUI-axis-shaped schema** — rejected; the taxonomy is independent. A `/create`-mapping layer may exist later, but the descriptive schema never bends to the builder's vocabulary.
+- **Hard product funnel (recreate-in-dotUI CTAs, per-system dotUI themes)** — rejected for v1; the flow is research→product, not product-marketing→reader.

--- a/docs/plans/2026-07-03-ds-research-site/README.md
+++ b/docs/plans/2026-07-03-ds-research-site/README.md
@@ -45,7 +45,7 @@ All resolved with the maintainer; these are binding for every plan in this folde
 | Plan | Title | Status |
 |---|---|---|
 | 000 | Phase 0 product decisions | DONE — resolved 2026-07-03 (grill session; 12 decisions above) |
-| [001](001-roster-selection.md) | Roster selection research | TODO |
+| [001](001-roster-selection.md) | Roster selection research | DONE — 2026-07-03; ~30 candidates recon'd by 8 parallel agent sessions, report + `roster.json` in [docs/research/2026-07-03-ds-roster-selection/](../../research/2026-07-03-ds-roster-selection/README.md). Maintainer-approved tier-1 = **15 systems** (approved deviation from the 8–12 cap; STOP condition honored — tradeoff was presented): Spectrum 2 (+Leonardo), Material 3, Radix, USWDS, Ant Design, Fluent 2, Polaris, Primer, Astryx (Meta — verified real, June 2026), Linear (RE), Stripe (RE), Carbon, Geist, shadcn/ui, Tailwind palette. 8 watchlist, 8 rejected with reasons (binding). |
 | [002](002-schema-and-question-bank.md) | Fact schema + canonical question bank + 2-system pilot | TODO |
 | [003](003-app-scaffold.md) | `ds/` app scaffold, Vercel project, dogfooded UI, data build pipeline | TODO |
 | [004](004-research-execution.md) | Per-system research execution across the roster | TODO |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -10,6 +10,7 @@ Audit-generated, executor-ready implementation plans. One date-prefixed folder p
 | [2026-06-11-colors-audit/](2026-06-11-colors-audit/README.md) | `packages/colors` kernel + its `www/src/registry/theme` consumption boundary — spec recovery, characterization, open algorithm registry, kernel dark mode, new color axes | `05b44151` | 9 |
 | [2026-06-12-docs-module-audit/](2026-06-12-docs-module-audit/README.md) | Docs module — `modules/docs` + `modules/references` + `content/docs` + docs/llms routes + api-docs-builder: typeLinks payload/determinism, fail-loud MDX pipeline, fumadocs security bump, legacy engine retirement, shiki deploy weight, content fixes | `e0ca5b16` | 7 |
 | [2026-06-13-charts/](2026-06-13-charts/README.md) | Charts feature (design plan, not an audit) — Recharts-based chart registry items with shadcn parity, a `--chart-N` builder colors axis, a new Charts docs section + gallery + nav, and the build/publish/SSR/a11y discipline to ship them | `a4c39a38` | 5 |
+| [2026-07-03-ds-research-site/](2026-07-03-ds-research-site/README.md) | ds.dotui.org (design plan, not an audit) — new `ds/` app: citation-backed research on design systems' color & token architectures across a curated ~8–12 system roster; agent-driven research pipeline, interactive topic showpieces, generated matrices, and a research→`/create` findings pipeline | `9c86ac02` | 6 |
 
 ## Cross-audit notes
 

--- a/docs/research/2026-07-03-ds-roster-selection/README.md
+++ b/docs/research/2026-07-03-ds-roster-selection/README.md
@@ -1,0 +1,123 @@
+# ds.dotui.org roster selection — which design systems deserve deep color/token analysis
+
+> Status: **DONE** — researched 2026-07-03, tier-1 roster approved by the maintainer the same day (15 systems, an approved deviation from plan 001's 8–12 cap; see Deviations). Snapshot, not kept current.
+> Companion machine-readable output: [`roster.json`](roster.json). Executes [plan 001](../../plans/2026-07-03-ds-research-site/001-roster-selection.md).
+
+## Method
+
+~30 candidates were researched by parallel agent recon sessions (8 batches, 2026-07-03). Ground rule: no scoring from memory or reputation — agents had to open docs pages, GitHub source files, npm metadata, or shipped CSS, and every claim below carries the source the agent actually opened. Closed systems (Linear, Stripe, Airbnb) were probed for shipped-CSS extractability specifically.
+
+**Recon ≠ citation-standard research.** These scorecards are selection evidence, good enough to rank candidates. Plan 004's per-system deep dives re-verify everything to the site's per-fact citation standard before anything publishes; treat details below as strong leads, not published facts.
+
+### Criteria (0–3 each, scored for the color/token dimension only)
+
+- **technical-depth** — real architecture (generation, layering, contrast strategy) vs a flat palette
+- **originality-lessons** — does studying it teach something the others don't?
+- **inspectability** — public repo = 3, docs only = 2, shipped CSS only = 1, effectively closed = 0
+- **docs-quality** — can facts be cited to stable URLs?
+- **influence** — tiebreaker only
+
+## Tier-1 roster (approved 2026-07-03)
+
+Scores: depth / originality / inspectability / docs / influence.
+
+| # | System | Type | Scores | Why it's in (one line) |
+|---|---|---|---|---|
+| 1 | Adobe Spectrum 2 (+ Leonardo) | corporate-design-system | 3/3/3/2/3 | Contrast-solved generation (CAM02-UCS), true 3-tier tokens, JSON-Schema-validated pipeline — deepest public color/token stack found |
+| 2 | Google Material 3 | corporate-design-system | 3/3/3/2/2 | HCT color space + runtime dynamic color + contrast-by-construction via tone deltas; open in 6 language ports |
+| 3 | Radix Colors + Themes | token-or-color-system | 3/3/2/3/3 | The 12-step role semantics everyone imitates; only major system with APCA-by-construction text contrast (Lc 60/90) |
+| 4 | USWDS | corporate-design-system | 3/3/3/3/2 | The "magic number" grade system — numeric grade difference deterministically guarantees WCAG contrast |
+| 5 | Ant Design | component-library | 3/3/3/3/3 | Fully open, documented parametric HSV ramp algorithm + the seed→map→alias derivation pipeline |
+| 6 | Microsoft Fluent 2 | corporate-design-system | 3/3/3/2/2 | Open Lab/LCH curve-based ramp generator (`paletteShadesFromCurve`) + clean global→alias split + public Theme Designer |
+| 7 | Shopify Polaris | corporate-design-system | 3/3/2/2/2 | Open HSLuv color factory purpose-built for cross-hue contrast parity |
+| 8 | GitHub Primer | corporate-design-system | 3/2/3/2/2 | 3-tier Style Dictionary pipeline, HSLuv Prism authoring tool, automated WCAG token-pair audits, `org.primer.llm` extension |
+| 9 | Meta Astryx | corporate-design-system | 3/3/3/3/2 | Semantic-only tokens (no numeric ramps), `light-dark()` dual-mode values, 10 swappable themes; open since June 2026 |
+| 10 | Linear | corporate-design-system (closed) | 2/2/1/1/3 | LCH 3-variable theme generation (base/accent/contrast) replacing 98 vars; the reverse-engineering exemplar |
+| 11 | Stripe | corporate-design-system (closed) | 3/3/1/2/3 | Canonical CIELAB contrast methodology (2019 post) + 284 extractable custom properties in shipped dashboard CSS |
+| 12 | IBM Carbon | corporate-design-system | 2/2/3/2/3 | Mature 3-tier token layering at scale (~235 semantic tokens, 4 built-in themes) — architecture, not generation |
+| 13 | Vercel Geist | corporate-design-system | 1/1/1/3/2 | Step-as-role 100–1000 numbering + machine-readable `/design.md` spec; maintainer pick despite thin color science |
+| 14 | shadcn/ui | styling-distribution | 1/1/3/2/3 | The ecosystem's reference point; its thin color layer (borrowed static scales, no contrast strategy) is itself a publishable finding |
+| 15 | Tailwind palette | token-or-color-system | 2/2/2/3/3 | dotUI's own substrate; the v4 hex→OKLCH migration-preserving-balance and `@theme` namespace design |
+
+Suggested research order for plan 004 (alternating open/closed, algorithm-richest first): Material 3 → Spectrum 2 → Geist → Primer → shadcn → Ant → Fluent → Polaris → USWDS → Astryx → Stripe → Carbon → Tailwind (Radix and Linear are the plan-002 pilot systems).
+
+## Tier-1 scorecards (condensed recon evidence)
+
+### Adobe Spectrum 2 (+ Leonardo)
+Three related open projects: [spectrum-design-data](https://github.com/adobe/spectrum-design-data) (ex `spectrum-tokens`; npm `@adobe/spectrum-tokens` 14.13.2), [adobe/leonardo](https://github.com/adobe/leonardo) (the upstream generation tool — authoring-time, not runtime), and the spectrum-css/react-spectrum implementations. Verified by raw JSON inspection: 16-step ramps 100–1600 (`color-palette.json`, 372 keys), each primitive a color-set with **light/dark/wireframe** mode values; semantic aliases (`semantic-color-palette.json`, 94) + layering aliases (`color-aliases.json`, 170: `background-layer-1/2`, `elevated`, `pasteboard`, state tokens) + component color tokens (73) — a real 3-tier. Generation is contrast-solved via Leonardo (WCAG 2 targets; APCA requested in [issue #197](https://github.com/adobe/leonardo/issues/197), open), moved from HSL to **CAM02-UCS** with a Stevens'-Power-Law lightness curve per [adobe.design's "Reinventing Adobe Spectrum's colors"](https://adobe.design/stories/design-for-scale/reinventing-adobe-spectrum-s-colors); contrast ratios tuned per-theme as percentages of available contrast (Nate Baldwin's ["Adaptive Color"](https://medium.com/thinking-design/adaptive-color-in-spectrum-adobes-design-system-feeeec89a2c7)). Tokens carry JSON Schema + uuid, validated by a Rust CLI; an MCP server ships. P3: not found (sRGB `rgb()` shipped). Motion tokens: unverified.
+
+### Google Material 3
+[material-color-utilities](https://github.com/material-foundation/material-color-utilities) (Apache-2.0, TS/Java/Swift/Kotlin/Dart/C++): **HCT** — CAM16 hue/chroma + CIELAB L* tone. 5 tonal palettes + error, 13 tones (0–100). Runtime dynamic color from a wallpaper seed with scheme variants (TONAL_SPOT, VIBRANT, EXPRESSIVE…). 3-tier `md.ref → md.sys → md.comp`. Contrast by construction via tone-delta math (Δ40 ≈ 3:1, Δ50 ≈ 4.5:1; WCAG relative-luminance math confirmed in `contrast.ts`). sRGB-only — P3 explicitly out of scope per repo issue #131. Docs SPA is hard to fetch programmatically (noted for plan 004).
+
+### Radix Colors + Themes
+[radix-ui/colors](https://github.com/radix-ui/colors): 12 steps × 30 scales × 4 variants (light/dark × solid/alpha) + blackA/whiteA. Step semantics precisely documented (1-2 backgrounds, 3-5 interactive, 6-8 borders, 9-10 solid, 11-12 text) at [radix-ui.com/colors](https://www.radix-ui.com/colors/docs/palette-composition/understanding-the-scale). **APCA by construction for text**: step 11 = Lc 60, step 12 = Lc 90 against step-2 background — the only major system on APCA. P3 shipped via `@supports`/`color-gamut` (verified in the npm tarball's `blue.css`). Caveat: the repo ships static hand-authored tables — the generation algorithm itself is not public (the custom-palette tool is a black box). Pilot system in plan 002.
+
+### USWDS
+[uswds/uswds](https://github.com/uswds/uswds) + [color tokens docs](https://designsystem.digital.gov/design-tokens/color/overview/): 24 families × 10 grades (5–90, + vivid `v` variants), grades **regularized to relative-luminance ranges** so grade difference alone guarantees WCAG contrast ("magic number": 40+ = AA large text, 50+ = AA, 70+ = AAA). Palette explicitly hand-curated ("not generated by an algorithm") on an HSL model. 3 layers: system → theme (`$theme-color-primary: "blue-60v"`) → state; Sass `!default` theming. WCAG 2.0, no APCA. The one system where contrast is a mathematical property of the token grammar itself.
+
+### Ant Design
+[ant-design-colors `generate.ts`](https://github.com/ant-design/ant-design-colors): documented parametric **HSV** algorithm — 12 hues × 10 steps, index 5 = base, `hueStep=2`, saturation/brightness step constants, distinct dark-theme blend-with-background map. Token model: **seed → map → alias** ([customize-theme docs](https://ant.design/docs/react/customize-theme)) — map tokens are *algorithmically derived* from seeds (including non-color, e.g. `borderRadiusLG/SM/XS` from `borderRadius`), the closest published analogue to dotUI's own derivation ambitions. CSS-in-JS with an optional CSS-variables mode (dedicated blog post). Contrast: WCAG mentioned, no targets/tooling. Everything open and readable.
+
+### Microsoft Fluent 2
+[microsoft/fluentui](https://github.com/microsoft/fluentui) `packages/tokens`: Neutral 51-step grey ramp (2–98+99), Brand 16-step per-product ramps, shared + alpha palettes. Generation open: `paletteShadesFromCurve()` (theme-designer) draws a curved path through **Lab/LCH** with blended log/linear lightness (`defaultLinearity=0.75`), gamut-snapped to sRGB — powers the public Theme Designer (one brand color → full ramp). Two-tier **global → alias** (~180 alias color tokens, `color[Category][Variant][Number][State]`); `createLightTheme/DarkTheme/HighContrastTheme` factories from `BrandVariants`. Motion/spacing/radius/typography tokenized. WCAG by convention/tooling; no APCA.
+
+### Shopify Polaris
+[polaris-tokens `color-factory.ts`](https://github.com/Shopify/polaris-tokens) (archived 2022, source folded into the polaris monorepo; npm `@shopify/polaris-tokens` 9.4.2): **algorithmic in HSLuv** — hex → HSLuv → per-variant transforms → RGB — purpose-built so same-lightness steps deliver equal WCAG 2.1 contrast across hues. 12 color roles × 16 shades (v12). Two-tier primitive → semantic (`color-bg-surface-hover`), `--p-` CSS vars, multi-format export. Enforcement mechanism (CI vs design-time) unconfirmed.
+
+### GitHub Primer
+[primer/primitives](https://github.com/primer/primitives): 9 scales with deliberately non-uniform step counts (blue 0–9, neutral 0–13). Generation hybrid: hand-authored HSL shaped in **Primer Prism** (HSLuv-based authoring tool, [archived Dec 2024](https://github.com/primer/prism)) + an automated WCAG audit script over ~100+ token pairs per theme ([github.blog writeup](https://github.blog/engineering/user-experience/unlocking-inclusive-design-how-primers-color-system-is-making-github-com-more-inclusive/)). True 3-tier: base → functional (`bgColor`/`fgColor`/`borderColor`, per-theme inline overrides) → component (27 files), built with Style Dictionary from DTCG-style JSON5. Notable: an `org.primer.llm` machine-readable token-usage extension. HSL/hex shipped; no OKLCH/P3 found.
+
+### Meta Astryx
+Verified real (resolves plan 001's open question — not a mix-up with StyleX, which it builds on): open-sourced June 2026 at [astryx.atmeta.com](https://astryx.atmeta.com/) / [github.com/facebook/astryx](https://github.com/facebook/astryx), grown internally ~8 years. **Semantic-purpose tokens only** (`--color-text-primary`, `--color-background-surface`) — no numeric ramps except a 5-step categorical data palette. Dark mode via CSS `light-dark()` dual values per token. 10 stock themes as CSS custom-property override sets. Token source `@astryxdesign/core/theme/tokens.stylex`; CLI + MCP server dump the token reference. The strongest counter-model to ramp-based systems on the roster.
+
+### Linear (reverse-engineered)
+No public repo (confirmed). First-party evidence: ["How we redesigned the Linear UI"](https://linear.app/now/how-we-redesigned-the-linear-ui) — themes generated in **LCH** (migrated from HSL for perceptual uniformity) from **three variables** (base, accent, contrast), replacing "98 specific variables for each theme"; automatic high-contrast a11y themes; named elevation surfaces. Shipped CSS successfully fetched (`static.linear.app/web/_next/static/css/*`): semantic layer confirmed (`--color-bg-level-1/-3`, `--color-text-primary…quaternary`, `--color-border-translucent`, plus motion/z-layer/radius/shadow tokens); no `lch()`/`oklch()` literals — color math happens in JS. Contrast algorithm and P3: unknown. Pilot system in plan 002 (tests the reverse-engineering method).
+
+### Stripe (reverse-engineered)
+No public design system. Two assets: (1) the canonical ["Designing accessible color systems"](https://stripe.com/blog/accessible-color-systems) post (2019, still live) — CIELAB perceptual space, a custom Lab-space visualization tool, WCAG 4.5:1 targets, and a "5 levels apart guarantees text contrast" ramp rule; (2) shipped dashboard login CSS (`b.stripecdn.com/dashboard-fe-statics-srv/…`) exposing **284 color custom properties** — numeric ramps (`--color-blue4`, `--color-slate2/3/6`; non-contiguous digits imply a larger internal scale) plus a composed semantic layer (`--border-color--field--bottom--invalid--focus`). Deep-dive = methodology post + variable extraction, claimed-vs-shipped comparison.
+
+### IBM Carbon
+[carbon monorepo](https://github.com/carbon-design-system/carbon): 12 ramps + black/white, 10 steps (10–100) with paired hover shades (~104 swatches); palette explicitly hand-picked (Photoshop grayscale + manual contrast checks, per the [team's Medium retrospective](https://medium.com/carbondesign/because-colors-are-beautiful-52dd4cc39f09)). Value is the architecture: `@carbon/colors` → `@carbon/themes` (~235 semantic tokens in `white.ts`: `layer01`, `borderSubtle01`…) → component tokens; 4 built-in themes (White/g10/g90/g100) over `--cds-*` CSS vars; spacing (01–13 + fluid), type, and motion in dedicated packages. WCAG AA by convention. Hex/RGB.
+
+### Vercel Geist
+Docs-only inspectability (no public DS repo; `@vercel/geistcn` npm; do not confuse with the unrelated, archived `geist-ui`). 10 scales × 10 steps numbered **100–1000 where the number IS the role** (100–300 backgrounds, 400–600 borders, 700–800 solids, 900 secondary text, 1000 primary text) — [vercel.com/geist/colors](https://vercel.com/geist/colors). Values read as hand-tuned; no generation methodology published. WCAG AA stated as guidance. sRGB hex + per-accent `*-p3` `oklch()` variants. Standout: [vercel.com/design.md](https://vercel.com/design.md) (+`/design.dark.md`) — a machine-readable full-system spec (colors, spacing, radius, shadows, motion), the most agent-friendly docs artifact found in the entire sweep. On the roster as a maintainer pick for its conventions and dev-tool relevance, not its color science.
+
+### shadcn/ui
+[shadcn-ui/ui](https://github.com/shadcn-ui/ui) read directly: 9 neutral base scales — 5 byte-identical to Tailwind's, 4 newer (Mauve/Olive/Mist/Taupe, Radix-named, origin unconfirmed) — all static tables in `themes.ts`; **no generation, no contrast strategy anywhere**. The real system is the semantic CSS-variable convention (`--background`/`--foreground` pairs, `--primary`, `--muted`, `--destructive`, `--border`/`--input`/`--ring`, `--chart-1..5`, `--sidebar-*`) + `.dark` class override. OKLCH migration confirmed (Tailwind v4 era). `--radius` derivation (sm…4xl computed from one base) is more systematic than the color layer. On the roster because it's the audience's reference point and the honest profile is itself valuable truth; also a direct competitive reference for `/create` (their preset builder).
+
+### Tailwind palette
+[tailwindcss.com/docs/colors](https://tailwindcss.com/docs/colors): 26 families × 11 steps (50–950), expert-curated (explicitly not algorithmic). v4 converted the v3 hex values to **OKLCH while deliberately preserving cross-hue balance**, targeting Display P3 — the industry's largest OKLCH migration. `@theme` namespaces auto-generate `--color-*` (+ `--spacing-*`, `--radius-*`, `--ease-*`…) custom properties and utilities; **no semantic/alias layer and no documented contrast strategy** — a load-bearing absence worth publishing. Catalyst (paywalled) adds no token layer and is excluded.
+
+## Watchlist (not v1; revisit per dimension)
+
+- **Salesforce Lightning** (2/3/2/3/3) — the literal origin of "design tokens"; SLDS 2 "global styling hooks" (`--slds-g-*`) + 1–100 ramps + a hard SLDS1→2 migration break. Generation tooling (HCL/HSL hybrid per a Medium post) not open. Strong candidate for a history-of-tokens topic page.
+- **Atlassian** (2/3/1/2/2) — the `Foundation.Property.Modifier` naming grammar and 4-plane elevation model are distinctive; palette/generation story thin and the JS-rendered docs resist inspection (their server-rendered [DESIGN.md](https://atlassian.design/DESIGN.md) is the workaround).
+- **Chakra v3** (2/2/3/3/3) — hand-picked hex, but the Panda-derived semantic-token shape (contrast/fg/subtle/muted/emphasized/solid per palette) and `colorPalette` CSS-variable indirection are a clean re-theming pattern.
+- **Mantine** (2/2/3/2/2) — open chroma-js generator with fixed HSL lightness/saturation maps whose docs admit light-hue failure modes, plus an off-by-default WCAG-luminance `autoContrast`; a useful honest counter-example.
+- **Open Props** (2/2/3/2/2) — dual generation (composited from open-color/colar vs a parametric single-hue OKLCH curve); no semantic layer, no contrast tooling. Lesson-rich in both directions.
+- **GOV.UK** (2/1/3/3/2) — a11y-process exemplar (WCAG 2.2 AA by developer responsibility; APCA proposed in issue #4066, unshipped); hand-authored functional-colour Sass layer.
+- **Arco** (2/2/3/1/1) — targeted look only: `palette-dark.js` computes dark ramps with hue-band-dependent piecewise logic (more elaborate than Ant's dark map); but docs unreachable and the color package is stale (v0.4.0, 2024).
+- **Hero UI** (2/2/3/1/2) — footnote-level: real-world v2→v3 case of abandoning shade scales + computed contrast for flat OKLCH semantic roles + `color-mix()` states.
+
+## Rejected (binding until revisited — do not re-research without new evidence)
+
+- **Airbnb DLS** — effectively closed: no public docs/repo, site 403s bot fetching, only philosophy pieces and community reconstructions. Inspectability 0.
+- **Nord (Provet)** — competent docs but the source repo is not public, npm ships compiled output only, and the FAQ restricts usage to Nordhealth products; generation algorithm undisclosed. Dead end for deep study.
+- **Orbit (Kiwi)** — thin color/token story; docs site unreachable during recon; token repo archived. Alive but not roster material.
+- **Uber Base** — hand-curated hex ramps, Styletron CSS-in-JS theming (no CSS variables), no contrast methodology, "internal-first" engagement posture; little transferable to a CSS-var/OKLCH builder.
+- **Park UI** — a curation layer: the color science is Radix's (vendored wholesale) and the token mechanics are Panda's. Study Radix and Panda instead.
+- **Once UI** — the "algorithmic color generation" impression did not survive source inspection: 19 hardcoded hex palettes swapped via `data-brand` attributes, a `custom` mode referencing variables that are never defined, no contrast code, no OKLCH. Rejected on merit.
+- **Untitled UI** — the maintainer's "check if it's slop" verdict: **not slop, but not color science**. A real, verified 3-layer semantic token architecture in an open MIT repo (`theme.css`: brand scale → utility aliases → semantic layer, dark via overrides) — but plain `rgb()` values, zero generation methodology, and WCAG claims that exist only as marketing copy. Its alias-layer structure merits at most a footnote in the token-layers topic page.
+- **Tailwind Catalyst** — paywalled, utility-styled, adds no token layer beyond Tailwind itself (covered by the Tailwind roster entry).
+
+## Deviations from plan 001
+
+- **Roster size 15 > the 8–12 cap.** The STOP condition fired (more than 12 strong candidates); the tradeoff was presented to the maintainer, who chose to include both Carbon and Geist and to seat shadcn/ui and the Tailwind palette as tier-1. Cost acknowledged: each tier-1 system is a full plan-004 research pass now and on every future dimension. If v1 timeline pressure appears, the four late additions (Carbon, Geist, shadcn, Tailwind) are the natural deferral candidates, in reverse-score order (Geist first).
+- **"Astryx by Meta" verified** rather than dropped — it's real and fully open (June 2026); the plan's caution about the name is resolved.
+
+## Notable cross-cutting findings (candidate topic-page seeds)
+
+- Contrast-by-construction exists in three distinct flavors: Leonardo/Spectrum (solve color for target ratio), Material (tone-delta arithmetic), USWDS (luminance-locked grades). Radix is the lone APCA adopter; everyone else is WCAG 2.x or nothing.
+- Perceptual-space fragmentation: CAM02-UCS (Spectrum), HCT (Material), LCH (Linear, Fluent), HSLuv (Polaris, Primer's Prism), CIELAB (Stripe), OKLCH (Tailwind, shadcn, Hero v3), HSV (Ant, Arco), HSL (Mantine, legacy). Nobody agrees; the "same seed through every algorithm" showpiece (plan 005) will make this visible.
+- Two architectures are converging from opposite ends: ramp-first (Radix, Tailwind, Ant) vs semantic-only (Astryx, Linear, shadcn). Geist's step-as-role numbering is the hybrid.
+- Machine-readable design-system specs are emerging independently (Vercel `design.md`, Atlassian `DESIGN.md`, Primer `org.primer.llm`, Spectrum + Leonardo + Astryx MCP servers) — a trend worth its own analysis.

--- a/docs/research/2026-07-03-ds-roster-selection/roster.json
+++ b/docs/research/2026-07-03-ds-roster-selection/roster.json
@@ -1,0 +1,493 @@
+{
+  "$comment": "ds.dotui.org tier-1 roster — approved by maintainer 2026-07-03 (see README.md). Moves to ds/data/roster.json when plan 003 lands. Scores: color/token dimension only, 0-3: [technical-depth, originality-lessons, inspectability, docs-quality, influence].",
+  "version": 1,
+  "approvedAt": "2026-07-03",
+  "systems": [
+    {
+      "slug": "spectrum-2",
+      "name": "Adobe Spectrum 2",
+      "org": "Adobe",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": ["leonardo"],
+      "scores": [3, 3, 3, 2, 3],
+      "sources": {
+        "docs": "https://s2.spectrum.adobe.com",
+        "repo": "https://github.com/adobe/spectrum-design-data",
+        "npm": ["@adobe/spectrum-tokens"],
+        "other": [
+          "https://github.com/adobe/leonardo",
+          "https://adobe.design/stories/design-for-scale/reinventing-adobe-spectrum-s-colors",
+          "https://medium.com/thinking-design/adaptive-color-in-spectrum-adobes-design-system-feeeec89a2c7"
+        ]
+      },
+      "rationale": "Contrast-solved generation (Leonardo, CAM02-UCS), true 3-tier tokens with light/dark/wireframe modes, JSON-Schema-validated pipeline."
+    },
+    {
+      "slug": "material-3",
+      "name": "Google Material 3",
+      "org": "Google",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [3, 3, 3, 2, 2],
+      "sources": {
+        "docs": "https://m3.material.io",
+        "repo": "https://github.com/material-foundation/material-color-utilities",
+        "npm": ["@material/material-color-utilities"],
+        "other": []
+      },
+      "rationale": "HCT color space, runtime dynamic color from a seed, contrast-by-construction via tone deltas; open in six language ports."
+    },
+    {
+      "slug": "radix",
+      "name": "Radix Colors + Themes",
+      "org": "WorkOS",
+      "type": "token-or-color-system",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [3, 3, 2, 3, 3],
+      "sources": {
+        "docs": "https://www.radix-ui.com/colors",
+        "repo": "https://github.com/radix-ui/colors",
+        "npm": ["@radix-ui/colors"],
+        "other": []
+      },
+      "rationale": "12-step role semantics the industry imitates; only major APCA-by-construction system (step 11 = Lc 60, step 12 = Lc 90); P3 progressive enhancement. Plan-002 pilot (open method)."
+    },
+    {
+      "slug": "uswds",
+      "name": "USWDS",
+      "org": "U.S. GSA",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [3, 3, 3, 3, 2],
+      "sources": {
+        "docs": "https://designsystem.digital.gov/design-tokens/color/overview/",
+        "repo": "https://github.com/uswds/uswds",
+        "npm": ["@uswds/uswds"],
+        "other": []
+      },
+      "rationale": "Luminance-locked color grades: numeric grade difference deterministically guarantees WCAG contrast (the 'magic number' system)."
+    },
+    {
+      "slug": "ant-design",
+      "name": "Ant Design",
+      "org": "Ant Group",
+      "type": "component-library",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [3, 3, 3, 3, 3],
+      "sources": {
+        "docs": "https://ant.design/docs/spec/colors",
+        "repo": "https://github.com/ant-design/ant-design-colors",
+        "npm": ["@ant-design/colors", "antd"],
+        "other": ["https://ant.design/docs/react/customize-theme"]
+      },
+      "rationale": "Fully open parametric HSV ramp algorithm plus the seed-to-map-to-alias derivation pipeline (derived non-color tokens too)."
+    },
+    {
+      "slug": "fluent-2",
+      "name": "Microsoft Fluent 2",
+      "org": "Microsoft",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [3, 3, 3, 2, 2],
+      "sources": {
+        "docs": "https://fluent2.microsoft.design/color",
+        "repo": "https://github.com/microsoft/fluentui",
+        "npm": ["@fluentui/react-theme", "@fluentui/tokens"],
+        "other": []
+      },
+      "rationale": "Open Lab/LCH curve-based ramp generator (paletteShadesFromCurve) with a public Theme Designer; clean global-to-alias token split; high-contrast theme factory."
+    },
+    {
+      "slug": "polaris",
+      "name": "Shopify Polaris",
+      "org": "Shopify",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [3, 3, 2, 2, 2],
+      "sources": {
+        "docs": "https://polaris-react.shopify.com/design/colors/palettes-and-roles",
+        "repo": "https://github.com/Shopify/polaris",
+        "npm": ["@shopify/polaris-tokens"],
+        "other": ["https://github.com/Shopify/polaris-tokens"]
+      },
+      "rationale": "Open HSLuv color factory built for cross-hue contrast parity at equal lightness."
+    },
+    {
+      "slug": "primer",
+      "name": "GitHub Primer",
+      "org": "GitHub",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [3, 2, 3, 2, 2],
+      "sources": {
+        "docs": "https://primer.style/foundations/color",
+        "repo": "https://github.com/primer/primitives",
+        "npm": ["@primer/primitives"],
+        "other": [
+          "https://github.com/primer/prism",
+          "https://github.blog/engineering/user-experience/unlocking-inclusive-design-how-primers-color-system-is-making-github-com-more-inclusive/"
+        ]
+      },
+      "rationale": "3-tier Style Dictionary pipeline (base/functional/component), HSLuv Prism authoring, automated WCAG token-pair audits, org.primer.llm machine-readable extension."
+    },
+    {
+      "slug": "astryx",
+      "name": "Astryx",
+      "org": "Meta",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": ["stylex"],
+      "scores": [3, 3, 3, 3, 2],
+      "sources": {
+        "docs": "https://astryx.atmeta.com",
+        "repo": "https://github.com/facebook/astryx",
+        "npm": ["@astryxdesign/core"],
+        "other": ["https://astryx.atmeta.com/blog/introducing-astryx", "https://astryx.atmeta.com/blog/how-astryx-works"]
+      },
+      "rationale": "Semantic-purpose tokens with no numeric ramps, light-dark() dual-mode values, 10 swappable CSS-variable themes; the strongest counter-model to ramp-based systems. Open since June 2026."
+    },
+    {
+      "slug": "linear",
+      "name": "Linear",
+      "org": "Linear",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "reverse-engineered",
+      "upstream": [],
+      "scores": [2, 2, 1, 1, 3],
+      "sources": {
+        "docs": null,
+        "repo": null,
+        "npm": [],
+        "other": [
+          "https://linear.app/now/how-we-redesigned-the-linear-ui",
+          "https://linear.app/changelog/2020-12-04-themes",
+          "https://static.linear.app/web/_next/static/css/"
+        ]
+      },
+      "rationale": "LCH three-variable theme generation (base/accent/contrast) replacing 98 per-theme variables; semantic token layer extractable from shipped CSS. Plan-002 pilot (reverse-engineered method)."
+    },
+    {
+      "slug": "stripe",
+      "name": "Stripe",
+      "org": "Stripe",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "reverse-engineered",
+      "upstream": [],
+      "scores": [3, 3, 1, 2, 3],
+      "sources": {
+        "docs": null,
+        "repo": null,
+        "npm": [],
+        "other": ["https://stripe.com/blog/accessible-color-systems"]
+      },
+      "rationale": "Canonical CIELAB contrast methodology (2019 post, still live) plus 284 color custom properties extractable from shipped dashboard CSS — a claimed-vs-shipped study."
+    },
+    {
+      "slug": "carbon",
+      "name": "IBM Carbon",
+      "org": "IBM",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [2, 2, 3, 2, 3],
+      "sources": {
+        "docs": "https://carbondesignsystem.com",
+        "repo": "https://github.com/carbon-design-system/carbon",
+        "npm": ["@carbon/colors", "@carbon/themes"],
+        "other": ["https://medium.com/carbondesign/because-colors-are-beautiful-52dd4cc39f09"]
+      },
+      "rationale": "Mature 3-tier token layering at enterprise scale (~235 semantic tokens, 4 built-in themes); palette hand-picked — architecture lessons, not generation."
+    },
+    {
+      "slug": "geist",
+      "name": "Vercel Geist",
+      "org": "Vercel",
+      "type": "corporate-design-system",
+      "status": "tier1",
+      "method": "documented",
+      "upstream": [],
+      "scores": [1, 1, 1, 3, 2],
+      "sources": {
+        "docs": "https://vercel.com/geist/introduction",
+        "repo": null,
+        "npm": ["@vercel/geistcn"],
+        "other": ["https://vercel.com/design.md", "https://vercel.com/geist/colors"]
+      },
+      "rationale": "Step-as-role 100-1000 numbering and the machine-readable design.md spec; maintainer pick for dev-tool relevance despite thin color science."
+    },
+    {
+      "slug": "shadcn-ui",
+      "name": "shadcn/ui",
+      "org": "shadcn / Vercel",
+      "type": "styling-distribution",
+      "status": "tier1",
+      "method": "source-read",
+      "upstream": ["radix", "tailwind"],
+      "scores": [1, 1, 3, 2, 3],
+      "sources": {
+        "docs": "https://ui.shadcn.com/docs/theming",
+        "repo": "https://github.com/shadcn-ui/ui",
+        "npm": ["shadcn"],
+        "other": ["https://ui.shadcn.com/colors"]
+      },
+      "rationale": "The ecosystem reference point: semantic CSS-variable convention over borrowed static scales, no generation, no contrast strategy — the honest profile is itself a finding."
+    },
+    {
+      "slug": "tailwind",
+      "name": "Tailwind CSS palette",
+      "org": "Tailwind Labs",
+      "type": "token-or-color-system",
+      "status": "tier1",
+      "method": "documented",
+      "upstream": [],
+      "scores": [2, 2, 2, 3, 3],
+      "sources": {
+        "docs": "https://tailwindcss.com/docs/colors",
+        "repo": "https://github.com/tailwindlabs/tailwindcss",
+        "npm": ["tailwindcss"],
+        "other": ["https://tailwindcss.com/blog/tailwindcss-v4"]
+      },
+      "rationale": "dotUI's substrate: 26x11 curated palette, the v4 hex-to-OKLCH migration preserving cross-hue balance, @theme token namespaces; no semantic layer or contrast strategy — a load-bearing absence."
+    },
+    {
+      "slug": "lightning",
+      "name": "Salesforce Lightning",
+      "org": "Salesforce",
+      "type": "corporate-design-system",
+      "status": "watchlist",
+      "method": "documented",
+      "upstream": [],
+      "scores": [2, 3, 2, 3, 3],
+      "sources": {
+        "docs": "https://www.lightningdesignsystem.com",
+        "repo": "https://github.com/salesforce-ux/design-system",
+        "npm": ["@salesforce-ux/design-system"],
+        "other": ["https://medium.com/salesforce-ux/the-salesforce-color-system-c7c6b5b9c577"]
+      },
+      "rationale": "Origin of 'design tokens'; SLDS 2 global styling hooks and the hard SLDS1-to-2 break; generation tooling not open. Candidate for a history topic page."
+    },
+    {
+      "slug": "atlassian",
+      "name": "Atlassian Design System",
+      "org": "Atlassian",
+      "type": "corporate-design-system",
+      "status": "watchlist",
+      "method": "documented",
+      "upstream": [],
+      "scores": [2, 3, 1, 2, 2],
+      "sources": {
+        "docs": "https://atlassian.design/foundations/color",
+        "repo": null,
+        "npm": ["@atlaskit/tokens"],
+        "other": ["https://atlassian.design/DESIGN.md"]
+      },
+      "rationale": "Foundation.Property.Modifier naming grammar and 4-plane elevation model; generation story thin, docs resist inspection."
+    },
+    {
+      "slug": "chakra",
+      "name": "Chakra UI v3",
+      "org": "Chakra",
+      "type": "component-library",
+      "status": "watchlist",
+      "method": "source-read",
+      "upstream": ["panda-css"],
+      "scores": [2, 2, 3, 3, 3],
+      "sources": {
+        "docs": "https://www.chakra-ui.com/docs/theming/overview",
+        "repo": "https://github.com/chakra-ui/chakra-ui",
+        "npm": ["@chakra-ui/react"],
+        "other": []
+      },
+      "rationale": "Hand-picked hex, but the per-palette semantic shape and colorPalette CSS-variable indirection are a clean re-theming pattern."
+    },
+    {
+      "slug": "mantine",
+      "name": "Mantine",
+      "org": "Mantine",
+      "type": "component-library",
+      "status": "watchlist",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [2, 2, 3, 2, 2],
+      "sources": {
+        "docs": "https://mantine.dev/theming/colors/",
+        "repo": "https://github.com/mantinedev/mantine",
+        "npm": ["@mantine/core", "@mantine/colors-generator"],
+        "other": []
+      },
+      "rationale": "Open HSL fixed-map generator with self-admitted light-hue failure modes plus off-by-default luminance autoContrast — an honest legacy counter-example."
+    },
+    {
+      "slug": "open-props",
+      "name": "Open Props",
+      "org": "Adam Argyle",
+      "type": "token-or-color-system",
+      "status": "watchlist",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [2, 2, 3, 2, 2],
+      "sources": {
+        "docs": "https://open-props.style",
+        "repo": "https://github.com/argyleink/open-props",
+        "npm": ["open-props"],
+        "other": ["https://nerdy.dev/open-props-oklch-palettes-beta"]
+      },
+      "rationale": "Dual generation strategies (composited palettes vs parametric OKLCH single-hue curve); no semantic layer or contrast tooling."
+    },
+    {
+      "slug": "govuk",
+      "name": "GOV.UK Design System",
+      "org": "UK Government Digital Service",
+      "type": "corporate-design-system",
+      "status": "watchlist",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [2, 1, 3, 3, 2],
+      "sources": {
+        "docs": "https://design-system.service.gov.uk/styles/colour/",
+        "repo": "https://github.com/alphagov/govuk-frontend",
+        "npm": ["govuk-frontend"],
+        "other": []
+      },
+      "rationale": "Accessibility-process exemplar with a functional-colour Sass layer; contrast is developer-verified convention, palette hand-authored."
+    },
+    {
+      "slug": "arco",
+      "name": "Arco Design",
+      "org": "ByteDance",
+      "type": "component-library",
+      "status": "watchlist",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [2, 2, 3, 1, 1],
+      "sources": {
+        "docs": "https://arco.design",
+        "repo": "https://github.com/arco-design/color",
+        "npm": ["@arco-design/color"],
+        "other": []
+      },
+      "rationale": "Targeted look only: hue-band-dependent dark-mode palette algorithm (palette-dark.js); docs unreachable and the color package is stale."
+    },
+    {
+      "slug": "hero-ui",
+      "name": "Hero UI",
+      "org": "HeroUI",
+      "type": "component-library",
+      "status": "watchlist",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [2, 2, 3, 1, 2],
+      "sources": {
+        "docs": "https://heroui.com",
+        "repo": "https://github.com/heroui-inc/heroui",
+        "npm": ["@heroui/theme"],
+        "other": []
+      },
+      "rationale": "Footnote-level case study: v2-to-v3 abandoned shade scales plus computed contrast for flat OKLCH roles with color-mix() states."
+    },
+    {
+      "slug": "airbnb-dls",
+      "name": "Airbnb DLS",
+      "org": "Airbnb",
+      "type": "corporate-design-system",
+      "status": "rejected",
+      "method": "reverse-engineered",
+      "upstream": [],
+      "scores": [1, 1, 0, 1, 2],
+      "sources": { "docs": null, "repo": null, "npm": [], "other": ["https://karrisaarinen.com/dls/"] },
+      "rationale": "Effectively closed: no public artifacts, site blocks bot inspection, only philosophy pieces and community reconstructions."
+    },
+    {
+      "slug": "nord",
+      "name": "Nord Design System",
+      "org": "Nordhealth",
+      "type": "corporate-design-system",
+      "status": "rejected",
+      "method": "documented",
+      "upstream": [],
+      "scores": [2, 1, 1, 2, 1],
+      "sources": { "docs": "https://nordhealth.design/tokens/", "repo": null, "npm": ["@nordhealth/tokens"], "other": [] },
+      "rationale": "Source repo not public, npm ships compiled output only, usage restricted to Nordhealth products; generation algorithm undisclosed."
+    },
+    {
+      "slug": "orbit",
+      "name": "Orbit",
+      "org": "Kiwi.com",
+      "type": "corporate-design-system",
+      "status": "rejected",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [1, 1, 2, 1, 1],
+      "sources": { "docs": "https://orbit.kiwi", "repo": "https://github.com/kiwicom/orbit", "npm": ["@kiwicom/orbit-components"], "other": [] },
+      "rationale": "Thin color/token story; docs unreachable during recon; dedicated tokens repo archived."
+    },
+    {
+      "slug": "base-web",
+      "name": "Uber Base",
+      "org": "Uber",
+      "type": "component-library",
+      "status": "rejected",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [1, 1, 3, 2, 1],
+      "sources": { "docs": "https://base.uber.com", "repo": "https://github.com/uber/baseweb", "npm": ["baseui"], "other": [] },
+      "rationale": "Hand-curated hex, Styletron CSS-in-JS theming, no contrast methodology, internal-first posture; little transferable."
+    },
+    {
+      "slug": "park-ui",
+      "name": "Park UI",
+      "org": "Chakra",
+      "type": "component-library",
+      "status": "rejected",
+      "method": "source-read",
+      "upstream": ["radix", "panda-css", "ark-ui"],
+      "scores": [1, 1, 3, 2, 1],
+      "sources": { "docs": "https://park-ui.com", "repo": "https://github.com/chakra-ui/park-ui", "npm": [], "other": [] },
+      "rationale": "Curation layer: the color science is Radix's (vendored) and the token mechanics are Panda's — study those instead."
+    },
+    {
+      "slug": "once-ui",
+      "name": "Once UI",
+      "org": "Once UI",
+      "type": "component-library",
+      "status": "rejected",
+      "method": "source-read",
+      "upstream": [],
+      "scores": [1, 0, 3, 1, 0],
+      "sources": { "docs": "https://docs.once-ui.com", "repo": "https://github.com/once-ui-system/core", "npm": ["@once-ui-system/core"], "other": [] },
+      "rationale": "The algorithmic-generation impression did not survive source inspection: hardcoded palettes swapped by data-brand attribute, an unfinished custom escape hatch, no contrast code."
+    },
+    {
+      "slug": "untitled-ui",
+      "name": "Untitled UI",
+      "org": "Untitled UI",
+      "type": "component-library",
+      "status": "rejected",
+      "method": "source-read",
+      "upstream": ["tailwind", "react-aria"],
+      "scores": [1, 1, 3, 1, 2],
+      "sources": { "docs": "https://www.untitledui.com/react/docs/theming", "repo": "https://github.com/untitleduico/react", "npm": [], "other": [] },
+      "rationale": "Not slop, but not color science: real 3-layer semantic architecture in an open repo, undermined by plain-RGB values, no generation methodology, and marketing-only WCAG claims. Footnote in the token-layers topic page at most."
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `docs/plans/2026-07-03-ds-research-site/` — a design plan (README index + 6 executor-ready plans, following the charts-plan convention) for a new site at **ds.dotui.org**: a citation-backed research property on how the best design systems actually work. Also registers the folder in the top-level plans catalog.

Docs only — no app code yet.

## Why

Decisions were resolved with the maintainer in a structured Q&A session on 2026-07-03 and are recorded as Phase 0 in the folder README. The headline choices:

- **Curated quality roster (~8–12 systems), not a 60+ catalog** — Geist, Linear, Spectrum 2, Primer, Material 3, Radix, shadcn… selected by a scored research pass (plan 001).
- **V1 covers one dimension definitively: color & token systems** — palette structure, generation algorithms, token layers, contrast guarantees — via a canonical question bank (plan 002, piloted on Radix + Linear before roster fan-out).
- **Fixed direction of truth: research → `/create`, never the reverse.** Findings feed the builder through `research-finding` GitHub issues.
- **Every fact cited + dated**, with reverse-engineered facts (shipped-CSS inspection) first-class but labeled.
- **New `ds/` TanStack Start app**, own Vercel project, git-source data + build-time static index, UI dogfooded from the dotUI registry (plan 003).
- **Interactive-first topic showpieces** with guardrails (shared widget kit, timeboxes, SSR fallbacks) (plan 005); profiles + generated matrices + progressive open-data launch (plan 006).

## Reviewer notes

- Execution order and the rejected/deferred list (binding) are in the folder README.
- Two maintainer gates are built in: final roster sign-off (001) and "Astryx by Meta" needs verification — the name couldn't be placed and is 001's first task.