### PR TITLE
feat(docs): add scroll-progress ring to mobile TOC

### DIFF
--- a/ds/src/components/system/toc-select.tsx
+++ b/ds/src/components/system/toc-select.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { type ComponentProps, useEffect, useState } from 'react'
 import { useMatch } from '@tanstack/react-router'
 import { ChevronDownIcon } from 'lucide-react'
 import { Button } from 'react-aria-components/Button'
@@ -50,7 +50,9 @@ function TocSelect({
   className?: string
 }) {
   const activeId = useActiveSection(items)
-  const active = items.find((item) => item.id === activeId) ?? items[0]
+  const activeIndex = items.findIndex((item) => item.id === activeId)
+  const active = items[activeIndex] ?? items[0]
+  const progress = items.length > 0 ? (activeIndex + 1) / items.length : 0
 
   return (
     <Select
@@ -59,7 +61,8 @@ function TocSelect({
       onSelectionChange={(key) => scrollToSection(String(key))}
       className={cn('flex', className)}
     >
-      <Button className="flex cursor-pointer items-center gap-1 text-sm text-fg-muted transition-colors outline-none hover:text-fg data-pressed:text-fg">
+      <Button className="flex cursor-pointer items-center gap-1.5 text-sm text-fg-muted transition-colors outline-none hover:text-fg data-pressed:text-fg">
+        <ProgressCircle value={progress} className="shrink-0" />
         <span className="max-w-36 truncate">{active?.label ?? ''}</span>
         <ChevronDownIcon className="size-4 shrink-0" />
       </Button>
@@ -74,5 +77,48 @@ function TocSelect({
         ))}
       </SelectContent>
     </Select>
+  )
+}
+
+/**
+ * A ring that fills as you move down the page — one section's worth per step,
+ * smoothed by the dash-offset transition. Borrowed from fumadocs' mobile TOC.
+ */
+function ProgressCircle({
+  value,
+  className,
+  ...props
+}: ComponentProps<'svg'> & { value: number }) {
+  const size = 16
+  const strokeWidth = 2
+  const radius = size / 2 - strokeWidth
+  const circumference = 2 * Math.PI * radius
+  const progress = Math.min(1, Math.max(0, value)) * circumference
+  const circle = {
+    cx: size / 2,
+    cy: size / 2,
+    r: radius,
+    fill: 'none',
+    strokeWidth,
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${size} ${size}`}
+      aria-hidden
+      className={cn('size-4', className)}
+      {...props}
+    >
+      <circle {...circle} className="stroke-current/20" />
+      <circle
+        {...circle}
+        stroke="currentColor"
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference - progress}
+        strokeLinecap="round"
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        className="transition-[stroke-dashoffset] duration-300 ease-out"
+      />
+    </svg>
   )
 }

--- a/www/src/modules/docs/docs-toc-select.tsx
+++ b/www/src/modules/docs/docs-toc-select.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { type ComponentProps, useEffect, useState } from 'react'
 import { useMatch } from '@tanstack/react-router'
 import { ChevronDownIcon } from 'lucide-react'
 import { Button } from 'react-aria-components/Button'
@@ -46,7 +46,9 @@ function TocSelect({
   className?: string
 }) {
   const activeId = useActiveSection(toc)
-  const active = toc.find((item) => item.url === activeId) ?? toc[0]
+  const activeIndex = toc.findIndex((item) => item.url === activeId)
+  const active = toc[activeIndex] ?? toc[0]
+  const progress = toc.length > 0 ? (activeIndex + 1) / toc.length : 0
 
   return (
     <Select
@@ -55,7 +57,8 @@ function TocSelect({
       onSelectionChange={(key) => scrollToSection(String(key))}
       className={cn('flex', className)}
     >
-      <Button className="flex items-center gap-1 text-sm text-fg-muted transition-colors outline-none hover:text-fg data-pressed:text-fg">
+      <Button className="flex items-center gap-1.5 text-sm text-fg-muted transition-colors outline-none hover:text-fg data-pressed:text-fg">
+        <ProgressCircle value={progress} className="shrink-0" />
         <span className="max-w-36 truncate">{active?.title ?? ''}</span>
         <ChevronDownIcon className="size-4 shrink-0" />
       </Button>
@@ -78,6 +81,49 @@ function TocSelect({
         ))}
       </SelectContent>
     </Select>
+  )
+}
+
+/**
+ * A ring that fills as you move down the page — one heading's worth per step,
+ * smoothed by the dash-offset transition. Borrowed from fumadocs' mobile TOC.
+ */
+function ProgressCircle({
+  value,
+  className,
+  ...props
+}: ComponentProps<'svg'> & { value: number }) {
+  const size = 16
+  const strokeWidth = 2
+  const radius = size / 2 - strokeWidth
+  const circumference = 2 * Math.PI * radius
+  const progress = Math.min(1, Math.max(0, value)) * circumference
+  const circle = {
+    cx: size / 2,
+    cy: size / 2,
+    r: radius,
+    fill: 'none',
+    strokeWidth,
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${size} ${size}`}
+      aria-hidden
+      className={cn('size-4', className)}
+      {...props}
+    >
+      <circle {...circle} className="stroke-current/20" />
+      <circle
+        {...circle}
+        stroke="currentColor"
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference - progress}
+        strokeLinecap="round"
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        className="transition-[stroke-dashoffset] duration-300 ease-out"
+      />
+    </svg>
   )
 }
 


### PR DESCRIPTION
## Summary

Steal fumadocs' mobile TOC progress ring: a small circle next to the "on this page" control that fills as you move down the page.

- **www** ([docs-toc-select.tsx](www/src/modules/docs/docs-toc-select.tsx)) — the small-screen docs TOC select in the header now shows a `ProgressCircle` before the section title.
- **ds** ([toc-select.tsx](ds/src/components/system/toc-select.tsx)) — the same ring on the system-page mobile TOC select.

**How it works:** a two-circle SVG (faint `stroke-current/20` track + `currentColor` arc via `strokeDasharray`/`strokeDashoffset`, rotated `-90°`, `transition-[stroke-dashoffset]` smoothing). The fill value is fumadocs' own metric — the fraction of headings/sections passed, `(activeIndex + 1) / total` — driven by the existing `useActiveSection` tracker, so the ring and the section label stay in sync with no new scroll listener.

**Verified in the preview (mobile, 375px):**
- www: ring fills monotonically — `0.091` (1/11) near top → `0.545` (6/11) mid → `0.909` (10/11) at bottom, matching the active section.
- ds: ring shows `0.333` (1/3) on the shadcn-ui system page; section anchors (`color-system`, `colors`, `tokens`) match the toc ids so it advances per section.
- `pnpm typecheck` and `pnpm check` pass. No registry/types touched.

Like fumadocs, the fill is heading-based, so at the very bottom it lands on the last-passed heading rather than a hard 100%. If preferred, it's a one-line swap to track true document scroll-percentage instead.
