### PR TITLE
perf(www): consolidate react-aria vendor chunks

### DIFF
--- a/www/vite.config.ts
+++ b/www/vite.config.ts
@@ -11,6 +11,31 @@ export default defineConfig({
   server: {
     port: 4444,
   },
+  environments: {
+    client: {
+      build: {
+        rollupOptions: {
+          output: {
+            // The react-aria / base-ui vendor graph is split into ~100 tiny
+            // per-hook chunks that all sit in the shared client graph, so every
+            // page modulepreloads the lot — a request storm for no byte benefit.
+            // Group them into a few stable chunks (client build only, so the
+            // nitro server build is untouched). advancedChunks' minShareCount
+            // keeps route-only modules out, avoiding cross-route duplication.
+            advancedChunks: {
+              groups: [
+                {
+                  name: 'react-aria',
+                  test: /[\\/](react-aria-components|react-aria|react-stately|@react-aria|@react-stately|@react-types|@internationalized)[\\/]/,
+                },
+                { name: 'base-ui', test: /[\\/]@base-ui[\\/]/ },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
   resolve: {
     alias: [
       {


### PR DESCRIPTION
## What

Tames the modulepreload storm. `react-aria` and `@base-ui` ship as **~100 tiny per-hook chunks** that all live in the shared client graph, so every page `modulepreload`s the entire set — the bulk of the ~130-link storm — with no byte benefit (they're all needed to boot).

## Fix

Group them into a few stable vendor chunks via rolldown `advancedChunks`, scoped to the **client** build (`environments.client`) so the nitro server build is untouched:

```ts
environments: { client: { build: { rollupOptions: { output: { advancedChunks: {
  groups: [
    { name: 'react-aria', test: /…react-aria|@react-stately|@internationalized…/ },
    { name: 'base-ui', test: /@base-ui/ },
  ],
} } } } } }
```

## Before / after (production build)

| metric | before | after | Δ |
|---|---|---|---|
| home modulepreloads | 131 | **57** | **−74** |
| docs/button preloads | 128 | **54** | −74 |
| create preloads | 133 | **59** | −74 |
| entry chunk `index-*.js` (gz) | 398.8 KB | **300.1 KB** | −98.7 |
| home first-load JS (gz) | 795.3 KB | 803.7 KB | +8.5 |

**Trade-off, stated plainly:** total first-load JS rises ~8.5 KB gz (~1%) from lost cross-chunk dedup when the tiny chunks merge. In exchange, the render-blocking **entry chunk is ~99 KB gz smaller**, and the same code now downloads across a handful of parallel, cache-stable vendor chunks instead of ~100 requests. Net expected win on TTI; it's a one-block revert if the byte trade isn't wanted.

Vendor libraries change only on dependency upgrades, so the coarser chunks cache well across deploys.

## Verification (production server, real page drive)

- Home, `/docs/components/button`, `/presets`, `/create` all return 200 and render.
- react-aria components work through the vendor chunk: 56 buttons render; clicking the playground **Controls** toggle opens the panel (8 widgets). No console errors.
- `pnpm typecheck` clean.

Independent of the other perf PRs; stacks with them (its +8.5 KB is far outweighed by their reductions).

Refs #395.
