### PR TITLE
fix(docs): overlay demo preview toolbar instead of taking a row

### DIFF
--- a/www/src/modules/docs/demo.tsx
+++ b/www/src/modules/docs/demo.tsx
@@ -80,7 +80,7 @@ export function Demo({ component: Component, children, ...props }: DemoProps) {
         <PreviewPanel>
           <PreviewControls />
           <DemoPreset>
-            <div className="flex min-h-56 items-center justify-center overflow-x-auto bg-bg p-6 sm:p-10">
+            <div className="flex min-h-56 items-center justify-center overflow-x-auto bg-bg p-6 pt-10 sm:p-10 sm:pt-14">
               <Component />
             </div>
           </DemoPreset>

--- a/www/src/modules/docs/interactive-demo/interactive-demo.tsx
+++ b/www/src/modules/docs/interactive-demo/interactive-demo.tsx
@@ -149,7 +149,7 @@ export function InteractiveDemo({
             )}
           />
           <DemoPreset>
-            <div className="flex min-h-56 flex-1 items-center justify-center bg-bg p-10">
+            <div className="flex min-h-56 flex-1 items-center justify-center bg-bg p-10 pt-14">
               {previewElement}
             </div>
           </DemoPreset>

--- a/www/src/modules/docs/interactive-demo/interactive-demo.tsx
+++ b/www/src/modules/docs/interactive-demo/interactive-demo.tsx
@@ -120,7 +120,7 @@ export function InteractiveDemo({
             included) to the preview mode; the preset only themes the canvas.
             While the panel is closed, right padding keeps the mode toggle
             clear of the trigger pinned in the corner. */}
-        <PreviewPanel className="relative flex min-w-0 flex-1 flex-col">
+        <PreviewPanel className="flex min-w-0 flex-1 flex-col">
           {/* The panel trigger stays mounted so its visibility can tween;
               `inert` takes it out of the tab order and the a11y tree while
               hidden. */}

--- a/www/src/modules/docs/preview-controls.tsx
+++ b/www/src/modules/docs/preview-controls.tsx
@@ -91,7 +91,8 @@ export function PreviewPanel({
 }) {
   return (
     <DesignSystemProvider forcedMode={useForcedPreviewMode()} scoped>
-      <div className={cn('bg-bg', className)}>{children}</div>
+      {/* `relative` anchors the absolutely-positioned PreviewControls toolbar. */}
+      <div className={cn('relative bg-bg', className)}>{children}</div>
     </DesignSystemProvider>
   )
 }
@@ -183,12 +184,15 @@ function PreviewModeToggle({ className }: { className?: string }) {
   )
 }
 
-/** The toolbar above each docs preview: preset selector left, mode toggle right. */
+/**
+ * The toolbar over each docs preview: preset selector left, mode toggle right.
+ * Absolutely positioned so it overlays the canvas instead of taking its own row.
+ */
 export function PreviewControls({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        'flex items-center justify-between gap-2 px-2 pt-2',
+        'absolute inset-x-0 top-0 z-10 flex items-center justify-between gap-2 px-2 pt-2',
         className,
       )}
     >


### PR DESCRIPTION
## What

The preset selector + mode toggle header (`PreviewControls`) in the docs demos and interactive playgrounds is now absolutely positioned, floating over the preview canvas instead of sitting in its own row above it.

## Why

The header was a normal-flow child, so it consumed vertical space and pushed the preview canvas down. Overlaying it lets the canvas fill the whole panel — the toolbar no longer eats space in the preview.

## How

- `PreviewControls` → `absolute inset-x-0 top-0 z-10` (was a plain flex row).
- `PreviewPanel` — the frame both `Demo` and `InteractiveDemo` wrap the toolbar in — gains `relative` as the single positioning anchor.
- Dropped the now-redundant `relative` from `interactive-demo`'s `PreviewPanel` className.

Since both demo variants share `PreviewControls`, a single toolbar change covers both.

## Verification

Verified in-browser via DOM measurements (www screenshots come back black — known issue):
- Plain `<Demo>` (date-picker page): panel height dropped to **224px** (exactly the canvas `min-h-56`), vs ~260px before (36px toolbar + 224px canvas).
- `<InteractiveDemo>` (button page): toolbar computes to `position: absolute`, `top: 0`, `z-index: 10` over a `relative` panel.

Centered preview content isn't obscured — the canvas keeps its `p-6`/`p-10` padding, so the ~36px toolbar floats over the top-padding region. `pnpm check` passes (0 errors, formatting clean).