### PR TITLE
fix(docs): show toggle button selected state in preview cards

### DIFF
--- a/www/src/modules/docs/components-list/autoplay/interaction.tsx
+++ b/www/src/modules/docs/components-list/autoplay/interaction.tsx
@@ -101,12 +101,17 @@ export function DemoPress({
   phase,
   pressing,
   hovering,
+  selected,
   target,
   children,
 }: {
   phase?: string
   pressing?: boolean
   hovering?: boolean
+  /** Mirror a selected/toggled state — needed when the pressable IS the styled
+   * element (e.g. ToggleButton), where the real `data-selected` would otherwise
+   * be stripped on re-apply. */
+  selected?: boolean
   target?: 'first' | 'last' | 'all'
   children: ReactNode
 }) {
@@ -114,7 +119,7 @@ export function DemoPress({
   const isHovered = isPressed || hovering || phase === 'hover'
   return (
     <DemoState
-      flags={{ hovered: isHovered, pressed: isPressed }}
+      flags={{ hovered: isHovered, pressed: isPressed, selected }}
       target={target}
     >
       {children}

--- a/www/src/modules/docs/components-list/demos/toggle-button.tsx
+++ b/www/src/modules/docs/components-list/demos/toggle-button.tsx
@@ -9,7 +9,7 @@ import { DemoPress, useToggleAutoplay } from '../autoplay'
 export function ToggleButtonDemo() {
   const { selected, pressing } = useToggleAutoplay({ initial: true })
   return (
-    <DemoPress pressing={pressing}>
+    <DemoPress pressing={pressing} selected={selected}>
       <ToggleButton
         isIconOnly
         aria-label="Toggle pin"


### PR DESCRIPTION
## Summary

Toggle buttons in the `/docs/components` preview cards only showed a brief press dip on hover, never the selected-state color change — so the toggle read as "just a click" with no state change.

The cards mirror React Aria state attributes onto the real component via `DemoState`, which rewrites the full attribute set on every render. `data-selected` is in that set, so it was stripped on re-apply because `DemoPress` never forwarded a `selected` flag: the demo set `isSelected` (React Aria added `data-selected`), then `DemoState`'s layout effect removed it right back.

Thread `selected` through `DemoPress` → `DemoState`. The prop is optional and defaults to `undefined`, so the other `DemoPress` callers (button, group, file-trigger, number-field, switch, checkbox) are byte-identical. Checkbox/Switch already worked because their `isSelected` sits on the **root** element while `DemoPress` wraps only the inner control; on ToggleButton the pressable and the styled element are the same node, so wrapping it directly stripped the very `data-selected` it needs.

## Verification

- **At rest** (`initial: true` → `selected: true`): `data-selected` is now present and the background resolves to `--color-selected` (`oklch(0.3281 0 0)`) instead of `--color-neutral` (`oklch(0.2287 0 0)`), with the active border and `fg-on-selected` text. The hover animation drives the same `DemoState` code path, so it now swaps between the selected and neutral backgrounds on each flip.
- `pnpm check` (oxlint + oxfmt) and `pnpm typecheck` pass.
- Docs-module only — no registry or publisher changes.