### PR TITLE
docs: add concept sections to component docs

### DIFF
--- a/www/content/docs/components/accordion.mdx
+++ b/www/content/docs/components/accordion.mdx
@@ -41,6 +41,19 @@ import {
 </Accordion>
 ```
 
+## Open state
+
+Expanded items are tracked by each `Disclosure`'s `id`. Give the group `defaultExpandedKeys` for uncontrolled state, or `expandedKeys` with `onExpandedChange` to control it — both are a `Set` of ids. Pass `allowsMultipleExpanded` to let the set hold more than one id at a time.
+
+```tsx
+<Accordion defaultExpandedKeys={['getting-started']}>
+  <Disclosure id="getting-started">
+    <DisclosureTrigger>How do I get started?</DisclosureTrigger>
+    <DisclosurePanel>…</DisclosurePanel>
+  </Disclosure>
+</Accordion>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2 lg:grid-cols-3">

--- a/www/content/docs/components/alert.mdx
+++ b/www/content/docs/components/alert.mdx
@@ -39,6 +39,28 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 </Alert>
 ```
 
+## Anatomy
+
+An alert composes a title, a description, and an optional action. To add an icon, place an icon element as the alert's first child — styles pick it up positionally, there is no icon prop.
+
+```tsx
+import {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+  AlertAction,
+} from '@/components/ui/alert'
+import { CircleAlert } from 'lucide-react'
+;<Alert>
+  <CircleAlert />
+  <AlertTitle>Title</AlertTitle>
+  <AlertDescription>Description</AlertDescription>
+  <AlertAction>Action</AlertAction>
+</Alert>
+```
+
+`AlertAction` renders at the end and typically wraps a `Button` or `Badge`.
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/avatar.mdx
+++ b/www/content/docs/components/avatar.mdx
@@ -46,6 +46,38 @@ import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 </Avatar>
 ```
 
+## Anatomy
+
+```tsx
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarBadge,
+  AvatarGroup,
+  AvatarGroupCount,
+} from '@/components/ui/avatar'
+```
+
+```tsx
+<Avatar>
+  <AvatarImage />
+  <AvatarFallback />
+  <AvatarBadge />
+</Avatar>
+
+<AvatarGroup>
+  <Avatar>{/* ... */}</Avatar>
+  <AvatarGroupCount />
+</AvatarGroup>
+```
+
+`Avatar` is the container. `AvatarImage` renders the picture, `AvatarFallback` the initials or icon shown in its place, and `AvatarBadge` a status indicator overlaid on the corner. `AvatarGroup` stacks avatars with an overlapping layout, and `AvatarGroupCount` shows the remaining count.
+
+## Fallback
+
+`AvatarImage` and `AvatarFallback` share loading state, so you always render both. `AvatarImage` appears only once its `src` finishes loading; until then — and if loading fails — `AvatarFallback` is shown instead.
+
 ## Examples
 
 <Examples className="grid-cols-2 sm:grid-cols-3">

--- a/www/content/docs/components/breadcrumbs.mdx
+++ b/www/content/docs/components/breadcrumbs.mdx
@@ -52,6 +52,22 @@ import {
 </Breadcrumbs>
 ```
 
+## Anatomy
+
+Each `BreadcrumbItem` wraps a `BreadcrumbLink` and its own `BreadcrumbSeparator`. The separator lives inside the item, so omit it on the last one. It defaults to a chevron; pass `children` to override.
+
+```tsx
+<Breadcrumbs>
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Home</BreadcrumbLink>
+    <BreadcrumbSeparator>/</BreadcrumbSeparator>
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink>Current</BreadcrumbLink>
+  </BreadcrumbItem>
+</Breadcrumbs>
+```
+
 ## Framework Setup
 
 By default, `BreadcrumbLink` renders a plain `<a>` tag. To integrate with your framework's router, override the component in your project's `breadcrumbs.tsx`.

--- a/www/content/docs/components/button.mdx
+++ b/www/content/docs/components/button.mdx
@@ -41,6 +41,15 @@ import { Button } from '@dotui/registry/ui/button'
 <Button>Button</Button>
 ```
 
+## As a link
+
+Use `LinkButton` with `href` to render a navigation control styled as a button. Internal paths integrate with the client router; external URLs render a plain `<a>`.
+
+```tsx
+import { LinkButton } from '@dotui/registry/ui/button'
+;<LinkButton href="/dashboard">Dashboard</LinkButton>
+```
+
 ## Examples
 
 <Examples className="grid-cols-2 md:grid-cols-3">

--- a/www/content/docs/components/calendar.mdx
+++ b/www/content/docs/components/calendar.mdx
@@ -61,7 +61,9 @@ For full control, compose the calendar from its parts.
 
 ```tsx
 import {
+  Calendar,
   CalendarHeader,
+  CalendarHeading,
   CalendarGrid,
   CalendarGridHeader,
   CalendarHeaderCell,
@@ -72,18 +74,21 @@ import {
 
 ```tsx
 <Calendar>
+  <CalendarHeader>
+    <Button slot="previous">
+      <ChevronLeftIcon />
+    </Button>
+    <CalendarHeading />
+    <Button slot="next">
+      <ChevronRightIcon />
+    </Button>
+  </CalendarHeader>
   <CalendarGrid>
-    <CalendarHeader>
-      <Button slot="previous"><ChevronLeftIcon /></Button>
-      <CalendarHeading />
-      <Button slot="next"><ChevronRightIcon /></Button>
-    </CalendarHeader>
-    <CalendarGridBody>
-      <CalendarGridHeader>
-      {day => <CalendarHeaderCell />}
+    <CalendarGridHeader>
+      {(day) => <CalendarHeaderCell>{day}</CalendarHeaderCell>}
     </CalendarGridHeader>
     <CalendarGridBody>
-      {date => <CalendarCell date={date} />}
+      {(date) => <CalendarCell date={date} />}
     </CalendarGridBody>
   </CalendarGrid>
 </Calendar>
@@ -106,6 +111,24 @@ import type { DateValue } from 'react-aria-components'
 const [value, setValue] = useState<DateValue>(parseDate('2020-02-03'))
 
 ;<Calendar value={value} onChange={setValue} />
+```
+
+## Date availability
+
+Constrain the selectable range with `minValue` and `maxValue`, or disable individual dates with `isDateUnavailable`. All take [`@internationalized/date`](https://react-spectrum.adobe.com/internationalized/date/) values, so derive them from `today(getLocalTimeZone())`.
+
+```tsx
+import { getLocalTimeZone, today } from '@internationalized/date'
+
+const now = today(getLocalTimeZone())
+
+;<Calendar
+  minValue={now}
+  maxValue={now.add({ months: 1 })}
+  isDateUnavailable={(date) =>
+    [0, 6].includes(date.toDate(getLocalTimeZone()).getDay())
+  }
+/>
 ```
 
 ## Examples

--- a/www/content/docs/components/card.mdx
+++ b/www/content/docs/components/card.mdx
@@ -41,6 +41,38 @@ import {
 </Card>
 ```
 
+## Anatomy
+
+```tsx
+<Card>
+  <CardHeader>
+    <CardTitle />
+    <CardDescription />
+    <CardAction />
+  </CardHeader>
+  <CardContent />
+  <CardFooter />
+</Card>
+```
+
+`CardHeader` holds the `CardTitle`, `CardDescription`, and an optional `CardAction` pinned at the end of the header row. `CardContent` is the main body and `CardFooter` sits below it, usually for actions.
+
+## Size
+
+Pass `size="sm"` to `Card` for a more compact card with tighter spacing.
+
+```tsx
+<Card size="sm">{/* ... */}</Card>
+```
+
+## Section borders
+
+Add `border-b` to `CardHeader` or `border-t` to `CardFooter` to visually separate them from the content.
+
+```tsx
+<CardHeader className="border-b">{/* ... */}</CardHeader>
+```
+
 ## Examples
 
 <Examples className="lg:grid-cols-2">

--- a/www/content/docs/components/checkbox-group.mdx
+++ b/www/content/docs/components/checkbox-group.mdx
@@ -80,6 +80,20 @@ const [frameworks, setFrameworks] = useState<string[]>(['nextjs'])
 </CheckboxGroup>
 ```
 
+## Validation
+
+Set `isRequired` to require a selection, or drive `isInvalid` yourself. Render errors with `FieldError` — with the default `validationBehavior="native"` it surfaces the browser's message on form submit; use `validationBehavior="aria"` to validate live without native form semantics.
+
+```tsx
+import { CheckboxGroup } from '@/components/ui/checkbox-group'
+import { FieldError, FieldGroup, Label } from '@/components/ui/field'
+;<CheckboxGroup isRequired>
+  <Label>React frameworks</Label>
+  <FieldGroup>{/* ... */}</FieldGroup>
+  <FieldError>Please select a framework.</FieldError>
+</CheckboxGroup>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/checkbox.mdx
+++ b/www/content/docs/components/checkbox.mdx
@@ -59,18 +59,38 @@ import { Label } from '@/components/ui/field'
 </Checkbox>
 ```
 
-## Selection
+## Anatomy
 
-Use `defaultSelected` for uncontrolled checkboxes, or `isSelected` and `onChange` for controlled checkboxes.
+Pass a plain string and `Checkbox` wraps it in a `CheckboxControl` and `Label` for you. Pass elements instead and you compose the tree yourself — `CheckboxControl` renders the `CheckboxIndicator` (the box) and can hold `FieldContent` with a `Label` and `Description`.
 
 ```tsx
-<Checkbox defaultSelected />
+import {
+  Checkbox,
+  CheckboxControl,
+  CheckboxIndicator,
+} from '@/components/ui/checkbox'
+import { Description, FieldContent, Label } from '@/components/ui/field'
+;<Checkbox>
+  <CheckboxControl>
+    <CheckboxIndicator />
+    <FieldContent>
+      <Label>I agree to the terms</Label>
+      <Description>Please read them before proceeding</Description>
+    </FieldContent>
+  </CheckboxControl>
+</Checkbox>
 ```
 
-```tsx
-const [isSelected, setIsSelected] = useState(false)
+## Selection
 
-;<Checkbox isSelected={isSelected} onChange={setIsSelected} />
+The checkbox is selected or not. Use `defaultSelected` for uncontrolled state, or `isSelected` with `onChange` to control it.
+
+```tsx
+const [isSelected, setIsSelected] = React.useState(false)
+
+<Checkbox isSelected={isSelected} onChange={setIsSelected}>
+  Accept terms
+</Checkbox>
 ```
 
 ## Examples

--- a/www/content/docs/components/color-area.mdx
+++ b/www/content/docs/components/color-area.mdx
@@ -38,6 +38,38 @@ import { ColorThumb } from '@/components/ui/color-thumb'
 </ColorArea>
 ```
 
+## Anatomy
+
+A `ColorArea` renders the gradient and positions a `ColorThumb`. If you omit children, a default `ColorThumb` is rendered for you.
+
+```tsx
+import { ColorArea } from '@/components/ui/color-area'
+import { ColorThumb } from '@/components/ui/color-thumb'
+;<ColorArea>
+  <ColorThumb />
+</ColorArea>
+```
+
+## Value
+
+Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it. Uncontrolled values accept a color string; controlled values are `Color` objects created with `parseColor`.
+
+```tsx
+import { parseColor } from 'react-aria-components'
+
+const [value, setValue] = React.useState(parseColor('hsl(0, 100%, 50%)'))
+
+<ColorArea value={value} onChange={setValue} />
+```
+
+## Channels
+
+`xChannel` and `yChannel` map two channels of the color to the horizontal and vertical axes of the gradient.
+
+```tsx
+<ColorArea xChannel="saturation" yChannel="lightness" />
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/color-editor.mdx
+++ b/www/content/docs/components/color-editor.mdx
@@ -41,9 +41,9 @@ import { ColorEditor } from '@/components/ui/color-editor'
 <ColorEditor defaultValue="#5100FF" />
 ```
 
-### Composition
+## Anatomy
 
-The default children render an area row and a fields row. Pass your own children to reorder, drop, or extend them.
+`ColorEditor` renders a saturation/brightness area with channel sliders, then a row of format-aware fields. Omit children for the default layout, or compose the parts yourself.
 
 ```tsx
 import {
@@ -58,6 +58,42 @@ import {
   <ColorEditorArea showAlphaChannel />
   <ColorEditorFields defaultFormat="rgb" />
 </ColorEditor>
+```
+
+- `ColorEditorArea` — the color area, hue slider, and optional alpha slider.
+- `ColorEditorFields` — channel inputs for the current format, with an optional format selector.
+
+## Composition
+
+The default children render an area row and a fields row. Pass your own children to reorder, drop, or extend them — for example, dropping a swatch picker between the two parts.
+
+```tsx
+<ColorEditor defaultValue="#f80">
+  <ColorEditorArea showAlphaChannel />
+  <ColorSwatchPicker>{/* ... */}</ColorSwatchPicker>
+  <ColorEditorFields defaultFormat="rgb" showFormatSelector={false} />
+</ColorEditor>
+```
+
+## Value
+
+The value is a React Aria `Color`. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it. Pass a hex string (including alpha, e.g. `#5100FF80`) or a `Color` from `parseColor`.
+
+```tsx
+<ColorEditor defaultValue="#5100FF" onChange={setColor} />
+```
+
+<Alert>
+  Inside a [Color Picker](/docs/components/color-picker), the editor adopts the
+  picker's color — `value`, `defaultValue`, and `onChange` are ignored.
+</Alert>
+
+## Color format
+
+`ColorEditorFields` picks its channel inputs from the current format. Set the initial format with `defaultFormat` (`hex`, `rgb`, `hsl`, or `hsb`), or control it with `format` and `onFormatChange`.
+
+```tsx
+<ColorEditorFields format={format} onFormatChange={setFormat} />
 ```
 
 ## Examples

--- a/www/content/docs/components/color-field.mdx
+++ b/www/content/docs/components/color-field.mdx
@@ -51,6 +51,49 @@ import { Input } from '@/components/ui/input'
 </ColorField>
 ```
 
+## Anatomy
+
+A `ColorField` wraps a `Label` and an `Input`. To attach an icon, replace the bare `Input` with an `InputGroup` and place an `InputGroupAddon` on either side.
+
+```tsx
+import { ColorField } from '@/components/ui/color-field'
+import { Label } from '@/components/ui/field'
+import { Input, InputGroup, InputGroupAddon } from '@/components/ui/input'
+;<ColorField>
+  <Label />
+  <InputGroup>
+    <InputGroupAddon />
+    <Input />
+  </InputGroup>
+</ColorField>
+```
+
+## Value
+
+The value is a `Color` object. Pass a hex string to `defaultValue` for uncontrolled state, or control it with `value` + `onChange` using `parseColor`, and read it back with `color.toString('hex')`.
+
+```tsx
+import { type Color, parseColor } from 'react-aria-components'
+
+const [color, setColor] = React.useState<Color | null>(parseColor('#7f007f'))
+
+<ColorField value={color} onChange={setColor}>
+  <Label>Color</Label>
+  <Input />
+</ColorField>
+```
+
+## Channels
+
+Set `colorSpace` and `channel` to bind the field to a single channel of a color space instead of the full hex value.
+
+```tsx
+<ColorField colorSpace="hsl" channel="hue" value={color} onChange={setColor}>
+  <Label>Hue</Label>
+  <Input />
+</ColorField>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/color-picker.mdx
+++ b/www/content/docs/components/color-picker.mdx
@@ -38,6 +38,46 @@ import { Popover } from '@/components/ui/popover'
 </ColorPicker>
 ```
 
+## Anatomy
+
+`ColorPicker` wraps a `Button` trigger and a `Popover` holding the editing surface. A `Button` with no children auto-fills with a `ColorSwatch` reflecting the current value.
+
+```tsx
+<ColorPicker>
+  <Button isIconOnly />
+  <Popover>
+    <DialogContent>
+      <ColorArea />
+      <ColorSlider />
+    </DialogContent>
+  </Popover>
+</ColorPicker>
+```
+
+## Value
+
+`ColorPicker` syncs a `Color` value across its children. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it. Both accept a hex string or a `Color` from `parseColor`.
+
+```tsx
+import { parseColor } from 'react-aria-components'
+
+const [value, setValue] = React.useState(parseColor('hsl(26, 33%, 78%)'))
+
+<ColorPicker value={value} onChange={setValue}>
+  {/* ... */}
+</ColorPicker>
+```
+
+## Open state
+
+The popover is uncontrolled by default. Use `defaultOpen`, or `isOpen` with `onOpenChange` to control it; `ColorPicker` forwards these to its internal dialog.
+
+```tsx
+<ColorPicker isOpen={isOpen} onOpenChange={setIsOpen}>
+  {/* ... */}
+</ColorPicker>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2 md:grid-cols-3">

--- a/www/content/docs/components/color-slider.mdx
+++ b/www/content/docs/components/color-slider.mdx
@@ -52,6 +52,43 @@ import { Label } from '@/components/ui/field'
 </ColorSlider>
 ```
 
+## Anatomy
+
+`ColorSlider` wraps a `ColorSliderControl` (the draggable track) and, optionally, a `ColorSliderOutput` (the current value as text) and a `Label`. If you render no children, `ColorSlider` falls back to a bare `ColorSliderControl`.
+
+```tsx
+import {
+  ColorSlider,
+  ColorSliderControl,
+  ColorSliderOutput,
+} from '@/components/ui/color-slider'
+import { Label } from '@/components/ui/field'
+```
+
+```tsx
+<ColorSlider>
+  <Label />
+  <ColorSliderOutput />
+  <ColorSliderControl />
+</ColorSlider>
+```
+
+## Value
+
+The value is a `Color` object. Use `defaultValue` for uncontrolled state — it accepts a color string like `#f00` or `hsl(0, 100%, 50%)`. For controlled state, pass `value` + `onChange`, where `value` is a parsed `Color` from `parseColor` and `onChange` receives a `Color`.
+
+```tsx
+import { parseColor } from 'react-aria-components'
+
+const [value, setValue] = React.useState(parseColor('hsl(0, 100%, 50%)'))
+
+<ColorSlider value={value} onChange={setValue} channel="hue">
+  <ColorSliderControl />
+</ColorSlider>
+```
+
+Use `channel` to pick which channel the slider edits (`hue`, `saturation`, `lightness`, `alpha`…), and `colorSpace` (`rgb`, `hsl`, `hsb`) to interpret the value in a given space.
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/color-swatch-picker.mdx
+++ b/www/content/docs/components/color-swatch-picker.mdx
@@ -43,6 +43,35 @@ import {
 </ColorSwatchPicker>
 ```
 
+## Anatomy
+
+```tsx
+import {
+  ColorSwatchPicker,
+  ColorSwatchPickerItem,
+} from '@/components/ui/color-swatch-picker'
+;<ColorSwatchPicker>
+  <ColorSwatchPickerItem color="#ff0000" />
+</ColorSwatchPicker>
+```
+
+`ColorSwatchPicker` is the selectable list; each `ColorSwatchPickerItem` declares one swatch via its `color` prop and renders the color internally.
+
+## Value
+
+The value is the selected color. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it. Values are `Color` objects (via `parseColor`) or color strings, and `onChange` receives a `Color`.
+
+```tsx
+import { parseColor } from 'react-aria-components'
+
+const [color, setColor] = React.useState(parseColor('#f80'))
+
+<ColorSwatchPicker value={color} onChange={setColor}>
+  <ColorSwatchPickerItem color="#f80" />
+  <ColorSwatchPickerItem color="#08f" />
+</ColorSwatchPicker>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2 md:grid-cols-3">

--- a/www/content/docs/components/color-swatch.mdx
+++ b/www/content/docs/components/color-swatch.mdx
@@ -36,6 +36,15 @@ import { ColorSwatch } from '@/components/ui/color-swatch'
 <ColorSwatch color="#ff0000" />
 ```
 
+## Value
+
+The `color` prop accepts a hex or CSS color string, or a `Color` object from `parseColor`. Translucent colors render over a checkerboard so their transparency shows through.
+
+```tsx
+import { parseColor } from 'react-aria-components'
+;<ColorSwatch color={parseColor('#7f0000aa')} />
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2 lg:grid-cols-3">

--- a/www/content/docs/components/combobox.mdx
+++ b/www/content/docs/components/combobox.mdx
@@ -44,22 +44,127 @@ npx shadcn@latest add @dotui/combobox
 Use `Combobox` to allow users to filter a list of options to items matching a query and select an item from the list.
 
 ```tsx
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxInput,
-  ComboboxItem,
-} from '@/components/ui/combobox'
+import { Combobox } from '@/components/ui/combobox'
+import { Input, InputGroup, InputGroupAddon } from '@/components/ui/input'
+import { ListBox, ListBoxItem } from '@/components/ui/list-box'
+import { Popover } from '@/components/ui/popover'
 ```
 
 ```tsx
-<Combobox>
-  <ComboboxInput />
-  <ComboboxContent>
-    <ComboboxItem>Option 1</ComboboxItem>
-    <ComboboxItem>Option 2</ComboboxItem>
-  </ComboboxContent>
+<Combobox aria-label="Country">
+  <InputGroup>
+    <Input placeholder="Select a country..." />
+    <InputGroupAddon>
+      <Button variant="quiet" isIconOnly>
+        <ChevronDownIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Popover>
+    <ListBox>
+      <ListBoxItem>Canada</ListBoxItem>
+      <ListBoxItem>France</ListBoxItem>
+    </ListBox>
+  </Popover>
 </Combobox>
+```
+
+## Anatomy
+
+`Combobox` is assembled from the field, input, list-box, and popover primitives. `InputGroup` wraps the text `Input` and an `InputGroupAddon` trigger; the `Popover` holds a `ListBox` of `ListBoxItem` options.
+
+```tsx
+<Combobox>
+  <Label />
+  <InputGroup>
+    <Input />
+    <InputGroupAddon />
+  </InputGroup>
+  <Popover>
+    <ListBox>
+      <ListBoxItem />
+    </ListBox>
+  </Popover>
+</Combobox>
+```
+
+## Value
+
+The value is the selected item's key. Use `defaultSelectedKey` for uncontrolled state, or `selectedKey` with `onSelectionChange` to control it.
+
+```tsx
+const [country, setCountry] = React.useState<Key | null>('tn')
+
+<Combobox selectedKey={country} onSelectionChange={setCountry}>
+  {/* ... */}
+</Combobox>
+```
+
+## Multiple selection
+
+Set `selectionMode="multiple"` to select several items; the value becomes an array of keys via `defaultValue`/`value`. Render `ComboboxValue` with a function to display the selected items as a `TagGroup`.
+
+```tsx
+<Combobox<Framework, 'multiple'>
+  selectionMode="multiple"
+  defaultValue={['next']}
+>
+  <InputGroup>
+    <ComboboxValue<Framework>>
+      {({ selectedItems, state }) => (
+        <TagGroup
+          onRemove={(keys) =>
+            state.setValue(state.value.filter((k) => !keys.has(k)))
+          }
+        >
+          <TagList items={selectedItems.filter(Boolean)}>
+            {(item) => <Tag>{item.name}</Tag>}
+          </TagList>
+        </TagGroup>
+      )}
+    </ComboboxValue>
+    <Input placeholder="Select frameworks" />
+  </InputGroup>
+  {/* ... */}
+</Combobox>
+```
+
+## Content
+
+Pass static `ListBoxItem` children, or render options from data with `items` and a render function. Give each item a stable `id`, and a `textValue` when its content isn't a plain string.
+
+```tsx
+<ListBox items={countries}>
+  {(item) => (
+    <ListBoxItem id={item.id} textValue={item.label}>
+      {item.label}
+    </ListBoxItem>
+  )}
+</ListBox>
+```
+
+## Sections
+
+Group options with `ListBoxSection` and `ListBoxSectionHeader` — see the [Sections](#examples) demo.
+
+## Async loading
+
+Source items from `useAsyncList` and pass `isLoading` to the `ListBox` to show a loading state while fetching.
+
+```tsx
+const list = useAsyncList({ async load({ signal }) { /* ... */ } })
+
+<ListBox items={list.items} isLoading={list.isLoading}>
+  {(item) => <ListBoxItem id={item.name}>{item.name}</ListBoxItem>}
+</ListBox>
+```
+
+## Custom values
+
+Set `allowsCustomValue` to let users submit text that doesn't match any option.
+
+```tsx
+<Combobox allowsCustomValue>{/* ... */}</Combobox>
 ```
 
 ## Examples

--- a/www/content/docs/components/command.mdx
+++ b/www/content/docs/components/command.mdx
@@ -59,6 +59,38 @@ Filtering matches against each item's **`textValue`**. String children set it au
 
 Because the input and the list are ordinary primitives, anything they support works here too: put the `Command` inside a `Modal` for a `⌘K` palette, inside a `Popover` to filter a `Select`, or swap the `ListBox` for a `TagGroup`. See the [examples](#examples) below.
 
+## Anatomy
+
+`Command` re-exports the underlying primitives under `Command*` aliases so the whole palette imports from one place: `CommandInput` is a `SearchField`, `CommandContent` is a `ListBox`, and `CommandItem`, `CommandSection`, and `CommandSectionHeader` map to their `ListBox*` counterparts.
+
+```tsx
+import {
+  Command,
+  CommandContent,
+  CommandInput,
+  CommandItem,
+  CommandSection,
+  CommandSectionHeader,
+} from '@/components/ui/command'
+;<Command>
+  <CommandInput />
+  <CommandContent>
+    <CommandSection>
+      <CommandSectionHeader />
+      <CommandItem />
+    </CommandSection>
+  </CommandContent>
+</Command>
+```
+
+## Filtering
+
+Matching is case- and punctuation-insensitive by default (`sensitivity: 'base'`, `ignorePunctuation: true`). Pass `filter` with any [`Intl.CollatorOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#options) to tune it — for example make matching accent-sensitive.
+
+```tsx
+<Command filter={{ sensitivity: 'accent' }}>{/* … */}</Command>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/context-menu.mdx
+++ b/www/content/docs/components/context-menu.mdx
@@ -39,6 +39,39 @@ import { Popover } from '@/components/ui/popover'
 </ContextMenu>
 ```
 
+## Anatomy
+
+`ContextMenu` is a right-click / long-press trigger wrapping a `Popover` and a `MenuContent`. Items, submenus (`MenuSub`), and every menu concept come from the [Menu](/docs/components/menu) component.
+
+```tsx
+import { ContextMenu } from '@/components/ui/context-menu'
+import { MenuContent, MenuItem, MenuSub } from '@/components/ui/menu'
+import { Popover } from '@/components/ui/popover'
+import { Separator } from '@/components/ui/separator'
+;<ContextMenu>
+  {/* trigger content */}
+  <Popover>
+    <MenuContent>
+      <MenuItem />
+      <Separator />
+      <MenuSub />
+    </MenuContent>
+  </Popover>
+</ContextMenu>
+```
+
+## Open state
+
+The menu is uncontrolled by default. Pass `defaultOpen` for uncontrolled state, or `isOpen` with `onOpenChange` to control it. Use `isDisabled` to suppress the trigger entirely.
+
+```tsx
+const [isOpen, setIsOpen] = React.useState(false)
+
+<ContextMenu isOpen={isOpen} onOpenChange={setIsOpen}>
+  {/* ... */}
+</ContextMenu>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/date-field.mdx
+++ b/www/content/docs/components/date-field.mdx
@@ -56,6 +56,48 @@ import { Label } from '@/components/ui/field'
 </DateField>
 ```
 
+## Anatomy
+
+`DateField` wraps a `Label`, a `DateInput` that renders the individually editable segments, and optionally a `Description` and `FieldError`.
+
+```tsx
+import { DateField } from '@/components/ui/date-field'
+import { DateInput } from '@/components/ui/input'
+import { Description, FieldError, Label } from '@/components/ui/field'
+;<DateField>
+  <Label />
+  <DateInput />
+  <Description />
+  <FieldError />
+</DateField>
+```
+
+## Value
+
+Values are [`@internationalized/date`](https://react-spectrum.adobe.com/internationalized/date/index.html) objects. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it.
+
+```tsx
+import { parseDate } from '@internationalized/date'
+;<DateField defaultValue={parseDate('2020-02-03')}>
+  <Label>Date</Label>
+  <DateInput />
+</DateField>
+```
+
+Set `granularity` (`day`, `hour`, `minute`, or `second`) to control which segments render, and constrain the range with `minValue` and `maxValue`.
+
+## Validation
+
+Mark the field with `isRequired`, or drive it with `isInvalid` and a custom `validate`. Errors surface through `FieldError`.
+
+```tsx
+<DateField isInvalid>
+  <Label>Event date</Label>
+  <DateInput />
+  <FieldError>Please select a date.</FieldError>
+</DateField>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/date-picker.mdx
+++ b/www/content/docs/components/date-picker.mdx
@@ -27,7 +27,7 @@ import { Calendar } from '@/components/ui/calendar'
 import { DatePicker } from '@/components/ui/date-picker'
 import { DialogContent } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/field'
-import { DateInput, InputAddon, InputGroup } from '@/components/ui/input'
+import { DateInput, InputGroup, InputGroupAddon } from '@/components/ui/input'
 import { Popover } from '@/components/ui/popover'
 ```
 
@@ -36,11 +36,11 @@ import { Popover } from '@/components/ui/popover'
   <Label>Date</Label>
   <InputGroup>
     <DateInput />
-    <InputAddon>
+    <InputGroupAddon>
       <Button variant="default" size="sm" isIconOnly>
         <CalendarIcon />
       </Button>
-    </InputAddon>
+    </InputGroupAddon>
   </InputGroup>
   <Popover>
     <DialogContent>
@@ -48,6 +48,76 @@ import { Popover } from '@/components/ui/popover'
     </DialogContent>
   </Popover>
 </DatePicker>
+```
+
+## Anatomy
+
+A date picker assembles a date field and a calendar overlay. The `InputGroup` holds the `DateInput` and a trigger `Button`; the `Popover` reveals a `Calendar`. `Label`, `Description`, and `FieldError` are optional field parts.
+
+```tsx
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import { DatePicker } from '@/components/ui/date-picker'
+import { DialogContent } from '@/components/ui/dialog'
+import { Description, FieldError, Label } from '@/components/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/components/ui/input'
+import { Popover } from '@/components/ui/popover'
+;<DatePicker>
+  <Label />
+  <InputGroup>
+    <DateInput />
+    <InputGroupAddon>
+      <Button />
+    </InputGroupAddon>
+  </InputGroup>
+  <Description />
+  <FieldError />
+  <Popover>
+    <DialogContent>
+      <Calendar />
+    </DialogContent>
+  </Popover>
+</DatePicker>
+```
+
+## Value
+
+The value is an [`@internationalized/date`](https://react-spectrum.adobe.com/internationalized/date/) object. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it. `granularity` (`"day"`, `"hour"`, `"minute"`, `"second"`) sets the smallest editable unit, and `minValue`/`maxValue` bound the selectable range.
+
+```tsx
+import { parseDate } from '@internationalized/date'
+;<DatePicker
+  defaultValue={parseDate('2020-02-03')}
+  minValue={parseDate('2020-01-01')}
+/>
+```
+
+## Date range
+
+`DateRangePicker` selects a start and end date as a `{ start, end }` value. Use two `DateInput`s with `slot="start"` and `slot="end"`, and a `RangeCalendar` in the popover.
+
+```tsx
+import { parseDate } from '@internationalized/date'
+
+import { RangeCalendar } from '@/components/ui/calendar'
+import { DateRangePicker } from '@/components/ui/date-picker'
+;<DateRangePicker
+  defaultValue={{
+    start: parseDate('2020-02-03'),
+    end: parseDate('2020-02-12'),
+  }}
+>
+  <InputGroup>
+    <DateInput slot="start" />
+    <span>–</span>
+    <DateInput slot="end" />
+  </InputGroup>
+  <Popover>
+    <DialogContent>
+      <RangeCalendar />
+    </DialogContent>
+  </Popover>
+</DateRangePicker>
 ```
 
 ## Examples

--- a/www/content/docs/components/dialog.mdx
+++ b/www/content/docs/components/dialog.mdx
@@ -70,6 +70,60 @@ import { Modal } from '@/components/ui/modal'
 </Dialog>
 ```
 
+## Anatomy
+
+The trigger `Button` and the overlay are siblings inside `Dialog`. The overlay (`Modal`, `Drawer`, or `Popover`) is a separate component the dialog does not ship, and `DialogContent` renders inside it. Pass `showCloseButton` to `DialogContent` for a built-in close button.
+
+```tsx
+<Dialog>
+  <Button>Open dialog</Button>
+  <Modal>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Title</DialogTitle>
+        <DialogDescription>Description</DialogDescription>
+      </DialogHeader>
+      <DialogBody>Content</DialogBody>
+      <DialogFooter>
+        <Button slot="close">Close</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Modal>
+</Dialog>
+```
+
+## Role
+
+Pass `role="alertdialog"` to `DialogContent` for destructive confirmations that interrupt the user and require a response.
+
+```tsx
+<DialogContent role="alertdialog">
+  <DialogHeader>
+    <DialogTitle>Delete project</DialogTitle>
+    <DialogDescription>This action cannot be undone.</DialogDescription>
+  </DialogHeader>
+  <DialogFooter>
+    <Button slot="close">Cancel</Button>
+    <Button slot="close" variant="danger">
+      Delete
+    </Button>
+  </DialogFooter>
+</DialogContent>
+```
+
+## Open state
+
+The dialog opens when the trigger is pressed. Control it with `isOpen` and `onOpenChange` (or set `defaultOpen`), and close it from inside with a `Button` that has `slot="close"`.
+
+```tsx
+const [isOpen, setOpen] = React.useState(false)
+
+<Dialog isOpen={isOpen} onOpenChange={setOpen}>
+  <Button>Open dialog</Button>
+  <Modal>{/* ... */}</Modal>
+</Dialog>
+```
+
 ## Examples
 
 <Examples>

--- a/www/content/docs/components/disclosure.mdx
+++ b/www/content/docs/components/disclosure.mdx
@@ -20,19 +20,21 @@ npx shadcn@latest add @dotui/disclosure
 ```tsx
 import {
   Disclosure,
-  DisclosureHeading,
   DisclosurePanel,
+  DisclosureTrigger,
 } from '@/components/ui/disclosure'
 ```
 
+`DisclosureTrigger` renders the heading, button, and chevron; `DisclosurePanel` holds the collapsible content.
+
 ```tsx
 <Disclosure>
-  <DisclosureHeading>What is dotUI?</DisclosureHeading>
+  <DisclosureTrigger>What is dotUI?</DisclosureTrigger>
   <DisclosurePanel>dotUI is a design system platform.</DisclosurePanel>
 </Disclosure>
 ```
 
-for more advanced composition, you can use this structure
+For full control over the trigger, compose the header from `Heading` and `Button` yourself.
 
 ```tsx
 import { Disclosure, DisclosurePanel } from '@/components/ui/disclosure'
@@ -44,12 +46,25 @@ import { ChevronDownIcon } from 'your-icon-library'
 ```tsx
 <Disclosure>
   <Heading>
-    <Button>
+    <Button slot="trigger">
       What is dotUI?
       <ChevronDownIcon />
     </Button>
   </Heading>
   <DisclosurePanel>dotUI is a design system platform.</DisclosurePanel>
+</Disclosure>
+```
+
+## Open state
+
+Use `defaultExpanded` for uncontrolled state, or `isExpanded` with `onExpandedChange` to control it.
+
+```tsx
+const [isExpanded, setExpanded] = React.useState(false)
+
+<Disclosure isExpanded={isExpanded} onExpandedChange={setExpanded}>
+  <DisclosureTrigger>System requirements</DisclosureTrigger>
+  <DisclosurePanel>...</DisclosurePanel>
 </Disclosure>
 ```
 

--- a/www/content/docs/components/drawer.mdx
+++ b/www/content/docs/components/drawer.mdx
@@ -44,6 +44,55 @@ import { Drawer } from '@/components/ui/drawer'
 </Dialog>
 ```
 
+## Anatomy
+
+A `Drawer` has no built-in trigger. Wrap it in a `Dialog` with a `Button` child as the trigger, and put your content inside `DialogContent`.
+
+```tsx
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
+import {
+  Drawer,
+  DrawerHandle,
+  DrawerSwipeArea,
+  DrawerProvider,
+  DrawerIndent,
+  DrawerIndentBackground,
+} from '@/components/ui/drawer'
+;<Dialog>
+  <Button />
+  <Drawer>
+    <DialogContent>
+      <DrawerHandle />
+    </DialogContent>
+  </Drawer>
+</Dialog>
+```
+
+`DrawerHandle` is a visible drag affordance. `DrawerSwipeArea` is an edge region that opens the drawer by swiping. `DrawerIndent` and `DrawerIndentBackground` wrap page content that scales and translates behind an open drawer, and `DrawerProvider` scopes visual state explicitly — most apps don't need it.
+
+## Open state
+
+Rendered under a `Dialog`, the drawer shares the dialog's open state, so the trigger `Button` opens it with no wiring. To drive it yourself, pass `isOpen` with `onOpenChange` (or `defaultOpen` for uncontrolled).
+
+```tsx
+const [isOpen, setIsOpen] = React.useState(false)
+
+<Drawer isOpen={isOpen} onOpenChange={setIsOpen}>
+  <DialogContent>...</DialogContent>
+</Drawer>
+```
+
+## Dismissal
+
+The drawer dismisses on swipe, outside interaction, and Escape. Disable each with `swipeToDismiss`, `isDismissable`, and `isKeyboardDismissDisabled` respectively.
+
+```tsx
+<Drawer swipeToDismiss={false} isDismissable={false} isKeyboardDismissDisabled>
+  <DialogContent>...</DialogContent>
+</Drawer>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/drop-zone.mdx
+++ b/www/content/docs/components/drop-zone.mdx
@@ -43,6 +43,59 @@ import { DropZone, DropZoneLabel } from '@/components/ui/drop-zone'
 </DropZone>
 ```
 
+## Anatomy
+
+`DropZoneLabel` nests inside `DropZone` and provides its accessible name.
+
+```tsx
+<DropZone>
+  <DropZoneLabel />
+</DropZone>
+```
+
+## Handling drops
+
+Read dropped data in `onDrop` from `e.items`, filtering by `kind` and `types`, and call `getText` on text items.
+
+```tsx
+import type { TextDropItem } from 'react-aria-components'
+;<DropZone
+  onDrop={async (e) => {
+    const items = await Promise.all(
+      e.items
+        .filter((item) => item.kind === 'text' && item.types.has('text/plain'))
+        .map((item) => (item as TextDropItem).getText('text/plain')),
+    )
+  }}
+>
+  <DropZoneLabel>Droppable</DropZoneLabel>
+</DropZone>
+```
+
+## Accepted drop types
+
+Restrict what the zone accepts by returning `'copy'` or `'cancel'` from `getDropOperation` based on the dragged `types`.
+
+```tsx
+<DropZone
+  getDropOperation={(types) => (types.has('image/png') ? 'copy' : 'cancel')}
+  onDrop={handleDrop}
+/>
+```
+
+## Pairing with FileTrigger
+
+Add a `FileTrigger` with a `Button` so users can drop files or click to browse.
+
+```tsx
+<DropZone>
+  <DropZoneLabel>Drag and drop files here</DropZoneLabel>
+  <FileTrigger>
+    <Button>Select files</Button>
+  </FileTrigger>
+</DropZone>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/empty.mdx
+++ b/www/content/docs/components/empty.mdx
@@ -33,6 +33,29 @@ import {
 </Empty>
 ```
 
+## Anatomy
+
+`EmptyHeader` groups the media, title, and description; `EmptyContent` holds the actions below. Pass `variant="icon"` to `EmptyMedia` to render its child inside a bordered icon container.
+
+```tsx
+import {
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from '@/components/ui/empty'
+;<Empty>
+  <EmptyHeader>
+    <EmptyMedia variant="icon">{/* icon */}</EmptyMedia>
+    <EmptyTitle>{/* heading */}</EmptyTitle>
+    <EmptyDescription>{/* supporting text */}</EmptyDescription>
+  </EmptyHeader>
+  <EmptyContent>{/* actions */}</EmptyContent>
+</Empty>
+```
+
 ## Examples
 
 <Examples className="md:grid-cols-2">

--- a/www/content/docs/components/field.mdx
+++ b/www/content/docs/components/field.mdx
@@ -24,6 +24,70 @@ import { Field, Label, Description, FieldError } from '@/components/ui/field'
 </Field>
 ```
 
+## Anatomy
+
+```tsx
+import {
+  Field,
+  FieldContent,
+  Label,
+  Description,
+  FieldError,
+  FieldGroup,
+  Fieldset,
+  Legend,
+} from '@/components/ui/field'
+```
+
+```tsx
+<Fieldset>
+  <Legend>…</Legend>
+  <FieldGroup>
+    <Field>
+      <FieldContent>
+        <Label>…</Label>
+        <Description>…</Description>
+      </FieldContent>
+      <FieldError>…</FieldError>
+    </Field>
+  </FieldGroup>
+</Fieldset>
+```
+
+`Field` wraps a control with its `Label`, `Description`, and `FieldError`. `FieldContent` stacks the label and description so they can sit beside the control. `FieldGroup` spaces stacked fields, and `Fieldset` with `Legend` semantically groups related fields.
+
+## Accessible wiring
+
+`Field` links the `Label` (`htmlFor`), the control (`id`), and the `Description` (`aria-describedby`) through context, so no manual ids are needed. Input-specific wrappers like `TextField`, `Select`, and `Checkbox` do this themselves — reach for `Field` only around standalone controls like `Switch`.
+
+```tsx
+<Field>
+  <Label>Notifications</Label>
+  <Switch>
+    <SwitchControl />
+  </Switch>
+  <Description>Send me product updates.</Description>
+</Field>
+```
+
+`FieldError` renders validation messages and accepts a render function for the current validation state.
+
+## Orientation
+
+Set `orientation="horizontal"` to place the control beside its label, using `FieldContent` to stack the label and description on the left.
+
+```tsx
+<Field orientation="horizontal">
+  <FieldContent>
+    <Label>Airplane Mode</Label>
+    <Description>Disable all connections.</Description>
+  </FieldContent>
+  <Switch aria-label="Airplane Mode">
+    <SwitchControl />
+  </Switch>
+</Field>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/file-trigger.mdx
+++ b/www/content/docs/components/file-trigger.mdx
@@ -39,6 +39,22 @@ import { FileTrigger } from '@/components/ui/file-trigger'
 </FileTrigger>
 ```
 
+## File selection
+
+`onSelect` receives a `FileList` (or `null`), so wrap it in `Array.from` to work with the files. Restrict what users can pick with `acceptedFileTypes`, allow multiple with `allowsMultiple`, pick whole folders with `acceptDirectory`, or open a device camera with `defaultCamera` (`user` or `environment`).
+
+```tsx
+<FileTrigger
+  acceptedFileTypes={['image/*']}
+  allowsMultiple
+  onSelect={(e) => {
+    if (e) console.log(Array.from(e).map((file) => file.name))
+  }}
+>
+  <Button>Upload images</Button>
+</FileTrigger>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2 lg:grid-cols-3">

--- a/www/content/docs/components/form.mdx
+++ b/www/content/docs/components/form.mdx
@@ -39,6 +39,25 @@ import { Input } from '@/components/ui/input'
 </Form>
 ```
 
+## Validation
+
+Mark fields `isRequired` (or add `validate` per field) to enforce validation. By default `validationBehavior` is `'native'`, using the browser's constraint validation; set it to `'aria'` to keep the DOM valid and surface errors purely through ARIA. Pass server-side errors keyed by field `name` via `validationErrors`.
+
+```tsx
+<Form
+  validationBehavior="aria"
+  validationErrors={{ email: 'Email already taken' }}
+>
+  <TextField name="email" isRequired>
+    <Label>Email</Label>
+    <Input type="email" />
+  </TextField>
+  <Button type="submit" variant="primary">
+    Submit
+  </Button>
+</Form>
+```
+
 ## Examples
 
 <Examples>

--- a/www/content/docs/components/group.mdx
+++ b/www/content/docs/components/group.mdx
@@ -25,6 +25,20 @@ import { Group } from '@/components/ui/group'
 </Group>
 ```
 
+## Anatomy
+
+`Group` is the container; `GroupText` renders an inline text segment between controls (prefixes, suffixes, labels).
+
+```tsx
+import { Group, GroupText } from '@/components/ui/group'
+;<Group>
+  <GroupText>Label</GroupText>
+  <Button>Action</Button>
+</Group>
+```
+
+Set `orientation` to `"vertical"` to stack children instead of the default `"horizontal"` row.
+
 ## Examples
 
 <Examples className="sm:grid-cols-2 lg:grid-cols-3">

--- a/www/content/docs/components/input-group.mdx
+++ b/www/content/docs/components/input-group.mdx
@@ -24,24 +24,31 @@ import { Input, InputGroup, InputGroupAddon } from '@/components/ui/input'
 </InputGroup>
 ```
 
-## Orientation
+## Anatomy
 
-Use `orientation="vertical"` to stack addons above or below the input — useful with a `TextArea`.
+An `InputGroup` wraps an `Input` or `TextArea` together with one or more `InputGroupAddon` parts. Order the children to place an addon before or after the control.
 
 ```tsx
-<InputGroup orientation="vertical">
-  <TextArea placeholder="Write a comment..." />
-  <InputGroupAddon>
-    <Button size="sm" variant="primary">
-      Comment
-    </Button>
-  </InputGroupAddon>
+import {
+  Input,
+  InputGroup,
+  InputGroupAddon,
+  TextArea,
+} from '@/components/ui/input'
+;<InputGroup>
+  <InputGroupAddon />
+  <Input />
+  <InputGroupAddon />
 </InputGroup>
 ```
 
+- `InputGroup` — the wrapper; clicking anywhere inside focuses the control.
+- `InputGroupAddon` — a slot for buttons, icons, labels, or `Kbd` alongside the control.
+- `Input` / `TextArea` — the wrapped control.
+
 ## Sizes
 
-The `size` prop is forwarded to the wrapped input. Available sizes are `sm`, `md` (default), and `lg`.
+Set `size` on the `InputGroup` to scale the group and its control. Available sizes are `sm`, `md` (default), and `lg`.
 
 ```tsx
 <InputGroup size="sm">…</InputGroup>

--- a/www/content/docs/components/kbd.mdx
+++ b/www/content/docs/components/kbd.mdx
@@ -20,6 +20,18 @@ import { Kbd } from '@/components/ui/kbd'
 ;<Kbd>⌘</Kbd> + <Kbd>K</Kbd>
 ```
 
+## Anatomy
+
+Use `Kbd` for a single key. Wrap several in `KbdGroup` to present a key combination as one unit.
+
+```tsx
+import { Kbd, KbdGroup } from '@/components/ui/kbd'
+;<KbdGroup>
+  <Kbd>⌘</Kbd>
+  <Kbd>K</Kbd>
+</KbdGroup>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/link.mdx
+++ b/www/content/docs/components/link.mdx
@@ -23,6 +23,16 @@ import { Link } from '@/components/ui/link'
 <Link href="/docs">Documentation</Link>
 ```
 
+## As a link
+
+Passing `href` renders a real `<a>`; add `target="_blank"` (with `rel`) to open a new tab. To route internal `href`s through your app router, override `Link` in your project the same way [Breadcrumbs](/docs/components/breadcrumbs) does for `BreadcrumbLink`.
+
+```tsx
+<Link href="https://dotui.org" target="_blank" rel="noreferrer">
+  dotUI
+</Link>
+```
+
 ## Examples
 
 <Examples className="grid-cols-2 md:grid-cols-3">

--- a/www/content/docs/components/list-box.mdx
+++ b/www/content/docs/components/list-box.mdx
@@ -47,6 +47,85 @@ import { ListBox, ListBoxItem } from '@/components/ui/list-box'
 </ListBox>
 ```
 
+## Anatomy
+
+```tsx
+import {
+  ListBox,
+  ListBoxItem,
+  ListBoxItemLabel,
+  ListBoxItemDescription,
+  ListBoxSection,
+  ListBoxSectionHeader,
+} from '@/components/ui/list-box'
+```
+
+```tsx
+<ListBox>
+  <ListBoxSection>
+    <ListBoxSectionHeader />
+    <ListBoxItem>
+      <ListBoxItemLabel />
+      <ListBoxItemDescription />
+    </ListBoxItem>
+  </ListBoxSection>
+</ListBox>
+```
+
+`ListBox` is the container. Each `ListBoxItem` is an option; give it a `ListBoxItemLabel` and optional `ListBoxItemDescription` when it holds more than a string. Group options under a `ListBoxSection` with a `ListBoxSectionHeader`.
+
+## Content
+
+Pass items statically as children, or dynamically via `items` plus a render function. Each item needs a stable `id`.
+
+```tsx
+<ListBox aria-label="Animals" items={animals}>
+  {(item) => <ListBoxItem id={item.id}>{item.name}</ListBoxItem>}
+</ListBox>
+```
+
+## Selection
+
+`selectionMode` sets whether options are selectable and how many. Control the selection with `selectedKeys` and `onSelectionChange`, or use `defaultSelectedKeys` for uncontrolled state. Pass `onAction` to make rows pressable without selecting them.
+
+```tsx
+<ListBox
+  aria-label="Options"
+  selectionMode="multiple"
+  selectedKeys={selected}
+  onSelectionChange={setSelected}
+>
+  <ListBoxItem id="a">Option A</ListBoxItem>
+  <ListBoxItem id="b">Option B</ListBoxItem>
+</ListBox>
+```
+
+## Disabled items
+
+Disable individual options by passing their keys to `disabledKeys` — the rest of the list stays interactive.
+
+```tsx
+<ListBox aria-label="Options" disabledKeys={['b']}>
+  <ListBoxItem id="a">Option A</ListBoxItem>
+  <ListBoxItem id="b">Option B</ListBoxItem>
+</ListBox>
+```
+
+## Async loading
+
+Load items on scroll with `isLoading` and `onLoadMore`, typically driven by `useAsyncList`, and render an empty state via `renderEmptyState`. See the [Async Loading](#examples) example.
+
+## Links
+
+Give a `ListBoxItem` an `href` to render it as a link. With a client router configured, links use client-side navigation.
+
+```tsx
+<ListBox aria-label="Links">
+  <ListBoxItem href="/home">Home</ListBoxItem>
+  <ListBoxItem href="/settings">Settings</ListBoxItem>
+</ListBox>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/loader.mdx
+++ b/www/content/docs/components/loader.mdx
@@ -20,6 +20,14 @@ import { Loader } from '@/components/ui/loader'
 <Loader />
 ```
 
+## Accessibility
+
+`Loader` renders a React Aria `ProgressBar` and has no visible text, so pass `aria-label` to name the operation for screen readers.
+
+```tsx
+<Loader aria-label="Loading" />
+```
+
 ## Examples
 
 <Examples className="grid-cols-2 md:grid-cols-3">

--- a/www/content/docs/components/mention.mdx
+++ b/www/content/docs/components/mention.mdx
@@ -71,6 +71,42 @@ The `trigger` prop changes the character that opens the list, and `getItemText` 
 </Mention>
 ```
 
+## Anatomy
+
+```tsx
+import { TextArea } from '@/components/ui/input'
+import { MenuContent, MenuItem } from '@/components/ui/menu'
+import { Mention } from '@/components/ui/mention'
+import { Popover } from '@/components/ui/popover'
+```
+
+```tsx
+<Mention>
+  <TextArea />
+  <Popover>
+    <MenuContent>
+      <MenuItem />
+    </MenuContent>
+  </Popover>
+</Mention>
+```
+
+`Mention` owns the value and caret-anchored popover, the input renders the text, and the `Popover` + `MenuContent` render the suggestions. These are children, not props — there are no bespoke sub-components.
+
+## Value
+
+The value is a plain `string`. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it — controlling the value is what powers highlight-overlay patterns that re-render the text with styled mention tokens.
+
+```tsx
+<Mention value={value} onChange={setValue}>
+  {/* ... */}
+</Mention>
+```
+
+## Placement
+
+Set `placement` to move the suggestions popover relative to the caret (default `"bottom start"`).
+
 ## Examples
 
 <Examples className="md:grid-cols-2">

--- a/www/content/docs/components/menu.mdx
+++ b/www/content/docs/components/menu.mdx
@@ -48,6 +48,70 @@ import { Popover } from '@/components/ui/popover'
 </Menu>
 ```
 
+## Anatomy
+
+A `Menu` links a trigger (`Button`) to an overlay (`Popover`) that wraps the `MenuContent`. Each `MenuItem` auto-wraps string children in a `MenuItemLabel`; add a `MenuItemDescription` for secondary text, group items with `MenuSection` + `MenuSectionHeader`, and nest a submenu with `MenuSub`.
+
+```tsx
+import { Button } from '@/components/ui/button'
+import {
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuItemLabel,
+  MenuItemDescription,
+  MenuSection,
+  MenuSectionHeader,
+  MenuSub,
+} from '@/components/ui/menu'
+import { Popover } from '@/components/ui/popover'
+;<Menu>
+  <Button>Open Menu</Button>
+  <Popover>
+    <MenuContent>
+      <MenuItem>
+        <MenuItemLabel>Label</MenuItemLabel>
+        <MenuItemDescription>Description</MenuItemDescription>
+      </MenuItem>
+      <MenuSection>
+        <MenuSectionHeader>Section</MenuSectionHeader>
+        <MenuItem>Item</MenuItem>
+      </MenuSection>
+      <MenuSub>
+        <MenuItem>Submenu</MenuItem>
+        <Popover>
+          <MenuContent>
+            <MenuItem>Nested item</MenuItem>
+          </MenuContent>
+        </Popover>
+      </MenuSub>
+    </MenuContent>
+  </Popover>
+</Menu>
+```
+
+## Selection
+
+Set `selectionMode` to `single` or `multiple` on `MenuContent` to turn items into checkbox or radio items. Control the selection with `selectedKeys`/`onSelectionChange` (or `defaultSelectedKeys`), and disable specific items with `disabledKeys`.
+
+```tsx
+<MenuContent selectionMode="single" disabledKeys={['right']}>
+  <MenuItem id="top">Top</MenuItem>
+  <MenuItem id="bottom">Bottom</MenuItem>
+  <MenuItem id="right">Right</MenuItem>
+</MenuContent>
+```
+
+## Links
+
+Pass `href` to a `MenuItem` to render it as an `<a>`; add `target` for the link target. Client-side routing depends on your router setup.
+
+```tsx
+<MenuItem href="https://twitter.com/mehdibha" target="_blank">
+  X
+</MenuItem>
+```
+
 ## Examples
 
 <Examples className="md:grid-cols-2">

--- a/www/content/docs/components/modal.mdx
+++ b/www/content/docs/components/modal.mdx
@@ -43,6 +43,37 @@ import { Modal } from '@/components/ui/modal'
 </Dialog>
 ```
 
+## Anatomy
+
+`Modal` composes the full overlay stack for you, so basic usage is just `<Modal>{children}</Modal>`. For full control, import the parts and assemble them yourself.
+
+```tsx
+import {
+  ModalOverlay,
+  ModalBackdrop,
+  ModalViewport,
+  ModalPanel,
+} from '@/components/ui/modal'
+;<ModalOverlay>
+  <ModalBackdrop />
+  <ModalViewport>
+    <ModalPanel>{children}</ModalPanel>
+  </ModalViewport>
+</ModalOverlay>
+```
+
+`ModalOverlay` renders the overlay and holds the open state, `ModalBackdrop` dims the page, `ModalViewport` centers the modal, and `ModalPanel` is the panel that wraps the dialog content.
+
+## Open state
+
+The trigger is `Dialog`: wrap a `Button` and the `Modal` in it and opening is handled for you. To control it, pass `isOpen`/`defaultOpen` and `onOpenChange` to the modal.
+
+```tsx
+<Modal isOpen={isOpen} onOpenChange={setIsOpen}>
+  <DialogContent>Modal content</DialogContent>
+</Modal>
+```
+
 ## Examples
 
 <Examples className="md:grid-cols-2">

--- a/www/content/docs/components/number-field.mdx
+++ b/www/content/docs/components/number-field.mdx
@@ -56,6 +56,74 @@ import { Label } from '@/components/ui/field'
 </NumberField>
 ```
 
+## Anatomy
+
+Wrap the `Input` in a `NumberFieldGroup` alongside `NumberFieldDecrement` and `NumberFieldIncrement` to expose the stepper buttons. Add `Label` and `FieldError` for labelling and validation.
+
+```tsx
+import {
+  NumberField,
+  NumberFieldGroup,
+  NumberFieldDecrement,
+  NumberFieldIncrement,
+} from '@/components/ui/number-field'
+import { Input } from '@/components/ui/input'
+import { Label, FieldError } from '@/components/ui/field'
+;<NumberField>
+  <Label />
+  <NumberFieldGroup>
+    <NumberFieldDecrement />
+    <Input />
+    <NumberFieldIncrement />
+  </NumberFieldGroup>
+  <FieldError />
+</NumberField>
+```
+
+## Value
+
+The value is a number. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it — `onChange` receives the new number.
+
+```tsx
+const [value, setValue] = React.useState(69)
+
+<NumberField value={value} onChange={setValue}>
+  <Input />
+</NumberField>
+```
+
+## Format options
+
+Pass `formatOptions` (an `Intl.NumberFormat` options object) to format the value as a decimal, percent, currency, or unit.
+
+```tsx
+<NumberField formatOptions={{ style: 'currency', currency: 'EUR' }}>
+  <Input />
+</NumberField>
+```
+
+## Min, max, and step
+
+Use `minValue` and `maxValue` to constrain the range, and `step` to set the increment applied by the stepper buttons.
+
+```tsx
+<NumberField minValue={0} maxValue={100} step={5}>
+  <Input />
+</NumberField>
+```
+
+## Validation
+
+Mark the field with `isRequired`, drive the invalid state with `isInvalid`, and render the message with `FieldError`.
+
+```tsx
+<NumberField isRequired isInvalid>
+  <Label>Width</Label>
+  <Input />
+  <FieldError>Please fill out this field.</FieldError>
+</NumberField>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/otp-field.mdx
+++ b/www/content/docs/components/otp-field.mdx
@@ -40,6 +40,65 @@ import { Input } from '@/components/ui/input'
 </OTPField>
 ```
 
+## Anatomy
+
+`OTPField` wraps a `Label`, one or more `Group`s of single-character `Input` slots, and optional `Description`, `FieldError`, and `OTPFieldSeparator` parts. `length` sets how many slots render. Split the slots across `Group`s with an `OTPFieldSeparator` between them.
+
+```tsx
+import { OTPField, OTPFieldSeparator } from '@/components/ui/otp-field'
+import { Description, FieldError, Label } from '@/components/ui/field'
+import { Group } from '@/components/ui/group'
+import { Input } from '@/components/ui/input'
+```
+
+```tsx
+<OTPField length={6}>
+  <Label />
+  <Group>
+    <Input />
+  </Group>
+  <OTPFieldSeparator />
+  <Group>
+    <Input />
+  </Group>
+  <Description />
+  <FieldError />
+</OTPField>
+```
+
+## Value
+
+The value is a string sized by `length`. Pass `defaultValue` for uncontrolled state, or `value` with `onChange` to control it.
+
+```tsx
+const [value, setValue] = React.useState('')
+
+<OTPField length={6} value={value} onChange={setValue}>
+  {/* ... */}
+</OTPField>
+```
+
+## Validation
+
+Mark the field `isRequired`, drive `isInvalid` to surface a `FieldError` alongside a `Description`, and set `name` for form submission. Use `validationType` to restrict input to `"numeric"` (default) or `"alphanumeric"`.
+
+```tsx
+<OTPField
+  length={6}
+  name="code"
+  isInvalid={isInvalid}
+  validationType="alphanumeric"
+>
+  <Label>Recovery code</Label>
+  <Group>
+    <Input />
+    {/* ... */}
+  </Group>
+  <Description>Enter the code we sent you.</Description>
+  <FieldError>Enter all six characters.</FieldError>
+</OTPField>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/pagination.mdx
+++ b/www/content/docs/components/pagination.mdx
@@ -51,6 +51,40 @@ import {
 </Pagination>
 ```
 
+## Anatomy
+
+```tsx
+<Pagination>
+  <PaginationList>
+    <PaginationItem>
+      <PaginationPrevious />
+    </PaginationItem>
+    <PaginationItem>
+      <PaginationLink />
+    </PaginationItem>
+    <PaginationItem>
+      <PaginationEllipsis />
+    </PaginationItem>
+    <PaginationItem>
+      <PaginationNext />
+    </PaginationItem>
+  </PaginationList>
+</Pagination>
+```
+
+`Pagination` is the `nav` landmark and `PaginationList` the `ul` that wraps each `PaginationItem`. `PaginationLink` is a page cell, `PaginationPrevious` and `PaginationNext` are the directional links, and `PaginationEllipsis` marks a gap of skipped pages.
+
+## State
+
+Pagination holds no page state of its own — you own the current page. Wire `onPress` on each link to update it, pass `isActive` to the current page (which sets `aria-current="page"` and the active style), and `isDisabled` to cap the ends.
+
+```tsx
+<PaginationPrevious isDisabled={page === 1} onPress={() => setPage(page - 1)} />
+<PaginationLink isActive={page === n} onPress={() => setPage(n)}>
+  {n}
+</PaginationLink>
+```
+
 ## Framework Setup
 
 `PaginationLink`, `PaginationPrevious`, and `PaginationNext` are built on the Link button, so they pick up router integration from your `button.tsx` — there's nothing pagination-specific to wire up. See the [Button](/docs/components/button) docs to connect `LinkButton` to your framework's router, and pagination links with an `href` will route through it automatically.

--- a/www/content/docs/components/popover.mdx
+++ b/www/content/docs/components/popover.mdx
@@ -47,6 +47,53 @@ import { Popover } from '@/components/ui/popover'
 </Dialog>
 ```
 
+## Anatomy
+
+A `Dialog` wraps the trigger `Button` and the `Popover`; the popover holds a `DialogContent` with its title and body.
+
+```tsx
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { Popover } from '@/components/ui/popover'
+;<Dialog>
+  <Button />
+  <Popover>
+    <DialogContent>
+      <DialogTitle />
+    </DialogContent>
+  </Popover>
+</Dialog>
+```
+
+## Placement
+
+Set `placement` to position the popover relative to its trigger. Values are a side with an optional alignment, e.g. `bottom start` or `bottom end`.
+
+```tsx
+<Popover placement="bottom start" />
+```
+
+## Arrow
+
+Set `showArrow` to render an arrow pointing at the trigger (default `false`).
+
+```tsx
+<Popover showArrow />
+```
+
+## Open state
+
+Control visibility with `isOpen` and `onOpenChange` on the `Dialog` trigger (or `defaultOpen` for uncontrolled).
+
+```tsx
+<Dialog isOpen={isOpen} onOpenChange={setIsOpen}>
+  <Button />
+  <Popover>
+    <DialogContent>...</DialogContent>
+  </Popover>
+</Dialog>
+```
+
 ## Examples
 
 <Examples className="md:grid-cols-2">

--- a/www/content/docs/components/progress-bar.mdx
+++ b/www/content/docs/components/progress-bar.mdx
@@ -50,6 +50,43 @@ import { ProgressBar, ProgressBarControl } from '@/components/ui/progress-bar'
 </ProgressBar>
 ```
 
+## Anatomy
+
+`ProgressBar` wraps `ProgressBarControl` (the track) and an optional `ProgressBarOutput` that renders the value as text.
+
+```tsx
+import {
+  ProgressBar,
+  ProgressBarControl,
+  ProgressBarOutput,
+} from '@/components/ui/progress-bar'
+;<ProgressBar>
+  <ProgressBarOutput />
+  <ProgressBarControl />
+</ProgressBar>
+```
+
+## Value
+
+`value` is measured against `minValue` and `maxValue`, which default to `0` and `100`. When progress can't be measured, set `isIndeterminate`.
+
+```tsx
+<ProgressBar minValue={50} maxValue={150} value={100}>
+  <ProgressBarControl />
+</ProgressBar>
+```
+
+## Value formatting
+
+Pass `formatOptions` (an `Intl.NumberFormat` config) to format the value `ProgressBarOutput` renders, or replace the text entirely with `valueLabel`.
+
+```tsx
+<ProgressBar formatOptions={{ style: 'currency', currency: 'JPY' }} value={60}>
+  <ProgressBarOutput />
+  <ProgressBarControl />
+</ProgressBar>
+```
+
 ## Examples
 
 <Examples className="md:grid-cols-2">

--- a/www/content/docs/components/radio-group.mdx
+++ b/www/content/docs/components/radio-group.mdx
@@ -70,6 +70,68 @@ import { FieldGroup, Label } from '@/components/ui/field'
 </RadioGroup>
 ```
 
+## Anatomy
+
+A `RadioGroup` wraps a `Label` and a `FieldGroup` of `Radio` options. Each `Radio` holds a `RadioControl` (which renders the `RadioIndicator`) and its own `Label`.
+
+```tsx
+import {
+  Radio,
+  RadioControl,
+  RadioGroup,
+  RadioIndicator,
+} from '@/components/ui/radio-group'
+import {
+  Description,
+  FieldError,
+  FieldGroup,
+  Label,
+} from '@/components/ui/field'
+;<RadioGroup>
+  <Label />
+  <FieldGroup>
+    <Radio>
+      <RadioControl>
+        <RadioIndicator />
+      </RadioControl>
+      <Label />
+    </Radio>
+  </FieldGroup>
+  <Description />
+  <FieldError />
+</RadioGroup>
+```
+
+Pass a string as the `Radio` child to render its `RadioControl` and `Label` for you.
+
+```tsx
+<Radio value="nextjs">Next.js</Radio>
+```
+
+## Value
+
+The value is the selected `Radio`'s string `value`. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it.
+
+```tsx
+const [framework, setFramework] = React.useState('nextjs')
+
+<RadioGroup value={framework} onChange={setFramework}>
+  {/* ... */}
+</RadioGroup>
+```
+
+## Validation
+
+Mark the group `isRequired`, and render a `FieldError` to surface the message when `isInvalid`.
+
+```tsx
+<RadioGroup isRequired isInvalid>
+  <Label>React frameworks</Label>
+  <FieldGroup>{/* ... */}</FieldGroup>
+  <FieldError>Please select a framework.</FieldError>
+</RadioGroup>
+```
+
 ## Examples
 
 <Examples className="md:grid-cols-2">

--- a/www/content/docs/components/search-field.mdx
+++ b/www/content/docs/components/search-field.mdx
@@ -56,6 +56,46 @@ import { Label } from '@/components/ui/field'
 </SearchField>
 ```
 
+## Anatomy
+
+A `SearchField` wraps an optional `Label`, an `Input`, and optional `Description` and `FieldError`. Rendered on its own it supplies a default `InputGroup` with a search icon and a clear button, so `<SearchField><Input /></SearchField>` is enough.
+
+```tsx
+import { SearchField } from '@/components/ui/search-field'
+import { Label, Description, FieldError } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+;<SearchField>
+  <Label />
+  <Input />
+  <Description />
+  <FieldError />
+</SearchField>
+```
+
+## Value
+
+The value is a string. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it.
+
+```tsx
+const [value, setValue] = React.useState('')
+
+<SearchField value={value} onChange={setValue}>
+  <Label>Search</Label>
+  <Input />
+</SearchField>
+```
+
+## Submit & clear
+
+`onSubmit` fires with the current value when the user presses <kbd>Enter</kbd>; `onClear` fires when they press <kbd>Escape</kbd> or the clear button, which appears once the field is non-empty.
+
+```tsx
+<SearchField onSubmit={(value) => search(value)} onClear={() => reset()}>
+  <Label>Search</Label>
+  <Input />
+</SearchField>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/segmented-control.mdx
+++ b/www/content/docs/components/segmented-control.mdx
@@ -34,6 +34,38 @@ import {
 </SegmentedControl>
 ```
 
+## Anatomy
+
+A `SegmentedControl` wraps one `SegmentedControlItem` per option. Each item needs a unique `id`, which is the value the control reports as selected.
+
+```tsx
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@/components/ui/segmented-control'
+;<SegmentedControl>
+  <SegmentedControlItem id="…">…</SegmentedControlItem>
+</SegmentedControl>
+```
+
+## Selection
+
+Selection is single-only and can never be empty (`disallowEmptySelection`). Use `defaultSelectedKeys` for uncontrolled state, or `selectedKeys` with `onSelectionChange` to control it — both are a `Set` of item ids.
+
+```tsx
+const [selected, setSelected] = React.useState(new Set(['week']))
+
+<SegmentedControl
+  aria-label="Date range"
+  selectedKeys={selected}
+  onSelectionChange={setSelected}
+>
+  <SegmentedControlItem id="day">Day</SegmentedControlItem>
+  <SegmentedControlItem id="week">Week</SegmentedControlItem>
+  <SegmentedControlItem id="month">Month</SegmentedControlItem>
+</SegmentedControl>
+```
+
 ## Examples
 
 <Examples className="grid-cols-1">

--- a/www/content/docs/components/select.mdx
+++ b/www/content/docs/components/select.mdx
@@ -62,26 +62,96 @@ import {
 </Select>
 ```
 
-## Composition
-
-Select is built on top of primitive components that you can use directly for full customization:
-
-- `SelectTrigger` → wraps `Button`
-- `SelectContent` → wraps `Popover` + `ListBox`
-- `SelectItem` → re-exports `ListBoxItem`
-
-When you need more control, you can compose the primitives directly:
+## Anatomy
 
 ```tsx
-import { Select, SelectValue } from '@/components/ui/select'
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectSection,
+  SelectSectionHeader,
+} from '@/components/ui/select'
+```
+
+```tsx
+<Select>
+  <SelectTrigger />
+  <SelectContent>
+    <SelectSection>
+      <SelectSectionHeader />
+      <SelectItem />
+    </SelectSection>
+  </SelectContent>
+</Select>
+```
+
+`Select` holds the state, `SelectTrigger` opens the popover and shows the current value, `SelectContent` is the option list, and `SelectItem` is an option. `SelectSection` with `SelectSectionHeader` groups items.
+
+## Value
+
+`Select` selects by key: each `SelectItem` has an `id`, and the value is that id. Use `defaultSelectedKey` for uncontrolled state, or `value` with `onChange` to control it.
+
+```tsx
+<Select value={provider} onChange={setProvider}>
+  <SelectTrigger />
+  <SelectContent>
+    <SelectItem id="perplexity">Perplexity</SelectItem>
+    <SelectItem id="replicate">Replicate</SelectItem>
+  </SelectContent>
+</Select>
+```
+
+## Selection
+
+Selection is single by default. Pass the `M` type param as `'multiple'` (`SelectProps<T, 'multiple'>`) and set `selectionMode="multiple"` on `SelectContent` to allow selecting several options.
+
+## Content
+
+Render items statically as children, or dynamically by passing `items` to `SelectContent` with a render function.
+
+```tsx
+<SelectContent items={providers}>
+  {(item) => <SelectItem id={item.id}>{item.name}</SelectItem>}
+</SelectContent>
+```
+
+## Async loading
+
+Feed a `useAsyncList` result into `SelectContent` via `items`, and wire `isLoading` and `onLoadMore` for infinite scrolling. See the [Async Loading](#examples) example.
+
+## Validation
+
+Add a `Label` and a `FieldError` inside `Select`, and set `isRequired` or `isInvalid` to surface validation.
+
+```tsx
+import { FieldError, Label } from '@/components/ui/field'
+;<Select isRequired>
+  <Label>Provider</Label>
+  <SelectTrigger />
+  <SelectContent>
+    <SelectItem>Perplexity</SelectItem>
+  </SelectContent>
+  <FieldError />
+</Select>
+```
+
+## Composition
+
+`SelectTrigger` wraps `Button`, `SelectContent` wraps `Popover` + `ListBox`, and `SelectItem` re-exports `ListBoxItem`. For full control, drop the wrappers and compose the primitives directly.
+
+```tsx
+import { ChevronDownIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Popover } from '@/components/ui/popover'
 import {
   ListBox,
   ListBoxItem,
   ListBoxSection,
   ListBoxSectionHeader,
 } from '@/components/ui/list-box'
+import { Popover } from '@/components/ui/popover'
+import { Select, SelectValue } from '@/components/ui/select'
 ```
 
 ```tsx
@@ -90,7 +160,7 @@ import {
     <SelectValue placeholder="Select provider" />
     <ChevronDownIcon />
   </Button>
-  <Popover placement="bottom-start">
+  <Popover placement="bottom start">
     <ListBox>
       <ListBoxSection>
         <ListBoxSectionHeader>AI Providers</ListBoxSectionHeader>
@@ -101,13 +171,6 @@ import {
   </Popover>
 </Select>
 ```
-
-This approach lets you:
-
-- Use any `Button` variant or custom trigger
-- Control `Popover` placement and behavior
-- Add sections, headers, and custom `ListBoxItem` content
-- Reuse the same primitives across `Select`, `Combobox`, `Menu`, etc.
 
 ## Examples
 

--- a/www/content/docs/components/slider.mdx
+++ b/www/content/docs/components/slider.mdx
@@ -49,6 +49,64 @@ import { Slider, SliderControl } from '@/components/ui/slider'
 </Slider>
 ```
 
+## Anatomy
+
+`SliderControl` renders the track, fill, and thumbs for you, so most sliders only need `Slider` + `SliderControl`. Compose the parts by hand for full control over layout.
+
+```tsx
+import {
+  Slider,
+  SliderControl,
+  SliderTrack,
+  SliderFill,
+  SliderThumb,
+  SliderOutput,
+} from '@/components/ui/slider'
+;<Slider>
+  <SliderOutput />
+  <SliderControl>
+    <SliderTrack>
+      <SliderFill />
+    </SliderTrack>
+    <SliderThumb />
+  </SliderControl>
+</Slider>
+```
+
+## Value
+
+A single number renders a standard slider; a `number[]` renders a multi-thumb range. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it.
+
+```tsx
+<Slider defaultValue={[200, 300]} minValue={100} maxValue={500}>
+  <SliderControl />
+</Slider>
+```
+
+## Range and step
+
+`minValue` and `maxValue` set the bounds (default `0`–`100`), and `step` snaps movement to fixed increments.
+
+```tsx
+<Slider minValue={0} maxValue={100} step={5} defaultValue={50}>
+  <SliderControl />
+</Slider>
+```
+
+## Format
+
+`formatOptions` accepts any `Intl.NumberFormat` options to format the `SliderOutput` label, such as currency or percent.
+
+```tsx
+<Slider
+  formatOptions={{ style: 'currency', currency: 'JPY' }}
+  defaultValue={60}
+>
+  <SliderOutput />
+  <SliderControl />
+</Slider>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/switch.mdx
+++ b/www/content/docs/components/switch.mdx
@@ -43,6 +43,45 @@ import { Switch, SwitchControl } from '@/components/ui/switch'
 </Switch>
 ```
 
+## Anatomy
+
+A `Switch` wraps a `SwitchControl` (which auto-renders its `SwitchIndicator` and `SwitchThumb`) and a `Label`. Pass a string child for the label shorthand, or omit children for a standalone control with an `aria-label`.
+
+```tsx
+import { Label } from '@/components/ui/field'
+import {
+  Switch,
+  SwitchControl,
+  SwitchIndicator,
+  SwitchThumb,
+} from '@/components/ui/switch'
+
+<Switch>
+  <SwitchControl>
+    <SwitchIndicator>
+      <SwitchThumb />
+    </SwitchIndicator>
+  </SwitchControl>
+  <Label>Focus mode</Label>
+</Switch>
+
+<Switch>Focus mode</Switch>
+
+<Switch aria-label="Focus mode" />
+```
+
+## Value
+
+The switch is on or off. Use `defaultSelected` for uncontrolled state, or `isSelected` with `onChange` to control it.
+
+```tsx
+const [isSelected, setSelected] = React.useState(true)
+
+<Switch isSelected={isSelected} onChange={setSelected}>
+  Focus mode
+</Switch>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/table.mdx
+++ b/www/content/docs/components/table.mdx
@@ -104,6 +104,113 @@ Use `TableVirtualizer` for large collections. It uses the table layout exported 
 </TableContainer>
 ```
 
+## Anatomy
+
+A `Table` composes a `TableHeader` of `TableColumn`s with a `TableBody` of `TableRow`s and `TableCell`s, optionally a `TableFooter`, all inside a `TableContainer` scroll region. Mark one column `isRowHeader` so each row is labeled by that cell.
+
+```tsx
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContainer,
+  TableFooter,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+;<TableContainer>
+  <Table>
+    <TableHeader>
+      <TableColumn isRowHeader>Name</TableColumn>
+      <TableColumn>Type</TableColumn>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableCell>Games</TableCell>
+        <TableCell>File folder</TableCell>
+      </TableRow>
+    </TableBody>
+    <TableFooter>
+      <TableRow>
+        <TableCell colSpan={2}>1 item</TableCell>
+      </TableRow>
+    </TableFooter>
+  </Table>
+</TableContainer>
+```
+
+## Content
+
+Pass static `TableRow`s as children, or drive the table from data by giving `TableHeader` and `TableBody` an `items` array with a render function. Give each `TableColumn` an `id` matching a data key, and pass the same `columns` to each `TableRow`.
+
+```tsx
+<Table aria-label="Files">
+  <TableHeader columns={columns}>
+    {(column) => (
+      <TableColumn isRowHeader={column.isRowHeader}>{column.name}</TableColumn>
+    )}
+  </TableHeader>
+  <TableBody items={data}>
+    {(item) => (
+      <TableRow columns={columns}>
+        {(column) => <TableCell>{item[column.id]}</TableCell>}
+      </TableRow>
+    )}
+  </TableBody>
+</Table>
+```
+
+## Selection
+
+Set `selectionMode` to `single` or `multiple` to enable row selection. Control it with `selectedKeys` and `onSelectionChange` (the value is `'all'` or a `Set` of keys), and pass `disallowEmptySelection` to keep at least one row selected.
+
+```tsx
+<Table
+  aria-label="Files"
+  selectionMode="multiple"
+  selectedKeys={selected}
+  onSelectionChange={setSelected}
+  disallowEmptySelection
+>
+  {/* ... */}
+</Table>
+```
+
+## Sorting
+
+Mark sortable columns with `allowsSorting`, then hold a `sortDescriptor` (`{ column, direction }`) and update it via `onSortChange` — you sort the data yourself.
+
+```tsx
+<Table
+  aria-label="Files"
+  sortDescriptor={sortDescriptor}
+  onSortChange={setSortDescriptor}
+>
+  <TableHeader>
+    <TableColumn id="name" isRowHeader allowsSorting>
+      Name
+    </TableColumn>
+  </TableHeader>
+  <TableBody items={sortedItems}>{/* ... */}</TableBody>
+</Table>
+```
+
+## Async loading
+
+Pair `useAsyncList` with `TableBody`'s `onLoadMore` and `isLoading` for infinite loading; `TableLoadMore` renders the loading row.
+
+```tsx
+const list = useAsyncList({ async load({ signal }) { /* ... */ } })
+
+<TableBody
+  onLoadMore={list.loadMore}
+  isLoading={list.loadingState === 'loadingMore'}
+>
+  {/* ... */}
+</TableBody>
+```
+
 ## Examples
 
 <Examples className="md:grid-cols-2">

--- a/www/content/docs/components/tabs.mdx
+++ b/www/content/docs/components/tabs.mdx
@@ -51,6 +51,51 @@ import { Tab, TabList, TabPanel, Tabs } from '@/components/ui/tabs'
 </Tabs>
 ```
 
+## Anatomy
+
+```tsx
+import { Tab, TabList, TabPanel, Tabs } from '@/components/ui/tabs'
+```
+
+```tsx
+<Tabs>
+  <TabList>
+    <Tab id="…" />
+  </TabList>
+  <TabPanel id="…" />
+</Tabs>
+```
+
+`Tabs` provides selection state, `TabList` groups the `Tab` titles, and each `TabPanel` renders the content for the `Tab` whose `id` matches.
+
+## Selection
+
+Each `Tab` and `TabPanel` is keyed by `id`. Use `defaultSelectedKey` for uncontrolled state, or `selectedKey` with `onSelectionChange` to control it.
+
+```tsx
+const [selectedKey, setSelectedKey] = React.useState('overview')
+
+<Tabs selectedKey={selectedKey} onSelectionChange={setSelectedKey}>
+  {/* … */}
+</Tabs>
+```
+
+## Keyboard activation
+
+By default, focusing a tab with the arrow keys selects it. Set `keyboardActivation="manual"` to require <kbd>Enter</kbd> or <kbd>Space</kbd> to switch panels.
+
+```tsx
+<Tabs keyboardActivation="manual">{/* … */}</Tabs>
+```
+
+## Links
+
+Pass `href` to a `Tab` to render an anchor for tab-based navigation. Use it with your client router's link integration for internal routes.
+
+```tsx
+<Tab href="/overview">Overview</Tab>
+```
+
 ## Examples
 
 <Examples className="md:grid-cols-2">

--- a/www/content/docs/components/tag-group.mdx
+++ b/www/content/docs/components/tag-group.mdx
@@ -30,6 +30,66 @@ import { TagGroup, TagList, Tag } from '@/components/ui/tag-group'
 </TagGroup>
 ```
 
+## Anatomy
+
+A `TagGroup` wraps an optional `Label` and a `TagList` of `Tag` items.
+
+```tsx
+import { TagGroup, TagList, Tag } from '@/components/ui/tag-group'
+import { Label } from '@/components/ui/field'
+;<TagGroup>
+  <Label />
+  <TagList>
+    <Tag />
+  </TagList>
+</TagGroup>
+```
+
+## Selection
+
+Set `selectionMode` to `single` or `multiple` to make tags selectable, giving each `Tag` an `id`. Control selection with `selectedKeys` + `onSelectionChange`, or default it with `defaultSelectedKeys`.
+
+```tsx
+<TagGroup selectionMode="multiple" defaultSelectedKeys={['news', 'gaming']}>
+  <TagList>
+    <Tag id="news">News</Tag>
+    <Tag id="gaming">Gaming</Tag>
+    <Tag id="travel">Travel</Tag>
+  </TagList>
+</TagGroup>
+```
+
+## Removal
+
+Pass `onRemove` to `TagGroup` to make tags removable — each `Tag` renders a remove button, and users can also delete a focused tag with <kbd>⌫</kbd>.
+
+```tsx
+<TagGroup onRemove={(keys) => remove(keys)}>
+  <TagList>
+    <Tag id="news">News</Tag>
+    <Tag id="gaming">Gaming</Tag>
+  </TagList>
+</TagGroup>
+```
+
+## Content
+
+Render tags statically as children, or pass `items` to `TagList` with a render function to build them from data.
+
+```tsx
+<TagList items={items}>{(item) => <Tag>{item.name}</Tag>}</TagList>
+```
+
+## Links
+
+Pass `href` to a `Tag` to render it as an `<a>`; add `target` for the link target. Client-side routing depends on your router setup.
+
+```tsx
+<Tag href="https://tailwindcss.com" target="_blank">
+  Tailwind
+</Tag>
+```
+
 ## Examples
 
 <Examples>

--- a/www/content/docs/components/text-area.mdx
+++ b/www/content/docs/components/text-area.mdx
@@ -71,6 +71,10 @@ import { Label } from '@/components/ui/field'
 </TextField>
 ```
 
+## Auto-resize
+
+`TextArea` grows its height to fit its content as the user types. This is automatic — there's no prop to toggle it.
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/text-field.mdx
+++ b/www/content/docs/components/text-field.mdx
@@ -68,6 +68,53 @@ import { Label } from '@/components/ui/field'
 </TextField>
 ```
 
+## Anatomy
+
+A `TextField` wraps a `Label`, an `Input`, and optional `Description` and `FieldError`. Wrap the `Input` in an `InputGroup` with `InputGroupAddon` to render a prefix or suffix inside the field.
+
+```tsx
+import { TextField } from '@/components/ui/text-field'
+import { Label, Description, FieldError } from '@/components/ui/field'
+import { Input, InputGroup, InputGroupAddon } from '@/components/ui/input'
+;<TextField>
+  <Label />
+  <InputGroup>
+    <InputGroupAddon />
+    <Input />
+  </InputGroup>
+  <Description />
+  <FieldError />
+</TextField>
+```
+
+## Value
+
+The value is a string. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it.
+
+```tsx
+const [value, setValue] = React.useState('')
+
+<TextField value={value} onChange={setValue}>
+  <Label>Email</Label>
+  <Input />
+</TextField>
+```
+
+## Validation
+
+Mark a field with `isRequired`, and supply a custom `validate` function that returns an error string. By default validation is native (browser); set `validationBehavior="aria"` to defer to your own logic. Errors render in `FieldError`.
+
+```tsx
+<TextField
+  isRequired
+  validate={(value) => (value.includes('@') ? null : 'Enter a valid email')}
+>
+  <Label>Email</Label>
+  <Input />
+  <FieldError />
+</TextField>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/time-field.mdx
+++ b/www/content/docs/components/time-field.mdx
@@ -56,6 +56,68 @@ import { Label } from '@/components/ui/field'
 </TimeField>
 ```
 
+## Anatomy
+
+`TimeField` wraps a `Label`, the `DateInput` that holds the editable time segments, and an optional `Description` or `FieldError`.
+
+```tsx
+import { TimeField } from '@/components/ui/time-field'
+import { DateInput } from '@/components/ui/input'
+import { Label, Description, FieldError } from '@/components/ui/field'
+;<TimeField>
+  <Label />
+  <DateInput />
+  <Description />
+  <FieldError />
+</TimeField>
+```
+
+## Value
+
+Values are `Time` objects from `@internationalized/date`. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it. Parse a string with `parseTime`.
+
+```tsx
+import { Time } from '@internationalized/date'
+;<TimeField defaultValue={new Time(11, 45)}>
+  <Label>Time</Label>
+  <DateInput />
+</TimeField>
+```
+
+## Granularity
+
+`granularity` sets the smallest editable segment — `hour`, `minute` (the default), or `second`.
+
+```tsx
+<TimeField granularity="second" defaultValue={new Time(11, 45, 22)}>
+  <Label>Time</Label>
+  <DateInput />
+</TimeField>
+```
+
+## Hour cycle
+
+`hourCycle` forces 12- or 24-hour display regardless of the locale.
+
+```tsx
+<TimeField hourCycle={24} defaultValue={new Time(18, 45)}>
+  <Label>Time</Label>
+  <DateInput />
+</TimeField>
+```
+
+## Validation
+
+Set `isRequired` or `isInvalid` and render messages with `FieldError`; `minValue` and `maxValue` constrain the allowed time.
+
+```tsx
+<TimeField isRequired minValue={new Time(9)} maxValue={new Time(17)}>
+  <Label>Meeting time</Label>
+  <DateInput />
+  <FieldError />
+</TimeField>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2 md:grid-cols-2">

--- a/www/content/docs/components/time-picker.mdx
+++ b/www/content/docs/components/time-picker.mdx
@@ -49,6 +49,63 @@ import { TimePicker, TimePickerColumns } from '@/components/ui/time-picker'
 </TimePicker>
 ```
 
+## Anatomy
+
+There is no React Aria `TimePicker`, so it's composed from field and overlay primitives: `TimePicker` wraps a labeled `InputGroup` (the editable `DateInput` plus a `Button` trigger in an `InputGroupAddon`) and a `Popover` whose `DialogContent` renders the scrollable `TimePickerColumns`. `Description` and `FieldError` are optional field slots.
+
+```tsx
+<TimePicker>
+  <Label />
+  <InputGroup>
+    <DateInput />
+    <InputGroupAddon>
+      <Button />
+    </InputGroupAddon>
+  </InputGroup>
+  <Description />
+  <FieldError />
+  <Popover>
+    <DialogContent>
+      <TimePickerColumns />
+    </DialogContent>
+  </Popover>
+</TimePicker>
+```
+
+## Value
+
+The value is an `@internationalized/date` `Time` object. Use `defaultValue` for uncontrolled state, or `value` with `onChange` to control it. Bound the selectable range with `minValue` and `maxValue`.
+
+```tsx
+import { Time } from '@internationalized/date'
+
+const [value, setValue] = React.useState(new Time(9, 30))
+
+<TimePicker value={value} onChange={setValue}>
+  {/* ... */}
+</TimePicker>
+```
+
+## Granularity
+
+`granularity` (`"hour"`, `"minute"`, or `"second"`) controls both the editable segments and which scrollable columns render. `hourCycle` switches between 12- and 24-hour display.
+
+```tsx
+<TimePicker granularity="second" hourCycle={24}>
+  {/* ... */}
+</TimePicker>
+```
+
+## Open state
+
+The popover is uncontrolled by default. Open it initially with `defaultOpen`, or control it with `isOpen` and `onOpenChange`.
+
+```tsx
+<TimePicker isOpen={isOpen} onOpenChange={setIsOpen}>
+  {/* ... */}
+</TimePicker>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">

--- a/www/content/docs/components/toast.mdx
+++ b/www/content/docs/components/toast.mdx
@@ -30,6 +30,73 @@ toastManager.add({
 })
 ```
 
+## Imperative API
+
+Toasts aren't rendered as JSX. Mount `<ToastProvider />` once at your app root, then push notifications imperatively with `toastManager`. `add` returns an id you can pass to `close`.
+
+```tsx
+import { ToastProvider, toastManager } from '@/components/ui/toast'
+;<ToastProvider />
+
+const id = toastManager.add({ title: 'Your message has been sent.' })
+toastManager.close(id)
+```
+
+## Variants
+
+Pass `type` to `add` to select a semantic variant, each with its own icon and color. Values are `neutral`, `success`, `error`, `danger`, `warning`, `info`, and `loading`. `neutral` renders no icon.
+
+```tsx
+toastManager.add({
+  title: 'Changes saved',
+  description: 'Your update is live.',
+  type: 'success',
+})
+```
+
+## Actions
+
+Pass `actionProps` to render an action button inside the toast, typically to undo the operation and close the current toast by id.
+
+```tsx
+const id = toastManager.add({
+  title: 'Message archived',
+  type: 'info',
+  actionProps: {
+    children: 'Undo',
+    onClick: () => toastManager.close(id),
+  },
+})
+```
+
+## Promise
+
+Use `toastManager.promise` to drive loading, success, and error states from a promise. Each key takes the same options as `add`.
+
+```tsx
+toastManager.promise(publish(), {
+  loading: { title: 'Publishing changes', type: 'loading' },
+  success: { title: 'Published', type: 'success' },
+  error: { title: 'Publish failed', type: 'error' },
+})
+```
+
+## Placement
+
+The `position` prop on `ToastProvider` sets the viewport corner and derives the swipe-to-dismiss direction. Values are `top-left`, `top-center`, `top-right`, `bottom-left`, `bottom-center`, and `bottom-right`; it defaults to `bottom-right`.
+
+```tsx
+<ToastProvider position="top-center" />
+```
+
+## Provider options
+
+`ToastProvider` caps visible toasts with `limit` (default `3`) and sets the auto-dismiss duration in milliseconds with `timeout` (default `5000`).
+
+```tsx
+<ToastProvider limit={5} timeout={8000} />
+```
+
 ## Examples
 
 <Examples>

--- a/www/content/docs/components/toggle-button-group.mdx
+++ b/www/content/docs/components/toggle-button-group.mdx
@@ -32,6 +32,25 @@ import { ToggleButtonGroup } from '@/components/ui/toggle-button-group'
 </ToggleButtonGroup>
 ```
 
+## Selection
+
+Each `ToggleButton` needs an `id`; selection keys map to those ids. Selection is `single` by default — set `selectionMode="multiple"` to allow several. Use `defaultSelectedKeys` for uncontrolled state, or `selectedKeys` with `onSelectionChange` to control it, and pass `disallowEmptySelection` to keep at least one selected.
+
+```tsx
+const [selected, setSelected] = React.useState(new Set(['bold']))
+
+<ToggleButtonGroup
+  selectionMode="multiple"
+  selectedKeys={selected}
+  onSelectionChange={setSelected}
+  aria-label="Text formatting"
+>
+  <ToggleButton id="bold">Bold</ToggleButton>
+  <ToggleButton id="italic">Italic</ToggleButton>
+  <ToggleButton id="underline">Underline</ToggleButton>
+</ToggleButtonGroup>
+```
+
 ## Examples
 
 <Examples className="grid-cols-2">

--- a/www/content/docs/components/toggle-button.mdx
+++ b/www/content/docs/components/toggle-button.mdx
@@ -40,6 +40,18 @@ import { ToggleButton } from '@/components/ui/toggle-button'
 </ToggleButton>
 ```
 
+## Selection
+
+Use `defaultSelected` for uncontrolled state, or `isSelected` with `onChange` to control it. The value is a boolean.
+
+```tsx
+<ToggleButton defaultSelected>Pin</ToggleButton>
+
+<ToggleButton isSelected={isSelected} onChange={setSelected}>
+  Pin
+</ToggleButton>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2 md:grid-cols-3">

--- a/www/content/docs/components/tooltip.mdx
+++ b/www/content/docs/components/tooltip.mdx
@@ -51,6 +51,40 @@ import { Tooltip, TooltipContent } from '@/components/ui/tooltip'
 </Tooltip>
 ```
 
+## Anatomy
+
+`Tooltip` wraps a focusable trigger (any element that takes focus, like a `Button` or `Link`) and a `TooltipContent`. The trigger opens the tooltip on hover or focus.
+
+```tsx
+import { Tooltip, TooltipContent } from '@/components/ui/tooltip'
+;<Tooltip>
+  <Button />
+  <TooltipContent />
+</Tooltip>
+```
+
+## Delay
+
+`Tooltip` opens after a `delay` (default `700`ms) on hover and closes after `closeDelay` (default `0`) when the pointer leaves.
+
+```tsx
+<Tooltip delay={0} closeDelay={200}>
+  <Button>Hover me</Button>
+  <TooltipContent>Opens instantly</TooltipContent>
+</Tooltip>
+```
+
+## Open state
+
+Use `defaultOpen` for uncontrolled open state, or `isOpen` with `onOpenChange` to control it.
+
+```tsx
+<Tooltip isOpen={isOpen} onOpenChange={setIsOpen}>
+  <Button>Hover me</Button>
+  <TooltipContent>Controlled</TooltipContent>
+</Tooltip>
+```
+
 ## Examples
 
 <Examples className="grid-cols-2 md:grid-cols-3">

--- a/www/content/docs/components/tree.mdx
+++ b/www/content/docs/components/tree.mdx
@@ -78,6 +78,58 @@ import { Collection } from 'react-aria-components'
 </Tree>
 ```
 
+## Anatomy
+
+A `Tree` wraps `TreeItem`s. Each `TreeItem` holds a `TreeItemContent` for its row — the expand chevron, optional checkbox and drag handle, and the label — and nests child `TreeItem`s directly beneath it.
+
+```tsx
+<Tree>
+  <TreeItem>
+    <TreeItemContent />
+    <TreeItem>
+      <TreeItemContent />
+    </TreeItem>
+  </TreeItem>
+</Tree>
+```
+
+## Selection
+
+Set `selectionMode` to `single` or `multiple` to make rows selectable. Control the selection with `selectedKeys` and `onSelectionChange`, typed as `Selection` from `react-aria-components`. Use `disabledKeys` to make specific rows non-interactive.
+
+```tsx
+import { useState } from 'react'
+import type { Selection } from 'react-aria-components'
+
+const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set(['report']))
+
+<Tree
+  selectionMode="multiple"
+  selectedKeys={selectedKeys}
+  onSelectionChange={setSelectedKeys}
+>
+  {items}
+</Tree>
+```
+
+## Expansion
+
+Set `defaultExpandedKeys` to expand parents by default (uncontrolled), or control which parents are open with `expandedKeys` and `onExpandedChange`.
+
+```tsx
+<Tree defaultExpandedKeys={['documents']}>{items}</Tree>
+```
+
+## Links
+
+Pass `href` to a `TreeItem` to render it as an `<a>`; add `target` for the link target. Client-side routing depends on your router setup.
+
+```tsx
+<TreeItem href="/documents/report" textValue="Weekly report">
+  <TreeItemContent>Weekly report</TreeItemContent>
+</TreeItem>
+```
+
 ## Examples
 
 <Examples className="sm:grid-cols-2">


### PR DESCRIPTION
## Summary

- Component docs jumped from a one-line **Usage** straight to **Examples** with no dedicated sections explaining core concepts. This adds lean, source-grounded concept sections to **61 of 67** component docs (+2.4k lines), so each page teaches the mental model for humans *and* AI agents — not just shows examples.
- Sections follow the existing house style (models: `calendar`, `sidebar`, `checkbox`, `chart`) and the "signal, no noise" bar. Most common: **Anatomy** (47), **Value** controlled/uncontrolled (22), **Selection** (11), **Open state** (10), **Validation** (9), plus **Content**, **Links**, **Async loading**, **Placement**, and date/color-specific ones (granularity, channels, `parseColor`).
- Each section is 1–3 sentences + one focused snippet. Thin primitives (`badge`, `separator`, `skeleton`, `input`) and already-complete docs (`chart`, `sidebar`) were intentionally left alone — no padding.

## A few pre-existing inaccuracies fixed along the way

- `select` — hyphenated `placement="bottom-start"` → space-separated `"bottom start"` (the real React Aria placement format, confirmed against demos).
- `color-field` — `parseColor` import aligned to `react-aria-components` root, matching all sibling color docs.
- `input-group` — dropped a documented `orientation` prop that **doesn't exist** (vertical layout is automatic with a `TextArea`).

## Reviewer notes

- Docs-only change: every non-obvious API claim was verified against `www/src/registry/ui/<component>/` source (`types.ts`, `base.tsx`, `demos/`) — no invented props/parts/examples.
- Verified all **67 component docs + 3 root docs render 200** through the fumadocs pipeline, no console errors, `oxfmt --check` clean.
- No registry source touched, so no `build:registry` regeneration is included.