### PR TITLE
feat(ds): sticky header with progressive blur

### DIFF
--- a/ds/src/components/progressive-blur.tsx
+++ b/ds/src/components/progressive-blur.tsx
@@ -1,0 +1,78 @@
+import type { CSSProperties } from 'react'
+
+import { cn } from '@/lib/utils'
+
+// Each layer adds a larger backdrop blur over an overlapping gradient window; where
+// the windows overlap the blurs compound, ramping smoothly from sharp (bottom edge)
+// to heavily blurred (top). `to top` puts the strongest blur under the pinned bar.
+const BLUR_LAYERS = [
+  {
+    blur: 0.5,
+    mask: 'linear-gradient(to top, transparent 0%, #000 10%, #000 30%, transparent 40%)',
+  },
+  {
+    blur: 1,
+    mask: 'linear-gradient(to top, transparent 10%, #000 20%, #000 40%, transparent 50%)',
+  },
+  {
+    blur: 2,
+    mask: 'linear-gradient(to top, transparent 15%, #000 30%, #000 50%, transparent 60%)',
+  },
+  {
+    blur: 4,
+    mask: 'linear-gradient(to top, transparent 20%, #000 40%, #000 60%, transparent 70%)',
+  },
+  {
+    blur: 8,
+    mask: 'linear-gradient(to top, transparent 40%, #000 60%, #000 80%, transparent 90%)',
+  },
+  { blur: 16, mask: 'linear-gradient(to top, transparent 60%, #000 80%)' },
+  { blur: 24, mask: 'linear-gradient(to top, transparent 70%, #000 100%)' },
+]
+
+interface ProgressiveBlurProps {
+  className?: string
+  style?: CSSProperties
+}
+
+/** Reveal ramps with --blur-progress (0 → 1) on this element — driven by a scroll
+ *  timeline (header) or a stuck-state transition (pinned bars). Stays mask-free: a
+ *  mask here establishes a backdrop root and kills the cross-layer compounding. */
+export function ProgressiveBlur({ className, style }: ProgressiveBlurProps) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%]',
+        className,
+      )}
+      style={style}
+    >
+      {BLUR_LAYERS.map(({ blur, mask }) => (
+        <div
+          key={blur}
+          className="absolute inset-0"
+          style={{
+            backdropFilter: `blur(calc(var(--blur-progress, 0) * ${blur}px))`,
+            WebkitBackdropFilter: `blur(calc(var(--blur-progress, 0) * ${blur}px))`,
+            maskImage: mask,
+            WebkitMaskImage: mask,
+          }}
+        />
+      ))}
+      <div
+        className="absolute inset-0"
+        style={{
+          opacity: 'calc(var(--blur-progress, 0) * 0.9)',
+          background:
+            'linear-gradient(to top, transparent 0%, color-mix(in oklab, var(--color-bg) 76%, transparent) 55%, var(--color-bg) 100%)',
+        }}
+      />
+      <div
+        aria-hidden
+        className="absolute inset-0 header-blur-dither"
+        style={{ opacity: 'calc(var(--blur-progress, 0) * 0.035)' }}
+      />
+    </div>
+  )
+}

--- a/ds/src/routes/__root.tsx
+++ b/ds/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import { ThemeProvider } from 'starter-themes'
 
 import { siteConfig } from '@/config/site'
 import { GitHubIcon } from '@/components/icons/github'
+import { ProgressiveBlur } from '@/components/progressive-blur'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { LinkButton } from '@/ui/button'
 
@@ -49,7 +50,11 @@ function RootDocument() {
         <HeadContent />
       </head>
       <body className="flex min-h-screen flex-col bg-bg font-sans text-fg antialiased">
-        <header>
+        <header className="sticky top-0 z-30 header-blur-fallback">
+          {/* iOS-style progressive blur revealed on scroll — the header-blur-reveal
+              scroll timeline (styles.css) ramps --blur-progress over the first
+              header-height of scroll. */}
+          <ProgressiveBlur className="header-blur-reveal" />
           <div className="mx-auto flex w-full max-w-4xl items-center justify-between px-6 py-3.5">
             <Link to="/" className="flex items-baseline gap-3">
               <span className="text-lg font-semibold tracking-tight">

--- a/ds/src/styles.css
+++ b/ds/src/styles.css
@@ -129,6 +129,52 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+/* header-blur-reveal — reveals the nav's iOS-style progressive blur on scroll. A
+   scroll timeline ramps --blur-progress 0 → 1 across the first header-height; the
+   stacked blur layers scale their radius by it and the tint scales its opacity (see
+   __root.tsx), so the container never carries a fractional opacity — which would make
+   it an opacity group and break backdrop sampling. Where scroll timelines are
+   unsupported the blur stays at 0 and the header falls back to a solid background. */
+@property --blur-progress {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0;
+}
+
+@keyframes blur-reveal {
+  from {
+    --blur-progress: 0;
+  }
+  to {
+    --blur-progress: 1;
+  }
+}
+
+@utility header-blur-reveal {
+  @supports (animation-timeline: scroll()) {
+    animation: blur-reveal 1ms linear;
+    animation-timeline: scroll(root y);
+    animation-range: 0 var(--header-height, calc(var(--spacing) * 14));
+    animation-fill-mode: both;
+  }
+}
+
+@utility header-blur-fallback {
+  @supports not (animation-timeline: scroll()) {
+    background-color: var(--color-bg);
+  }
+}
+
+/* header-blur-dither — low-opacity tiled noise that dithers the tint gradient so
+   8-bit color banding doesn't show as horizontal steps. Opacity is ramped by
+   --blur-progress inline; masked to the upper band where the tint sits. */
+@utility header-blur-dither {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='140'%20height='140'%3E%3Cfilter%20id='n'%3E%3CfeTurbulence%20type='fractalNoise'%20baseFrequency='0.85'%20numOctaves='2'%20stitchTiles='stitch'/%3E%3CfeColorMatrix%20type='saturate'%20values='0'/%3E%3C/filter%3E%3Crect%20width='100%25'%20height='100%25'%20filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 140px 140px;
+  mask-image: linear-gradient(to top, transparent 10%, #000 60%);
+  -webkit-mask-image: linear-gradient(to top, transparent 10%, #000 60%);
+}
+
 @layer base {
   * {
     @apply border-border;
@@ -148,6 +194,7 @@
 
 :root {
   --radius-factor: 1;
+  --header-height: --spacing(14);
   /* Warm-paper neutrals — the archive's chrome stays ink-on-paper so each
      studied system's palette is the only saturated color on the page. */
   --neutral-50: oklch(0.9777 0.0041 91.45);


### PR DESCRIPTION
## What

The `ds.directory` app header is now **sticky** with an iOS-style **progressive blur** that reveals on scroll — matching the treatment on the main www site. Content scrolling under the pinned bar ramps from sharp (bottom edge) to heavily blurred (top), with a `--color-bg` tint and a noise dither to avoid banding.

## How

- New shared [`ProgressiveBlur`](ds/src/components/progressive-blur.tsx) component: 7 stacked `backdrop-filter` layers with overlapping mask gradients that compound into a smooth blur ramp, plus the tint + dither overlays. Reveal is driven by a registered `--blur-progress` custom property (0 → 1).
- `styles.css`: ports the `header-blur-reveal` scroll timeline (`@property --blur-progress`, `blur-reveal` keyframe, `scroll(root y)` over the first `--header-height` of scroll), `header-blur-fallback` (solid background where scroll-driven animations are unsupported), and `header-blur-dither`. Adds `--header-height: --spacing(14)`.
- `__root.tsx`: makes `<header>` `sticky top-0 z-30` and renders `<ProgressiveBlur className="header-blur-reveal" />` behind the existing centered bar.

Adapts to light/dark automatically (the tint reads `--color-bg`); browsers without scroll-timeline support fall back to a solid header background.

## Verification

- Scroll timeline measured ramping `--blur-progress` `0 → 0.71 → 1` across the first 56px of scroll; heaviest layer `blur(0px) → blur(24px)`.
- Sticky header confirmed (`position: sticky`, `top: 0`, `z-30`, 56px height).
- `pnpm check` and `pnpm --filter ds typecheck` pass (pre-existing warnings only); no console errors.

## Notes for reviewer

An earlier iteration also pinned the directory's search/filter bar under the header with the same blur; it was reverted (didn't feel good), so this PR is header-only. The `ProgressiveBlur` component is intentionally kept as a shared piece — it keeps `__root` tidy and is ready for reuse.