### PR TITLE
perf(www): move shiki off the entry bundle

### DIFF
--- a/www/src/modules/docs/dynamic-pre.tsx
+++ b/www/src/modules/docs/dynamic-pre.tsx
@@ -1,38 +1,96 @@
-import { useDeferredValue, useMemo } from 'react'
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
+import type { Root } from 'hast'
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 
 import { cn } from '@/registry/lib/utils'
 
 import { Pre } from './code-block'
-import { highlightTsx } from './highlight'
+import type { highlightTsx } from './highlight'
 
 export interface DynamicPreProps {
   lang: 'tsx'
   children: string
   className?: string
+  /**
+   * Build-time highlighted HAST for the INITIAL `children`. When provided, the
+   * initial render paints highlighted without the runtime highlighter — shiki
+   * loads lazily only once `children` diverges (i.e. a control moved). Consumers
+   * without it (chart modal, /create preview) fall back to plain text until the
+   * highlighter loads on first interaction.
+   */
+  initialHast?: Root
+}
+
+// Module-scoped so the runtime highlighter loads once per session; after that,
+// re-highlights are synchronous.
+let highlightFn: typeof highlightTsx | null = null
+let highlightPromise: Promise<typeof highlightTsx> | null = null
+function loadHighlighter(): Promise<typeof highlightTsx> {
+  if (highlightFn) return Promise.resolve(highlightFn)
+  if (!highlightPromise) {
+    highlightPromise = import('./highlight').then((m) => {
+      highlightFn = m.highlightTsx
+      return m.highlightTsx
+    })
+  }
+  return highlightPromise
+}
+
+function renderHast(hast: Root, className?: string) {
+  return toJsxRuntime(hast, {
+    Fragment,
+    jsx,
+    jsxs,
+    components: {
+      pre: (props) => (
+        <Pre {...props} className={cn(props.className, className)} />
+      ),
+    },
+  })
 }
 
 /**
- * Highlighted <pre> for code generated at runtime. Highlighting is fully
- * synchronous (see ./highlight), so SSR output and the first client render are
- * already highlighted — no fallback state. `useDeferredValue` keeps control
- * interactions responsive by letting React defer re-highlights under load.
+ * Highlighted <pre> for code generated at runtime. First paint uses the
+ * build-time `initialHast` (see ./highlight); the shiki highlighter is loaded
+ * lazily and only after the code changes, keeping it off the entry/critical path.
+ * `useDeferredValue` keeps control interactions responsive under load.
  */
-export function DynamicPre({ children: code, className }: DynamicPreProps) {
+export function DynamicPre({
+  children: code,
+  className,
+  initialHast,
+}: DynamicPreProps) {
+  const initialCodeRef = useRef(code)
   const deferredCode = useDeferredValue(code)
-  return useMemo(
-    () =>
-      toJsxRuntime(highlightTsx(deferredCode), {
-        Fragment,
-        jsx,
-        jsxs,
-        components: {
-          pre: (props) => (
-            <Pre {...props} className={cn(props.className, className)} />
-          ),
-        },
-      }),
-    [deferredCode, className],
-  )
+  const [hast, setHast] = useState<Root | null>(initialHast ?? null)
+
+  useEffect(() => {
+    // The initial value is covered by the build-time HAST — no runtime highlighter.
+    if (initialHast && deferredCode === initialCodeRef.current) {
+      setHast(initialHast)
+      return
+    }
+    if (highlightFn) {
+      setHast(highlightFn(deferredCode))
+      return
+    }
+    let cancelled = false
+    void loadHighlighter().then((fn) => {
+      if (!cancelled) setHast(fn(deferredCode))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [deferredCode, initialHast])
+
+  return useMemo(() => {
+    if (hast) return renderHast(hast, className)
+    // Not yet highlighted (no initialHast + highlighter still loading): plain text.
+    return (
+      <Pre className={className}>
+        <code>{deferredCode}</code>
+      </Pre>
+    )
+  }, [hast, deferredCode, className])
 }

--- a/www/src/modules/docs/interactive-demo/interactive-demo.tsx
+++ b/www/src/modules/docs/interactive-demo/interactive-demo.tsx
@@ -6,6 +6,7 @@ import {
   type ComponentType,
 } from 'react'
 import { flushSync } from 'react-dom'
+import type { Root } from 'hast'
 import {
   ChevronDownIcon,
   ChevronUpIcon,
@@ -49,6 +50,8 @@ interface InteractiveDemoProps {
   controls: SerializableControl[]
   codeTemplate: CodeTemplate
   className?: string
+  /** Build-time highlighted HAST for the initial code (see DynamicPre). */
+  initialHast?: Root
 }
 
 export function InteractiveDemo({
@@ -56,6 +59,7 @@ export function InteractiveDemo({
   controls,
   codeTemplate,
   className,
+  initialHast,
 }: InteractiveDemoProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const [controlsOpen, setControlsOpen] = useState(false)
@@ -231,7 +235,9 @@ export function InteractiveDemo({
           </Button>
         }
       >
-        <DynamicPre lang="tsx">{displayedCode}</DynamicPre>
+        <DynamicPre lang="tsx" initialHast={initialHast}>
+          {displayedCode}
+        </DynamicPre>
       </CodeBlock>
     </div>
   )

--- a/www/src/modules/docs/interactive-demo/types.ts
+++ b/www/src/modules/docs/interactive-demo/types.ts
@@ -3,6 +3,7 @@
  * Controls are enriched at build time and passed as props to the client component.
  */
 
+import type { Root } from 'hast'
 import type { MdxJsxFlowElementHast } from 'mdast-util-mdx-jsx'
 
 import type { CodeTemplate } from '../codegen/code-template'
@@ -159,4 +160,10 @@ export interface ProcessedInteractiveDemo {
   controls: SerializableControl[]
   /** Template-with-holes over the demo source; fills the displayed code. */
   codeTemplate: CodeTemplate
+  /**
+   * Build-time highlighted HAST for the demo's initial code (default controls,
+   * collapsed). Lets the client render a highlighted first paint without loading
+   * the runtime shiki highlighter — it loads lazily only after a control moves.
+   */
+  initialHast: Root
 }

--- a/www/src/modules/docs/mdx-plugins/rehype-transform.ts
+++ b/www/src/modules/docs/mdx-plugins/rehype-transform.ts
@@ -10,7 +10,10 @@ import { createHighlighter, type HighlighterGeneric } from 'shiki'
 import type { Plugin } from 'unified'
 import { visit } from 'unist-util-visit'
 
+import { renderCode } from '../codegen/code-template'
 import { buildSourceOverlay } from '../codegen/source-overlay'
+import { highlightTsx } from '../highlight'
+import { defaultControlValues } from '../interactive-demo/control-defaults'
 import {
   buildControlsFromReference,
   enrichControlsForSerialization,
@@ -702,12 +705,23 @@ async function processInteractiveDemoNode(
       componentName: info.name,
     })
 
+    // 4. Highlight the initial code (default controls, collapsed) at build time so
+    //    the client's first paint is highlighted without shipping the runtime
+    //    highlighter. Uses the same highlightTsx the client would — identical HAST.
+    const initialCode = renderCode(
+      codeTemplate,
+      defaultControlValues(enrichedControls),
+      { expanded: false },
+    )
+    const initialHast = highlightTsx(initialCode)
+
     return {
       nodeInfo: info,
       importName: `${toPascalCase(info.name)}Playground`,
       importPath: `@/registry/ui/${info.name}/demos/${fileSlug}`,
       controls: enrichedControls,
       codeTemplate,
+      initialHast,
     }
   } catch (error) {
     console.error(
@@ -763,6 +777,11 @@ function transformInteractiveDemoNode(
   // codeTemplate={JSON.parse("…")}
   node.attributes.push(
     makeJsonParseAttr('codeTemplate', JSON.stringify(processed.codeTemplate)),
+  )
+
+  // initialHast={JSON.parse("…")} — build-time highlighted initial code
+  node.attributes.push(
+    makeJsonParseAttr('initialHast', JSON.stringify(processed.initialHast)),
   )
 }
 


### PR DESCRIPTION
## What

Removes the runtime **shiki** highlighter (core + tsx TextMate grammar + JS regex engine, **~65 KB gz**) from the client **entry chunk**, where it was shipped on every page — landing included.

## Why it was in the entry

`routeTree.gen.ts` statically imports the docs route's critical module. `$.tsx`'s module-level `clientLoader` closes over `mdxComponents → InteractiveDemo → DynamicPre → highlight.ts`, so the highlighter is pinned to the entry-bound reference graph and inlined into `index-*.js`, loaded on every page.

## Approach (issue #405, not the dropped PR #400)

The docs body is client-rendered (fumadocs `createClientLoader`), so first paint is the client's first render, not SSR HTML — a naive `React.lazy` split flashes unhighlighted (what killed [#400](https://github.com/mehdibha/dotUI/pull/400)).

Instead:
- **Build time** (`rehype-transform.ts`): highlight the playground's initial code (default controls, collapsed) with the shiki highlighter already used for static code, and emit it as a serialized `initialHast` prop.
- **Runtime** (`DynamicPre`): render `initialHast` for the initial value (highlighted, **zero** runtime shiki), then `import('./highlight')` lazily only once the code diverges (a control moves).

First paint is highlighted on **every** render path; the runtime highlighter never touches the critical path. Other `DynamicPre` consumers (chart code modal, `/create` preview — the latter frozen) keep working via the optional prop's lazy path (aligned with #405's "lazy runtime shiki for re-highlights").

## Before / after (production build, `.output/public`)

| metric | before | after | Δ |
|---|---|---|---|
| entry chunk `index-*.js` (gz) | 398.8 KB | **333.9 KB** | −64.9 |
| home first-load JS (gz) | 795.3 KB | **730.4 KB** | −64.9 |
| docs/button first-load (gz) | 735.8 KB | **671.0 KB** | −64.8 |
| create first-load (gz) | 806.5 KB | **741.7 KB** | −64.8 |
| shiki chunk preloaded on any page | yes (in entry) | **no** (lazy `highlight-*.js`) | ✓ |

Preload count is unchanged (shiki was *inlined* in the entry, not a separate preloaded chunk) — the count is addressed in a separate PR.

## Verification (production server, real page drive)

- `/docs/components/button`: playground code **highlighted on first paint** with `highlight-*.js` **not** loaded (5 shiki-var token spans present).
- Clicking **Expand** (code diverges) → `highlight-D3Posyth.js` lazy-loads and the code re-highlights (expanded source, 16 spans).
- Home renders, no shiki loaded, no console errors.

Refs #405, #395.
