### PR TITLE
fix(docs): correct OTPField preview borders and focus timing

### DIFF
--- a/www/src/modules/docs/components-list/demos/otp-field.tsx
+++ b/www/src/modules/docs/components-list/demos/otp-field.tsx
@@ -1,38 +1,54 @@
 'use client'
 
+import { useEffect, useLayoutEffect, useRef } from 'react'
+
 import { Label } from '@/registry/ui/field'
 import { Group } from '@/registry/ui/group'
 import { Input } from '@/registry/ui/input'
 import { OTPField, OTPFieldSeparator } from '@/registry/ui/otp-field'
 
-import { DemoFocus, useTypewriter } from '../autoplay'
+import { useTypewriter } from '../autoplay'
+
+// Layout effect on the client, no-op on the server (avoids the SSR warning).
+const useIsoLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect
 
 export function OTPFieldDemo() {
+  const ref = useRef<HTMLDivElement>(null)
   const { value, active } = useTypewriter('284917', {
+    startDelay: 200,
     charInterval: 220,
     holdAfter: 1600,
   })
-  // Focus follows the digit being entered (the next empty slot), like a real OTP.
-  const current = Math.min(value.length, 5)
-  const digit = (i: number, label?: string) => (
-    <DemoFocus active={active && i === current}>
-      <Input aria-label={label} />
-    </DemoFocus>
-  )
+  // Focus follows the next empty slot, like a real OTP entry.
+  const current = active ? Math.min(value.length, 5) : -1
+
+  // Focus the active input directly, not via a DemoFocus wrapper: the wrapper
+  // element would break the Group's direct-child border-collapse/radius selectors.
+  useIsoLayoutEffect(() => {
+    const inputs = ref.current?.querySelectorAll(
+      '[data-slot="otp-field-input"]',
+    )
+    inputs?.forEach((el, i) => {
+      if (i === current) el.setAttribute('data-focused', '')
+      else el.removeAttribute('data-focused')
+    })
+  })
+
   return (
     <OTPField length={6} value={value} onChange={() => {}}>
       <Label>Code</Label>
-      <div className="flex items-center">
+      <div ref={ref} className="flex items-center">
         <Group>
-          {digit(0)}
-          {digit(1, 'Digit 2')}
-          {digit(2, 'Digit 3')}
+          <Input />
+          <Input aria-label="Digit 2" />
+          <Input aria-label="Digit 3" />
         </Group>
         <OTPFieldSeparator className="px-2 text-fg-muted">-</OTPFieldSeparator>
         <Group>
-          {digit(3, 'Digit 4')}
-          {digit(4, 'Digit 5')}
-          {digit(5, 'Digit 6')}
+          <Input aria-label="Digit 4" />
+          <Input aria-label="Digit 5" />
+          <Input aria-label="Digit 6" />
         </Group>
       </div>
     </OTPField>


### PR DESCRIPTION
## Summary

Fixes the OTPField preview card on the components gallery (`/docs/components`).

- **Border radius / pixel-perfect match.** Each `<Input>` was wrapped in a `DemoFocus`, whose `display:contents` span became the `<Group>`'s direct child — silently breaking the Group's `& > *` selectors (`-space-x-px` border-collapse and `*:not-first:rounded-l-none` segmented radius). Every digit rendered fully rounded with doubled borders instead of one unified segmented group. The inputs are now the Group's direct children (matching the real `basic.tsx` demo), so the preview reproduces the real component exactly.
- **Focus timing.** Dropped the typewriter `startDelay` from 450ms → 200ms so the first digit follows the focus ring promptly instead of lagging ~half a second behind it.
- Focus is now mirrored onto the active slot's input via a post-commit layout effect (a prop won't work — React Aria / base-ui rewrite `data-focused` on every render), which is what lets the inputs stay direct Group children.

## Verification

Verified via DOM tools (screenshots black-frame on www):

- Radii now match the real component byte-for-byte — slot 0 `TL6/TR0/BR0/BL6`, middle square, slot 2 `TL0/TR6/BR6/BL0`, `margin-right:-1px` collapse, for both groups. Direct children are `<input>` again.
- Focused-state computed style is identical to focusing the real component: `2px oklch(…251)` blue ring + `z-3`.
- Animation tracks the next-empty slot 0→5 with the ring visible at every step, then loops.
- `pnpm check` and `pnpm typecheck` pass; only one file changed, no registry/generated drift.
