### PR TITLE
fix(www): correct acronym component names in customizer

### DIFF
--- a/www/src/modules/create/components/index.tsx
+++ b/www/src/modules/create/components/index.tsx
@@ -54,8 +54,13 @@ function toTitleCase(slug: string): string {
     .join(' ')
 }
 
+const COMPONENT_DISPLAY_NAMES: Record<string, string> = {
+  'otp-field': 'OTP Field',
+  'qr-code': 'QR Code',
+}
+
 export function getComponentDisplayName(slug: string): string {
-  return toTitleCase(slug)
+  return COMPONENT_DISPLAY_NAMES[slug] ?? toTitleCase(slug)
 }
 
 export function getGroupDisplayName(slug: string): string {
@@ -102,7 +107,7 @@ export function AllComponentsView({ onSelect }: AllComponentsViewProps) {
             className={cardClass}
           >
             <div className="flex items-center justify-between">
-              <span>{toTitleCase(comp.name)}</span>
+              <span>{getComponentDisplayName(comp.name)}</span>
               <ChevronRightIcon className="size-4 text-fg-muted" />
             </div>
             {count > 0 && (
@@ -455,7 +460,7 @@ export function GroupDetailView({
               className={cardClass}
             >
               <div className="flex items-center justify-between">
-                <span>{toTitleCase(comp.name)}</span>
+                <span>{getComponentDisplayName(comp.name)}</span>
                 <ChevronRightIcon className="size-4 text-fg-muted" />
               </div>
               {count > 0 && (


### PR DESCRIPTION
## Problem

`getComponentDisplayName(slug)` in the /create customizer mechanically title-cased slugs, producing wrong labels for acronym components: `otp-field` rendered as "Otp Field" (should be "OTP Field"). The forthcoming `qr-code` component (PR #425) would render as "Qr Code" (should be "QR Code").

## Fix

Added a small `COMPONENT_DISPLAY_NAMES` map consulted before falling back to `toTitleCase`, with entries `otp-field` → "OTP Field" and `qr-code` → "QR Code".

Two surfaces (`AllComponentsView`, `GroupDetailView`) rendered component names via `toTitleCase(comp.name)` directly, bypassing `getComponentDisplayName`. Routed both through `getComponentDisplayName` so the override applies at a single source across every surface that shows a component label:

- Flat "all components" list
- Group detail component list
- Component detail view header (`customizer-panel.tsx`, already used `getComponentDisplayName`)

`qr-code` entry is forward-compatible — harmless until PR #425 merges (the component isn't on `main` yet). Resolves suggested refactor #2 from PR #425.

The other `toTitleCase` call sites (param names/values, color-token labels) are intentionally left unchanged — they don't render component names.

## Verification

- `pnpm check` — 0 errors, formatting clean (3 pre-existing unrelated warnings).
- `pnpm typecheck` — passes.
- Verified via code reading (not the live dev server): confirmed `otp-field` exists in the registry under group `inputs`, so it surfaces in both the group list and the detail header, and all three surfaces now route through the override.