### PR TITLE
perf(www): dedupe zod to a single v4 instance

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,7 @@ catalogs:
 overrides:
   '@types/react': 19.2.2
   '@types/react-dom': 19.2.1
+  zod@^4: 4.4.3
 
 packageExtensionsChecksum: sha256-MiHZ3mgtOUb60KfpkAkui5ad/9eLmcQda0MiZKaTRqA=
 
@@ -93,8 +94,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       zod:
-        specifier: ^4.2.1
-        version: 4.2.1
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@dotui/ts-config':
         specifier: workspace:*
@@ -1109,7 +1110,7 @@ packages:
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
       react-hook-form: ^7.55.0
-      zod: '*'
+      zod: 4.4.3
     peerDependenciesMeta:
       zod:
         optional: true
@@ -1354,7 +1355,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      zod: 4.4.3
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -3874,7 +3875,7 @@ packages:
       react-dom: ^19.2.0
       react-router: 7.x.x
       waku: '*'
-      zod: 4.x.x
+      zod: 4.4.3
     peerDependenciesMeta:
       '@mdx-js/mdx':
         optional: true
@@ -6274,13 +6275,10 @@ packages:
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.25.28 || ^4
+      zod: 4.4.3
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
-  zod@4.2.1:
-    resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -12153,8 +12151,6 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
-
-  zod@4.2.1: {}
 
   zod@4.4.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,6 +42,11 @@ supportedArchitectures:
 overrides:
   '@types/react': 19.2.2
   '@types/react-dom': 19.2.1
+  # Collapse the two zod v4 minors that ship to the client — @dotui/colors
+  # (4.2.1) and @hookform/resolvers + fumadocs-core (4.4.3) — onto one instance
+  # so zod isn't bundled twice. Scoped to ^4 so zod v3 (dev-only, via
+  # @modelcontextprotocol/sdk) is left alone.
+  'zod@^4': 4.4.3
 
 # @hookform/resolvers/zod imports zod/v4/core but doesn't declare zod as a
 # peer, so pnpm never links zod into its instance; the import only survives


### PR DESCRIPTION
## What

The client shipped **zod twice**. `@dotui/colors` resolved zod **4.2.1** while `@hookform/resolvers` and `fumadocs-core` resolved **4.4.3** — two v4 minors can't share a module, so both landed in the preloaded client graph (one copy inlined in the entry chunk, one in the `styles-*.js` chunk).

## Fix

A single scoped pnpm override in `pnpm-workspace.yaml`:

```yaml
overrides:
  'zod@^4': 4.4.3
```

collapses the two v4 minors onto one instance and regenerates the lockfile. Scoped to `^4` so the **dev-only** zod v3 (a transitive dep of `@modelcontextprotocol/sdk`, never in `www/src` or the client bundle) is untouched.

## Before / after (production build)

| metric | before | after | Δ |
|---|---|---|---|
| entry chunk `index-*.js` (gz) | 398.8 KB | **382.5 KB** | −16.3 |
| home first-load JS (gz) | 795.3 KB | **780.3 KB** | −15.0 |
| zod copies in client | 2 (4.2.1 + 4.4.3) | **1** (4.4.3) | ✓ |

After the change `ZodError` appears in exactly one chunk (the `styles-*.js` chunk); the entry no longer carries a zod copy. (The audit's "~58 KB in the entry" was optimistic — the entry's duplicate was ~16 KB gz; one necessary zod instance remains in the preloaded styles chunk.)

## Verification

- `pnpm test` → 249/249 pass, including the 47 `@dotui/colors` engine tests that exercise zod (4.2.1 → 4.4.3 is safe).
- `pnpm typecheck` clean.
- Production server drive: `/create` (heaviest zod user — validated forms + preset codec) renders fully with no console errors; home renders.

Refs #395.
