### PR TITLE
fix(docs): make preview toolbar click-transparent outside its controls

### DIFF
--- a/www/src/modules/docs/preview-controls.tsx
+++ b/www/src/modules/docs/preview-controls.tsx
@@ -187,12 +187,14 @@ function PreviewModeToggle({ className }: { className?: string }) {
 /**
  * The toolbar over each docs preview: preset selector left, mode toggle right.
  * Absolutely positioned so it overlays the canvas instead of taking its own row.
+ * Click-transparent outside its controls, so it never blocks the canvas or
+ * siblings layered under the strip (e.g. the playground's controls trigger).
  */
 export function PreviewControls({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        'absolute inset-x-0 top-0 z-10 flex items-center justify-between gap-2 px-2 pt-2',
+        'pointer-events-none absolute inset-x-0 top-0 z-10 flex items-center justify-between gap-2 px-2 pt-2 *:pointer-events-auto',
         className,
       )}
     >


### PR DESCRIPTION
## Problem

The Controls trigger in every docs playground (`InteractiveDemo`) is unclickable. `PreviewControls` renders a full-width `absolute inset-x-0 top-0 z-10` strip over the preview canvas, and it comes *after* the trigger (also `z-10`) in the DOM — so the strip wins hit-testing across its entire width and swallows the click. The trigger's `onPress` never fires; the panel state never opens. The empty parts of the strip also ate clicks on the top edge of the preview canvas everywhere `PreviewControls` is used (playgrounds and `Demo` cards).

Regressed in #372, when the toolbar became an overlay instead of its own row, without pointer-events management.

## Fix

`pointer-events-none` on the strip, `*:pointer-events-auto` on its two controls. The toolbar stays visually identical; it just stops capturing clicks outside the preset selector and mode toggle.

## Verified (live, real clicks)

- Controls trigger opens the panel on /docs/components/button; the X closes it.
- Preset selector and preview mode toggle remain clickable.
- `document.elementFromPoint` at the trigger's center resolves to the trigger (previously resolved to the toolbar strip).
- `pnpm check` passes.