### PR TITLE
fix(docs): clip component previews to a coherent padding

### DIFF
--- a/www/src/modules/docs/components-list/component-card.tsx
+++ b/www/src/modules/docs/components-list/component-card.tsx
@@ -18,11 +18,15 @@ function ComponentPreview({
   return (
     <div
       className={cn(
-        'relative flex h-40 w-full items-center justify-center overflow-hidden rounded-lg border bg-bg p-4',
+        'relative h-40 w-full overflow-hidden rounded-lg border bg-bg',
         className,
       )}
     >
-      {children}
+      {/* Clip on this inset, not the padded box (which clips at the border), so no
+          demo — any scale, overlay, preset or density — paints past the gap. */}
+      <div className="absolute inset-4 flex items-center justify-center overflow-hidden">
+        {children}
+      </div>
     </div>
   )
 }
@@ -33,8 +37,8 @@ interface ComponentCardProps {
   href: string
   scale?: number
   previewClassName?: string
-  /** Full-bleed demos (overlay scenes) fill the preview instead of being centered
-   *  and scaled — they manage their own framing and the "zoom out" choreography. */
+  /** Overlay-scene demos fill the stage instead of being centered and scaled —
+   *  they manage their own framing and the "zoom out" choreography. */
   fill?: boolean
   /** Field-like demos render full-width (not scaled), so the field is responsive
    *  to the card and consistent across the set; the demo caps itself via max-width. */


### PR DESCRIPTION
## What

Every preview card in the components gallery (`/docs/components`) now enforces a **coherent 16px padding that no component can paint past** — regardless of the demo, its scale, whether it's an overlay scene, or the current preview preset/density.

## Why

`ComponentPreview` put `p-4` and `overflow-hidden` on the *same* box, so `overflow-hidden` clipped at the **padding box (the border), not the padding's inner edge**. Combined with:

- `transform: scale()` — layout ignores the scale, so a scaled-up (or intrinsically large) demo could visually bleed into the padding,
- `fill` overlay scenes using `absolute inset-0` — full-bleed to the border, ignoring `p-4` entirely,

…components and overlays could paint into the padding and only get clipped at the border. The visible gap around each preview was inconsistent across scale / component / overlay / preset / density.

## How

Move the clip off the padded outer box and onto an inner `absolute inset-4` stage that every demo renders into:

```diff
- <div className="relative flex h-40 w-full items-center justify-center overflow-hidden rounded-lg border bg-bg p-4">
-   {children}
+ <div className="relative h-40 w-full overflow-hidden rounded-lg border bg-bg">
+   <div className="absolute inset-4 flex items-center justify-center overflow-hidden">
+     {children}
+   </div>
```

The stage has zero padding, so its content box equals its inset rect — `overflow-hidden` there clips at the padding's inner edge. The three render modes (scale / stretch / fill) are unchanged; `fill` overlays' `absolute inset-0` now resolves to the padded stage, so backdrops and trigger columns respect the padding too.

## Verification

- Confirmed via DOM across **all 57 cards**: each stage is `overflow: hidden` with a uniform 16px inset on all four sides.
- `fill` overlays went from `~1px` gap-to-border (full-bleed) to respecting the inset.
- Visually checked the Buttons, Inputs, Pickers, Overlays and Data-display sections render cleanly with consistent padding.
- `pnpm check` (0 errors) and `pnpm typecheck` pass; no console errors.

## Follow-up (open)

Enforcing the padding is a hard clip. At the default preset **46/48** scaled+stretch demos already fit within it; a couple that were scaled to fill up to the *old* edge (`card`, and the `accordion` at narrow widths) now clip a few px at the padding rather than shrinking. Constant per-component `scale` values can't adapt to runtime size changes (density / typography / card width), so the robust fix is to auto-scale each preview to fit the stage — discussing whether to do that vs. retuning the few offenders. Not included here so this padding-enforcement change can land on its own.