### PR TITLE
perf(docs): lazy-load runtime shiki highlighter

### DIFF
--- a/www/src/modules/charts/chart-code-modal.tsx
+++ b/www/src/modules/charts/chart-code-modal.tsx
@@ -6,10 +6,17 @@ import { CodeIcon, LoaderCircleIcon, XIcon } from 'lucide-react'
 import { Button } from '@/registry/ui/button'
 import { Dialog, DialogContent } from '@/registry/ui/dialog'
 import { Modal } from '@/registry/ui/modal'
+import { preloadDynamicPre } from '@/modules/docs/dynamic-pre'
 
 // Code-split the body: it pulls in the syntax highlighter, which shouldn't ship
 // in the charts route until someone actually opens a modal.
 const ChartCodeModalContent = lazy(() => import('./chart-code-modal-content'))
+
+// Warm both lazy chunks on trigger intent so the modal opens fully rendered.
+function preloadContent() {
+  void import('./chart-code-modal-content')
+  preloadDynamicPre()
+}
 
 interface ChartCodeModalProps {
   /** Demo key, e.g. `chart-bar/demos/multiple`. */
@@ -26,7 +33,13 @@ interface ChartCodeModalProps {
 export function ChartCodeModal({ demoKey, label }: ChartCodeModalProps) {
   return (
     <Dialog>
-      <Button variant="quiet" size="sm" className="text-fg-muted hover:text-fg">
+      <Button
+        variant="quiet"
+        size="sm"
+        className="text-fg-muted hover:text-fg"
+        onHoverStart={preloadContent}
+        onFocus={preloadContent}
+      >
         <CodeIcon />
         Show code
       </Button>

--- a/www/src/modules/create/code-options/index.tsx
+++ b/www/src/modules/create/code-options/index.tsx
@@ -9,6 +9,7 @@ import { Code2Icon } from 'lucide-react'
 import { Button } from '@/registry/ui/button'
 import { Dialog, DialogContent } from '@/registry/ui/dialog'
 import { Modal } from '@/registry/ui/modal'
+import { preloadDynamicPre } from '@/modules/docs/dynamic-pre'
 
 import { CodeOptionsControls } from './controls'
 import { CodeOptionsPreview } from './preview'
@@ -16,7 +17,13 @@ import { CodeOptionsPreview } from './preview'
 export function CodeOptionsDialog() {
   return (
     <Dialog>
-      <Button variant="default" size="sm" className="w-full">
+      <Button
+        variant="default"
+        size="sm"
+        className="w-full"
+        onHoverStart={preloadDynamicPre}
+        onFocus={preloadDynamicPre}
+      >
         <Code2Icon data-icon-start="" />
         Code style
       </Button>

--- a/www/src/modules/docs/dynamic-pre-impl.tsx
+++ b/www/src/modules/docs/dynamic-pre-impl.tsx
@@ -1,0 +1,34 @@
+import { useDeferredValue, useMemo } from 'react'
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
+import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
+
+import { cn } from '@/registry/lib/utils'
+
+import { Pre } from './code-block'
+import type { DynamicPreProps } from './dynamic-pre'
+import { highlightTsx } from './highlight'
+
+/**
+ * The highlighting half of DynamicPre, split into its own chunk so shiki
+ * (grammar + themes ≈ 35KB gzipped) stays out of the shared entry bundle.
+ * Highlighting itself is synchronous: SSR output and every render after the
+ * chunk loads are fully highlighted. `useDeferredValue` keeps control
+ * interactions responsive by letting React defer re-highlights under load.
+ */
+export function DynamicPreImpl({ children: code, className }: DynamicPreProps) {
+  const deferredCode = useDeferredValue(code)
+  return useMemo(
+    () =>
+      toJsxRuntime(highlightTsx(deferredCode), {
+        Fragment,
+        jsx,
+        jsxs,
+        components: {
+          pre: (props) => (
+            <Pre {...props} className={cn(props.className, className)} />
+          ),
+        },
+      }),
+    [deferredCode, className],
+  )
+}

--- a/www/src/modules/docs/dynamic-pre.tsx
+++ b/www/src/modules/docs/dynamic-pre.tsx
@@ -1,11 +1,10 @@
-import { useDeferredValue, useMemo } from 'react'
-import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
-import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
-
-import { cn } from '@/registry/lib/utils'
+import { lazy, Suspense } from 'react'
 
 import { Pre } from './code-block'
-import { highlightTsx } from './highlight'
+
+const DynamicPreImpl = lazy(() =>
+  import('./dynamic-pre-impl').then((m) => ({ default: m.DynamicPreImpl })),
+)
 
 export interface DynamicPreProps {
   lang: 'tsx'
@@ -14,25 +13,30 @@ export interface DynamicPreProps {
 }
 
 /**
- * Highlighted <pre> for code generated at runtime. Highlighting is fully
- * synchronous (see ./highlight), so SSR output and the first client render are
- * already highlighted — no fallback state. `useDeferredValue` keeps control
- * interactions responsive by letting React defer re-highlights under load.
+ * Highlighted <pre> for code generated at runtime (playground output). The
+ * highlighter lives in a lazy chunk (see ./dynamic-pre-impl): SSR resolves it
+ * and emits highlighted HTML, which Suspense keeps on screen while the client
+ * loads the chunk — the plain fallback only shows for client-only mounts.
  */
-export function DynamicPre({ children: code, className }: DynamicPreProps) {
-  const deferredCode = useDeferredValue(code)
-  return useMemo(
-    () =>
-      toJsxRuntime(highlightTsx(deferredCode), {
-        Fragment,
-        jsx,
-        jsxs,
-        components: {
-          pre: (props) => (
-            <Pre {...props} className={cn(props.className, className)} />
-          ),
-        },
-      }),
-    [deferredCode, className],
+export function DynamicPre(props: DynamicPreProps) {
+  return (
+    <Suspense fallback={<PlainPre {...props} />}>
+      <DynamicPreImpl {...props} />
+    </Suspense>
+  )
+}
+
+/** Same line structure as shiki's output so swapping in highlights doesn't shift layout. */
+function PlainPre({ children: code, className }: DynamicPreProps) {
+  return (
+    <Pre className={className}>
+      <code>
+        {code.split('\n').map((line, i) => (
+          <span key={i} className="line">
+            {line}
+          </span>
+        ))}
+      </code>
+    </Pre>
   )
 }

--- a/www/src/modules/docs/dynamic-pre.tsx
+++ b/www/src/modules/docs/dynamic-pre.tsx
@@ -6,6 +6,11 @@ const DynamicPreImpl = lazy(() =>
   import('./dynamic-pre-impl').then((m) => ({ default: m.DynamicPreImpl })),
 )
 
+/** Warm the highlighter chunk before a DynamicPre mounts, e.g. on a modal trigger's hover. */
+export function preloadDynamicPre() {
+  void import('./dynamic-pre-impl')
+}
+
 export interface DynamicPreProps {
   lang: 'tsx'
   children: string

--- a/www/src/modules/docs/highlight.ts
+++ b/www/src/modules/docs/highlight.ts
@@ -12,8 +12,9 @@ import githubLight from 'shiki/themes/github-light.mjs'
  * user moves a control.
  *
  * Everything is statically imported (grammar + themes ≈ 35KB gzipped) so
- * highlighting works during SSR and on the very first render — no async
- * highlighter load, no flash of unhighlighted code, ever.
+ * highlighting is synchronous once this module loads. Only import it from the
+ * lazy dynamic-pre-impl chunk — a static import from shared code would put
+ * shiki back in the entry bundle on every page.
  */
 const highlighter = createHighlighterCoreSync({
   langs: [tsx],

--- a/www/src/routes/_app/docs/$.tsx
+++ b/www/src/routes/_app/docs/$.tsx
@@ -9,6 +9,7 @@ import { docsSource } from '@/lib/source'
 import { truncateOnWord } from '@/lib/text'
 import { DocsCopyPage } from '@/modules/docs/docs-copy-page'
 import { DocsPager } from '@/modules/docs/docs-pager'
+import { preloadDynamicPre } from '@/modules/docs/dynamic-pre'
 import { PageLastUpdate } from '@/modules/docs/last-update'
 import { mdxComponents } from '@/modules/docs/mdx-components'
 import {
@@ -18,6 +19,12 @@ import {
 } from '@/modules/docs/page-layout'
 import { MiniTOC, TOC, TOCProvider } from '@/modules/docs/toc'
 import browserCollections from '@/.source/browser'
+
+// Playgrounds highlight their code client-side from a lazy chunk. On an SPA
+// navigation there's no SSR HTML to lean on, so the code renders plain until
+// that chunk arrives — warm it as soon as the docs route loads (which the
+// router's intent preload triggers on link hover, before the click).
+if (typeof window !== 'undefined') preloadDynamicPre()
 
 export const Route = createFileRoute('/_app/docs/$')({
   component: DocsPage,


### PR DESCRIPTION
Part of #395

## Summary

- Split `DynamicPre`'s highlighting implementation into a lazy chunk (`dynamic-pre-impl.tsx`): shiki core, the tsx TextMate grammar, and the JS regex engine (~314 KB raw / ~80 KB gz) no longer sit in the shared entry chunk loaded on every page.
- `dynamic-pre.tsx` is now a `React.lazy` + `Suspense` wrapper. SSR/prerender resolves the lazy import, so prerendered pages still ship fully highlighted HTML (verified: resolved Suspense markers, no fallback markers in build output). The plain-text fallback mirrors shiki's `.line` span structure so a pre-hydration swap can't shift layout.
- Static docs code is unaffected — it's highlighted at build time by the rehype pipeline; this only changes code generated at runtime (playground output, chart code modal, /create code-options preview).

Measured on a production build (before → after):

| Metric | Before | After |
|---|---|---|
| Entry chunk | 1,471 KB raw / 397 KB gz | 1,098 KB raw / 319 KB gz |
| First-load JS, landing | 800 KB gz | 719 KB gz |
| First-load JS, docs page | 741 KB gz | 659 KB gz |

Reviewer note: the trade-off is that a playground control moved before the chunk loads on a slow connection renders unhighlighted code briefly; once loaded, highlighting is synchronous exactly as before. Verified live: docs playground re-highlights on control changes, no console errors.