### PR TITLE
ci(www): add client bundle perf budget check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,18 @@ jobs:
           git status --porcelain -- www/src/modules/docs/references/generated/ | grep -q . \
           && { git status --porcelain -- www/src/modules/docs/references/generated/; echo '::error::Committed API reference files are out of date. Run `pnpm build:references` and commit the result.'; exit 1; } \
           || true
+
+  perf-budget:
+    runs-on: ubuntu-latest
+    name: Check client bundle stays within perf budget
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+
+      - name: Build www (production)
+        run: pnpm build:www
+
+      - name: Assert client bundle within perf budget
+        run: node www/scripts/perf-budget.mjs

--- a/www/package.json
+++ b/www/package.json
@@ -10,6 +10,7 @@
     "build": "pnpm build:registry && NODE_OPTIONS='--max-old-space-size=8192' vite build && pnpm build:postprocess",
     "build:postprocess": "node scripts/patch-vercel-config.mjs",
     "preview": "vite preview",
+    "perf:budget": "node scripts/perf-budget.mjs",
     "typecheck": "pnpm build:registry && tsc --noEmit",
     "clean": "git clean -xdf .output .nitro .cache .turbo node_modules",
     "build:references": "tsx scripts/api-docs-builder/src/index.ts"

--- a/www/scripts/perf-budget.json
+++ b/www/scripts/perf-budget.json
@@ -1,0 +1,12 @@
+{
+  "comment": "Client-bundle perf budget for the production build. Thresholds sit just above the post-fix numbers (shiki off the entry chunk, zod deduped, search lazy-loaded, react-aria/base-ui grouped into vendor chunks). They exist to catch silent regressions of those wins — chiefly shiki returning to the entry chunk and the modulepreload storm coming back. Measured by scripts/perf-budget.mjs against www/.output/public. Raise a threshold only with a deliberate, reviewed reason.",
+  "entryChunkGzKB": 245,
+  "pages": {
+    "home": { "path": "index.html", "initialGzKB": 710, "preloads": 63 },
+    "create": {
+      "path": "create/index.html",
+      "initialGzKB": 720,
+      "preloads": 66
+    }
+  }
+}

--- a/www/scripts/perf-budget.mjs
+++ b/www/scripts/perf-budget.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Fail the build when the production client bundle regresses past its budget.
+//
+// Guards the entry-graph perf wins — chiefly shiki staying off the entry chunk
+// and the modulepreload storm staying tamed — by asserting, against the real
+// production build (www/.output/public), that:
+//   - the entry chunk stays under a gzip size cap (shiki/react-aria back in it
+//     would blow this),
+//   - key pages stay under a first-load JS gzip cap and a modulepreload count.
+//
+// Thresholds live in scripts/perf-budget.json. Run after `pnpm build`:
+//   node scripts/perf-budget.mjs [outputPublicDir]
+import { readFileSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { gzipSync } from 'node:zlib'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const budget = JSON.parse(readFileSync(join(here, 'perf-budget.json'), 'utf8'))
+const PUB = process.argv[2] || join(here, '..', '.output', 'public')
+const ASSETS = join(PUB, 'assets')
+
+if (!existsSync(ASSETS)) {
+  console.error(
+    `perf-budget: no build at ${PUB} — run \`pnpm build\` first (or pass the output dir).`,
+  )
+  process.exit(2)
+}
+
+const gzCache = new Map()
+function gzKB(file) {
+  if (gzCache.has(file)) return gzCache.get(file)
+  const p = join(ASSETS, file)
+  const kb = existsSync(p) ? gzipSync(readFileSync(p)).length / 1024 : 0
+  gzCache.set(file, kb)
+  return kb
+}
+
+function jsRefs(html) {
+  return [
+    ...new Set([...html.matchAll(/\/assets\/([^"']+?\.js)/g)].map((m) => m[1])),
+  ]
+}
+
+/** The entry chunk is what the inline bootstrap dynamically imports. */
+function entryChunk(html) {
+  const m = html.match(/import\(\s*["']\/assets\/([^"']+?\.js)["']\s*\)/)
+  return m?.[1] ?? null
+}
+
+const round = (n) => Math.round(n * 10) / 10
+const results = []
+let failed = false
+function check(label, actual, limit, unit) {
+  const over = actual > limit
+  if (over) failed = true
+  results.push({ label, actual: round(actual), limit, unit, over })
+}
+
+// Entry chunk gz (shared across pages — read it from home).
+const homeHtml = readFileSync(join(PUB, budget.pages.home.path), 'utf8')
+const entry = entryChunk(homeHtml)
+if (!entry) {
+  console.error('perf-budget: could not find the entry chunk in home HTML.')
+  process.exit(2)
+}
+check('entry chunk', gzKB(entry), budget.entryChunkGzKB, 'KB gz')
+
+// Per-page first-load JS gz + modulepreload count.
+for (const [name, page] of Object.entries(budget.pages)) {
+  const f = join(PUB, page.path)
+  if (!existsSync(f)) {
+    console.error(`perf-budget: missing prerendered page ${page.path}`)
+    process.exit(2)
+  }
+  const refs = jsRefs(readFileSync(f, 'utf8'))
+  const gz = refs.reduce((sum, r) => sum + gzKB(r), 0)
+  check(`${name} first-load JS`, gz, page.initialGzKB, 'KB gz')
+  check(`${name} modulepreloads`, refs.length, page.preloads, 'chunks')
+}
+
+const pad = (s, n) => String(s).padEnd(n)
+console.log(`\nperf budget — ${PUB}\n`)
+console.log(pad('metric', 22), pad('actual', 12), pad('budget', 10), 'status')
+for (const r of results) {
+  console.log(
+    pad(r.label, 22),
+    pad(`${r.actual} ${r.unit}`, 12),
+    pad(`${r.limit} ${r.unit}`, 10),
+    r.over ? '❌ OVER' : '✅ ok',
+  )
+}
+
+if (failed) {
+  console.error(
+    '\n::error::perf budget exceeded. A client-bundle perf win regressed. ' +
+      'Investigate (shiki back in the entry chunk? preload storm returned?) ' +
+      'or, if the growth is intended and reviewed, raise the threshold in www/scripts/perf-budget.json.',
+  )
+  process.exit(1)
+}
+console.log('\nperf budget: all metrics within budget ✅')


### PR DESCRIPTION
## What

Locks in the perf wins from #415–#418 with a CI budget check, so the two headline culprits — **shiki in the entry chunk** and the **~130-chunk modulepreload storm** — can't silently return.

- `www/scripts/perf-budget.mjs` — measures the production build (`www/.output/public`): entry-chunk gzip size, plus per-page first-load JS gzip and modulepreload count for **home** and **create**. Exits non-zero (with a `::error::`) on any breach.
- `www/scripts/perf-budget.json` — thresholds, set **just above the post-fix numbers**.
- New `perf-budget` job in `.github/workflows/ci.yml` (build + assert). Also runnable locally: `pnpm --filter=www perf:budget`.

## Thresholds vs. reality

| metric | post-fix actual | budget | catches |
|---|---|---|---|
| entry chunk gz | 219.5 KB | **245 KB** | shiki / react-aria back in the entry |
| home first-load gz | 676.9 KB | **710 KB** | shiki un-lazy, search un-lazy |
| home modulepreloads | 55 | **63** | preload storm returning |
| create first-load gz | 688.1 KB | **720 KB** | — |
| create modulepreloads | 57 | **66** | preload storm returning |

## Proven both ways (local)

**Passes** on the post-fix build (all four fixes integrated):
```
entry chunk            219.5 KB gz  245 KB gz  ✅ ok
home first-load JS     676.9 KB gz  710 KB gz  ✅ ok
home modulepreloads    55 chunks    63 chunks  ✅ ok
create first-load JS   688.1 KB gz  720 KB gz  ✅ ok
create modulepreloads  57 chunks    66 chunks  ✅ ok
→ exit 0
```

**Fails** on a synthetic regression — the pre-fix `main` bundle (shiki in entry, storm present):
```
entry chunk            398.8 KB gz  245 KB gz  ❌ OVER
home first-load JS     795.3 KB gz  710 KB gz  ❌ OVER
home modulepreloads    131 chunks   63 chunks  ❌ OVER
create first-load JS   806.5 KB gz  720 KB gz  ❌ OVER
create modulepreloads  133 chunks   66 chunks  ❌ OVER
→ exit 1  (::error:: perf budget exceeded)
```

## Merge order

The budget reflects the **combined** result of #415–#418, so **merge this after them**. Until they land, the `perf-budget` job on this branch reports the current-main bundle as over budget — which is exactly the regression it guards against (see the failing output above). Once the four fixes are on `main`, the job is green.

(Lighthouse-CI score assertions were considered but skipped — too flaky for a required check. Size + count are deterministic.)

Refs #395.
