### PR TITLE
feat(www): responsive docs table of contents

### DIFF
--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -112,7 +112,7 @@ export function Header({ className, items = [] }: HeaderProps) {
         <Logo />
         <nav
           aria-label="Main"
-          className="flex items-center gap-3 text-sm max-md:hidden"
+          className="flex items-center gap-3 text-sm max-lg:hidden"
         >
           {navItems.map((item) => {
             // Color highlights the whole section (Docs stays lit on /docs/button)
@@ -155,7 +155,7 @@ export function Header({ className, items = [] }: HeaderProps) {
           <GitHubIcon />
         </a>
         <ThemeToggle variant="quiet" isIconOnly />
-        <Separator orientation="vertical" className="mx-1.5 h-4 md:hidden" />
+        <Separator orientation="vertical" className="mx-1.5 h-4 lg:hidden" />
         <MobileNav items={items} />
       </div>
     </header>

--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -11,6 +11,7 @@ import { Logo } from '@/components/layout/logo'
 import { MobileNav } from '@/components/layout/mobile-nav'
 import { SearchCommand } from '@/components/search-command'
 import { ThemeToggle } from '@/components/theme-toggle'
+import { DocsTocSelect } from '@/modules/docs/docs-toc-select'
 
 // iOS-style progressive blur: each layer adds a larger backdrop blur over an
 // overlapping gradient window. Where the windows overlap the blurs compound,
@@ -110,6 +111,9 @@ export function Header({ className, items = [] }: HeaderProps) {
       </div>
       <div className="flex items-center gap-3 md:gap-6">
         <Logo />
+        {/* Small screens have no in-page TOC (the MiniTOC is md–xl); surface it
+            here next to the logo instead. Renders null off docs pages. */}
+        <DocsTocSelect className="md:hidden" />
         <nav
           aria-label="Main"
           className="flex items-center gap-3 text-sm max-lg:hidden"

--- a/www/src/components/layout/mobile-nav.tsx
+++ b/www/src/components/layout/mobile-nav.tsx
@@ -18,7 +18,7 @@ export function MobileNav({ items }: { items: PageTree.Node[] }) {
         variant="quiet"
         size="md"
         isIconOnly
-        className="relative flex items-center justify-center md:hidden"
+        className="relative flex items-center justify-center lg:hidden"
       >
         <div className="relative h-3.5 w-4 [&>span]:absolute [&>span]:left-0 [&>span]:block [&>span]:h-0.5 [&>span]:w-4 [&>span]:rounded-full [&>span]:bg-fg [&>span]:transition-all [&>span]:duration-150 [&>span]:ease-out">
           <span

--- a/www/src/lib/node-text.ts
+++ b/www/src/lib/node-text.ts
@@ -1,0 +1,12 @@
+import React from 'react'
+
+/** Flatten a ReactNode (e.g. a heading's TOC title) into plain text. */
+export function nodeText(node: React.ReactNode): string {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(nodeText).join('')
+  if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
+    return nodeText(node.props.children)
+  }
+  return ''
+}

--- a/www/src/modules/docs/docs-sidebar.tsx
+++ b/www/src/modules/docs/docs-sidebar.tsx
@@ -82,11 +82,20 @@ function DocsSidebarLink({
     >
       <span
         className={cn(
-          'flex items-center gap-2 rounded-md bg-transparent px-2 py-1 text-fg-muted transition-colors hover:text-fg',
-          isActive && 'bg-neutral font-medium text-fg',
+          'flex items-center gap-2 px-2 py-1 text-fg-muted transition-colors hover:text-fg',
+          isActive && 'font-medium text-fg',
         )}
       >
-        <span>{item.name}</span>
+        {/* Highlight hugs the text, not the full-width row: padding sizes the
+            pill, negative margins cancel it so nothing shifts when active. */}
+        <span
+          className={cn(
+            '-mx-1.5 -my-0.5 rounded-md px-1.5 py-0.5',
+            isActive && 'bg-neutral',
+          )}
+        >
+          {item.name}
+        </span>
       </span>
     </Link>
   )

--- a/www/src/modules/docs/docs-toc-select.tsx
+++ b/www/src/modules/docs/docs-toc-select.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+import { useMatch } from '@tanstack/react-router'
+import { ChevronDownIcon } from 'lucide-react'
+import { Button } from 'react-aria-components/Button'
+import { Select } from 'react-aria-components/Select'
+
+import { cn } from '@/registry/lib/utils'
+import { SelectContent, SelectItem } from '@/registry/ui/select'
+
+type TocEntry = { url: string; title: string; depth: number }
+
+/**
+ * Small-screen "on this page" control for the header. The header lives above
+ * the docs page's TOCProvider, so it reads the toc from route data (exposed by
+ * the /docs/$ loader) rather than context. It's a Select whose value tracks the
+ * section currently in view; opening it highlights that section.
+ */
+export function DocsTocSelect({ className }: { className?: string }) {
+  const toc = useMatch({
+    from: '/_app/docs/$',
+    shouldThrow: false,
+    select: (match) => match.loaderData?.toc,
+  })
+  if (!toc || toc.length === 0) return null
+  return <TocSelect toc={toc} className={className} />
+}
+
+function TocSelect({
+  toc,
+  className,
+}: {
+  toc: TocEntry[]
+  className?: string
+}) {
+  const activeId = useActiveSection(toc)
+  const active = toc.find((item) => item.url === activeId) ?? toc[0]
+
+  return (
+    <Select
+      aria-label="On this page"
+      selectedKey={activeId}
+      onSelectionChange={(key) => scrollToSection(String(key))}
+      className={cn('flex', className)}
+    >
+      <Button className="flex items-center gap-1 text-sm text-fg-muted transition-colors outline-none hover:text-fg data-pressed:text-fg">
+        <span className="max-w-36 truncate">{active?.title ?? ''}</span>
+        <ChevronDownIcon className="size-4 shrink-0" />
+      </Button>
+      <SelectContent
+        placement="bottom start"
+        className="max-h-[60svh] min-w-56"
+      >
+        {toc.map((item) => (
+          <SelectItem
+            key={item.url}
+            id={item.url}
+            textValue={item.title}
+            className={cn(
+              item.depth === 3 && 'pl-6',
+              item.depth >= 4 && 'pl-9',
+            )}
+          >
+            {item.title}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function scrollToSection(url: string) {
+  const el = document.getElementById(url.replace(/^#/, ''))
+  if (!el) return
+  el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  history.replaceState(null, '', url)
+}
+
+/** Tracks which heading is currently in view (the last one scrolled past the header). */
+function useActiveSection(toc: TocEntry[]) {
+  const [activeId, setActiveId] = useState(() => toc[0]?.url ?? '')
+
+  useEffect(() => {
+    const ids = toc.map((item) => item.url)
+    const offset = 100 // header height + a little breathing room
+
+    const compute = () => {
+      let index = 0
+      for (let i = 0; i < ids.length; i++) {
+        const url = ids[i]
+        if (!url) continue
+        const el = document.getElementById(url.replace(/^#/, ''))
+        if (!el) continue
+        if (el.getBoundingClientRect().top <= offset) index = i
+        else break
+      }
+      const nextId = ids[index]
+      if (nextId) setActiveId(nextId)
+    }
+
+    compute()
+    window.addEventListener('scroll', compute, { passive: true })
+    window.addEventListener('resize', compute)
+    return () => {
+      window.removeEventListener('scroll', compute)
+      window.removeEventListener('resize', compute)
+    }
+  }, [toc])
+
+  return activeId
+}

--- a/www/src/modules/docs/docs-toc-select.tsx
+++ b/www/src/modules/docs/docs-toc-select.tsx
@@ -21,8 +21,21 @@ export function DocsTocSelect({ className }: { className?: string }) {
     shouldThrow: false,
     select: (match) => match.loaderData?.toc,
   })
-  if (!toc || toc.length === 0) return null
+  const scrolled = useScrolled()
+  // Only surfaces once scrolled — at the top the page title is still in view.
+  if (!toc || toc.length === 0 || !scrolled) return null
   return <TocSelect toc={toc} className={className} />
+}
+
+function useScrolled() {
+  const [scrolled, setScrolled] = useState(false)
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 0)
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+  return scrolled
 }
 
 function TocSelect({

--- a/www/src/modules/docs/toc.tsx
+++ b/www/src/modules/docs/toc.tsx
@@ -113,3 +113,66 @@ function TOCItem({ item }: { item: TOCItemType }) {
     </PrimitiveTOCItem>
   )
 }
+
+/**
+ * Collapsed TOC for the md–xl range: a stack of lines standing in for the
+ * headings, one per item, with the active one highlighted. Hovering or
+ * focusing them reveals a panel listing every heading to jump to.
+ *
+ * The panel is a CSS group-hover/focus-within child sitting flush against the
+ * lines (right-full + a transparent pr bridge), so the pointer never crosses
+ * dead space between lines and panel — no open/close flicker.
+ */
+export function MiniTOC({ className }: { className?: string }) {
+  const items = useTOCItems()
+  if (items.length === 0) return null
+
+  return (
+    <div className={cn('group relative', className)}>
+      <div className="flex flex-col items-end">
+        {items.map((item) => (
+          <MiniTOCLine key={item.url} item={item} />
+        ))}
+      </div>
+      <div className="invisible absolute top-0 right-full origin-top-right scale-95 pr-2.5 opacity-0 transition-[opacity,scale,visibility] duration-150 ease-out group-focus-within:visible group-focus-within:scale-100 group-focus-within:opacity-100 group-hover:visible group-hover:scale-100 group-hover:opacity-100">
+        <div className="no-scrollbar max-h-[70svh] w-64 overflow-auto rounded-xl border bg-popover p-2 text-sm shadow-md">
+          <TOCItems
+            aria-label="On this page"
+            className="[&_a]:rounded-md [&_a]:pr-2 [&_a:hover]:bg-muted [&_a:hover]:text-fg"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function MiniTOCLine({ item }: { item: TOCItemType }) {
+  return (
+    // The link is a taller, transparent hit area so the whole column is
+    // clickable (no dead gaps); the thin bar is a child that shows the state.
+    <PrimitiveTOCItem
+      href={item.url}
+      aria-label={nodeText(item.title)}
+      className="flex h-3.5 items-center justify-end"
+    >
+      <span
+        className={cn(
+          'h-0.5 w-5 rounded-full bg-border transition-all [[data-active=true]>&]:w-6 [[data-active=true]>&]:bg-fg',
+          item.depth === 3 && 'w-4',
+          item.depth >= 4 && 'w-3',
+        )}
+      />
+    </PrimitiveTOCItem>
+  )
+}
+
+/** Flatten a heading's ReactNode title into plain text for aria-label. */
+function nodeText(node: React.ReactNode): string {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(nodeText).join('')
+  if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
+    return nodeText(node.props.children)
+  }
+  return ''
+}

--- a/www/src/modules/docs/toc.tsx
+++ b/www/src/modules/docs/toc.tsx
@@ -7,6 +7,7 @@ import {
 } from 'fumadocs-core/toc'
 import { mergeRefs } from 'react-aria/mergeRefs'
 
+import { nodeText } from '@/lib/node-text'
 import { cn } from '@/registry/lib/utils'
 
 export type { TableOfContents, TOCItemType } from 'fumadocs-core/toc'
@@ -164,15 +165,4 @@ function MiniTOCLine({ item }: { item: TOCItemType }) {
       />
     </PrimitiveTOCItem>
   )
-}
-
-/** Flatten a heading's ReactNode title into plain text for aria-label. */
-function nodeText(node: React.ReactNode): string {
-  if (node == null || typeof node === 'boolean') return ''
-  if (typeof node === 'string' || typeof node === 'number') return String(node)
-  if (Array.isArray(node)) return node.map(nodeText).join('')
-  if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
-    return nodeText(node.props.children)
-  }
-  return ''
 }

--- a/www/src/routes/_app/docs/$.tsx
+++ b/www/src/routes/_app/docs/$.tsx
@@ -2,9 +2,9 @@ import { createFileRoute, notFound } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
 import { setResponseHeader } from '@tanstack/react-start/server'
 import { findNeighbour } from 'fumadocs-core/page-tree'
-import { ChevronDownIcon } from 'lucide-react'
 
 import { siteConfig } from '@/config/site'
+import { nodeText } from '@/lib/node-text'
 import { docsSource } from '@/lib/source'
 import { truncateOnWord } from '@/lib/text'
 import { DocsCopyPage } from '@/modules/docs/docs-copy-page'
@@ -16,7 +16,7 @@ import {
   PageHeaderHeading,
   PageLayout,
 } from '@/modules/docs/page-layout'
-import { MiniTOC, TOC, TOCItems, TOCProvider } from '@/modules/docs/toc'
+import { MiniTOC, TOC, TOCProvider } from '@/modules/docs/toc'
 import browserCollections from '@/.source/browser'
 
 export const Route = createFileRoute('/_app/docs/$')({
@@ -91,6 +91,9 @@ const serverLoader = createServerFn({ method: 'GET' })
     const pageTree = docsSource.getPageTree()
     const { previous, next } = findNeighbour(pageTree, page.url)
     const rawContent = await page.data.getText('processed')
+    // Serializable copy of the page's toc (titles flattened to text) so the
+    // header — which lives above the TOCProvider — can read it from route data.
+    const { toc } = await page.data.load()
 
     return {
       path: page.path,
@@ -98,6 +101,11 @@ const serverLoader = createServerFn({ method: 'GET' })
       title: page.data.title,
       description: page.data.description,
       rawContent,
+      toc: toc.map((item) => ({
+        url: item.url,
+        title: nodeText(item.title),
+        depth: item.depth,
+      })),
       neighbours: {
         previous: previous
           ? {
@@ -152,19 +160,6 @@ const clientLoader = browserCollections.docs.createClientLoader({
               </div>
               <div className="absolute bottom-0 left-0 h-px w-full bg-linear-to-r from-[color-mix(in_oklab,var(--color-border)_40%,transparent)] via-[color-mix(in_oklab,var(--color-border)_90%,transparent)] to-[color-mix(in_oklab,var(--color-border)_50%,transparent)]" />
             </div>
-            {/* Mobile fallback for the right-rail TOC. The md–xl range uses the
-                in-flow MiniTOC column instead; below md there's no room. */}
-            {hasToc ? (
-              <details className="group rounded-lg border bg-card md:hidden">
-                <summary className="flex cursor-pointer list-none items-center justify-between px-3 py-2 text-sm font-medium [&::-webkit-details-marker]:hidden">
-                  On this page
-                  <ChevronDownIcon className="size-4 text-fg-muted transition-transform group-open:rotate-180" />
-                </summary>
-                <div className="relative border-t px-2 py-2">
-                  <TOCItems />
-                </div>
-              </details>
-            ) : null}
             <div>
               <MDX components={mdxComponents} />
             </div>

--- a/www/src/routes/_app/docs/$.tsx
+++ b/www/src/routes/_app/docs/$.tsx
@@ -16,7 +16,7 @@ import {
   PageHeaderHeading,
   PageLayout,
 } from '@/modules/docs/page-layout'
-import { TOC, TOCItems, TOCProvider } from '@/modules/docs/toc'
+import { MiniTOC, TOC, TOCItems, TOCProvider } from '@/modules/docs/toc'
 import browserCollections from '@/.source/browser'
 
 export const Route = createFileRoute('/_app/docs/$')({
@@ -134,7 +134,7 @@ const clientLoader = browserCollections.docs.createClientLoader({
     return (
       <TOCProvider toc={toc}>
         <PageLayout className="mt-4 flex scroll-mt-24 items-stretch pb-8 text-[1.05rem] sm:text-[15px] xl:w-full">
-          <div className="mx-auto flex w-full max-w-2xl min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-0 lg:py-8 dark:text-neutral-300">
+          <div className="mx-auto flex w-full max-w-2xl min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 lg:px-0 lg:py-8 dark:text-neutral-300">
             <div data-page-header="" className="relative mb-2 space-y-3 pb-4">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div className="flex min-w-0 flex-col gap-2">
@@ -152,10 +152,10 @@ const clientLoader = browserCollections.docs.createClientLoader({
               </div>
               <div className="absolute bottom-0 left-0 h-px w-full bg-linear-to-r from-[color-mix(in_oklab,var(--color-border)_40%,transparent)] via-[color-mix(in_oklab,var(--color-border)_90%,transparent)] to-[color-mix(in_oklab,var(--color-border)_50%,transparent)]" />
             </div>
-            {/* Tablet/mobile fallback for the right-rail TOC, which is xl-only.
-                Below xl there's otherwise no in-page navigation at all. */}
+            {/* Mobile fallback for the right-rail TOC. The md–xl range uses the
+                in-flow MiniTOC column instead; below md there's no room. */}
             {hasToc ? (
-              <details className="group rounded-lg border bg-card xl:hidden">
+              <details className="group rounded-lg border bg-card md:hidden">
                 <summary className="flex cursor-pointer list-none items-center justify-between px-3 py-2 text-sm font-medium [&::-webkit-details-marker]:hidden">
                   On this page
                   <ChevronDownIcon className="size-4 text-fg-muted transition-transform group-open:rotate-180" />
@@ -180,6 +180,14 @@ const clientLoader = browserCollections.docs.createClientLoader({
           <div className="sticky top-(--header-height) z-30 -mt-4 hidden max-h-[90svh] w-(--sidebar-width) flex-col gap-4 self-start overflow-hidden overscroll-none pb-8 xl:flex">
             {hasToc && <TOC className="pr-12" />}
           </div>
+          {/* In-flow TOC column for md–xl: it reserves layout space (instead of
+              floating) so the content column stays centered. Mirrors the xl
+              rail's sticky/-mt-4 alignment; pt lands the lines on the title. */}
+          {hasToc && (
+            <div className="sticky top-(--header-height) z-30 -mt-4 hidden w-16 shrink-0 justify-end self-start pt-10 pr-4 md:flex lg:pt-12 xl:hidden">
+              <MiniTOC />
+            </div>
+          )}
         </PageLayout>
       </TOCProvider>
     )

--- a/www/src/routes/_app/docs/$.tsx
+++ b/www/src/routes/_app/docs/$.tsx
@@ -177,9 +177,12 @@ const clientLoader = browserCollections.docs.createClientLoader({
           </div>
           {/* In-flow TOC column for md–xl: it reserves layout space (instead of
               floating) so the content column stays centered. Mirrors the xl
-              rail's sticky/-mt-4 alignment; pt lands the lines on the title. */}
+              rail's sticky/-mt-4 alignment; pt lands the lines on the title.
+              px-6 lines the bars up with the header's right-edge icon glyph
+              (which is inset ~8px inside its button), mirroring how the sidebar
+              text lines up with the logo on the left. */}
           {hasToc && (
-            <div className="sticky top-(--header-height) z-30 -mt-4 hidden w-16 shrink-0 justify-end self-start pt-10 pr-4 md:flex lg:pt-12 xl:hidden">
+            <div className="sticky top-(--header-height) z-30 -mt-4 hidden w-16 shrink-0 justify-end self-start px-6 pt-10 md:flex lg:pt-12 xl:hidden">
               <MiniTOC />
             </div>
           )}

--- a/www/src/routes/_app/docs/route.tsx
+++ b/www/src/routes/_app/docs/route.tsx
@@ -15,7 +15,7 @@ function DocsLayout() {
 
   return (
     <div className="flex min-h-[calc(100vh-var(--header-height))] [--sidebar-width:228px]">
-      <aside className="sticky top-(--header-height) hidden h-[calc(100vh-var(--header-height))] w-(--sidebar-width) shrink-0 md:block">
+      <aside className="sticky top-(--header-height) hidden h-[calc(100vh-var(--header-height))] w-(--sidebar-width) shrink-0 lg:block">
         <DocsSidebar items={items} />
       </aside>
       <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary

Reworks the docs "on this page" TOC so every breakpoint has a fitting in-page navigation, and cleans up the surrounding responsive layout. Each tier now:

- **`xl+`** — the existing right-rail TOC, unchanged.
- **`md`–`xl`** — a collapsed **mini-TOC**: a stack of lines standing in for the headings (active one highlighted) that reveals a full listbox-style panel on hover **or keyboard focus**. It lives in its own in-flow, sticky column (not a floating overlay) so the content column stays centered, is aligned to the page title, and its bars line up with the header's right-edge icon glyph.
- **`< md`** — a compact **Select** in the header, next to the logo, that appears once you scroll past the top. Its value tracks the section currently in view (scroll-spy) and opening it pre-highlights that section. Replaces the old in-content `<details>` fallback.

Along the way:

- **Moved the mobile/desktop boundary from `md` to `lg`** (header nav, hamburger, docs sidebar, content padding). The `md`–`lg` range previously crammed a 228px sidebar next to zero-padding content (~540px); now it gets the roomy full-width mobile layout, and the sidebar/top-nav return at `lg`.
- **Docs sidebar active highlight** now hugs the text instead of filling the whole link width.

## How the header reads the TOC

The header sits *above* the docs page's `TOCProvider`, so React context can't reach it. Following the React Aria docs' own approach (they avoid portals), the `/docs/$` loader exposes a **serializable toc** and the header reads it via `useMatch({ from: '/_app/docs/$', shouldThrow: false })` — no portal, no global store, no effect-syncing. The toc comes from `page.data.load()` (the exact toc the page renders, so anchors always match), with titles flattened to text by a shared `nodeText` util.

## Reviewer notes

- The boundary shift touches the **global header**, so every page (not just docs) now shows the hamburger up to `lg` instead of `md`.
- The mini-TOC column is capped at `w-16` — the widest that keeps content from re-cramping at the tight `lg` boundary where the 228px sidebar returns.
- The mini-TOC reveal panel is pure CSS (`group-hover`/`group-focus-within`), so no open/close flicker and it works from the keyboard.
- Scroll-spy is a `window` scroll listener + `getBoundingClientRect` (the standard pattern). Worth a real-browser check: the headless preview doesn't emit scroll events for programmatic scrolls, so the scroll-driven bits (section tracking + reveal-on-scroll) were verified via the event the listeners subscribe to rather than natural scrolling.

Verified across breakpoints (375 / 560 / 820 / 900 / 1100 / 1360px); typecheck, lint, and format pass.