### PR TITLE
fix(dev): hide tweaker trigger when no tweaks registered

### DIFF
--- a/www/src/dev/tweaker/tweaker.tsx
+++ b/www/src/dev/tweaker/tweaker.tsx
@@ -179,6 +179,9 @@ export function DevTweaker() {
 
   const count = controls.length
 
+  // Nothing to tweak → render nothing (no floating trigger).
+  if (count === 0) return null
+
   return (
     <>
       {/* Trigger — always visible, docked to a side, draggable (snaps to an edge). z-40 keeps
@@ -199,11 +202,9 @@ export function DevTweaker() {
         )}
       >
         <SlidersHorizontalIcon className="size-4 text-fg-muted" />
-        {count > 0 && (
-          <span className="absolute -top-1 -right-1 flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-fg-on-primary">
-            {count}
-          </span>
-        )}
+        <span className="absolute -top-1 -right-1 flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-fg-on-primary">
+          {count}
+        </span>
       </button>
 
       {/* Popover panel — anchored beside the trigger; the trigger stays visible. */}
@@ -217,11 +218,9 @@ export function DevTweaker() {
             <div className="flex items-center gap-2">
               <SlidersHorizontalIcon className="size-4 text-fg-muted" />
               <span className="text-sm font-medium">Tweaker</span>
-              {count > 0 && (
-                <span className="flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-fg-on-primary">
-                  {count}
-                </span>
-              )}
+              <span className="flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-fg-on-primary">
+                {count}
+              </span>
             </div>
             <div className="flex items-center gap-0.5">
               <Button
@@ -255,11 +254,7 @@ export function DevTweaker() {
           </div>
 
           <div className="flex-1 overflow-y-auto p-3">
-            {count === 0 ? (
-              <EmptyState />
-            ) : (
-              <GroupedControls controls={controls} />
-            )}
+            <GroupedControls controls={controls} />
           </div>
 
           <div className="flex items-center justify-between border-t border-border px-3 py-1.5 text-[10px] text-fg-muted">
@@ -271,18 +266,6 @@ export function DevTweaker() {
         </div>
       )}
     </>
-  )
-}
-
-function EmptyState() {
-  return (
-    <div className="flex flex-col items-center gap-1.5 px-2 py-6 text-center">
-      <SlidersHorizontalIcon className="size-5 text-fg-muted" />
-      <p className="text-sm font-medium text-fg">No tweaks yet</p>
-      <p className="text-xs text-balance text-fg-muted">
-        Ask the agent to add tweaks for the feature you&rsquo;re exploring.
-      </p>
-    </div>
   )
 }
 


### PR DESCRIPTION
## What

The dev-only tweaker's floating trigger was always rendered, even when no `useTweak()` calls had registered any controls. Now `DevTweaker` returns `null` when `count === 0`, so the trigger only appears once there's at least one tweak to adjust.

## Why

An always-visible trigger for an empty panel is noise. The tweaker is scaffolding that only matters while actively exploring a feature — when nothing is registered, there's nothing to show.

## Notes for reviewers

Removing the `count === 0` branch made a few code paths dead, cleaned up here too:
- The `EmptyState` component (only reachable when `count === 0`).
- The `count > 0 &&` guards on the trigger badge and panel-header badge (now always true inside the render).

Dev-only (`import.meta.env.DEV`), dead-code-eliminated from production — no shipped-registry or product impact.