### PR TITLE
feat(www): intro rewrite, composition animation, docs layout polish

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,5 +8,6 @@
       "port": 4444,
       "autoPort": true
     }
-  ]
+  ],
+  "autoVerify": false
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+      shiki-magic-move:
+        specifier: ^1.4.0
+        version: 1.4.0(react@19.2.1)(shiki@4.0.2)(solid-js@1.9.10)
       starter-themes:
         specifier: ^0.0.2
         version: 0.0.2(@tanstack/react-router@1.170.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@tanstack/react-start@1.168.2(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@8.1.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)))(react@19.2.1)
@@ -2159,6 +2162,27 @@ packages:
     resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
     engines: {node: '>=20'}
 
+  '@shikijs/magic-move@4.3.1':
+    resolution: {integrity: sha512-MZ2Zvb8NuCJWYYJbjCeygeMh2qReF40beuWUTGuBpNZPKQA1j+rJaQ+dctZgt6arTB80pbIVsgjcadpALASvxA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
+      shiki: ^4.0.0
+      solid-js: ^1.9.1
+      svelte: ^5.0.0-0
+      vue: ^3.4.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      shiki:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
   '@shikijs/primitive@4.0.2':
     resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
     engines: {node: '>=20'}
@@ -3446,6 +3470,9 @@ packages:
 
   devtools-protocol@0.0.1608973:
     resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
+
+  diff-match-patch-es@1.0.1:
+    resolution: {integrity: sha512-KhSofrZDERg/NE6Nd+TK53knp2qz0o2Ix8rhkXd3Chfm7Wlo58Eq/juNmkyS6bS+3xS26L3Pstz3BdY/q+e9UQ==}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -5449,6 +5476,28 @@ packages:
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
+
+  shiki-magic-move@1.4.0:
+    resolution: {integrity: sha512-DDEv7khyBMAQghQEfQ6Ab3KZxT5ub6tVNe8+NcvglWauKVV9jxiRYC055DoiFLgvs6Hd9+LuBndeaSPNOSxgSg==}
+    engines: {node: '>=20'}
+    deprecated: shiki-magic-move is now @shikijs/magic-move, please migrate by renaming the package
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
+      shiki: ^4.0.0
+      solid-js: ^1.9.1
+      svelte: ^5.0.0-0
+      vue: ^3.4.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      shiki:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   shiki@4.0.2:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
@@ -7603,6 +7652,15 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.0.2
 
+  '@shikijs/magic-move@4.3.1(react@19.2.1)(shiki@4.0.2)(solid-js@1.9.10)':
+    dependencies:
+      diff-match-patch-es: 1.0.1
+      ohash: 2.0.11
+    optionalDependencies:
+      react: 19.2.1
+      shiki: 4.0.2
+      solid-js: 1.9.10
+
   '@shikijs/primitive@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
@@ -8873,6 +8931,8 @@ snapshots:
       dequal: 2.0.3
 
   devtools-protocol@0.0.1608973: {}
+
+  diff-match-patch-es@1.0.1: {}
 
   diff@8.0.4: {}
 
@@ -11406,6 +11466,14 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  shiki-magic-move@1.4.0(react@19.2.1)(shiki@4.0.2)(solid-js@1.9.10):
+    dependencies:
+      '@shikijs/magic-move': 4.3.1(react@19.2.1)(shiki@4.0.2)(solid-js@1.9.10)
+    optionalDependencies:
+      react: 19.2.1
+      shiki: 4.0.2
+      solid-js: 1.9.10
 
   shiki@4.0.2:
     dependencies:

--- a/www/content/docs/(root)/index.mdx
+++ b/www/content/docs/(root)/index.mdx
@@ -1,91 +1,64 @@
 ---
 title: Introduction
-description: A design system platform and component registry. Built for humans and AI.
+description: A design-system builder and component registry. You compose it, preview it live, and own the code.
 ---
 
-**dotUI** is a design system platform and component registry that lets you generate a UI library that looks like your product, not a preset.
+**dotUI is a design-system builder.** You compose your system at [dotui.org/create](https://dotui.org/create) — colors, typography, icons, density, radius, per-component styles — preview every change on live components, and export code you own: into your codebase via the shadcn CLI, or straight into [v0](https://v0.dev), with more targets planned.
 
-You know how traditional UI libraries force a default aesthetic? Even the "Open Code" approach still requires hours (or weeks) of refactoring tokens, tweaking styles, and rewriting components. dotUI removes that friction.
+Open code alone doesn't get you there: you own the files, but the decisions inside them are still someone else's. dotUI makes the decisions yours. The output is not our library with your colors — it is your design system.
 
-You build your design system with our editor in a few clicks, then install it via the shadcn CLI or export it to your favorite AI tool such as [v0](https://v0.dev).
-
-## The foundational layer
-
-I evaluated all major options for the foundational layer. Radix is effectively unmaintained, so the choice came down to [Base UI](https://base-ui.com) and [React Aria](https://react-spectrum.adobe.com/react-aria/index.html). While Base UI is very promising, it's still quite new and missing critical features that dotUI relies on.
-
-**React Aria** was the clear winner: battle-tested, comprehensive, and **incredibly flexible**. I've taken its powerful, unstyled primitives and given them a design system that looks like your product.
+<Demo name="table/demos/invoices" />
 
 ## API philosophy
 
 ### Composition
 
-The API is designed around composition, where each component generally has a 1:1 relationship with a single DOM element. This makes it easy to style every element, and control the layout and DOM order as needed to implement any pattern.
+The API is built on composition: each component maps to a single DOM element, so you can style every element and control DOM order to implement any pattern. Every component also ships default children, so you only write the composition when you need to change it.
 
-```tsx
-<Select defaultValue="light">
-  <Button>
-    <SelectValue />
-    <ArrowDownIcon />
-  </Button>
-  <Popover>
-    <ListBox>
-      <Item id="light">Light</Item>
-      <Item id="dark">Dark</Item>
-      <Item id="system">System</Item>
-    </ListBox>
-  </Popover>
-</Select>
-```
+<CompositionAnimation />
 
-### With default children
+The same primitives recompose into every component in the library: an `Input` becomes a `TextField`, a `DateField`, a `DatePicker`; the same overlay shell becomes a `Dialog` and a `Menu`. Around ten primitives cover a dozen components, with zero parallel APIs.
 
-I've been using shadcn/ui and radix in several projects now, and yes, composition gives you much more flexibility, but it also adds too much boilerplate code.
+### Reusable primitives
 
-### Reusable components
+Most libraries claim composability and then ship parallel APIs for the same pattern: `MenuPopover`, `ComboboxPopover`, `SelectPopover` for one popover; `MenuTrigger`, `DialogTrigger`, `PopoverTrigger` for one button. You end up memorizing four names for every concept.
 
-Most UI libraries claim to be "composable" but end up creating duplicate components for
-every use case. You end up memorizing parallel APIs for the exact same pattern:
+dotUI has one of each:
 
-You'll find MenuPopover, ComboboxPopover, DialogPopover, SelectPopover, when really they're just a **Popover** component.
+- **Popover** — one component for menus, dialogs, selects, and comboboxes.
+- **Button** — one component for every trigger.
+- **Input** — one component for text, search, and number fields.
+- **Label** — one component everywhere a label appears.
 
-You'll also find "MenuTrigger", "ComboboxTrigger", "DialogTrigger", "ModalTrigger", "AlertDialogTrigger", "PopoverTrigger", when a "Button" should work everywhere.
+Learn a primitive once; it works across the entire library.
 
-**dotUI gives you true reusable primitives across the entire library.** One `Popover`
-component that works with menus, dialogs, selects, and comboboxes. One `Button` component
-that works as any trigger. One `Input` component that works in text fields, search fields,
-and number fields. One `Label` component that works everywhere you need a label.
+## The foundational layer
 
-This isn't just about a few components—it's a fundamental architectural principle. Every
-component is a true primitive that composes naturally with others, eliminating duplication
-and giving you real reusability.
+dotUI is built on [React Aria Components](https://react-spectrum.adobe.com/react-aria/), styled with Tailwind CSS v4 and tailwind-variants, and themed by an OKLCH color engine.
+
+We evaluated the alternatives for the behavior layer. Radix is effectively unmaintained. [Base UI](https://base-ui.com) is promising but young, and missing features dotUI relies on. React Aria is battle-tested, comprehensive, and unstyled all the way down — a foundation that disappears behind whatever design system you build on it.
 
 ## Documentation
 
-### Showing rather than telling
+The docs show rather than tell. Every component page opens with an interactive playground: change a prop, and the code and preview update in real time. Play with the props; read the prose only when you need it.
 
-Each component in dotUI comes with an interactive playground where you can play with the props and see the changes in code/preview in real time.
+<Demo name="menu/demos/account" />
 
-<Demo name="button/demos/default" />
-
-### Real-world examples
-
-Each component page includes multiple real-world examples showing how to use the component in actual application scenarios. From simple use cases to complex compositions, you'll see exactly how components work together.
+Below the playground, examples show components composed into real product UI:
 
 <div className='grid grid-cols-2 gap-4 mt-6'>
 
-<Example name="button/demos/default" />
-<Example name="button/demos/variants" />
-<Example name="button/demos/sizes" />
-<Example name="button/demos/shapes" />
+<Example name="calendar/demos/with-presets" />
+<Example name="combobox/demos/multi-select" />
+<Example name="date-picker/demos/with-modal" />
+<Example name="switch/demos/notification-preferences" />
 
 </div>
 
 ## Built for AI
 
-dotUI is built for humans and AI. All components were written with a clear, consistent, and predictable API.
+dotUI is built for humans and AI. The API is consistent and predictable across the library: an agent that has seen one trigger, one field, or one overlay has seen them all. Fewer APIs to learn means fewer APIs to get wrong — an agent that has written one component can write the next.
 
 ## Get involved
 
-If you have any feedback, a bug report, or a feature request, you can open an issue on our [GitHub](https://github.com/mehdibha/dotUI/issues) or just DM me on X at [@mehdibha](https://x.com/mehdibha).
-
-Contributions are also welcome! I would be happy to see more people contributing to the project and making it better.
+Open an issue on [GitHub](https://github.com/mehdibha/dotUI/issues) for feedback, bugs, or feature requests, or DM [@mehdibha](https://x.com/mehdibha) on X. Contributions are welcome.

--- a/www/package.json
+++ b/www/package.json
@@ -53,6 +53,7 @@
     "react-stately": "^3.48.0",
     "recharts": "^3.8.1",
     "shiki": "^4.0.2",
+    "shiki-magic-move": "^1.4.0",
     "starter-themes": "^0.0.2",
     "tailwind-merge": "^3.0.2",
     "tailwind-variants": "^3.1.1",

--- a/www/src/dev/tweaker/README.md
+++ b/www/src/dev/tweaker/README.md
@@ -82,7 +82,8 @@ Every config needs a `default` — and it **must match the current design** so n
 A small **trigger** is always docked to a screen edge (default: centre-right; a count badge shows how many controls are registered). Drag it to reposition — it follows the cursor and **snaps to the nearest edge** (left/right) when you let go, keeping the height you dropped it at.
 
 - **Click the trigger** → opens the panel as a popover beside it (the trigger stays put).
-- **Close** (×), click outside, or press **Escape** → closes the popover.
+- **Close** (×) or press **Escape** → closes the popover. Clicking the page does NOT close it — the page stays interactive while you tweak.
+- **Minimize** (⌄⌃) → collapses the panel to its header bar; expand the same way.
 - **⌘ .** (or **Ctrl .**) → toggles the popover from anywhere.
 - **Reset** (↺) → all controls back to their defaults.
 - **Copy for AI** (⧉) → copies a summary of the current selections to paste back to the agent.

--- a/www/src/dev/tweaker/README.md
+++ b/www/src/dev/tweaker/README.md
@@ -1,6 +1,6 @@
 # Dev tweaker
 
-A **dev-only** floating panel for live design/layout exploration. While working a PR, an AI agent adds `useTweak()` calls to the feature being explored; the panel (docked bottom-center, Vercel-toolbar style) lets you flip between the options live and pick one. None of it ships — `useTweak` compiles to a no-op in production and the panel + store are dead-code-eliminated.
+A **dev-only** floating panel (also enabled on Vercel previews) for live design/layout exploration. While working a PR, an AI agent adds `useTweak()` calls to the feature being explored; the panel (docked bottom-center, Vercel-toolbar style) lets you flip between the options live and pick one. None of it ships — `useTweak` compiles to a no-op in production and the panel + store are dead-code-eliminated.
 
 It is **not** a product feature and **not** a `/create` design-system axis. It's throwaway scaffolding for one exploration. Adding a real axis/variant/token is still a product decision (propose-and-approve — see the root `CLAUDE.md`).
 
@@ -91,7 +91,7 @@ State (open, side, vertical position, control values + order) persists in `local
 
 ## How it stays out of production
 
-`useTweak` is `import.meta.env.DEV ? useTweakDev : useTweakNoop` (see `use-tweak.ts`). In a prod build `DEV` is the constant `false`, so the dev arm — and its import of the store — is dead-code-eliminated. The panel is `lazy()`-imported behind the same constant in `__root.tsx`, so its chunk never enters the prod graph. `store.ts` is side-effect-free at module scope so it tree-shakes cleanly.
+`useTweak` is gated on `import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview'` (see `use-tweak.ts`) — both build-time constants (`VERCEL_ENV` is inlined via Vite `define`). In a real production build the condition is constant `false`, so the dev arm — and its import of the store — is dead-code-eliminated. The panel is `lazy()`-imported behind the same condition (plus a `!SSR` guard, so prerendering never evaluates the chunk) in `__root.tsx`. `store.ts` is side-effect-free at module scope so it tree-shakes cleanly.
 
 ## Files
 

--- a/www/src/dev/tweaker/store.ts
+++ b/www/src/dev/tweaker/store.ts
@@ -34,6 +34,7 @@ const STORAGE_KEY = 'dotui:tweaker'
 
 const DEFAULT_UI: TweakerUiState = {
   open: false,
+  minimized: false,
   side: 'right',
   y: 0.5,
 }

--- a/www/src/dev/tweaker/tweaker.tsx
+++ b/www/src/dev/tweaker/tweaker.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import {
   CheckIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
   CopyIcon,
   RotateCcwIcon,
   SlidersHorizontalIcon,
@@ -80,8 +82,6 @@ export function DevTweaker() {
   const [drag, setDrag] = useState<{ x: number; y: number } | null>(null)
   const dragStart = useRef<{ x: number; y: number } | null>(null)
   const moved = useRef(false)
-  const triggerRef = useRef<HTMLButtonElement>(null)
-  const panelRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const onResize = () =>
@@ -104,22 +104,10 @@ export function DevTweaker() {
     return () => window.removeEventListener('keydown', onKey)
   }, [])
 
-  // Dismiss the popover on an outside click (it stays anchored to the trigger otherwise).
-  useEffect(() => {
-    if (!ui.open) return
-    const onDown = (e: PointerEvent) => {
-      const target = e.target as Node
-      if (
-        panelRef.current?.contains(target) ||
-        triggerRef.current?.contains(target)
-      ) {
-        return
-      }
-      setUiState({ open: false })
-    }
-    window.addEventListener('pointerdown', onDown)
-    return () => window.removeEventListener('pointerdown', onDown)
-  }, [ui.open])
+  // No outside-click dismissal: the panel is a tool palette, and the page must
+  // stay clickable while it's open (a near-miss click landing on page content
+  // used to both act on the page and close the panel). Close via ×, Escape,
+  // ⌘., or tapping the trigger.
 
   if (!mounted) return null
 
@@ -187,7 +175,6 @@ export function DevTweaker() {
       {/* Trigger — always visible, docked to a side, draggable (snaps to an edge). z-40 keeps
           it above page content but below the popover layer (z-50) and modals (z-100). */}
       <button
-        ref={triggerRef}
         type="button"
         aria-label="Open tweaker"
         aria-expanded={ui.open}
@@ -210,7 +197,6 @@ export function DevTweaker() {
       {/* Popover panel — anchored beside the trigger; the trigger stays visible. */}
       {ui.open && !drag && (
         <div
-          ref={panelRef}
           style={{ ...panelSideStyle, top: panelTop }}
           className="fixed z-40 flex max-h-[70vh] w-75 max-w-[calc(100vw-5rem)] -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-border bg-bg shadow-2xl"
         >
@@ -245,6 +231,15 @@ export function DevTweaker() {
                 size="sm"
                 variant="quiet"
                 isIconOnly
+                aria-label={ui.minimized ? 'Expand' : 'Minimize'}
+                onPress={() => setUiState({ minimized: !ui.minimized })}
+              >
+                {ui.minimized ? <ChevronsUpDownIcon /> : <ChevronsDownUpIcon />}
+              </Button>
+              <Button
+                size="sm"
+                variant="quiet"
+                isIconOnly
                 aria-label="Close"
                 onPress={() => setUiState({ open: false })}
               >
@@ -253,16 +248,20 @@ export function DevTweaker() {
             </div>
           </div>
 
-          <div className="flex-1 overflow-y-auto p-3">
-            <GroupedControls controls={controls} />
-          </div>
+          {!ui.minimized && (
+            <>
+              <div className="flex-1 overflow-y-auto p-3">
+                <GroupedControls controls={controls} />
+              </div>
 
-          <div className="flex items-center justify-between border-t border-border px-3 py-1.5 text-[10px] text-fg-muted">
-            <span>dev only · not shipped</span>
-            <span className="flex items-center gap-1">
-              <Kbd>⌘ .</Kbd> to toggle
-            </span>
-          </div>
+              <div className="flex items-center justify-between border-t border-border px-3 py-1.5 text-[10px] text-fg-muted">
+                <span>dev only · not shipped</span>
+                <span className="flex items-center gap-1">
+                  <Kbd>⌘ .</Kbd> to toggle
+                </span>
+              </div>
+            </>
+          )}
         </div>
       )}
     </>

--- a/www/src/dev/tweaker/types.ts
+++ b/www/src/dev/tweaker/types.ts
@@ -84,6 +84,8 @@ export interface RegisteredControl {
 export interface TweakerUiState {
   /** Whether the popover panel is open (the docked trigger is always visible). */
   open: boolean
+  /** Collapsed to just the header bar (still open, controls hidden). */
+  minimized: boolean
   /** Which edge the trigger is docked to. */
   side: 'left' | 'right'
   /** Vertical position of the trigger as a fraction (0–1) of the viewport height. */

--- a/www/src/dev/tweaker/use-tweak.ts
+++ b/www/src/dev/tweaker/use-tweak.ts
@@ -54,10 +54,11 @@ function useTweakNoop<const C extends TweakConfig>(
 /**
  * Read a live, user-tweakable value while exploring a design in dev.
  *
- * Dev-only: an AI agent adds these to a feature component while you explore it, and
- * the floating Tweaker panel (mounted in `__root.tsx`) lets you flip the value live.
- * In production this compiles to a no-op that returns `config.default`, and the whole
- * tweaker (store + panel) tree-shakes away. See ./README.md for the full workflow.
+ * Dev + Vercel previews only: an AI agent adds these to a feature component while
+ * you explore it, and the floating Tweaker panel (mounted in `__root.tsx`) lets you
+ * flip the value live. In production this compiles to a no-op that returns
+ * `config.default`, and the whole tweaker (store + panel) tree-shakes away. See
+ * ./README.md for the full workflow.
  *
  * @example
  * const layout = useTweak('Layout', {
@@ -68,6 +69,7 @@ function useTweakNoop<const C extends TweakConfig>(
  * })
  * // → typed 'centered' | 'split' | 'fullbleed'
  */
-export const useTweak: UseTweak = import.meta.env.DEV
-  ? useTweakDev
-  : useTweakNoop
+export const useTweak: UseTweak =
+  import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview'
+    ? useTweakDev
+    : useTweakNoop

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -509,16 +509,46 @@ export function useCompositionPlayer({
     setHoverPausedState(next)
   }, [])
 
+  // A view transition lifts every named element into a snapshot overlay that is
+  // anchored to the viewport, not the scrolling page — so scrolling mid-morph
+  // makes the frozen snapshots detach and float. Skip the morph while scrolling,
+  // and snap any in-flight one to its end so it can't drift.
+  const scrollingRef = useRef(false)
+  const activeTransitionRef = useRef<{ skipTransition: () => void } | null>(
+    null,
+  )
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>
+    const onScroll = () => {
+      scrollingRef.current = true
+      activeTransitionRef.current?.skipTransition()
+      clearTimeout(timer)
+      timer = setTimeout(() => {
+        scrollingRef.current = false
+      }, 150)
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      clearTimeout(timer)
+    }
+  }, [])
+
   const stepRef = useRef(0)
   const goToStep = useCallback((next: number) => {
     stepRef.current = next
     const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (reduce || !document.startViewTransition) {
+    if (reduce || scrollingRef.current || !document.startViewTransition) {
       setStep(next)
       return
     }
-    document.startViewTransition(() => {
+    const transition = document.startViewTransition(() => {
       flushSync(() => setStep(next))
+    })
+    activeTransitionRef.current = transition
+    transition.finished.finally(() => {
+      if (activeTransitionRef.current === transition)
+        activeTransitionRef.current = null
     })
   }, [])
 

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -3,17 +3,20 @@ import 'shiki-magic-move/style.css'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
 import { parseDate } from '@internationalized/date'
+import { PauseIcon, PlayIcon } from 'lucide-react'
 import { ShikiMagicMove } from 'shiki-magic-move/react'
 import { useTheme } from 'starter-themes'
 
 import {
   CalendarIcon,
+  ChevronDownIcon,
   MailIcon,
   MoreHorizontalIcon,
 } from '@/registry/__generated__/icons'
 import { cn } from '@/registry/lib/utils'
 import { Button } from '@/registry/ui/button'
 import { Calendar, RangeCalendar } from '@/registry/ui/calendar'
+import { Combobox } from '@/registry/ui/combobox'
 import { DateField } from '@/registry/ui/date-field'
 import { DatePicker, DateRangePicker } from '@/registry/ui/date-picker'
 import {
@@ -31,22 +34,26 @@ import {
   InputGroup,
   InputGroupAddon,
 } from '@/registry/ui/input'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
 import { Menu, MenuContent, MenuItem } from '@/registry/ui/menu'
 import { Modal } from '@/registry/ui/modal'
 import { Popover } from '@/registry/ui/popover'
+import { Select, SelectTrigger } from '@/registry/ui/select'
 import { TextField } from '@/registry/ui/text-field'
 import { highlighter } from '@/modules/docs/highlight'
 
-const STEP_MS = 3200
-
 interface Step {
   title: string
+  // How long the step stays on screen — proportional to how much the diff
+  // asks the reader to take in, not to total snippet length.
+  durationMs: number
   code: string
   preview: React.ReactNode
 }
 
 const firstStep: Step = {
   title: 'Input',
+  durationMs: 2400,
   code: `<Input placeholder="hello@example.com" />`,
   preview: (
     <Input
@@ -61,6 +68,7 @@ const steps: Step[] = [
   firstStep,
   {
     title: 'TextField',
+    durationMs: 2600,
     code: `<TextField>
   <Input placeholder="hello@example.com" />
 </TextField>`,
@@ -75,6 +83,7 @@ const steps: Step[] = [
   },
   {
     title: 'Label & Description',
+    durationMs: 3200,
     code: `<TextField>
   <Label>Email</Label>
   <Input placeholder="hello@example.com" />
@@ -95,6 +104,7 @@ const steps: Step[] = [
   },
   {
     title: 'InputGroup',
+    durationMs: 4200,
     code: `<TextField>
   <Label>Email</Label>
   <InputGroup>
@@ -130,6 +140,7 @@ const steps: Step[] = [
   },
   {
     title: 'DateField',
+    durationMs: 3400,
     code: `<DateField>
   <Label>Meeting date</Label>
   <InputGroup>
@@ -153,6 +164,7 @@ const steps: Step[] = [
   },
   {
     title: 'DatePicker',
+    durationMs: 4200,
     code: `<DatePicker>
   <Label>Meeting date</Label>
   <InputGroup>
@@ -194,6 +206,7 @@ const steps: Step[] = [
   },
   {
     title: 'DateRangePicker',
+    durationMs: 3600,
     code: `<DateRangePicker>
   <Label>Trip dates</Label>
   <InputGroup>
@@ -244,7 +257,8 @@ const steps: Step[] = [
     ),
   },
   {
-    title: 'Same picker, drawer overlay',
+    title: 'Drawer overlay',
+    durationMs: 3000,
     code: `<DateRangePicker>
   <Label>Trip dates</Label>
   <InputGroup>
@@ -295,40 +309,36 @@ const steps: Step[] = [
     ),
   },
   {
-    title: 'Dialog',
-    code: `<Dialog>
-  <Button>Create issue</Button>
-  <Modal>
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>Create a new issue</DialogTitle>
-        <DialogDescription>
-          Report a bug or request a feature.
-        </DialogDescription>
-      </DialogHeader>
-    </DialogContent>
-  </Modal>
-</Dialog>`,
+    title: 'Select',
+    durationMs: 3400,
+    code: `<Select>
+  <Label>Provider</Label>
+  <SelectTrigger />
+  <Popover>
+    <ListBox>
+      <ListBoxItem>Perplexity</ListBoxItem>
+      <ListBoxItem>Replicate</ListBoxItem>
+      <ListBoxItem>Together AI</ListBoxItem>
+    </ListBox>
+  </Popover>
+</Select>`,
     preview: (
-      <Dialog>
-        <Button className="[view-transition-name:cmp-trigger]">
-          Create issue
-        </Button>
-        <Modal>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Create a new issue</DialogTitle>
-              <DialogDescription>
-                Report a bug or request a feature.
-              </DialogDescription>
-            </DialogHeader>
-          </DialogContent>
-        </Modal>
-      </Dialog>
+      <Select className="w-56" defaultSelectedKey="perplexity">
+        <Label className="[view-transition-name:cmp-label]">Provider</Label>
+        <SelectTrigger className="[view-transition-name:cmp-trigger]" />
+        <Popover>
+          <ListBox>
+            <ListBoxItem id="perplexity">Perplexity</ListBoxItem>
+            <ListBoxItem id="replicate">Replicate</ListBoxItem>
+            <ListBoxItem id="together-ai">Together AI</ListBoxItem>
+          </ListBox>
+        </Popover>
+      </Select>
     ),
   },
   {
     title: 'Menu',
+    durationMs: 3200,
     code: `<Menu>
   <Button size="sm" isIconOnly>
     <MoreHorizontalIcon />
@@ -361,21 +371,116 @@ const steps: Step[] = [
       </Menu>
     ),
   },
+  {
+    title: 'Dialog',
+    durationMs: 3400,
+    code: `<Dialog>
+  <Button>Create issue</Button>
+  <Modal>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Create a new issue</DialogTitle>
+        <DialogDescription>
+          Report a bug or request a feature.
+        </DialogDescription>
+      </DialogHeader>
+    </DialogContent>
+  </Modal>
+</Dialog>`,
+    preview: (
+      <Dialog>
+        <Button className="[view-transition-name:cmp-trigger]">
+          Create issue
+        </Button>
+        <Modal>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create a new issue</DialogTitle>
+              <DialogDescription>
+                Report a bug or request a feature.
+              </DialogDescription>
+            </DialogHeader>
+          </DialogContent>
+        </Modal>
+      </Dialog>
+    ),
+  },
+  {
+    // The finale: every part introduced above, recomposed into one component.
+    title: 'ComboBox',
+    durationMs: 4200,
+    code: `<Combobox>
+  <Label>Country</Label>
+  <InputGroup>
+    <Input placeholder="Search countries…" />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <ChevronDownIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Popover>
+    <ListBox>
+      <ListBoxItem>France</ListBoxItem>
+      <ListBoxItem>Germany</ListBoxItem>
+      <ListBoxItem>Tunisia</ListBoxItem>
+    </ListBox>
+  </Popover>
+</Combobox>`,
+    preview: (
+      <Combobox className="w-64">
+        <Label className="[view-transition-name:cmp-label]">Country</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <Input placeholder="Search countries…" />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <ChevronDownIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <ListBox>
+            <ListBoxItem>France</ListBoxItem>
+            <ListBoxItem>Germany</ListBoxItem>
+            <ListBoxItem>Tunisia</ListBoxItem>
+          </ListBox>
+        </Popover>
+      </Combobox>
+    ),
+  },
 ]
 
-// Shared player: auto-advance while visible, pause on hover/focus, and route
-// every step change through a view transition so the preview's named parts
-// (field shell, label, trigger…) morph instead of swapping.
-export function useCompositionPlayer() {
+export type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
+
+// Shared player: auto-advance while visible, with a CSS animation as the step
+// clock (see StepTimer) so the visible progress and the advance tick can never
+// drift. Hovering or focusing the showcase pauses; the play/pause button is a
+// sticky override. Every step change routes through a view transition so the
+// preview's named parts (field shell, label, trigger…) morph instead of swap.
+export function useCompositionPlayer({
+  durationScale = 1,
+}: { durationScale?: number } = {}) {
   const [step, setStep] = useState(0)
-  const [paused, setPaused] = useState(false)
+  const [userPaused, setUserPaused] = useState(false)
+  const [hoverPaused, setHoverPausedState] = useState(false)
+  const [hidden, setHidden] = useState(false)
   const [mounted, setMounted] = useState(false)
   const [inView, setInView] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => setMounted(true), [])
+  useEffect(() => {
+    setMounted(true)
+    // Auto-play is motion — reduced-motion users opt in via the play button.
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setUserPaused(true)
+    }
+  }, [])
 
-  // Only animate while on screen — the loop parks itself otherwise.
+  // Only animate while on screen — the clock parks itself otherwise.
   useEffect(() => {
     const el = containerRef.current
     if (!el) return
@@ -385,6 +490,23 @@ export function useCompositionPlayer() {
     )
     observer.observe(el)
     return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const onChange = () => setHidden(document.hidden)
+    document.addEventListener('visibilitychange', onChange)
+    return () => document.removeEventListener('visibilitychange', onChange)
+  }, [])
+
+  // Touch devices fire synthetic mouseenter with no matching leave — hover
+  // pause would stick forever, so it only applies to real pointers.
+  const setHoverPaused = useCallback((next: boolean) => {
+    if (
+      next &&
+      !window.matchMedia('(hover: hover) and (pointer: fine)').matches
+    )
+      return
+    setHoverPausedState(next)
   }, [])
 
   const stepRef = useRef(0)
@@ -400,32 +522,172 @@ export function useCompositionPlayer() {
     })
   }, [])
 
-  useEffect(() => {
-    if (paused || !inView || !mounted) return
-    const id = setInterval(
-      () => goToStep((stepRef.current + 1) % steps.length),
-      STEP_MS,
-    )
-    return () => clearInterval(id)
-  }, [paused, inView, mounted, goToStep])
+  const advance = useCallback(
+    () => goToStep((stepRef.current + 1) % steps.length),
+    [goToStep],
+  )
 
+  const togglePlay = useCallback(() => {
+    setUserPaused((paused) => !paused)
+    // Resuming with the cursor still inside must actually resume.
+    setHoverPausedState(false)
+  }, [])
+
+  const playing = mounted && inView && !hidden && !userPaused && !hoverPaused
   const current = steps[step] ?? firstStep
+  const stepDurationMs = current.durationMs * durationScale
   const reducedMotion =
     mounted && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  // Under reduced motion the CSS clock is disabled (StepTimer renders nothing),
+  // so an explicit play falls back to a plain timeout with instant swaps.
+  useEffect(() => {
+    if (!playing || !reducedMotion) return
+    const id = setTimeout(advance, stepDurationMs)
+    return () => clearTimeout(id)
+  }, [playing, reducedMotion, step, stepDurationMs, advance])
 
   return {
     steps,
     step,
     goToStep,
-    setPaused,
+    advance,
+    playing,
+    userPaused,
+    togglePlay,
+    setHoverPaused,
     mounted,
     containerRef,
     current,
+    stepDurationMs,
     reducedMotion,
   }
 }
 
-export function CompositionTransitionStyles() {
+// The step clock: an invisible bar animating over the step's duration. Render
+// exactly one per player — onAnimationEnd is what advances the sequence, so
+// the decorative progress bars (same animation, same play state) stay in sync
+// with the actual tick by construction.
+export function StepTimer({ player }: { player: CompositionPlayer }) {
+  const { step, stepDurationMs, playing, advance, reducedMotion } = player
+  if (reducedMotion) return null
+  return (
+    <span
+      key={step}
+      aria-hidden
+      onAnimationEnd={advance}
+      className="pointer-events-none fixed size-px opacity-0"
+      style={progressStyle(stepDurationMs, playing, 'x')}
+    />
+  )
+}
+
+function progressStyle(
+  durationMs: number,
+  playing: boolean,
+  axis: 'x' | 'y',
+): React.CSSProperties {
+  return {
+    animationName: axis === 'x' ? 'cmp-progress-x' : 'cmp-progress-y',
+    animationDuration: `${durationMs}ms`,
+    animationTimingFunction: 'linear',
+    animationFillMode: 'both',
+    animationPlayState: playing ? 'running' : 'paused',
+    willChange: 'transform',
+  }
+}
+
+// A track clipping a full-size bar that slides in via translate — scaling a
+// hairline bar re-rasterizes it every frame and visibly steps at slow speeds.
+export function StepProgress({
+  player,
+  axis = 'x',
+  className,
+}: {
+  player: CompositionPlayer
+  axis?: 'x' | 'y'
+  className?: string
+}) {
+  const { step, stepDurationMs, playing, reducedMotion } = player
+  return (
+    <span key={step} aria-hidden className={cn('overflow-hidden', className)}>
+      <span
+        className="block size-full bg-fg"
+        style={
+          reducedMotion
+            ? undefined
+            : progressStyle(stepDurationMs, playing, axis)
+        }
+      />
+    </span>
+  )
+}
+
+export function StepDots({
+  player,
+  className,
+}: {
+  player: CompositionPlayer
+  className?: string
+}) {
+  const { steps, step, goToStep } = player
+  return (
+    <div className={cn('flex items-center', className)}>
+      {steps.map((s, i) => (
+        <button
+          key={s.title}
+          type="button"
+          aria-label={`Step ${i + 1}: ${s.title}`}
+          aria-current={i === step ? 'step' : undefined}
+          onClick={() => goToStep(i)}
+          className="group flex h-8 cursor-pointer items-center px-[3px]"
+        >
+          <span
+            className={cn(
+              'relative h-1 overflow-hidden rounded-full transition-all duration-300',
+              i === step
+                ? 'w-5 bg-border'
+                : 'w-1.5 bg-border group-hover:bg-fg-muted',
+            )}
+          >
+            {i === step && (
+              <StepProgress
+                player={player}
+                className="absolute inset-0 block rounded-full"
+              />
+            )}
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function PlayPauseButton({
+  player,
+  className,
+}: {
+  player: CompositionPlayer
+  className?: string
+}) {
+  const { userPaused, togglePlay } = player
+  return (
+    <Button
+      size="sm"
+      variant="quiet"
+      isIconOnly
+      aria-label={userPaused ? 'Play steps' : 'Pause steps'}
+      onPress={togglePlay}
+      className={cn('text-fg-muted', className)}
+    >
+      {userPaused ? <PlayIcon /> : <PauseIcon />}
+    </Button>
+  )
+}
+
+export function CompositionTransitionStyles({
+  morphMs = 450,
+}: { morphMs?: number } = {}) {
   return (
     <style>{`
       /* Keep the page interactive while a transition runs, and confine the
@@ -437,11 +699,13 @@ export function CompositionTransitionStyles() {
       ::view-transition-group(cmp-label),
       ::view-transition-group(cmp-desc),
       ::view-transition-group(cmp-trigger) {
-        animation-duration: 450ms;
+        animation-duration: ${morphMs}ms;
         animation-timing-function: cubic-bezier(0.645, 0.045, 0.355, 1);
       }
       ::view-transition-old(cmp-code) { display: none; }
       ::view-transition-new(cmp-code) { animation: none; }
+      @keyframes cmp-progress-x { from { transform: translateX(-100%); } to { transform: translateX(0); } }
+      @keyframes cmp-progress-y { from { transform: translateY(-100%); } to { transform: translateY(0); } }
       @media (prefers-reduced-motion: reduce) {
         ::view-transition-group(*),
         ::view-transition-old(*),
@@ -454,9 +718,13 @@ export function CompositionTransitionStyles() {
 export function CompositionCode({
   code,
   reducedMotion,
+  duration = 700,
+  stagger = 2,
 }: {
   code: string
   reducedMotion: boolean
+  duration?: number
+  stagger?: number
 }) {
   const { resolvedTheme } = useTheme()
   return (
@@ -466,8 +734,8 @@ export function CompositionCode({
       theme={resolvedTheme === 'light' ? 'github-light' : 'github-dark'}
       code={code}
       options={{
-        duration: reducedMotion ? 0 : 700,
-        stagger: 2,
+        duration: reducedMotion ? 0 : duration,
+        stagger,
         containerStyle: false,
       }}
     />
@@ -475,47 +743,28 @@ export function CompositionCode({
 }
 
 export function CompositionAnimation({ className }: { className?: string }) {
-  const {
-    step,
-    goToStep,
-    setPaused,
-    mounted,
-    containerRef,
-    current,
-    reducedMotion,
-  } = useCompositionPlayer()
+  const player = useCompositionPlayer()
+  const { mounted, containerRef, current, reducedMotion, setHoverPaused } =
+    player
 
   return (
     <div
       ref={containerRef}
       className={cn('overflow-hidden rounded-md border bg-card', className)}
-      onMouseEnter={() => setPaused(true)}
-      onMouseLeave={() => setPaused(false)}
-      onFocus={() => setPaused(true)}
-      onBlur={() => setPaused(false)}
+      onMouseEnter={() => setHoverPaused(true)}
+      onMouseLeave={() => setHoverPaused(false)}
+      onFocus={() => setHoverPaused(true)}
+      onBlur={() => setHoverPaused(false)}
     >
       <CompositionTransitionStyles />
-      <div className="flex items-center justify-between gap-2 border-b py-1.5 pr-2.5 pl-2.5">
+      <StepTimer player={player} />
+      <div className="flex items-center justify-between gap-2 border-b py-1.5 pr-1.5 pl-2.5">
         <span className="truncate font-mono text-[0.8125rem] text-fg-muted">
           {current.title}
         </span>
-        <div className="flex items-center">
-          {steps.map((s, i) => (
-            <button
-              key={s.title}
-              type="button"
-              aria-label={`Step ${i + 1}: ${s.title}`}
-              onClick={() => goToStep(i)}
-              className="group flex size-5 cursor-pointer items-center justify-center"
-            >
-              <span
-                className={cn(
-                  'size-1.5 rounded-full transition-colors',
-                  i === step ? 'bg-fg' : 'bg-border group-hover:bg-fg-muted',
-                )}
-              />
-            </button>
-          ))}
+        <div className="flex items-center gap-1">
+          <StepDots player={player} />
+          <PlayPauseButton player={player} />
         </div>
       </div>
       <div className="grid sm:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -49,6 +49,10 @@ interface Step {
   durationMs: number
   code: string
   preview: React.ReactNode
+  // Short transitional beat that plays during auto-advance but isn't a
+  // clickable stop in the pagination (e.g. building an InputGroup addon by
+  // addon before landing on the headline step).
+  mid?: boolean
 }
 
 const firstStep: Step = {
@@ -103,6 +107,61 @@ const steps: Step[] = [
     ),
   },
   {
+    // Mid beat: wrap the input in an InputGroup — no addons yet.
+    title: 'InputGroup',
+    mid: true,
+    durationMs: 1500,
+    code: `<TextField>
+  <Label>Email</Label>
+  <InputGroup>
+    <Input placeholder="hello@example.com" />
+  </InputGroup>
+  <Description>No spam, unsubscribe anytime.</Description>
+</TextField>`,
+    preview: (
+      <TextField className="w-72">
+        <Label className="[view-transition-name:cmp-label]">Email</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <Input placeholder="hello@example.com" />
+        </InputGroup>
+        <Description className="[view-transition-name:cmp-desc]">
+          No spam, unsubscribe anytime.
+        </Description>
+      </TextField>
+    ),
+  },
+  {
+    // Mid beat: add the leading addon.
+    title: 'InputGroup',
+    mid: true,
+    durationMs: 1500,
+    code: `<TextField>
+  <Label>Email</Label>
+  <InputGroup>
+    <InputGroupAddon>
+      <MailIcon />
+    </InputGroupAddon>
+    <Input placeholder="hello@example.com" />
+  </InputGroup>
+  <Description>No spam, unsubscribe anytime.</Description>
+</TextField>`,
+    preview: (
+      <TextField className="w-72">
+        <Label className="[view-transition-name:cmp-label]">Email</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <InputGroupAddon>
+            <MailIcon />
+          </InputGroupAddon>
+          <Input placeholder="hello@example.com" />
+        </InputGroup>
+        <Description className="[view-transition-name:cmp-desc]">
+          No spam, unsubscribe anytime.
+        </Description>
+      </TextField>
+    ),
+  },
+  {
+    // Headline step: add the trailing addon — the full InputGroup.
     title: 'InputGroup',
     durationMs: 4200,
     code: `<TextField>
@@ -454,6 +513,13 @@ const steps: Step[] = [
   },
 ]
 
+// Pagination lists only the headline steps; mid steps play during auto-advance
+// but aren't clickable stops. Each entry keeps its index into `steps` so the
+// rail/dots can jump straight to it.
+const paginatedSteps = steps
+  .map((s, index) => ({ title: s.title, index, mid: s.mid }))
+  .filter((s) => !s.mid)
+
 export type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
 
 // Shared player: auto-advance while visible, with a CSS animation as the step
@@ -463,7 +529,8 @@ export type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
 // preview's named parts (field shell, label, trigger…) morph instead of swap.
 export function useCompositionPlayer({
   durationScale = 1,
-}: { durationScale?: number } = {}) {
+  midDurationMs,
+}: { durationScale?: number; midDurationMs?: number } = {}) {
   const [step, setStep] = useState(0)
   const [userPaused, setUserPaused] = useState(false)
   const [hoverPaused, setHoverPausedState] = useState(false)
@@ -565,7 +632,17 @@ export function useCompositionPlayer({
 
   const playing = mounted && inView && !hidden && !userPaused && !hoverPaused
   const current = steps[step] ?? firstStep
-  const stepDurationMs = current.durationMs * durationScale
+  // A mid step maps to the headline step it's building toward (the next
+  // paginated entry), so that entry stays lit while the beats play.
+  const activePaginated = Math.max(
+    0,
+    paginatedSteps.findIndex((p) => p.index >= step),
+  )
+  // Mid steps share one dwell time; the tweaker can override it (undefined in
+  // production, where each mid keeps its own durationMs).
+  const stepDurationMs =
+    (current.mid ? (midDurationMs ?? current.durationMs) : current.durationMs) *
+    durationScale
   const reducedMotion =
     mounted && window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
@@ -591,6 +668,8 @@ export function useCompositionPlayer({
     current,
     stepDurationMs,
     reducedMotion,
+    paginated: paginatedSteps,
+    activePaginated,
   }
 }
 
@@ -660,27 +739,27 @@ export function StepDots({
   player: CompositionPlayer
   className?: string
 }) {
-  const { steps, step, goToStep } = player
+  const { paginated, activePaginated, goToStep } = player
   return (
     <div className={cn('flex items-center', className)}>
-      {steps.map((s, i) => (
+      {paginated.map((p, pos) => (
         <button
-          key={s.title}
+          key={p.title}
           type="button"
-          aria-label={`Step ${i + 1}: ${s.title}`}
-          aria-current={i === step ? 'step' : undefined}
-          onClick={() => goToStep(i)}
+          aria-label={`Step ${pos + 1}: ${p.title}`}
+          aria-current={pos === activePaginated ? 'step' : undefined}
+          onClick={() => goToStep(p.index)}
           className="group flex h-8 cursor-pointer items-center px-[3px]"
         >
           <span
             className={cn(
               'relative h-1 overflow-hidden rounded-full transition-all duration-300',
-              i === step
+              pos === activePaginated
                 ? 'w-5 bg-border'
                 : 'w-1.5 bg-border group-hover:bg-fg-muted',
             )}
           >
-            {i === step && (
+            {pos === activePaginated && (
               <StepProgress
                 player={player}
                 className="absolute inset-0 block rounded-full"

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -1,0 +1,538 @@
+import 'shiki-magic-move/style.css'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
+import { parseDate } from '@internationalized/date'
+import { ShikiMagicMove } from 'shiki-magic-move/react'
+import { useTheme } from 'starter-themes'
+
+import {
+  CalendarIcon,
+  MailIcon,
+  MoreHorizontalIcon,
+} from '@/registry/__generated__/icons'
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+import { Calendar, RangeCalendar } from '@/registry/ui/calendar'
+import { DateField } from '@/registry/ui/date-field'
+import { DatePicker, DateRangePicker } from '@/registry/ui/date-picker'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/registry/ui/dialog'
+import { Drawer } from '@/registry/ui/drawer'
+import { Description, Label } from '@/registry/ui/field'
+import {
+  DateInput,
+  Input,
+  InputGroup,
+  InputGroupAddon,
+} from '@/registry/ui/input'
+import { Menu, MenuContent, MenuItem } from '@/registry/ui/menu'
+import { Modal } from '@/registry/ui/modal'
+import { Popover } from '@/registry/ui/popover'
+import { TextField } from '@/registry/ui/text-field'
+import { highlighter } from '@/modules/docs/highlight'
+
+const STEP_MS = 3200
+
+interface Step {
+  title: string
+  code: string
+  preview: React.ReactNode
+}
+
+const firstStep: Step = {
+  title: 'Input',
+  code: `<Input placeholder="hello@example.com" />`,
+  preview: (
+    <Input
+      aria-label="Email"
+      placeholder="hello@example.com"
+      className="w-56 [view-transition-name:cmp-field]"
+    />
+  ),
+}
+
+const steps: Step[] = [
+  firstStep,
+  {
+    title: 'TextField',
+    code: `<TextField>
+  <Input placeholder="hello@example.com" />
+</TextField>`,
+    preview: (
+      <TextField aria-label="Email" className="w-56">
+        <Input
+          placeholder="hello@example.com"
+          className="[view-transition-name:cmp-field]"
+        />
+      </TextField>
+    ),
+  },
+  {
+    title: 'Label & Description',
+    code: `<TextField>
+  <Label>Email</Label>
+  <Input placeholder="hello@example.com" />
+  <Description>No spam, unsubscribe anytime.</Description>
+</TextField>`,
+    preview: (
+      <TextField className="w-56">
+        <Label className="[view-transition-name:cmp-label]">Email</Label>
+        <Input
+          placeholder="hello@example.com"
+          className="[view-transition-name:cmp-field]"
+        />
+        <Description className="[view-transition-name:cmp-desc]">
+          No spam, unsubscribe anytime.
+        </Description>
+      </TextField>
+    ),
+  },
+  {
+    title: 'InputGroup',
+    code: `<TextField>
+  <Label>Email</Label>
+  <InputGroup>
+    <InputGroupAddon>
+      <MailIcon />
+    </InputGroupAddon>
+    <Input placeholder="hello@example.com" />
+    <InputGroupAddon>
+      <Button size="sm">Subscribe</Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Description>No spam, unsubscribe anytime.</Description>
+</TextField>`,
+    preview: (
+      <TextField className="w-72">
+        <Label className="[view-transition-name:cmp-label]">Email</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <InputGroupAddon>
+            <MailIcon />
+          </InputGroupAddon>
+          <Input placeholder="hello@example.com" />
+          <InputGroupAddon>
+            <Button size="sm" className="[view-transition-name:cmp-trigger]">
+              Subscribe
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Description className="[view-transition-name:cmp-desc]">
+          No spam, unsubscribe anytime.
+        </Description>
+      </TextField>
+    ),
+  },
+  {
+    title: 'DateField',
+    code: `<DateField>
+  <Label>Meeting date</Label>
+  <InputGroup>
+    <InputGroupAddon>
+      <CalendarIcon />
+    </InputGroupAddon>
+    <DateInput />
+  </InputGroup>
+</DateField>`,
+    preview: (
+      <DateField className="w-56" defaultValue={parseDate('2026-07-10')}>
+        <Label className="[view-transition-name:cmp-label]">Meeting date</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <InputGroupAddon>
+            <CalendarIcon />
+          </InputGroupAddon>
+          <DateInput />
+        </InputGroup>
+      </DateField>
+    ),
+  },
+  {
+    title: 'DatePicker',
+    code: `<DatePicker>
+  <Label>Meeting date</Label>
+  <InputGroup>
+    <DateInput />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <CalendarIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Popover>
+    <DialogContent>
+      <Calendar />
+    </DialogContent>
+  </Popover>
+</DatePicker>`,
+    preview: (
+      <DatePicker className="w-56" defaultValue={parseDate('2026-07-10')}>
+        <Label className="[view-transition-name:cmp-label]">Meeting date</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <DateInput />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <CalendarIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <DialogContent>
+            <Calendar />
+          </DialogContent>
+        </Popover>
+      </DatePicker>
+    ),
+  },
+  {
+    title: 'DateRangePicker',
+    code: `<DateRangePicker>
+  <Label>Trip dates</Label>
+  <InputGroup>
+    <DateInput slot="start" />
+    <span>–</span>
+    <DateInput slot="end" />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <CalendarIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Popover>
+    <DialogContent>
+      <RangeCalendar />
+    </DialogContent>
+  </Popover>
+</DateRangePicker>`,
+    preview: (
+      <DateRangePicker
+        className="w-64"
+        defaultValue={{
+          start: parseDate('2026-07-10'),
+          end: parseDate('2026-07-17'),
+        }}
+      >
+        <Label className="[view-transition-name:cmp-label]">Trip dates</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <DateInput slot="start" />
+          <span>–</span>
+          <DateInput slot="end" />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <CalendarIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <DialogContent>
+            <RangeCalendar />
+          </DialogContent>
+        </Popover>
+      </DateRangePicker>
+    ),
+  },
+  {
+    title: 'Same picker, drawer overlay',
+    code: `<DateRangePicker>
+  <Label>Trip dates</Label>
+  <InputGroup>
+    <DateInput slot="start" />
+    <span>–</span>
+    <DateInput slot="end" />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <CalendarIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Drawer placement="bottom">
+    <DialogContent>
+      <RangeCalendar />
+    </DialogContent>
+  </Drawer>
+</DateRangePicker>`,
+    preview: (
+      <DateRangePicker
+        className="w-64"
+        defaultValue={{
+          start: parseDate('2026-07-10'),
+          end: parseDate('2026-07-17'),
+        }}
+      >
+        <Label className="[view-transition-name:cmp-label]">Trip dates</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <DateInput slot="start" />
+          <span>–</span>
+          <DateInput slot="end" />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <CalendarIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Drawer placement="bottom">
+          <DialogContent>
+            <RangeCalendar />
+          </DialogContent>
+        </Drawer>
+      </DateRangePicker>
+    ),
+  },
+  {
+    title: 'Dialog',
+    code: `<Dialog>
+  <Button>Create issue</Button>
+  <Modal>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Create a new issue</DialogTitle>
+        <DialogDescription>
+          Report a bug or request a feature.
+        </DialogDescription>
+      </DialogHeader>
+    </DialogContent>
+  </Modal>
+</Dialog>`,
+    preview: (
+      <Dialog>
+        <Button className="[view-transition-name:cmp-trigger]">
+          Create issue
+        </Button>
+        <Modal>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create a new issue</DialogTitle>
+              <DialogDescription>
+                Report a bug or request a feature.
+              </DialogDescription>
+            </DialogHeader>
+          </DialogContent>
+        </Modal>
+      </Dialog>
+    ),
+  },
+  {
+    title: 'Menu',
+    code: `<Menu>
+  <Button size="sm" isIconOnly>
+    <MoreHorizontalIcon />
+  </Button>
+  <Popover>
+    <MenuContent>
+      <MenuItem>Edit</MenuItem>
+      <MenuItem>Duplicate</MenuItem>
+      <MenuItem>Delete</MenuItem>
+    </MenuContent>
+  </Popover>
+</Menu>`,
+    preview: (
+      <Menu>
+        <Button
+          size="sm"
+          isIconOnly
+          aria-label="Actions"
+          className="[view-transition-name:cmp-trigger]"
+        >
+          <MoreHorizontalIcon />
+        </Button>
+        <Popover>
+          <MenuContent>
+            <MenuItem>Edit</MenuItem>
+            <MenuItem>Duplicate</MenuItem>
+            <MenuItem>Delete</MenuItem>
+          </MenuContent>
+        </Popover>
+      </Menu>
+    ),
+  },
+]
+
+// Shared player: auto-advance while visible, pause on hover/focus, and route
+// every step change through a view transition so the preview's named parts
+// (field shell, label, trigger…) morph instead of swapping.
+export function useCompositionPlayer() {
+  const [step, setStep] = useState(0)
+  const [paused, setPaused] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const [inView, setInView] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => setMounted(true), [])
+
+  // Only animate while on screen — the loop parks itself otherwise.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => setInView(entry?.isIntersecting ?? false),
+      { threshold: 0.4 },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  const stepRef = useRef(0)
+  const goToStep = useCallback((next: number) => {
+    stepRef.current = next
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduce || !document.startViewTransition) {
+      setStep(next)
+      return
+    }
+    document.startViewTransition(() => {
+      flushSync(() => setStep(next))
+    })
+  }, [])
+
+  useEffect(() => {
+    if (paused || !inView || !mounted) return
+    const id = setInterval(
+      () => goToStep((stepRef.current + 1) % steps.length),
+      STEP_MS,
+    )
+    return () => clearInterval(id)
+  }, [paused, inView, mounted, goToStep])
+
+  const current = steps[step] ?? firstStep
+  const reducedMotion =
+    mounted && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  return {
+    steps,
+    step,
+    goToStep,
+    setPaused,
+    mounted,
+    containerRef,
+    current,
+    reducedMotion,
+  }
+}
+
+export function CompositionTransitionStyles() {
+  return (
+    <style>{`
+      /* Keep the page interactive while a transition runs, and confine the
+         animation to the named preview parts — everything else swaps instantly. */
+      ::view-transition { pointer-events: none; }
+      ::view-transition-old(root) { display: none; }
+      ::view-transition-new(root) { animation: none; }
+      ::view-transition-group(cmp-field),
+      ::view-transition-group(cmp-label),
+      ::view-transition-group(cmp-desc),
+      ::view-transition-group(cmp-trigger) {
+        animation-duration: 450ms;
+        animation-timing-function: cubic-bezier(0.645, 0.045, 0.355, 1);
+      }
+      ::view-transition-old(cmp-code) { display: none; }
+      ::view-transition-new(cmp-code) { animation: none; }
+      @media (prefers-reduced-motion: reduce) {
+        ::view-transition-group(*),
+        ::view-transition-old(*),
+        ::view-transition-new(*) { animation: none; }
+      }
+    `}</style>
+  )
+}
+
+export function CompositionCode({
+  code,
+  reducedMotion,
+}: {
+  code: string
+  reducedMotion: boolean
+}) {
+  const { resolvedTheme } = useTheme()
+  return (
+    <ShikiMagicMove
+      highlighter={highlighter}
+      lang="tsx"
+      theme={resolvedTheme === 'light' ? 'github-light' : 'github-dark'}
+      code={code}
+      options={{
+        duration: reducedMotion ? 0 : 700,
+        stagger: 2,
+        containerStyle: false,
+      }}
+    />
+  )
+}
+
+export function CompositionAnimation({ className }: { className?: string }) {
+  const {
+    step,
+    goToStep,
+    setPaused,
+    mounted,
+    containerRef,
+    current,
+    reducedMotion,
+  } = useCompositionPlayer()
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn('overflow-hidden rounded-md border bg-card', className)}
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      onFocus={() => setPaused(true)}
+      onBlur={() => setPaused(false)}
+    >
+      <CompositionTransitionStyles />
+      <div className="flex items-center justify-between gap-2 border-b py-1.5 pr-2.5 pl-2.5">
+        <span className="truncate font-mono text-[0.8125rem] text-fg-muted">
+          {current.title}
+        </span>
+        <div className="flex items-center">
+          {steps.map((s, i) => (
+            <button
+              key={s.title}
+              type="button"
+              aria-label={`Step ${i + 1}: ${s.title}`}
+              onClick={() => goToStep(i)}
+              className="group flex size-5 cursor-pointer items-center justify-center"
+            >
+              <span
+                className={cn(
+                  'size-1.5 rounded-full transition-colors',
+                  i === step ? 'bg-fg' : 'bg-border group-hover:bg-fg-muted',
+                )}
+              />
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="grid sm:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+        <div className="no-scrollbar h-88 overflow-auto p-4 font-mono text-[0.8125rem] leading-relaxed [view-transition-name:cmp-code]">
+          {mounted ? (
+            <CompositionCode
+              code={current.code}
+              reducedMotion={reducedMotion}
+            />
+          ) : (
+            <pre className="whitespace-pre">{current.code}</pre>
+          )}
+        </div>
+        <div className="flex min-h-40 items-center justify-center border-t bg-bg p-6 sm:border-t-0 sm:border-l">
+          {current.preview}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/docs/docs-copy-page.tsx
+++ b/www/src/modules/docs/docs-copy-page.tsx
@@ -91,7 +91,7 @@ export function DocsCopyPage({
   const { copyToClipboard, isCopied } = useCopyToClipboard()
 
   return (
-    <Group>
+    <Group className="hidden sm:flex">
       <Button size="sm" onPress={() => copyToClipboard(content)}>
         {isCopied ? (
           <CheckIcon data-icon-start="" />

--- a/www/src/modules/docs/docs-pager.tsx
+++ b/www/src/modules/docs/docs-pager.tsx
@@ -1,7 +1,6 @@
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 
 import { Button, LinkButton } from '@/registry/ui/button'
-import { Group } from '@/registry/ui/group'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
 
 type Neighbour = { name: string; path: string }
@@ -42,9 +41,9 @@ export function DocsPager({ neighbours }: { neighbours: Neighbours }) {
     )
 
   return (
-    <Group>
+    <div className="flex gap-2">
       {renderNeighbour(previous, <ChevronLeftIcon />, 'Go to previous page')}
       {renderNeighbour(next, <ChevronRightIcon />, 'Go to next page')}
-    </Group>
+    </div>
   )
 }

--- a/www/src/modules/docs/highlight.ts
+++ b/www/src/modules/docs/highlight.ts
@@ -21,6 +21,9 @@ const highlighter = createHighlighterCoreSync({
   engine: createJavaScriptRegexEngine({ forgiving: true }),
 })
 
+/** The raw highlighter, for consumers that need token-level access (magic-move). */
+export { highlighter }
+
 /** Highlight TSX to HAST with the same dual-theme CSS variables the build uses. */
 export function highlightTsx(code: string): Root {
   return highlighter.codeToHast(code, {

--- a/www/src/modules/docs/mdx-components.tsx
+++ b/www/src/modules/docs/mdx-components.tsx
@@ -12,6 +12,7 @@ import {
   CodeBlockTabsTrigger,
 } from '@/modules/docs/code-block-tabs'
 import { ComponentsGrid } from '@/modules/docs/components-list/components-grid'
+import { CompositionAnimation } from '@/modules/docs/composition-animation'
 import {
   Demo,
   DemoCode,
@@ -209,4 +210,13 @@ export const mdxComponents: MDXComponents = {
     <Reference className={cn('mt-4', className)} {...props} />
   ),
   ComponentsGrid,
+  CompositionAnimation: ({
+    className,
+    ...props
+  }: React.ComponentProps<typeof CompositionAnimation>) => (
+    <CompositionAnimation
+      className={cn('not-first:mt-6', className)}
+      {...props}
+    />
+  ),
 }

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -10,73 +10,9 @@ import {
   StepTimer,
   useCompositionPlayer,
 } from '@/modules/docs/composition-animation'
-import { useTweak } from '@/dev/tweaker'
 
 export function CompositionSection() {
-  // Tweaker scaffolding — bake the picked values and remove before merging.
-  const durationScale = useTweak('Step duration ×', {
-    type: 'number',
-    min: 0.5,
-    max: 2.5,
-    step: 0.1,
-    default: 1,
-    group: 'Composition',
-  })
-  const midDurationMs = useTweak('Mid step (ms)', {
-    type: 'number',
-    min: 400,
-    max: 3000,
-    step: 100,
-    default: 1500,
-    group: 'Composition',
-  })
-  const codeMoveMs = useTweak('Code move (ms)', {
-    type: 'number',
-    min: 200,
-    max: 1500,
-    step: 50,
-    default: 700,
-    group: 'Composition',
-  })
-  const codeStaggerMs = useTweak('Code stagger (ms)', {
-    type: 'number',
-    min: 0,
-    max: 20,
-    step: 1,
-    default: 2,
-    group: 'Composition',
-  })
-  const heightMs = useTweak('Height tween (ms)', {
-    type: 'number',
-    min: 150,
-    max: 1200,
-    step: 50,
-    default: 500,
-    group: 'Composition',
-  })
-  const morphMs = useTweak('Preview morph (ms)', {
-    type: 'number',
-    min: 150,
-    max: 1000,
-    step: 25,
-    default: 450,
-    group: 'Composition',
-  })
-  const railMs = useTweak('Rail slide (ms)', {
-    type: 'number',
-    min: 150,
-    max: 1000,
-    step: 25,
-    default: 450,
-    group: 'Composition',
-  })
-  const hoverPause = useTweak('Pause on hover', {
-    type: 'boolean',
-    default: true,
-    group: 'Composition',
-  })
-
-  const player = useCompositionPlayer({ durationScale, midDurationMs })
+  const player = useCompositionPlayer()
   const {
     paginated,
     activePaginated,
@@ -124,16 +60,16 @@ export function CompositionSection() {
   }, [mounted, current.code])
 
   const pauseHandlers = {
-    onMouseEnter: () => hoverPause && setHoverPaused(true),
+    onMouseEnter: () => setHoverPaused(true),
     onMouseLeave: () => setHoverPaused(false),
-    onFocus: () => hoverPause && setHoverPaused(true),
+    onFocus: () => setHoverPaused(true),
     onBlur: () => setHoverPaused(false),
   }
 
   return (
     // Width mirrors the cards strip: 1500px grid + 8rem rail gutters.
     <section className="mx-auto mt-24 w-full max-w-[calc(1500px+16rem)] px-4 sm:px-6 md:mt-32 lg:px-32">
-      <CompositionTransitionStyles morphMs={morphMs} />
+      <CompositionTransitionStyles />
       <StepTimer player={player} />
       <div
         ref={containerRef}
@@ -165,7 +101,7 @@ export function CompositionSection() {
               className="absolute top-5 left-0 z-10 h-8 w-px bg-fg transition-transform ease-[cubic-bezier(0.645,0.045,0.355,1)] motion-reduce:transition-none"
               style={{
                 transform: `translateY(${activePaginated * 2}rem)`,
-                transitionDuration: `${railMs}ms`,
+                transitionDuration: '450ms',
               }}
             />
             {paginated.map((p, pos) => (
@@ -224,7 +160,7 @@ export function CompositionSection() {
               className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out [view-transition-name:cmp-code] motion-reduce:transition-none"
               style={{
                 height: codeHeight ?? 'auto',
-                transitionDuration: `${heightMs}ms`,
+                transitionDuration: '500ms',
               }}
             >
               <div
@@ -235,8 +171,6 @@ export function CompositionSection() {
                   <CompositionCode
                     code={current.code}
                     reducedMotion={reducedMotion}
-                    duration={codeMoveMs}
-                    stagger={codeStaggerMs}
                   />
                 ) : (
                   <pre className="whitespace-pre">{current.code}</pre>

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -1,0 +1,132 @@
+import { cn } from '@/registry/lib/utils'
+import { LinkButton } from '@/registry/ui/button'
+import {
+  CompositionCode,
+  CompositionTransitionStyles,
+  useCompositionPlayer,
+} from '@/modules/docs/composition-animation'
+
+const stats = [
+  { value: '1', label: 'Button, every trigger' },
+  { value: '1', label: 'Popover, every overlay' },
+  { value: '0', label: 'parallel APIs' },
+]
+
+export function CompositionSection() {
+  const {
+    steps,
+    step,
+    goToStep,
+    setPaused,
+    mounted,
+    containerRef,
+    current,
+    reducedMotion,
+  } = useCompositionPlayer()
+
+  return (
+    <section className="container mt-24 md:mt-32">
+      <CompositionTransitionStyles />
+      <div
+        ref={containerRef}
+        className="grid items-center gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,6fr)] lg:gap-16"
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+        onFocus={() => setPaused(true)}
+        onBlur={() => setPaused(false)}
+      >
+        {/* Copy */}
+        <div className="flex flex-col items-start gap-4 max-lg:items-center max-lg:text-center">
+          <h2 className="font-mono text-sm tracking-wide text-fg-muted">
+            Composition
+          </h2>
+          <p className="text-4xl font-semibold tracking-tighter text-balance sm:text-5xl">
+            Ten primitives.
+            <br />
+            <span className="text-fg-muted">Every component.</span>
+          </p>
+          <p className="max-w-md text-base text-balance text-fg-muted">
+            Learn a primitive once — the same parts recompose into the whole
+            library.
+          </p>
+          <div className="flex flex-wrap gap-2 pt-2 max-lg:justify-center">
+            <LinkButton href="/docs/components" variant="primary">
+              Explore components
+            </LinkButton>
+            <LinkButton href="/docs" variant="default">
+              Read the docs
+            </LinkButton>
+          </div>
+          <div className="mt-6 flex gap-10">
+            {stats.map(({ value, label }) => (
+              <div key={label} className="max-lg:text-center">
+                <div className="text-xl font-semibold tracking-tight">
+                  {value}
+                </div>
+                <div className="mt-0.5 text-xs text-fg-muted">{label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Code window on a soft plate, preview as its result pane */}
+        <div>
+          <div className="relative rounded-2xl bg-linear-135 from-fg/6 via-fg/2 to-transparent p-3 sm:p-6">
+            <div className="overflow-hidden rounded-xl border bg-card shadow-2xl">
+              <div className="flex items-center justify-between border-b px-3.5 py-2.5">
+                <div className="flex items-center gap-1.5" aria-hidden>
+                  <span className="size-2.5 rounded-full bg-[#ff5f57]" />
+                  <span className="size-2.5 rounded-full bg-[#febc2e]" />
+                  <span className="size-2.5 rounded-full bg-[#28c840]" />
+                </div>
+                <span
+                  aria-live="polite"
+                  className="truncate font-mono text-xs text-fg-muted"
+                >
+                  {current.title}
+                </span>
+              </div>
+              <div className="flex h-104 items-center overflow-hidden p-4 font-mono text-[0.8125rem] leading-normal [view-transition-name:cmp-code]">
+                {mounted ? (
+                  <CompositionCode
+                    code={current.code}
+                    reducedMotion={reducedMotion}
+                  />
+                ) : (
+                  <pre className="whitespace-pre">{current.code}</pre>
+                )}
+              </div>
+              <div className="relative flex min-h-48 items-center justify-center border-t p-6">
+                <div
+                  aria-hidden
+                  className="absolute inset-0 bg-[radial-gradient(var(--color-border)_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_70%_80%_at_50%_50%,black,transparent)] bg-[size:14px_14px]"
+                />
+                <div className="relative">{current.preview}</div>
+              </div>
+            </div>
+          </div>
+          <div className="mt-4 flex items-center justify-center">
+            {steps.map((s, i) => (
+              <button
+                key={s.title}
+                type="button"
+                aria-label={`Step ${i + 1}: ${s.title}`}
+                onClick={() => goToStep(i)}
+                className="group flex h-8 cursor-pointer items-center px-1"
+              >
+                <span
+                  className={cn(
+                    'h-1 rounded-full transition-all duration-300',
+                    i === step
+                      ? 'w-6 bg-fg'
+                      : 'w-2.5 bg-border group-hover:bg-fg-muted',
+                  )}
+                />
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -131,7 +131,8 @@ export function CompositionSection() {
   }
 
   return (
-    <section className="container mt-24 md:mt-32">
+    // Width mirrors the cards strip: 1500px grid + 8rem rail gutters.
+    <section className="mx-auto mt-24 w-full max-w-[calc(1500px+16rem)] px-4 sm:px-6 md:mt-32 lg:px-32">
       <CompositionTransitionStyles morphMs={morphMs} />
       <StepTimer player={player} />
       <div
@@ -139,16 +140,16 @@ export function CompositionSection() {
         className="grid items-start gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] lg:gap-16"
       >
         {/* Copy + step rail */}
-        <div className="flex flex-col items-start gap-4 max-lg:items-center max-lg:text-center">
+        <div className="flex flex-col items-start gap-4">
           <h2 className="font-mono text-sm tracking-wide text-fg-muted">
             Composition
           </h2>
-          <p className="text-4xl font-semibold tracking-tighter text-balance sm:text-5xl">
+          <p className="text-3xl font-semibold tracking-tighter text-balance sm:text-4xl">
             Compose components.
             <br />
             <span className="text-fg-muted">Create your own patterns.</span>
           </p>
-          <p className="max-w-md text-base text-balance text-fg-muted">
+          <p className="text-base text-fg-muted lg:max-w-md">
             One compositional API across the library — the same parts combine
             into anything, from a simple field to a complex pattern.
           </p>
@@ -195,7 +196,7 @@ export function CompositionSection() {
               </li>
             ))}
           </ol>
-          <div className="flex flex-wrap gap-2 pt-2 max-lg:justify-center">
+          <div className="flex flex-wrap gap-2 pt-2">
             <LinkButton href="/docs/components" variant="primary">
               Explore components
             </LinkButton>
@@ -207,44 +208,39 @@ export function CompositionSection() {
 
         {/* Code with its rendered result below — one card, no window chrome */}
         <div {...pauseHandlers}>
-          {/* Reserved for the card at its tallest — preview (14rem + border) plus
-              the 18-line snippet (18 × 19.5px + p-6) — so the height animation
-              never shifts the layout around it. */}
-          <div className="h-[39.25rem] [contain:layout]">
-            <div className="overflow-hidden rounded-xl border bg-card shadow-xs">
-              <div className="relative flex min-h-56 items-center justify-center p-6">
-                <div
-                  aria-hidden
-                  className="absolute inset-0 bg-[radial-gradient(var(--color-border)_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_70%_80%_at_50%_50%,black,transparent)] bg-[size:14px_14px]"
-                />
-                <div className="relative">{current.preview}</div>
-                <PlayPauseButton
-                  player={player}
-                  className="absolute right-2 bottom-2"
-                />
-              </div>
+          <div className="overflow-hidden rounded-xl border bg-card shadow-xs">
+            <div className="relative flex min-h-56 items-center justify-center p-6">
               <div
-                className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out [view-transition-name:cmp-code] motion-reduce:transition-none"
-                style={{
-                  height: codeHeight ?? 'auto',
-                  transitionDuration: `${heightMs}ms`,
-                }}
+                aria-hidden
+                className="absolute inset-0 bg-[radial-gradient(var(--color-border)_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_70%_80%_at_50%_50%,black,transparent)] bg-[size:14px_14px]"
+              />
+              <div className="relative">{current.preview}</div>
+              <PlayPauseButton
+                player={player}
+                className="absolute right-2 bottom-2"
+              />
+            </div>
+            <div
+              className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out [view-transition-name:cmp-code] motion-reduce:transition-none"
+              style={{
+                height: codeHeight ?? 'auto',
+                transitionDuration: `${heightMs}ms`,
+              }}
+            >
+              <div
+                ref={codeInnerRef}
+                className="no-scrollbar overflow-x-auto p-6 font-mono text-[0.8125rem] leading-normal"
               >
-                <div
-                  ref={codeInnerRef}
-                  className="no-scrollbar overflow-x-auto p-6 font-mono text-[0.8125rem] leading-normal"
-                >
-                  {mounted ? (
-                    <CompositionCode
-                      code={current.code}
-                      reducedMotion={reducedMotion}
-                      duration={codeMoveMs}
-                      stagger={codeStaggerMs}
-                    />
-                  ) : (
-                    <pre className="whitespace-pre">{current.code}</pre>
-                  )}
-                </div>
+                {mounted ? (
+                  <CompositionCode
+                    code={current.code}
+                    reducedMotion={reducedMotion}
+                    duration={codeMoveMs}
+                    stagger={codeStaggerMs}
+                  />
+                ) : (
+                  <pre className="whitespace-pre">{current.code}</pre>
+                )}
               </div>
             </div>
           </div>

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -22,6 +22,14 @@ export function CompositionSection() {
     default: 1,
     group: 'Composition',
   })
+  const midDurationMs = useTweak('Mid step (ms)', {
+    type: 'number',
+    min: 400,
+    max: 3000,
+    step: 100,
+    default: 1500,
+    group: 'Composition',
+  })
   const codeMoveMs = useTweak('Code move (ms)', {
     type: 'number',
     min: 200,
@@ -68,10 +76,10 @@ export function CompositionSection() {
     group: 'Composition',
   })
 
-  const player = useCompositionPlayer({ durationScale })
+  const player = useCompositionPlayer({ durationScale, midDurationMs })
   const {
-    steps,
-    step,
+    paginated,
+    activePaginated,
     goToStep,
     setHoverPaused,
     mounted,
@@ -84,13 +92,15 @@ export function CompositionSection() {
   const railRef = useRef<HTMLOListElement>(null)
   useEffect(() => {
     const rail = railRef.current
-    const active = rail?.children[step] as HTMLElement | undefined
+    const active = rail?.querySelectorAll('li')[activePaginated] as
+      | HTMLElement
+      | undefined
     if (!rail || !active) return
     rail.scrollTo({
       top: active.offsetTop - rail.clientHeight / 2 + active.offsetHeight / 2,
       behavior: reducedMotion ? 'auto' : 'smooth',
     })
-  }, [step, reducedMotion])
+  }, [activePaginated, reducedMotion])
 
   // The code pane hugs its content. The target height is computed from the
   // step's line count (calibrated once against the first rendered snippet) so
@@ -134,13 +144,13 @@ export function CompositionSection() {
             Composition
           </h2>
           <p className="text-4xl font-semibold tracking-tighter text-balance sm:text-5xl">
-            Ten primitives.
+            Compose components.
             <br />
-            <span className="text-fg-muted">Every component.</span>
+            <span className="text-fg-muted">Create your own patterns.</span>
           </p>
           <p className="max-w-md text-base text-balance text-fg-muted">
-            Learn a primitive once — the same parts recompose into the whole
-            library.
+            One compositional API across the library — the same parts combine
+            into anything, from a simple field to a complex pattern.
           </p>
           <ol
             ref={railRef}
@@ -153,30 +163,34 @@ export function CompositionSection() {
               aria-hidden
               className="absolute top-5 left-0 z-10 h-8 w-px bg-fg transition-transform ease-[cubic-bezier(0.645,0.045,0.355,1)] motion-reduce:transition-none"
               style={{
-                transform: `translateY(${step * 2}rem)`,
+                transform: `translateY(${activePaginated * 2}rem)`,
                 transitionDuration: `${railMs}ms`,
               }}
             />
-            {steps.map((s, i) => (
-              <li key={s.title}>
+            {paginated.map((p, pos) => (
+              <li key={p.title}>
                 <button
                   type="button"
-                  aria-current={i === step ? 'step' : undefined}
-                  onClick={() => goToStep(i)}
+                  aria-current={pos === activePaginated ? 'step' : undefined}
+                  onClick={() => goToStep(p.index)}
                   className={cn(
                     'relative flex h-8 w-full cursor-pointer items-center gap-3 border-l pl-4 text-left text-sm transition-colors',
-                    i === step ? 'text-fg' : 'text-fg-muted hover:text-fg',
+                    pos === activePaginated
+                      ? 'text-fg'
+                      : 'text-fg-muted hover:text-fg',
                   )}
                 >
                   <span
                     className={cn(
                       'font-mono text-xs tabular-nums transition-colors',
-                      i === step ? 'text-fg-muted' : 'text-fg-muted/50',
+                      pos === activePaginated
+                        ? 'text-fg-muted'
+                        : 'text-fg-muted/50',
                     )}
                   >
-                    {String(i + 1).padStart(2, '0')}
+                    {String(pos + 1).padStart(2, '0')}
                   </span>
-                  {s.title}
+                  {p.title}
                 </button>
               </li>
             ))}

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -1,41 +1,134 @@
+import { useEffect, useRef, useState } from 'react'
+
 import { cn } from '@/registry/lib/utils'
 import { LinkButton } from '@/registry/ui/button'
 import {
   CompositionCode,
   CompositionTransitionStyles,
+  PlayPauseButton,
+  StepDots,
+  StepTimer,
   useCompositionPlayer,
 } from '@/modules/docs/composition-animation'
-
-const stats = [
-  { value: '1', label: 'Button, every trigger' },
-  { value: '1', label: 'Popover, every overlay' },
-  { value: '0', label: 'parallel APIs' },
-]
+import { useTweak } from '@/dev/tweaker'
 
 export function CompositionSection() {
+  // Tweaker scaffolding — bake the picked values and remove before merging.
+  const durationScale = useTweak('Step duration ×', {
+    type: 'number',
+    min: 0.5,
+    max: 2.5,
+    step: 0.1,
+    default: 1,
+    group: 'Composition',
+  })
+  const codeMoveMs = useTweak('Code move (ms)', {
+    type: 'number',
+    min: 200,
+    max: 1500,
+    step: 50,
+    default: 700,
+    group: 'Composition',
+  })
+  const codeStaggerMs = useTweak('Code stagger (ms)', {
+    type: 'number',
+    min: 0,
+    max: 20,
+    step: 1,
+    default: 2,
+    group: 'Composition',
+  })
+  const heightMs = useTweak('Height tween (ms)', {
+    type: 'number',
+    min: 150,
+    max: 1200,
+    step: 50,
+    default: 500,
+    group: 'Composition',
+  })
+  const morphMs = useTweak('Preview morph (ms)', {
+    type: 'number',
+    min: 150,
+    max: 1000,
+    step: 25,
+    default: 450,
+    group: 'Composition',
+  })
+  const railMs = useTweak('Rail slide (ms)', {
+    type: 'number',
+    min: 150,
+    max: 1000,
+    step: 25,
+    default: 450,
+    group: 'Composition',
+  })
+  const hoverPause = useTweak('Pause on hover', {
+    type: 'boolean',
+    default: true,
+    group: 'Composition',
+  })
+
+  const player = useCompositionPlayer({ durationScale })
   const {
     steps,
     step,
     goToStep,
-    setPaused,
+    setHoverPaused,
     mounted,
     containerRef,
     current,
     reducedMotion,
-  } = useCompositionPlayer()
+  } = player
+
+  // Keep the active step centered in the fixed-height rail as the loop runs.
+  const railRef = useRef<HTMLOListElement>(null)
+  useEffect(() => {
+    const rail = railRef.current
+    const active = rail?.children[step] as HTMLElement | undefined
+    if (!rail || !active) return
+    rail.scrollTo({
+      top: active.offsetTop - rail.clientHeight / 2 + active.offsetHeight / 2,
+      behavior: reducedMotion ? 'auto' : 'smooth',
+    })
+  }, [step, reducedMotion])
+
+  // The code pane hugs its content. The target height is computed from the
+  // step's line count (calibrated once against the first rendered snippet) so
+  // the tween starts in the same commit as the token animation — observing the
+  // DOM instead would only fire after departing tokens are removed, i.e. late.
+  // Until calibration the height stays auto (auto→px doesn't tween).
+  const codeInnerRef = useRef<HTMLDivElement>(null)
+  const codeMetrics = useRef<{ line: number; pad: number } | null>(null)
+  const [codeHeight, setCodeHeight] = useState<number | null>(null)
+  useEffect(() => {
+    const el = codeInnerRef.current
+    if (!el || !mounted) return
+    const lines = current.code.split('\n').length
+    if (!codeMetrics.current) {
+      const style = getComputedStyle(el)
+      const pad = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom)
+      codeMetrics.current = { line: (el.offsetHeight - pad) / lines, pad }
+    }
+    const { line, pad } = codeMetrics.current
+    setCodeHeight(lines * line + pad)
+  }, [mounted, current.code])
+
+  const pauseHandlers = {
+    onMouseEnter: () => hoverPause && setHoverPaused(true),
+    onMouseLeave: () => setHoverPaused(false),
+    onFocus: () => hoverPause && setHoverPaused(true),
+    onBlur: () => setHoverPaused(false),
+  }
 
   return (
     <section className="container mt-24 md:mt-32">
-      <CompositionTransitionStyles />
+      <CompositionTransitionStyles morphMs={morphMs} />
+      <StepTimer player={player} />
       <div
         ref={containerRef}
-        className="grid items-center gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,6fr)] lg:gap-16"
-        onMouseEnter={() => setPaused(true)}
-        onMouseLeave={() => setPaused(false)}
-        onFocus={() => setPaused(true)}
-        onBlur={() => setPaused(false)}
+        className="grid items-start gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] lg:gap-16"
       >
-        {/* Copy */}
+        {/* Copy + step rail */}
         <div className="flex flex-col items-start gap-4 max-lg:items-center max-lg:text-center">
           <h2 className="font-mono text-sm tracking-wide text-fg-muted">
             Composition
@@ -49,6 +142,45 @@ export function CompositionSection() {
             Learn a primitive once — the same parts recompose into the whole
             library.
           </p>
+          <ol
+            ref={railRef}
+            className="relative mt-2 no-scrollbar h-56 self-stretch overflow-y-auto [mask-image:linear-gradient(to_bottom,transparent,black_3rem,black_calc(100%-3rem),transparent)] py-5 max-lg:hidden"
+            {...pauseHandlers}
+          >
+            {/* One indicator for the whole rail — it travels to the active
+                step instead of each step lighting its own segment. */}
+            <span
+              aria-hidden
+              className="absolute top-5 left-0 z-10 h-8 w-px bg-fg transition-transform ease-[cubic-bezier(0.645,0.045,0.355,1)] motion-reduce:transition-none"
+              style={{
+                transform: `translateY(${step * 2}rem)`,
+                transitionDuration: `${railMs}ms`,
+              }}
+            />
+            {steps.map((s, i) => (
+              <li key={s.title}>
+                <button
+                  type="button"
+                  aria-current={i === step ? 'step' : undefined}
+                  onClick={() => goToStep(i)}
+                  className={cn(
+                    'relative flex h-8 w-full cursor-pointer items-center gap-3 border-l pl-4 text-left text-sm transition-colors',
+                    i === step ? 'text-fg' : 'text-fg-muted hover:text-fg',
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'font-mono text-xs tabular-nums transition-colors',
+                      i === step ? 'text-fg-muted' : 'text-fg-muted/50',
+                    )}
+                  >
+                    {String(i + 1).padStart(2, '0')}
+                  </span>
+                  {s.title}
+                </button>
+              </li>
+            ))}
+          </ol>
           <div className="flex flex-wrap gap-2 pt-2 max-lg:justify-center">
             <LinkButton href="/docs/components" variant="primary">
               Explore components
@@ -57,73 +189,56 @@ export function CompositionSection() {
               Read the docs
             </LinkButton>
           </div>
-          <div className="mt-6 flex gap-10">
-            {stats.map(({ value, label }) => (
-              <div key={label} className="max-lg:text-center">
-                <div className="text-xl font-semibold tracking-tight">
-                  {value}
-                </div>
-                <div className="mt-0.5 text-xs text-fg-muted">{label}</div>
-              </div>
-            ))}
-          </div>
         </div>
 
-        {/* Code window on a soft plate, preview as its result pane */}
-        <div>
-          <div className="relative rounded-2xl bg-linear-135 from-fg/6 via-fg/2 to-transparent p-3 sm:p-6">
-            <div className="overflow-hidden rounded-xl border bg-card shadow-2xl">
-              <div className="flex items-center justify-between border-b px-3.5 py-2.5">
-                <div className="flex items-center gap-1.5" aria-hidden>
-                  <span className="size-2.5 rounded-full bg-[#ff5f57]" />
-                  <span className="size-2.5 rounded-full bg-[#febc2e]" />
-                  <span className="size-2.5 rounded-full bg-[#28c840]" />
-                </div>
-                <span
-                  aria-live="polite"
-                  className="truncate font-mono text-xs text-fg-muted"
-                >
-                  {current.title}
-                </span>
-              </div>
-              <div className="flex h-104 items-center overflow-hidden p-4 font-mono text-[0.8125rem] leading-normal [view-transition-name:cmp-code]">
-                {mounted ? (
-                  <CompositionCode
-                    code={current.code}
-                    reducedMotion={reducedMotion}
-                  />
-                ) : (
-                  <pre className="whitespace-pre">{current.code}</pre>
-                )}
-              </div>
-              <div className="relative flex min-h-48 items-center justify-center border-t p-6">
+        {/* Code with its rendered result below — one card, no window chrome */}
+        <div {...pauseHandlers}>
+          {/* Reserved for the card at its tallest — preview (14rem + border) plus
+              the 18-line snippet (18 × 19.5px + p-6) — so the height animation
+              never shifts the layout around it. */}
+          <div className="h-[39.25rem] [contain:layout]">
+            <div className="overflow-hidden rounded-xl border bg-card shadow-xs">
+              <div className="relative flex min-h-56 items-center justify-center p-6">
                 <div
                   aria-hidden
                   className="absolute inset-0 bg-[radial-gradient(var(--color-border)_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_70%_80%_at_50%_50%,black,transparent)] bg-[size:14px_14px]"
                 />
                 <div className="relative">{current.preview}</div>
+                <PlayPauseButton
+                  player={player}
+                  className="absolute right-2 bottom-2"
+                />
+              </div>
+              <div
+                className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out [view-transition-name:cmp-code] motion-reduce:transition-none"
+                style={{
+                  height: codeHeight ?? 'auto',
+                  transitionDuration: `${heightMs}ms`,
+                }}
+              >
+                <div
+                  ref={codeInnerRef}
+                  className="no-scrollbar overflow-x-auto p-6 font-mono text-[0.8125rem] leading-normal"
+                >
+                  {mounted ? (
+                    <CompositionCode
+                      code={current.code}
+                      reducedMotion={reducedMotion}
+                      duration={codeMoveMs}
+                      stagger={codeStaggerMs}
+                    />
+                  ) : (
+                    <pre className="whitespace-pre">{current.code}</pre>
+                  )}
+                </div>
               </div>
             </div>
           </div>
-          <div className="mt-4 flex items-center justify-center">
-            {steps.map((s, i) => (
-              <button
-                key={s.title}
-                type="button"
-                aria-label={`Step ${i + 1}: ${s.title}`}
-                onClick={() => goToStep(i)}
-                className="group flex h-8 cursor-pointer items-center px-1"
-              >
-                <span
-                  className={cn(
-                    'h-1 rounded-full transition-all duration-300',
-                    i === step
-                      ? 'w-6 bg-fg'
-                      : 'w-2.5 bg-border group-hover:bg-fg-muted',
-                  )}
-                />
-              </button>
-            ))}
+          <div className="mt-3 flex items-center justify-between lg:hidden">
+            <span className="font-mono text-xs text-fg-muted">
+              {current.title}
+            </span>
+            <StepDots player={player} />
           </div>
         </div>
       </div>

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -92,7 +92,7 @@ export function HomePage() {
 
       <CompositionSection />
 
-      <div className="mt-20 md:mt-28">
+      <div className="mt-10 md:mt-14">
         <Footer />
       </div>
     </div>

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -18,6 +18,7 @@ import {
   type RotatingTextItem,
 } from '@/components/rotating-text'
 import Cards from '@/modules/marketing/cards'
+import { CompositionSection } from '@/modules/marketing/composition-section'
 
 export function HomePage() {
   return (
@@ -70,7 +71,7 @@ export function HomePage() {
           <h2 className="font-mono text-sm tracking-wide text-pretty text-fg-muted xs:text-base lg:text-base">
             Built on modern tools
           </h2>
-          <div className="flex flex-wrap items-center justify-center gap-4 sm:gap-8">
+          <div className="flex flex-wrap items-center justify-center gap-6 sm:gap-8">
             {tools.map(({ icon, label, href }) => (
               <Tooltip key={href}>
                 <Link
@@ -88,7 +89,12 @@ export function HomePage() {
           </div>
         </div>
       </section>
-      <Footer />
+
+      <CompositionSection />
+
+      <div className="mt-20 md:mt-28">
+        <Footer />
+      </div>
     </div>
   )
 }

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -2,6 +2,7 @@
 
 import { lazy, Suspense } from 'react'
 import {
+  ClientOnly,
   createRootRoute,
   HeadContent,
   Outlet,
@@ -119,10 +120,14 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body className="min-h-screen bg-bg font-sans text-fg antialiased">
         {children}
+        {/* ClientOnly: the devtools touch `window` at module scope, which
+            crashes build-time prerendering when previews include them. */}
         {RouterDevtools && (
-          <Suspense fallback={null}>
-            <RouterDevtools position="bottom-right" />
-          </Suspense>
+          <ClientOnly fallback={null}>
+            <Suspense fallback={null}>
+              <RouterDevtools position="bottom-right" />
+            </Suspense>
+          </ClientOnly>
         )}
         <Scripts />
       </body>

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -36,8 +36,11 @@ function ButtonGapTweak() {
 }
 
 // Router devtools: shown in dev and on Vercel previews, stripped from production.
+// The !SSR guard keeps the chunk out of the server bundle entirely — it touches
+// `window` at module scope, which crashes build-time prerendering.
 const RouterDevtools =
-  import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview'
+  !import.meta.env.SSR &&
+  (import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview')
     ? lazy(() =>
         import('@tanstack/react-router-devtools').then((m) => ({
           default: m.TanStackRouterDevtoolsInProd,

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -13,7 +13,6 @@ import { ThemeProvider } from 'starter-themes'
 import { siteConfig } from '@/config/site'
 import { truncateOnWord } from '@/lib/text'
 import { ToastProvider } from '@/registry/ui/toast'
-import { useTweak } from '@/dev/tweaker'
 
 import appCss from '@/styles.css?url'
 
@@ -27,19 +26,6 @@ const DevTweaker =
         import('@/dev/tweaker').then((m) => ({ default: m.DevTweaker })),
       )
     : null
-
-// Tweaker A/B for the proposed button icon-text gap bump: default/sm,
-// comfortable/xs+sm go 4px → 6px (also catches compact md/lg — same h-7/h-8
-// gap-1 signature — but the site runs default density).
-function ButtonGapTweak() {
-  const suggested = useTweak('Icon gap 4px → 6px', {
-    type: 'boolean',
-    default: false,
-    group: 'Button',
-  })
-  if (!suggested) return null
-  return <style>{`[data-button].gap-1:is(.h-7,.h-8){gap:0.375rem}`}</style>
-}
 
 // Router devtools: shown in dev and on Vercel previews, stripped from production.
 // The !SSR guard keeps the chunk out of the server bundle entirely — it touches
@@ -112,7 +98,6 @@ function RootComponent() {
         {DevTweaker && (
           <Suspense fallback={null}>
             <DevTweaker />
-            <ButtonGapTweak />
           </Suspense>
         )}
       </RootDocument>

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -7,7 +7,6 @@ import {
   Outlet,
   Scripts,
 } from '@tanstack/react-router'
-import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { ThemeProvider } from 'starter-themes'
 
 import { siteConfig } from '@/config/site'
@@ -20,6 +19,16 @@ import appCss from '@/styles.css?url'
 const DevTweaker = import.meta.env.DEV
   ? lazy(() => import('@/dev/tweaker').then((m) => ({ default: m.DevTweaker })))
   : null
+
+// Router devtools: shown in dev and on Vercel previews, stripped from production.
+const RouterDevtools =
+  import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview'
+    ? lazy(() =>
+        import('@tanstack/react-router-devtools').then((m) => ({
+          default: m.TanStackRouterDevtoolsInProd,
+        })),
+      )
+    : null
 
 export const Route = createRootRoute({
   head: () => {
@@ -95,7 +104,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body className="min-h-screen bg-bg font-sans text-fg antialiased">
         {children}
-        <TanStackRouterDevtools position="bottom-right" />
+        {RouterDevtools && (
+          <Suspense fallback={null}>
+            <RouterDevtools position="bottom-right" />
+          </Suspense>
+        )}
         <Scripts />
       </body>
     </html>

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -12,6 +12,7 @@ import { ThemeProvider } from 'starter-themes'
 import { siteConfig } from '@/config/site'
 import { truncateOnWord } from '@/lib/text'
 import { ToastProvider } from '@/registry/ui/toast'
+import { useTweak } from '@/dev/tweaker'
 
 import appCss from '@/styles.css?url'
 
@@ -19,6 +20,19 @@ import appCss from '@/styles.css?url'
 const DevTweaker = import.meta.env.DEV
   ? lazy(() => import('@/dev/tweaker').then((m) => ({ default: m.DevTweaker })))
   : null
+
+// Tweaker A/B for the proposed button icon-text gap bump: default/sm,
+// comfortable/xs+sm go 4px → 6px (also catches compact md/lg — same h-7/h-8
+// gap-1 signature — but the site runs default density).
+function ButtonGapTweak() {
+  const suggested = useTweak('Icon gap 4px → 6px', {
+    type: 'boolean',
+    default: false,
+    group: 'Button',
+  })
+  if (!suggested) return null
+  return <style>{`[data-button].gap-1:is(.h-7,.h-8){gap:0.375rem}`}</style>
+}
 
 // Router devtools: shown in dev and on Vercel previews, stripped from production.
 const RouterDevtools =
@@ -88,6 +102,7 @@ function RootComponent() {
         {DevTweaker && (
           <Suspense fallback={null}>
             <DevTweaker />
+            <ButtonGapTweak />
           </Suspense>
         )}
       </RootDocument>

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -17,10 +17,16 @@ import { useTweak } from '@/dev/tweaker'
 
 import appCss from '@/styles.css?url'
 
-// Dev-only floating panel for live design/layout exploration (see src/dev/tweaker).
-const DevTweaker = import.meta.env.DEV
-  ? lazy(() => import('@/dev/tweaker').then((m) => ({ default: m.DevTweaker })))
-  : null
+// Floating panel for live design/layout exploration (see src/dev/tweaker).
+// Dev + Vercel previews; the !SSR guard keeps the chunk out of the server
+// bundle so build-time prerendering never evaluates it.
+const DevTweaker =
+  !import.meta.env.SSR &&
+  (import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview')
+    ? lazy(() =>
+        import('@/dev/tweaker').then((m) => ({ default: m.DevTweaker })),
+      )
+    : null
 
 // Tweaker A/B for the proposed button icon-text gap bump: default/sm,
 // comfortable/xs+sm go 4px → 6px (also catches compact md/lg — same h-7/h-8

--- a/www/src/routes/_app/docs/$.tsx
+++ b/www/src/routes/_app/docs/$.tsx
@@ -142,21 +142,21 @@ const clientLoader = browserCollections.docs.createClientLoader({
     return (
       <TOCProvider toc={toc}>
         <PageLayout className="mt-4 flex scroll-mt-24 items-stretch pb-8 text-[1.05rem] sm:text-[15px] xl:w-full">
-          <div className="mx-auto flex w-full max-w-2xl min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 lg:px-0 lg:py-8 dark:text-neutral-300">
+          <div className="mx-auto flex w-full max-w-2xl min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 lg:px-0 dark:text-neutral-300">
             <div data-page-header="" className="relative mb-2 space-y-3 pb-4">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div className="flex min-w-0 flex-col gap-2">
-                  <PageHeaderHeading className="xl:leading-none">
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between gap-3">
+                  <PageHeaderHeading className="min-w-0 xl:leading-none">
                     {frontmatter.title}
                   </PageHeaderHeading>
-                  <PageHeaderDescription>
-                    {frontmatter.description}
-                  </PageHeaderDescription>
+                  <div className="flex shrink-0 items-center gap-3">
+                    <DocsCopyPage content={rawContent} url={url} />
+                    <DocsPager neighbours={neighbours} />
+                  </div>
                 </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  <DocsPager neighbours={neighbours} />
-                  <DocsCopyPage content={rawContent} url={url} />
-                </div>
+                <PageHeaderDescription>
+                  {frontmatter.description}
+                </PageHeaderDescription>
               </div>
               <div className="absolute bottom-0 left-0 h-px w-full bg-linear-to-r from-[color-mix(in_oklab,var(--color-border)_40%,transparent)] via-[color-mix(in_oklab,var(--color-border)_90%,transparent)] to-[color-mix(in_oklab,var(--color-border)_50%,transparent)]" />
             </div>
@@ -182,7 +182,7 @@ const clientLoader = browserCollections.docs.createClientLoader({
               (which is inset ~8px inside its button), mirroring how the sidebar
               text lines up with the logo on the left. */}
           {hasToc && (
-            <div className="sticky top-(--header-height) z-30 -mt-4 hidden w-16 shrink-0 justify-end self-start px-6 pt-10 md:flex lg:pt-12 xl:hidden">
+            <div className="sticky top-(--header-height) z-30 -mt-4 hidden w-16 shrink-0 justify-end self-start px-6 pt-10 md:flex xl:hidden">
               <MiniTOC />
             </div>
           )}

--- a/www/src/routes/_app/docs/route.tsx
+++ b/www/src/routes/_app/docs/route.tsx
@@ -15,7 +15,7 @@ function DocsLayout() {
 
   return (
     <div className="flex min-h-[calc(100vh-var(--header-height))] [--sidebar-width:228px]">
-      <aside className="sticky top-(--header-height) hidden h-[calc(100vh-var(--header-height))] w-(--sidebar-width) shrink-0 lg:block">
+      <aside className="sticky top-(--header-height) hidden h-[calc(100vh-var(--header-height))] w-fit shrink-0 lg:block xl:w-(--sidebar-width)">
         <DocsSidebar items={items} />
       </aside>
       <div className="min-w-0 flex-1">

--- a/www/vite.config.ts
+++ b/www/vite.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
   server: {
     port: 4444,
   },
+  // Build-time constant so client code can gate on Vercel previews.
+  define: {
+    'import.meta.env.VERCEL_ENV': JSON.stringify(process.env.VERCEL_ENV ?? ''),
+  },
   resolve: {
     alias: [
       {


### PR DESCRIPTION
## What's in here

**Docs introduction rewrite** — new copy in shadcn's register (short declaratives, no fluff): opens with the builder thesis ("you own the files, but the decisions inside them are still someone else's"), tightened React Aria section, real-world example grid (calendar/combobox/date-picker/switch demos), all demo names verified against the registry.

**Animated composition snippet** (`CompositionAnimation`, used on the intro page) — shiki-magic-move over the existing sync highlighter; 10 steps morphing token-by-token from `Input` through `TextField`/`DateField`/`DatePicker`/`DateRangePicker`/`Drawer`/`Dialog` to `Menu`, with the real registry component rendered live beside the code. Step changes run through the View Transitions API with shared-element names, scoped so only the preview morphs (root swaps instantly, `::view-transition { pointer-events: none }` keeps the page interactive mid-transition). Auto-advance pauses on hover and off-screen; `prefers-reduced-motion` disables all motion. Every code snippet uses the real registry API (verified against demos — `InputGroupAddon`, `slot="start"`, `Popover`⇄`Drawer`, `Modal`).

**Home page composition section** — same player, marketing presentation: split headline, CTAs, 1/1/0 stat row, mac-style code window on a gradient plate with the live component as its result pane, padded pagination pills (32×32 hit areas).

**Docs layout fixes** — sidebar group / page title / TOC all start at the same y on every breakpoint (removed the `lg:py-8` bump + mini-TOC compensation); title row holds the pager + copy-page group on all sizes (`items-center`); copy-page group hidden below `sm`; description full-width; sidebar `w-fit` at `lg` (228px of rail was ~78px dead space, content offset 82→50px).

**Router devtools on Vercel previews** — `TanStackRouterDevtoolsInProd` behind `import.meta.env.DEV || VERCEL_ENV === 'preview'` (build-time constant via Vite `define`, dead-code-eliminated in production). Verify on this PR's preview: devtools trigger should appear bottom-right.

## Note for review

- One commit is tweaker scaffolding (`chore(www): tweaker A/B for button icon-gap proposal`) — decision pending; drop or bake before merge.
- Verified live: alignment measured via DOM at lg/xl/mobile, animation step machinery + mid-transition hit-testing, `pnpm check` + `typecheck` clean. Registry source untouched.
- The left-align layout work now lives in its own stacked PR based on this branch.

## Suggested refactors

- `CompositionSection` (marketing) imports the shared player from `@/modules/docs/composition-animation` — if the cross-module import bothers, the player/steps could move to a neutral module.