### PR TITLE
feat(docs): animated cursor on gallery click demos

### DIFF
--- a/www/src/modules/docs/components-list/autoplay/cursor.tsx
+++ b/www/src/modules/docs/components-list/autoplay/cursor.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@/registry/lib/utils'
 
+import { Pointer } from './pointer'
 import type { ScenePhase } from './use-autoplay'
 
 /**
@@ -53,26 +54,7 @@ export function FakeCursor({
           style={{ left: 4, top: 3 }}
         />
       )}
-      {/* The arrow itself dips on press for the tactile click. */}
-      <svg
-        viewBox="0 0 24 24"
-        width={20}
-        height={20}
-        className="relative drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)]"
-        style={{
-          transform: pressed ? 'scale(0.82)' : 'scale(1)',
-          transformOrigin: '5px 4px',
-          transition: 'transform 130ms cubic-bezier(0.32, 0.72, 0, 1)',
-        }}
-      >
-        <path
-          d="M5 3.5 L5 19 L9 15 L11.5 20.5 L14 19.3 L11.6 14 L17 14 Z"
-          fill="white"
-          stroke="black"
-          strokeWidth={1.4}
-          strokeLinejoin="round"
-        />
-      </svg>
+      <Pointer pressed={pressed} />
     </div>
   )
 }

--- a/www/src/modules/docs/components-list/autoplay/demo-cursor.tsx
+++ b/www/src/modules/docs/components-list/autoplay/demo-cursor.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useReducedMotion } from 'motion/react'
+
+import { Pointer } from './pointer'
+
+/**
+ * A decorative macOS pointer that follows whatever control the card's autoplay is
+ * currently "clicking" and dips on each click. Where the overlay cursor runs a
+ * fixed choreography, this one reads the DOM: the demos already mirror real RAC
+ * state onto the real elements (see interaction.tsx), so we just find the pressed
+ * / selected / current element and glide the tip onto it.
+ *
+ * Mounted in the (unscaled) preview and measured against it, so the card's inner
+ * `scale()` is absorbed by getBoundingClientRect. Purely cosmetic — aria-hidden,
+ * pointer-events-none, and it never touches the real cursor.
+ */
+
+// The arrow tip's offset into the SVG at the default size — subtract it so the
+// tip, not the SVG's corner, lands on the target point.
+const TIP_X = 4
+const TIP_Y = 3
+// How long a click reads as "pressed" — long enough to cover the ripple and give
+// every click (even the briefest toggle beat) a deliberate dip.
+const PRESS_MS = 240
+
+interface Point {
+  x: number
+  y: number
+}
+
+function firstMatch(root: HTMLElement, selector: string): HTMLElement | null {
+  return root.querySelector<HTMLElement>(selector)
+}
+
+export function DemoCursor({
+  containerRef,
+  active,
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>
+  active: boolean
+}) {
+  const reduce = useReducedMotion() ?? false
+  const [point, setPoint] = useState<Point | null>(null)
+  const [pressed, setPressed] = useState(false)
+  const [shown, setShown] = useState(false)
+  // Bumping this remounts the ripple so it replays on every click.
+  const [clicks, setClicks] = useState(0)
+
+  useEffect(() => {
+    if (!active || reduce) {
+      setShown(false)
+      return
+    }
+
+    // The element pressed on the previous frame (to detect a fresh press) and the
+    // one the pointer currently rests on (to detect a selection jumping).
+    let lastPressEl: Element | null = null
+    let restTarget: Element | null = null
+    let pressUntil = 0
+    let placed = false
+    let raf = 0
+
+    const tick = (now: number) => {
+      const container = containerRef.current
+      if (!container) {
+        raf = requestAnimationFrame(tick)
+        return
+      }
+
+      const pressedEl = firstMatch(container, '[data-pressed]')
+      const selectedEl =
+        firstMatch(container, '[data-selected]:not([data-disabled])') ??
+        firstMatch(container, '[aria-current="page"]')
+      const hoveredEl = firstMatch(container, '[data-hovered]')
+
+      // Where the pointer wants to be. A live press wins; otherwise a moving
+      // selection; otherwise a plain hover. A selection that merely *contains* the
+      // last press target is a fixed control (a checkbox toggling its own box) —
+      // hold position there instead of jumping out to the row.
+      let target: HTMLElement | null = null
+      if (pressedEl) {
+        target = pressedEl
+      } else if (
+        selectedEl &&
+        !(lastPressEl && selectedEl.contains(lastPressEl))
+      ) {
+        target = selectedEl
+      } else if (hoveredEl && !selectedEl) {
+        target = hoveredEl
+      }
+
+      const pressRising = pressedEl != null && lastPressEl == null
+      const targetJumped =
+        target != null && restTarget != null && target !== restTarget
+      if (pressRising || targetJumped) {
+        pressUntil = now + PRESS_MS
+        setClicks((c) => c + 1)
+      }
+      lastPressEl = pressedEl
+      if (target) restTarget = target
+
+      if (target) {
+        const c = container.getBoundingClientRect()
+        const t = target.getBoundingClientRect()
+        const x = t.left - c.left + t.width / 2
+        const y = t.top - c.top + t.height / 2
+        setPoint((prev) =>
+          prev && Math.abs(prev.x - x) < 0.5 && Math.abs(prev.y - y) < 0.5
+            ? prev
+            : { x, y },
+        )
+        // Fade in a frame after the first placement so the pointer eases in at the
+        // target rather than appearing mid-air.
+        if (placed) setShown(true)
+        placed = true
+      }
+
+      const isPressed = now < pressUntil
+      setPressed((prev) => (prev === isPressed ? prev : isPressed))
+
+      raf = requestAnimationFrame(tick)
+    }
+
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [active, reduce, containerRef])
+
+  if (!point) return null
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute top-0 left-0 z-30"
+      style={{
+        transform: `translate(${point.x}px, ${point.y}px)`,
+        opacity: shown ? 1 : 0,
+        transition:
+          'transform 340ms cubic-bezier(0.16, 1, 0.3, 1), opacity 200ms ease-out',
+      }}
+    >
+      {/* Anchor the arrow tip on the target point. */}
+      <div className="absolute" style={{ left: -TIP_X, top: -TIP_Y }}>
+        {clicks > 0 && (
+          <span
+            key={clicks}
+            className="absolute size-6 [animation:cursor-click_320ms_ease-out_forwards] rounded-full bg-white/35 ring-1 ring-black/30"
+            style={{ left: TIP_X, top: TIP_Y }}
+          />
+        )}
+        <Pointer pressed={pressed} />
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/docs/components-list/autoplay/index.ts
+++ b/www/src/modules/docs/components-list/autoplay/index.ts
@@ -18,6 +18,8 @@ export type {
   ScenePhase,
 } from './use-autoplay'
 export { FakeCursor } from './cursor'
+export { DemoCursor } from './demo-cursor'
+export { Pointer } from './pointer'
 export {
   DemoState,
   DemoPress,

--- a/www/src/modules/docs/components-list/autoplay/pointer.tsx
+++ b/www/src/modules/docs/components-list/autoplay/pointer.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/registry/lib/utils'
+
+/**
+ * The macOS-style arrow shared by the component-gallery autoplay cursors. It dips
+ * (scales down toward its tip) while `pressed`, so a click reads tactilely. The
+ * hotspot — the arrow tip — sits at roughly (4px, 3px) from the top-left at the
+ * default size; offset the pointer by that to land the tip on a target.
+ */
+export function Pointer({
+  pressed = false,
+  size = 20,
+  className,
+}: {
+  pressed?: boolean
+  size?: number
+  className?: string
+}) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      className={cn(
+        'relative drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)]',
+        className,
+      )}
+      style={{
+        transform: pressed ? 'scale(0.82)' : 'scale(1)',
+        transformOrigin: '5px 4px',
+        transition: 'transform 130ms cubic-bezier(0.32, 0.72, 0, 1)',
+      }}
+    >
+      <path
+        d="M5 3.5 L5 19 L9 15 L11.5 20.5 L14 19.3 L11.6 14 L17 14 Z"
+        fill="white"
+        stroke="black"
+        strokeWidth={1.4}
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/www/src/modules/docs/components-list/component-card.tsx
+++ b/www/src/modules/docs/components-list/component-card.tsx
@@ -1,22 +1,25 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 
 import { cn } from '@/registry/lib/utils'
 
-import { CardHoverProvider } from './autoplay'
+import { CardHoverProvider, DemoCursor } from './autoplay'
 import { componentDemos } from './demos'
 
 function ComponentPreview({
   children,
   className,
+  ref,
 }: {
   children: React.ReactNode
   className?: string
+  ref?: React.Ref<HTMLDivElement>
 }) {
   return (
     <div
+      ref={ref}
       className={cn(
         'relative flex h-40 w-full items-center justify-center overflow-hidden rounded-lg border bg-bg p-4',
         className,
@@ -39,6 +42,9 @@ interface ComponentCardProps {
   /** Field-like demos render full-width (not scaled), so the field is responsive
    *  to the card and consistent across the set; the demo caps itself via max-width. */
   stretch?: boolean
+  /** Show a macOS pointer that follows the demo's simulated clicks (see DemoCursor).
+   *  Opt-in per component — only the demos that press/select a control. */
+  cursor?: boolean
 }
 
 export function ComponentCard({
@@ -49,12 +55,14 @@ export function ComponentCard({
   previewClassName,
   fill = false,
   stretch = false,
+  cursor = false,
 }: ComponentCardProps) {
   const Demo = componentDemos[slug]
   // Hover/keyboard-focus on the card drives the demo's autoplay animation. The
   // demo itself is `inert`, so the card is the only thing that can be pointed at
   // or focused — it broadcasts that state down through CardHoverProvider.
   const [active, setActive] = useState(false)
+  const previewRef = useRef<HTMLDivElement>(null)
 
   const content = Demo ? (
     <Demo />
@@ -75,6 +83,7 @@ export function ComponentCard({
       onBlur={() => setActive(false)}
     >
       <ComponentPreview
+        ref={previewRef}
         className={cn(
           'w-full transition-colors group-hover:border-border-hover',
           previewClassName,
@@ -104,6 +113,9 @@ export function ComponentCard({
             </div>
           )}
         </CardHoverProvider>
+        {cursor && !fill && (
+          <DemoCursor containerRef={previewRef} active={active} />
+        )}
       </ComponentPreview>
       <span className="text-sm font-medium text-fg group-hover:underline">
         {name}

--- a/www/src/modules/docs/components-list/components-data.ts
+++ b/www/src/modules/docs/components-list/components-data.ts
@@ -11,6 +11,9 @@ export interface ComponentInfo {
   /** Render the demo full-width (responsive, not scaled) — for field-like demos
    *  that should share one consistent, responsive width. */
   stretch?: boolean
+  /** Show a macOS pointer that follows the demo's simulated clicks. Set on demos
+   *  that press or select a control (buttons, toggles, tabs, lists…). */
+  cursor?: boolean
   status: ComponentStatus
 }
 
@@ -30,6 +33,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'button',
         href: '/docs/components/button',
         scale: 1,
+        cursor: true,
         status: 'done',
       },
       {
@@ -37,6 +41,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'toggle-button',
         href: '/docs/components/toggle-button',
         scale: 1,
+        cursor: true,
         status: 'in review',
       },
       {
@@ -44,6 +49,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'toggle-button-group',
         href: '/docs/components/toggle-button-group',
         scale: 1,
+        cursor: true,
         status: 'in review',
       },
       {
@@ -51,6 +57,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'file-trigger',
         href: '/docs/components/file-trigger',
         scale: 1,
+        cursor: true,
         status: 'done',
       },
       {
@@ -58,6 +65,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'group',
         href: '/docs/components/group',
         scale: 1,
+        cursor: true,
         status: 'done',
       },
     ],
@@ -120,6 +128,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'checkbox',
         href: '/docs/components/checkbox',
         scale: 0.95,
+        cursor: true,
         status: 'done',
       },
       {
@@ -127,6 +136,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'checkbox-group',
         href: '/docs/components/checkbox-group',
         scale: 0.9,
+        cursor: true,
         status: 'done',
       },
       {
@@ -134,6 +144,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'radio-group',
         href: '/docs/components/radio-group',
         scale: 0.9,
+        cursor: true,
         status: 'in review',
       },
       {
@@ -141,6 +152,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'switch',
         href: '/docs/components/switch',
         scale: 0.9,
+        cursor: true,
         status: 'in review',
       },
       {
@@ -281,6 +293,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'list-box',
         href: '/docs/components/list-box',
         scale: 0.8,
+        cursor: true,
         status: 'done',
       },
       {
@@ -295,6 +308,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'tag-group',
         href: '/docs/components/tag-group',
         scale: 0.9,
+        cursor: true,
         status: 'done',
       },
     ],
@@ -315,6 +329,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'tabs',
         href: '/docs/components/tabs',
         scale: 0.8,
+        cursor: true,
         status: 'pending',
       },
       {
@@ -336,6 +351,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'pagination',
         href: '/docs/components/pagination',
         scale: 0.8,
+        cursor: true,
         status: 'in review',
       },
       {
@@ -447,6 +463,7 @@ export const componentsData: ComponentCategory[] = [
         slug: 'color-swatch-picker',
         href: '/docs/components/color-swatch-picker',
         scale: 0.8,
+        cursor: true,
         status: 'pending',
       },
     ],

--- a/www/src/modules/docs/components-list/components-grid.tsx
+++ b/www/src/modules/docs/components-list/components-grid.tsx
@@ -47,6 +47,7 @@ export function ComponentsGrid({ category }: { category: string }) {
             scale={component.scale}
             fill={component.fill}
             stretch={component.stretch}
+            cursor={component.cursor}
             previewClassName={CATEGORY_PREVIEW_HEIGHT[category]}
           />
         ))}


### PR DESCRIPTION
## Summary

- On the components gallery (`/docs/components`), the "click" demos now show a **macOS pointer** that follows the control being interacted with and **scales down on each click** (with a click ripple). The gallery already had this cursor, but only for the overlay demos (popover/menu/modal…) — now it covers the inline click demos too.
- **`pointer.tsx`** — extracted the macOS arrow SVG into a shared `Pointer` that dips (`scale(0.82)`) when pressed. Both the overlay `FakeCursor` and the new follower use it, so they look identical.
- **`demo-cursor.tsx`** — a follower that reads the DOM. The demos already mirror real React-Aria state (`data-pressed` / `data-selected` / `aria-current`) onto the real elements, so it finds the pressed/selected control, glides the arrow tip onto it, and dips + emits a ripple on each click. It's measured against the unscaled preview, so the card's inner `scale()` is absorbed by `getBoundingClientRect`. Held on fixed controls between clicks, glides between moving selections.
- Wired in via an opt-in `cursor` flag in `components-data.ts`, threaded through the grid and card. Flagged 14 demos: button, toggle-button(+group), file-trigger, group, checkbox(+group), radio-group, switch, list-box, tag-group, tabs, pagination, color-swatch-picker. Non-click demos (fields type, sliders drag, breadcrumbs/tree static) are intentionally left out.

## Notes for reviewers

- The follower is `aria-hidden` + `pointer-events-none`, gated on card hover/focus and `prefers-reduced-motion`, and never touches the real cursor — same guarantees as the existing overlay cursor.
- It's a `requestAnimationFrame` loop that only runs while a card is active (one at a time in practice), and only re-renders when the target moves or the press state changes.
- Verified: `typecheck`, lint + format all pass; page loads with no console errors; cursor lands exactly on the target (button center matched to the pixel), follows `data-selected`, and dips + ripples on click; overlay cursor still works after the refactor.
- Verification caveat: the local preview tab runs hidden, which pauses `requestAnimationFrame` — I confirmed the full render/position/dip/ripple logic by temporarily driving the loop with `setInterval`, then reverted to rAF. It animates normally in a visible browser.