### PR TITLE
feat(www): rewrite composition animation to 16-step sequence

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       cnfast:
         specifier: ^0.0.8
         version: 0.0.8
+      diff-match-patch-es:
+        specifier: ^1.0.1
+        version: 1.0.1
       fumadocs-core:
         specifier: ^16.8.11
         version: 16.8.11(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.2)(lucide-react@1.16.0(react@19.2.1))(next@16.0.8(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.4.3)

--- a/www/content/docs/(root)/index.mdx
+++ b/www/content/docs/(root)/index.mdx
@@ -17,7 +17,7 @@ The API is built on composition: each component maps to a single DOM element, so
 
 <CompositionAnimation />
 
-The same primitives recompose into every component in the library: an `Input` becomes a `TextField`, a `DateField`, a `DatePicker`; the same overlay shell becomes a `Dialog` and a `Menu`. Around ten primitives cover a dozen components, with zero parallel APIs.
+The same primitives recompose into every component in the library: an `Input` becomes a `TextField`, a `DateField`, a `DatePicker`; the same list becomes a `Select`, a `Combobox`, a command palette; the same menu opens from a button, a right click, or an `@`-mention. Around ten primitives cover a dozen components, with zero parallel APIs.
 
 ### Reusable primitives
 

--- a/www/package.json
+++ b/www/package.json
@@ -36,6 +36,7 @@
     "@tanstack/router-plugin": "catalog:",
     "@vercel/og": "^0.11.1",
     "cnfast": "^0.0.8",
+    "diff-match-patch-es": "^1.0.1",
     "fumadocs-core": "^16.8.11",
     "fumadocs-mdx": "^15.0.5",
     "globals-docs": "^2.4.1",

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -3,6 +3,7 @@ import 'shiki-magic-move/style.css'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
 import { parseDate } from '@internationalized/date'
+import { diffCleanupSemanticLossless } from 'diff-match-patch-es'
 import { PauseIcon, PlayIcon } from 'lucide-react'
 import { ShikiMagicMove } from 'shiki-magic-move/react'
 import { useTheme } from 'starter-themes'
@@ -1440,6 +1441,9 @@ export function CompositionCode({
         duration: reducedMotion ? 0 : duration,
         stagger,
         containerStyle: false,
+        // Snap edit boundaries to line breaks, else the raw char diff strands
+        // `<` and `/>` on the old line and moves only the tag name.
+        diffCleanup: diffCleanupSemanticLossless,
       }}
     />
   )

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -12,20 +12,18 @@ import {
   ChevronDownIcon,
   MailIcon,
   MoreHorizontalIcon,
+  SearchIcon,
 } from '@/registry/__generated__/icons'
 import { cn } from '@/registry/lib/utils'
+import { Avatar, AvatarFallback } from '@/registry/ui/avatar'
 import { Button } from '@/registry/ui/button'
 import { Calendar, RangeCalendar } from '@/registry/ui/calendar'
 import { Combobox } from '@/registry/ui/combobox'
+import { Command } from '@/registry/ui/command'
+import { ContextMenu } from '@/registry/ui/context-menu'
 import { DateField } from '@/registry/ui/date-field'
 import { DatePicker, DateRangePicker } from '@/registry/ui/date-picker'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/registry/ui/dialog'
+import { DialogContent } from '@/registry/ui/dialog'
 import { Drawer } from '@/registry/ui/drawer'
 import { Description, Label } from '@/registry/ui/field'
 import {
@@ -33,12 +31,22 @@ import {
   Input,
   InputGroup,
   InputGroupAddon,
+  TextArea,
 } from '@/registry/ui/input'
-import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
-import { Menu, MenuContent, MenuItem } from '@/registry/ui/menu'
+import { Kbd } from '@/registry/ui/kbd'
+import {
+  ListBox,
+  ListBoxItem,
+  ListBoxSection,
+  ListBoxSectionHeader,
+} from '@/registry/ui/list-box'
+import { Mention } from '@/registry/ui/mention'
+import { Menu, MenuContent, MenuItem, MenuSub } from '@/registry/ui/menu'
 import { Modal } from '@/registry/ui/modal'
 import { Popover } from '@/registry/ui/popover'
+import { SearchField } from '@/registry/ui/search-field'
 import { Select, SelectTrigger } from '@/registry/ui/select'
+import { Tag, TagGroup, TagList } from '@/registry/ui/tag-group'
 import { TextField } from '@/registry/ui/text-field'
 import { highlighter } from '@/modules/docs/highlight'
 
@@ -87,7 +95,7 @@ const steps: Step[] = [
   },
   {
     title: 'Label & Description',
-    durationMs: 3200,
+    durationMs: 3000,
     code: `<TextField>
   <Label>Email</Label>
   <Input placeholder="hello@example.com" />
@@ -110,7 +118,7 @@ const steps: Step[] = [
     // Mid beat: wrap the input in an InputGroup — no addons yet.
     title: 'InputGroup',
     mid: true,
-    durationMs: 1500,
+    durationMs: 1400,
     code: `<TextField>
   <Label>Email</Label>
   <InputGroup>
@@ -134,7 +142,7 @@ const steps: Step[] = [
     // Mid beat: add the leading addon.
     title: 'InputGroup',
     mid: true,
-    durationMs: 1500,
+    durationMs: 1400,
     code: `<TextField>
   <Label>Email</Label>
   <InputGroup>
@@ -163,7 +171,7 @@ const steps: Step[] = [
   {
     // Headline step: add the trailing addon — the full InputGroup.
     title: 'InputGroup',
-    durationMs: 4200,
+    durationMs: 3600,
     code: `<TextField>
   <Label>Email</Label>
   <InputGroup>
@@ -198,8 +206,40 @@ const steps: Step[] = [
     ),
   },
   {
+    // Same anatomy, different field: swap in SearchField, a search icon, and a
+    // ⌘K hint that reappears in the command palette finale.
+    title: 'SearchField',
+    durationMs: 2800,
+    code: `<SearchField>
+  <Label>Search</Label>
+  <InputGroup>
+    <InputGroupAddon>
+      <SearchIcon />
+    </InputGroupAddon>
+    <Input placeholder="Search docs…" />
+    <InputGroupAddon>
+      <Kbd>⌘K</Kbd>
+    </InputGroupAddon>
+  </InputGroup>
+</SearchField>`,
+    preview: (
+      <SearchField className="w-72">
+        <Label className="[view-transition-name:cmp-label]">Search</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <InputGroupAddon>
+            <SearchIcon />
+          </InputGroupAddon>
+          <Input placeholder="Search docs…" />
+          <InputGroupAddon>
+            <Kbd className="[view-transition-name:cmp-kbd]">⌘K</Kbd>
+          </InputGroupAddon>
+        </InputGroup>
+      </SearchField>
+    ),
+  },
+  {
     title: 'DateField',
-    durationMs: 3400,
+    durationMs: 3000,
     code: `<DateField>
   <Label>Meeting date</Label>
   <InputGroup>
@@ -222,8 +262,44 @@ const steps: Step[] = [
     ),
   },
   {
+    // Mid beat: promote to DatePicker — move the icon to a trailing trigger,
+    // still no popover.
     title: 'DatePicker',
-    durationMs: 4200,
+    mid: true,
+    durationMs: 1400,
+    code: `<DatePicker>
+  <Label>Meeting date</Label>
+  <InputGroup>
+    <DateInput />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <CalendarIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+</DatePicker>`,
+    preview: (
+      <DatePicker className="w-56" defaultValue={parseDate('2026-07-10')}>
+        <Label className="[view-transition-name:cmp-label]">Meeting date</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <DateInput />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <CalendarIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+      </DatePicker>
+    ),
+  },
+  {
+    // Headline: attach the popover calendar.
+    title: 'DatePicker',
+    durationMs: 3400,
     code: `<DatePicker>
   <Label>Meeting date</Label>
   <InputGroup>
@@ -265,7 +341,7 @@ const steps: Step[] = [
   },
   {
     title: 'DateRangePicker',
-    durationMs: 3600,
+    durationMs: 3400,
     code: `<DateRangePicker>
   <Label>Trip dates</Label>
   <InputGroup>
@@ -316,8 +392,62 @@ const steps: Step[] = [
     ),
   },
   {
-    title: 'Drawer overlay',
-    durationMs: 3000,
+    // Mid beat: swap the overlay primitive — one word, Popover → Modal.
+    title: 'Modal',
+    mid: true,
+    durationMs: 1300,
+    code: `<DateRangePicker>
+  <Label>Trip dates</Label>
+  <InputGroup>
+    <DateInput slot="start" />
+    <span>–</span>
+    <DateInput slot="end" />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <CalendarIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Modal>
+    <DialogContent>
+      <RangeCalendar />
+    </DialogContent>
+  </Modal>
+</DateRangePicker>`,
+    preview: (
+      <DateRangePicker
+        className="w-64"
+        defaultValue={{
+          start: parseDate('2026-07-10'),
+          end: parseDate('2026-07-17'),
+        }}
+      >
+        <Label className="[view-transition-name:cmp-label]">Trip dates</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <DateInput slot="start" />
+          <span>–</span>
+          <DateInput slot="end" />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <CalendarIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Modal>
+          <DialogContent>
+            <RangeCalendar />
+          </DialogContent>
+        </Modal>
+      </DateRangePicker>
+    ),
+  },
+  {
+    title: 'Drawer',
+    durationMs: 2800,
     code: `<DateRangePicker>
   <Label>Trip dates</Label>
   <InputGroup>
@@ -368,36 +498,183 @@ const steps: Step[] = [
     ),
   },
   {
+    // Mid beat: collapse to a bare Select — label and trigger only.
     title: 'Select',
-    durationMs: 3400,
+    mid: true,
+    durationMs: 1300,
     code: `<Select>
-  <Label>Provider</Label>
+  <Label>Assignee</Label>
+  <SelectTrigger />
+</Select>`,
+    preview: (
+      <Select className="w-56">
+        <Label className="[view-transition-name:cmp-label]">Assignee</Label>
+        <SelectTrigger className="[view-transition-name:cmp-trigger]" />
+      </Select>
+    ),
+  },
+  {
+    // Headline: attach the options list.
+    title: 'Select',
+    durationMs: 3200,
+    code: `<Select>
+  <Label>Assignee</Label>
   <SelectTrigger />
   <Popover>
     <ListBox>
-      <ListBoxItem>Perplexity</ListBoxItem>
-      <ListBoxItem>Replicate</ListBoxItem>
-      <ListBoxItem>Together AI</ListBoxItem>
+      <ListBoxItem>Cara</ListBoxItem>
+      <ListBoxItem>Dan</ListBoxItem>
+      <ListBoxItem>Eve</ListBoxItem>
     </ListBox>
   </Popover>
 </Select>`,
     preview: (
-      <Select className="w-56" defaultSelectedKey="perplexity">
-        <Label className="[view-transition-name:cmp-label]">Provider</Label>
+      <Select className="w-56" defaultSelectedKey="cara">
+        <Label className="[view-transition-name:cmp-label]">Assignee</Label>
         <SelectTrigger className="[view-transition-name:cmp-trigger]" />
         <Popover>
-          <ListBox>
-            <ListBoxItem id="perplexity">Perplexity</ListBoxItem>
-            <ListBoxItem id="replicate">Replicate</ListBoxItem>
-            <ListBoxItem id="together-ai">Together AI</ListBoxItem>
+          <ListBox className="[view-transition-name:cmp-list]">
+            <ListBoxItem id="cara">Cara</ListBoxItem>
+            <ListBoxItem id="dan">Dan</ListBoxItem>
+            <ListBoxItem id="eve">Eve</ListBoxItem>
           </ListBox>
         </Popover>
       </Select>
     ),
   },
   {
-    title: 'Menu',
+    // Mid beat: the same list gains a section header.
+    title: 'Sections',
+    mid: true,
+    durationMs: 1400,
+    code: `<Select>
+  <Label>Assignee</Label>
+  <SelectTrigger />
+  <Popover>
+    <ListBox>
+      <ListBoxSection>
+        <ListBoxSectionHeader>Team</ListBoxSectionHeader>
+        <ListBoxItem>Cara</ListBoxItem>
+        <ListBoxItem>Dan</ListBoxItem>
+        <ListBoxItem>Eve</ListBoxItem>
+      </ListBoxSection>
+    </ListBox>
+  </Popover>
+</Select>`,
+    preview: (
+      <Select className="w-56" defaultSelectedKey="cara">
+        <Label className="[view-transition-name:cmp-label]">Assignee</Label>
+        <SelectTrigger className="[view-transition-name:cmp-trigger]" />
+        <Popover>
+          <ListBox className="[view-transition-name:cmp-list]">
+            <ListBoxSection>
+              <ListBoxSectionHeader>Team</ListBoxSectionHeader>
+              <ListBoxItem id="cara">Cara</ListBoxItem>
+              <ListBoxItem id="dan">Dan</ListBoxItem>
+              <ListBoxItem id="eve">Eve</ListBoxItem>
+            </ListBoxSection>
+          </ListBox>
+        </Popover>
+      </Select>
+    ),
+  },
+  {
+    // Headline: same list, now a typeahead — swap the trigger for an input.
+    title: 'Combobox',
     durationMs: 3200,
+    code: `<Combobox>
+  <Label>Assignee</Label>
+  <InputGroup>
+    <Input placeholder="Search people…" />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <ChevronDownIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Popover>
+    <ListBox>
+      <ListBoxItem>Cara</ListBoxItem>
+      <ListBoxItem>Dan</ListBoxItem>
+      <ListBoxItem>Eve</ListBoxItem>
+    </ListBox>
+  </Popover>
+</Combobox>`,
+    preview: (
+      <Combobox className="w-64">
+        <Label className="[view-transition-name:cmp-label]">Assignee</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <Input placeholder="Search people…" />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <ChevronDownIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <ListBox className="[view-transition-name:cmp-list]">
+            <ListBoxItem id="cara">Cara</ListBoxItem>
+            <ListBoxItem id="dan">Dan</ListBoxItem>
+            <ListBoxItem id="eve">Eve</ListBoxItem>
+          </ListBox>
+        </Popover>
+      </Combobox>
+    ),
+  },
+  {
+    // Headline: multi-select — selected people surface as tags.
+    title: 'Tags',
+    durationMs: 3000,
+    code: `<Combobox>
+  <Label>Assignee</Label>
+  <TagGroup>
+    <TagList>
+      <Tag>Ana</Tag>
+      <Tag>Ben</Tag>
+    </TagList>
+  </TagGroup>
+  <InputGroup>
+    <Input placeholder="Add people…" />
+  </InputGroup>
+  <Popover>
+    <ListBox>
+      <ListBoxItem>Cara</ListBoxItem>
+      <ListBoxItem>Dan</ListBoxItem>
+      <ListBoxItem>Eve</ListBoxItem>
+    </ListBox>
+  </Popover>
+</Combobox>`,
+    preview: (
+      <Combobox className="w-64">
+        <Label className="[view-transition-name:cmp-label]">Assignee</Label>
+        <TagGroup aria-label="Invitees">
+          <TagList>
+            <Tag>Ana</Tag>
+            <Tag>Ben</Tag>
+          </TagList>
+        </TagGroup>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <Input placeholder="Add people…" />
+        </InputGroup>
+        <Popover>
+          <ListBox className="[view-transition-name:cmp-list]">
+            <ListBoxItem id="cara">Cara</ListBoxItem>
+            <ListBoxItem id="dan">Dan</ListBoxItem>
+            <ListBoxItem id="eve">Eve</ListBoxItem>
+          </ListBox>
+        </Popover>
+      </Combobox>
+    ),
+  },
+  {
+    // Mid beat: a plain menu off an icon button.
+    title: 'Menu',
+    mid: true,
+    durationMs: 1400,
     code: `<Menu>
   <Button size="sm" isIconOnly>
     <MoreHorizontalIcon />
@@ -421,7 +698,7 @@ const steps: Step[] = [
           <MoreHorizontalIcon />
         </Button>
         <Popover>
-          <MenuContent>
+          <MenuContent className="[view-transition-name:cmp-list]">
             <MenuItem>Edit</MenuItem>
             <MenuItem>Duplicate</MenuItem>
             <MenuItem>Delete</MenuItem>
@@ -431,84 +708,352 @@ const steps: Step[] = [
     ),
   },
   {
-    title: 'Dialog',
-    durationMs: 3400,
-    code: `<Dialog>
-  <Button>Create issue</Button>
-  <Modal>
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>Create a new issue</DialogTitle>
-        <DialogDescription>
-          Report a bug or request a feature.
-        </DialogDescription>
-      </DialogHeader>
-    </DialogContent>
-  </Modal>
-</Dialog>`,
+    // Headline: the items gain keyboard shortcuts.
+    title: 'Menu',
+    durationMs: 2800,
+    code: `<Menu>
+  <Button size="sm" isIconOnly>
+    <MoreHorizontalIcon />
+  </Button>
+  <Popover>
+    <MenuContent>
+      <MenuItem>Edit <Kbd>⌘E</Kbd></MenuItem>
+      <MenuItem>Duplicate <Kbd>⌘D</Kbd></MenuItem>
+      <MenuItem>Delete <Kbd>⌘⌫</Kbd></MenuItem>
+    </MenuContent>
+  </Popover>
+</Menu>`,
     preview: (
-      <Dialog>
-        <Button className="[view-transition-name:cmp-trigger]">
-          Create issue
+      <Menu>
+        <Button
+          size="sm"
+          isIconOnly
+          aria-label="Actions"
+          className="[view-transition-name:cmp-trigger]"
+        >
+          <MoreHorizontalIcon />
         </Button>
-        <Modal>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Create a new issue</DialogTitle>
-              <DialogDescription>
-                Report a bug or request a feature.
-              </DialogDescription>
-            </DialogHeader>
-          </DialogContent>
-        </Modal>
-      </Dialog>
+        <Popover>
+          <MenuContent className="[view-transition-name:cmp-list]">
+            <MenuItem textValue="Edit">
+              Edit
+              <Kbd>⌘E</Kbd>
+            </MenuItem>
+            <MenuItem textValue="Duplicate">
+              Duplicate
+              <Kbd>⌘D</Kbd>
+            </MenuItem>
+            <MenuItem textValue="Delete">
+              Delete
+              <Kbd>⌘⌫</Kbd>
+            </MenuItem>
+          </MenuContent>
+        </Popover>
+      </Menu>
     ),
   },
   {
-    // The finale: every part introduced above, recomposed into one component.
-    title: 'ComboBox',
-    durationMs: 4200,
-    code: `<Combobox>
-  <Label>Country</Label>
-  <InputGroup>
-    <Input placeholder="Search countries…" />
-    <InputGroupAddon>
-      <Button size="sm" isIconOnly>
-        <ChevronDownIcon />
-      </Button>
-    </InputGroupAddon>
-  </InputGroup>
+    // Mid beat: one item nests a submenu.
+    title: 'Submenu',
+    mid: true,
+    durationMs: 1500,
+    code: `<Menu>
+  <Button size="sm" isIconOnly>
+    <MoreHorizontalIcon />
+  </Button>
   <Popover>
-    <ListBox>
-      <ListBoxItem>France</ListBoxItem>
-      <ListBoxItem>Germany</ListBoxItem>
-      <ListBoxItem>Tunisia</ListBoxItem>
-    </ListBox>
-  </Popover>
-</Combobox>`,
-    preview: (
-      <Combobox className="w-64">
-        <Label className="[view-transition-name:cmp-label]">Country</Label>
-        <InputGroup className="[view-transition-name:cmp-field]">
-          <Input placeholder="Search countries…" />
-          <InputGroupAddon>
-            <Button
-              size="sm"
-              isIconOnly
-              className="[view-transition-name:cmp-trigger]"
-            >
-              <ChevronDownIcon />
-            </Button>
-          </InputGroupAddon>
-        </InputGroup>
+    <MenuContent>
+      <MenuItem>Edit <Kbd>⌘E</Kbd></MenuItem>
+      <MenuSub>
+        <MenuItem>Move to</MenuItem>
         <Popover>
-          <ListBox>
-            <ListBoxItem>France</ListBoxItem>
-            <ListBoxItem>Germany</ListBoxItem>
-            <ListBoxItem>Tunisia</ListBoxItem>
-          </ListBox>
+          <MenuContent>
+            <MenuItem>Project</MenuItem>
+            <MenuItem>Team</MenuItem>
+          </MenuContent>
         </Popover>
-      </Combobox>
+      </MenuSub>
+      <MenuItem>Delete <Kbd>⌘⌫</Kbd></MenuItem>
+    </MenuContent>
+  </Popover>
+</Menu>`,
+    preview: (
+      <Menu>
+        <Button
+          size="sm"
+          isIconOnly
+          aria-label="Actions"
+          className="[view-transition-name:cmp-trigger]"
+        >
+          <MoreHorizontalIcon />
+        </Button>
+        <Popover>
+          <MenuContent className="[view-transition-name:cmp-list]">
+            <MenuItem textValue="Edit">
+              Edit
+              <Kbd>⌘E</Kbd>
+            </MenuItem>
+            <MenuSub>
+              <MenuItem>Move to</MenuItem>
+              <Popover>
+                <MenuContent>
+                  <MenuItem>Project</MenuItem>
+                  <MenuItem>Team</MenuItem>
+                </MenuContent>
+              </Popover>
+            </MenuSub>
+            <MenuItem textValue="Delete">
+              Delete
+              <Kbd>⌘⌫</Kbd>
+            </MenuItem>
+          </MenuContent>
+        </Popover>
+      </Menu>
+    ),
+  },
+  {
+    // Headline: the same menu, now opened by right-click — the trigger becomes
+    // the target surface.
+    title: 'ContextMenu',
+    durationMs: 3000,
+    code: `<ContextMenu>
+  Right click here
+  <Popover>
+    <MenuContent>
+      <MenuItem>Edit <Kbd>⌘E</Kbd></MenuItem>
+      <MenuItem>Duplicate <Kbd>⌘D</Kbd></MenuItem>
+      <MenuItem>Delete <Kbd>⌘⌫</Kbd></MenuItem>
+    </MenuContent>
+  </Popover>
+</ContextMenu>`,
+    preview: (
+      <ContextMenu className="bg-bg-muted flex h-24 w-64 items-center justify-center rounded-md border border-dashed text-sm text-fg-muted">
+        Right click here
+        <Popover>
+          <MenuContent className="[view-transition-name:cmp-list]">
+            <MenuItem textValue="Edit">
+              Edit
+              <Kbd>⌘E</Kbd>
+            </MenuItem>
+            <MenuItem textValue="Duplicate">
+              Duplicate
+              <Kbd>⌘D</Kbd>
+            </MenuItem>
+            <MenuItem textValue="Delete">
+              Delete
+              <Kbd>⌘⌫</Kbd>
+            </MenuItem>
+          </MenuContent>
+        </Popover>
+      </ContextMenu>
+    ),
+  },
+  {
+    // Mid beat: the same menu, filtered by an @-mention typed into a textarea.
+    title: 'Mention',
+    mid: true,
+    durationMs: 1500,
+    code: `<Mention>
+  <TextField>
+    <Label>Comment</Label>
+    <TextArea placeholder="Type @ to mention…" />
+  </TextField>
+  <Popover>
+    <MenuContent>
+      <MenuItem>Alex Miller</MenuItem>
+      <MenuItem>Sarah Jones</MenuItem>
+    </MenuContent>
+  </Popover>
+</Mention>`,
+    preview: (
+      <Mention className="w-64">
+        <TextField>
+          <Label className="[view-transition-name:cmp-label]">Comment</Label>
+          <TextArea placeholder="Type @ to mention…" />
+        </TextField>
+        <Popover>
+          <MenuContent className="[view-transition-name:cmp-list]">
+            {/* Ids are the full names — Mention inserts String(key) on select. */}
+            <MenuItem id="Alex Miller">Alex Miller</MenuItem>
+            <MenuItem id="Sarah Jones">Sarah Jones</MenuItem>
+          </MenuContent>
+        </Popover>
+      </Mention>
+    ),
+  },
+  {
+    // Headline: each suggestion gains an avatar.
+    title: 'Mention',
+    durationMs: 3200,
+    code: `<Mention>
+  <TextField>
+    <Label>Comment</Label>
+    <TextArea placeholder="Type @ to mention…" />
+  </TextField>
+  <Popover>
+    <MenuContent>
+      <MenuItem>
+        <Avatar><AvatarFallback>A</AvatarFallback></Avatar>
+        Alex Miller
+      </MenuItem>
+      <MenuItem>
+        <Avatar><AvatarFallback>S</AvatarFallback></Avatar>
+        Sarah Jones
+      </MenuItem>
+    </MenuContent>
+  </Popover>
+</Mention>`,
+    preview: (
+      <Mention className="w-64">
+        <TextField>
+          <Label className="[view-transition-name:cmp-label]">Comment</Label>
+          <TextArea placeholder="Type @ to mention…" />
+        </TextField>
+        <Popover>
+          <MenuContent className="[view-transition-name:cmp-list]">
+            <MenuItem id="Alex Miller" textValue="Alex Miller">
+              <Avatar size="sm">
+                <AvatarFallback>A</AvatarFallback>
+              </Avatar>
+              Alex Miller
+            </MenuItem>
+            <MenuItem id="Sarah Jones" textValue="Sarah Jones">
+              <Avatar size="sm">
+                <AvatarFallback>S</AvatarFallback>
+              </Avatar>
+              Sarah Jones
+            </MenuItem>
+          </MenuContent>
+        </Popover>
+      </Mention>
+    ),
+  },
+  {
+    // Mid beat: the command palette skeleton — a search input inside Command.
+    title: 'Command',
+    mid: true,
+    durationMs: 1400,
+    code: `<Command>
+  <SearchField>
+    <InputGroup>
+      <InputGroupAddon>
+        <SearchIcon />
+      </InputGroupAddon>
+      <Input placeholder="Type a command…" />
+    </InputGroup>
+  </SearchField>
+</Command>`,
+    preview: (
+      <div className="w-72 overflow-hidden rounded-md border bg-bg">
+        <Command aria-label="Command menu">
+          <SearchField aria-label="Search">
+            <InputGroup className="[view-transition-name:cmp-field]">
+              <InputGroupAddon>
+                <SearchIcon />
+              </InputGroupAddon>
+              <Input placeholder="Type a command…" />
+            </InputGroup>
+          </SearchField>
+        </Command>
+      </div>
+    ),
+  },
+  {
+    // Mid beat: the palette gains its list of commands.
+    title: 'Command',
+    mid: true,
+    durationMs: 1500,
+    code: `<Command>
+  <SearchField>
+    <InputGroup>
+      <InputGroupAddon>
+        <SearchIcon />
+      </InputGroupAddon>
+      <Input placeholder="Type a command…" />
+    </InputGroup>
+  </SearchField>
+  <ListBox>
+    <ListBoxItem>New issue</ListBoxItem>
+    <ListBoxItem>Assign to…</ListBoxItem>
+    <ListBoxItem>Search docs</ListBoxItem>
+  </ListBox>
+</Command>`,
+    preview: (
+      <div className="w-72 overflow-hidden rounded-md border bg-bg">
+        <Command aria-label="Command menu">
+          <SearchField aria-label="Search">
+            <InputGroup className="[view-transition-name:cmp-field]">
+              <InputGroupAddon>
+                <SearchIcon />
+              </InputGroupAddon>
+              <Input placeholder="Type a command…" />
+            </InputGroup>
+          </SearchField>
+          <ListBox
+            aria-label="Commands"
+            className="[view-transition-name:cmp-list]"
+          >
+            <ListBoxItem id="new-issue">New issue</ListBoxItem>
+            <ListBoxItem id="assign">Assign to…</ListBoxItem>
+            <ListBoxItem id="search-docs">Search docs</ListBoxItem>
+          </ListBox>
+        </Command>
+      </div>
+    ),
+  },
+  {
+    // The finale: every part recomposed into a live command palette — sectioned,
+    // shortcut-hinted, and typing filters it in place.
+    title: 'Command palette',
+    durationMs: 4200,
+    code: `<Command>
+  <SearchField>
+    <InputGroup>
+      <InputGroupAddon>
+        <SearchIcon />
+      </InputGroupAddon>
+      <Input placeholder="Type a command…" />
+    </InputGroup>
+  </SearchField>
+  <ListBox>
+    <ListBoxSection>
+      <ListBoxSectionHeader>Actions</ListBoxSectionHeader>
+      <ListBoxItem>New issue <Kbd>⌘N</Kbd></ListBoxItem>
+      <ListBoxItem>Assign to…</ListBoxItem>
+      <ListBoxItem>Search docs <Kbd>⌘K</Kbd></ListBoxItem>
+    </ListBoxSection>
+  </ListBox>
+</Command>`,
+    preview: (
+      <div className="w-72 overflow-hidden rounded-md border bg-bg">
+        <Command aria-label="Command menu">
+          <SearchField aria-label="Search">
+            <InputGroup className="[view-transition-name:cmp-field]">
+              <InputGroupAddon>
+                <SearchIcon />
+              </InputGroupAddon>
+              <Input placeholder="Type a command…" />
+            </InputGroup>
+          </SearchField>
+          <ListBox
+            aria-label="Commands"
+            className="[view-transition-name:cmp-list]"
+          >
+            <ListBoxSection>
+              <ListBoxSectionHeader>Actions</ListBoxSectionHeader>
+              <ListBoxItem id="new-issue" textValue="New issue">
+                New issue
+                <Kbd>⌘N</Kbd>
+              </ListBoxItem>
+              <ListBoxItem id="assign">Assign to…</ListBoxItem>
+              <ListBoxItem id="search-docs" textValue="Search docs">
+                Search docs
+                <Kbd className="[view-transition-name:cmp-kbd]">⌘K</Kbd>
+              </ListBoxItem>
+            </ListBoxSection>
+          </ListBox>
+        </Command>
+      </div>
     ),
   },
 ]
@@ -530,7 +1075,13 @@ export type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
 export function useCompositionPlayer({
   durationScale = 1,
   midDurationMs,
-}: { durationScale?: number; midDurationMs?: number } = {}) {
+  manualBeatMs = 500,
+}: {
+  durationScale?: number
+  midDurationMs?: number
+  // Dwell per mid beat when a manual navigation walks through them.
+  manualBeatMs?: number
+} = {}) {
   const [step, setStep] = useState(0)
   const [userPaused, setUserPaused] = useState(false)
   const [hoverPaused, setHoverPausedState] = useState(false)
@@ -602,7 +1153,7 @@ export function useCompositionPlayer({
   }, [])
 
   const stepRef = useRef(0)
-  const goToStep = useCallback((next: number) => {
+  const applyStep = useCallback((next: number) => {
     stepRef.current = next
     const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
     if (reduce || scrollingRef.current || !document.startViewTransition) {
@@ -619,9 +1170,50 @@ export function useCompositionPlayer({
     })
   }, [])
 
+  // Manual navigation (rail/dots): when the target is the next headline, play
+  // the mid beats between here and there on a fast cadence instead of
+  // hard-jumping, so the code still arrives in small blocks. Backward jumps
+  // and far jumps (crossing another headline) stay direct.
+  const walkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cancelWalk = useCallback(() => {
+    if (walkTimerRef.current) {
+      clearTimeout(walkTimerRef.current)
+      walkTimerRef.current = null
+    }
+  }, [])
+  useEffect(() => cancelWalk, [cancelWalk])
+
+  const goToStep = useCallback(
+    (next: number) => {
+      cancelWalk()
+      const from = stepRef.current
+      const between = steps.slice(from + 1, next)
+      const reduce = window.matchMedia(
+        '(prefers-reduced-motion: reduce)',
+      ).matches
+      if (
+        reduce ||
+        next <= from ||
+        between.length === 0 ||
+        !between.every((s) => s.mid)
+      ) {
+        applyStep(next)
+        return
+      }
+      const walk = () => {
+        applyStep(stepRef.current + 1)
+        if (stepRef.current < next) {
+          walkTimerRef.current = setTimeout(walk, manualBeatMs)
+        }
+      }
+      walk()
+    },
+    [applyStep, cancelWalk, manualBeatMs],
+  )
+
   const advance = useCallback(
-    () => goToStep((stepRef.current + 1) % steps.length),
-    [goToStep],
+    () => applyStep((stepRef.current + 1) % steps.length),
+    [applyStep],
   )
 
   const togglePlay = useCallback(() => {
@@ -807,7 +1399,9 @@ export function CompositionTransitionStyles({
       ::view-transition-group(cmp-field),
       ::view-transition-group(cmp-label),
       ::view-transition-group(cmp-desc),
-      ::view-transition-group(cmp-trigger) {
+      ::view-transition-group(cmp-trigger),
+      ::view-transition-group(cmp-list),
+      ::view-transition-group(cmp-kbd) {
         animation-duration: ${morphMs}ms;
         animation-timing-function: cubic-bezier(0.645, 0.045, 0.355, 1);
       }

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -1073,16 +1073,10 @@ export type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
 // drift. Hovering or focusing the showcase pauses; the play/pause button is a
 // sticky override. Every step change routes through a view transition so the
 // preview's named parts (field shell, label, trigger…) morph instead of swap.
-export function useCompositionPlayer({
-  durationScale = 1,
-  midDurationMs,
-  manualBeatMs = 500,
-}: {
-  durationScale?: number
-  midDurationMs?: number
-  // Dwell per mid beat when a manual navigation walks through them.
-  manualBeatMs?: number
-} = {}) {
+// Dwell per mid beat when a manual navigation walks through them.
+const MANUAL_BEAT_MS = 500
+
+export function useCompositionPlayer() {
   const [step, setStep] = useState(0)
   const [userPaused, setUserPaused] = useState(false)
   const [hoverPaused, setHoverPausedState] = useState(false)
@@ -1204,12 +1198,12 @@ export function useCompositionPlayer({
       const walk = () => {
         applyStep(stepRef.current + 1)
         if (stepRef.current < next) {
-          walkTimerRef.current = setTimeout(walk, manualBeatMs)
+          walkTimerRef.current = setTimeout(walk, MANUAL_BEAT_MS)
         }
       }
       walk()
     },
-    [applyStep, cancelWalk, manualBeatMs],
+    [applyStep, cancelWalk],
   )
 
   const advance = useCallback(
@@ -1217,13 +1211,17 @@ export function useCompositionPlayer({
     [applyStep],
   )
 
+  // Hovering is a real pause to the reader, so the button reads and toggles
+  // this rather than the explicit override alone. Excludes off-screen and
+  // background-tab parking, which pause the clock but aren't the reader's doing.
+  const paused = userPaused || hoverPaused
   const togglePlay = useCallback(() => {
-    setUserPaused((paused) => !paused)
+    setUserPaused(!paused)
     // Resuming with the cursor still inside must actually resume.
     setHoverPausedState(false)
-  }, [])
+  }, [paused])
 
-  const playing = mounted && inView && !hidden && !userPaused && !hoverPaused
+  const playing = mounted && inView && !hidden && !paused
   const current = steps[step] ?? firstStep
   // A mid step maps to the headline step it's building toward (the next
   // paginated entry), so that entry stays lit while the beats play.
@@ -1231,11 +1229,7 @@ export function useCompositionPlayer({
     0,
     paginatedSteps.findIndex((p) => p.index >= step),
   )
-  // Mid steps share one dwell time; the tweaker can override it (undefined in
-  // production, where each mid keeps its own durationMs).
-  const stepDurationMs =
-    (current.mid ? (midDurationMs ?? current.durationMs) : current.durationMs) *
-    durationScale
+  const stepDurationMs = current.durationMs
   const reducedMotion =
     mounted && window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
@@ -1253,7 +1247,7 @@ export function useCompositionPlayer({
     goToStep,
     advance,
     playing,
-    userPaused,
+    paused,
     togglePlay,
     setHoverPaused,
     mounted,
@@ -1372,17 +1366,17 @@ export function PlayPauseButton({
   player: CompositionPlayer
   className?: string
 }) {
-  const { userPaused, togglePlay } = player
+  const { paused, togglePlay } = player
   return (
     <Button
       size="sm"
       variant="quiet"
       isIconOnly
-      aria-label={userPaused ? 'Play steps' : 'Pause steps'}
+      aria-label={paused ? 'Play steps' : 'Pause steps'}
       onPress={togglePlay}
       className={cn('text-fg-muted', className)}
     >
-      {userPaused ? <PlayIcon /> : <PauseIcon />}
+      {paused ? <PlayIcon /> : <PauseIcon />}
     </Button>
   )
 }

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -10,9 +10,18 @@ import {
   StepTimer,
   useCompositionPlayer,
 } from '@/modules/docs/composition-animation'
+import { useTweak } from '@/dev/tweaker'
 
 export function CompositionSection() {
-  const player = useCompositionPlayer()
+  const manualBeatMs = useTweak('Manual beat dwell (ms)', {
+    type: 'number',
+    min: 150,
+    max: 1500,
+    step: 50,
+    default: 500,
+    group: 'Composition',
+  })
+  const player = useCompositionPlayer({ manualBeatMs })
   const {
     paginated,
     activePaginated,
@@ -178,11 +187,11 @@ export function CompositionSection() {
               </div>
             </div>
           </div>
-          <div className="mt-3 flex items-center justify-between lg:hidden">
-            <span className="font-mono text-xs text-fg-muted">
+          <div className="mt-3 flex items-center justify-between gap-2 lg:hidden">
+            <span className="truncate font-mono text-xs text-fg-muted">
               {current.title}
             </span>
-            <StepDots player={player} />
+            <StepDots player={player} className="shrink-0" />
           </div>
         </div>
       </div>

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -10,18 +10,9 @@ import {
   StepTimer,
   useCompositionPlayer,
 } from '@/modules/docs/composition-animation'
-import { useTweak } from '@/dev/tweaker'
 
 export function CompositionSection() {
-  const manualBeatMs = useTweak('Manual beat dwell (ms)', {
-    type: 'number',
-    min: 150,
-    max: 1500,
-    step: 50,
-    default: 500,
-    group: 'Composition',
-  })
-  const player = useCompositionPlayer({ manualBeatMs })
+  const player = useCompositionPlayer()
   const {
     paginated,
     activePaginated,
@@ -153,6 +144,16 @@ export function CompositionSection() {
 
         {/* Code with its rendered result below — one card, no window chrome */}
         <div {...pauseHandlers}>
+          {/* Stands in for the step rail, which is desktop-only. */}
+          <div className="mb-3 flex items-center justify-between gap-2 lg:hidden">
+            <span className="truncate font-mono text-xs text-fg-muted">
+              {current.title}
+            </span>
+            <div className="flex shrink-0 items-center gap-1">
+              <StepDots player={player} />
+              <PlayPauseButton player={player} />
+            </div>
+          </div>
           <div className="overflow-hidden rounded-xl border bg-card shadow-xs">
             <div className="relative flex min-h-56 items-center justify-center p-6">
               <div
@@ -162,7 +163,7 @@ export function CompositionSection() {
               <div className="relative">{current.preview}</div>
               <PlayPauseButton
                 player={player}
-                className="absolute right-2 bottom-2"
+                className="absolute right-2 bottom-2 max-lg:hidden"
               />
             </div>
             <div
@@ -186,12 +187,6 @@ export function CompositionSection() {
                 )}
               </div>
             </div>
-          </div>
-          <div className="mt-3 flex items-center justify-between gap-2 lg:hidden">
-            <span className="truncate font-mono text-xs text-fg-muted">
-              {current.title}
-            </span>
-            <StepDots player={player} className="shrink-0" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What changed

Rewrites the home-page Composition section (and the docs-intro `CompositionAnimation`) from 11 to 16 headline steps (27 total with mid-beats, ~65s loop), built around **morph carriers** — every transition shares components with the previous step so the code always arrives in small blocks and the preview morphs instead of swapping:

- **Act 1 — field anatomy** (kept): Input → TextField → Label & Description → InputGroup built addon by addon.
- **Act 2 — same anatomy, any data type**: new **SearchField** step (plants the ⌘K `Kbd`), DateField → DatePicker → DateRangePicker, then the overlay swapped one word at a time (Popover → Modal → Drawer).
- **Act 3 — collections**: one Assignee list travels Select → **Sections** → Combobox → **Tags** without the items changing.
- **Act 4 — menus & finale**: the same MenuContent survives Menu → **Submenu** → **ContextMenu** → **Mention** (avatars), ending on an inline, live **command palette** that recomposes everything (typing filters it).

Supporting changes:

- Two new view-transition carriers: `cmp-list` (the surviving list) and `cmp-kbd` (the ⌘K hint).
- **Manual navigation walks the mid-beats**: clicking the next rail step/dot plays the intervening beats on a fast cadence instead of hard-jumping; backward/far jumps stay direct. The dwell is exposed as a dev-only tweak (`Manual beat dwell (ms)`, default 500) — scaffolding to be removed once a value is picked.
- Mobile title+dots row hardened for 16 dots (truncate + shrink-0).
- Docs intro prose updated to match the new loop (Dialog step no longer exists).

## Reviewer notes

- Live previews are real components: MenuItems with `Kbd` children carry explicit `textValue` (typeahead), Mention item ids are the full names (Mention inserts `String(key)` on select).
- The Tags step shows static chips — a fully wired multi-select needs the verbose `ComboboxValue` render-prop and would blow the ≤18-line snippet budget.
- Known accepted tradeoff: beats whose diff lives inside a closed Popover (Sections, Menu shortcuts, Submenu, Mention avatars, Modal mid) don't change the preview visually — the code pane carries those beats, and hovering pauses so visitors can open the components.

## Suggested refactors (deferred)

- Docs-variant code pane is fixed `h-88` and clips 20-line snippets (pre-existing, slightly worsened) — needs a sizing pass.
- The new steps eagerly import Mention/Command/TagGroup/Avatar/SearchField into the home chunk — worth folding into the planned perf work (lazy-load the animation module).
- Mid-beats titled differently from their target headline (Modal, Sections, Submenu) light the next headline's rail entry while shown — cosmetic, 1.3–1.5s.