### PR TITLE
fix(www): full code transition on composition step walks

### DIFF
--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -396,7 +396,8 @@ const steps: Step[] = [
     // Mid beat: swap the overlay primitive — one word, Popover → Modal.
     title: 'Modal',
     mid: true,
-    durationMs: 1300,
+    // 110 tokens: the transition needs ~1410ms to land (see CODE_SPAN).
+    durationMs: 1500,
     code: `<DateRangePicker>
   <Label>Trip dates</Label>
   <InputGroup>
@@ -1068,14 +1069,28 @@ const paginatedSteps = steps
 
 export type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
 
+// shiki-magic-move delays each phase by a *fraction of* `duration` and then runs
+// it for a further 1×duration. Enter is last, so a transition ends at
+// (1 + delayEnter)×duration + the stagger tail — not at `duration`. Every dwell
+// above has to clear that, or the next step cuts the animation off mid-flight.
+const CODE_ENTER_DELAY = 0.7
+const CODE_SPAN = 1 + CODE_ENTER_DELAY
+const CODE_DURATION_MS = 700
+const CODE_STAGGER_MS = 2
+
+// A manual walk plays the exact same code transition as auto-play, only with a
+// smaller stagger — so each beat must clear the full span plus the stagger tail
+// of the longest (~120-token) snippet.
+const WALK_CODE_STAGGER_MS = 0.5
+const MANUAL_BEAT_MS = Math.ceil(
+  CODE_SPAN * CODE_DURATION_MS + 120 * WALK_CODE_STAGGER_MS,
+)
+
 // Shared player: auto-advance while visible, with a CSS animation as the step
 // clock (see StepTimer) so the visible progress and the advance tick can never
 // drift. Hovering or focusing the showcase pauses; the play/pause button is a
 // sticky override. Every step change routes through a view transition so the
 // preview's named parts (field shell, label, trigger…) morph instead of swap.
-// Dwell per mid beat when a manual navigation walks through them.
-const MANUAL_BEAT_MS = 500
-
 export function useCompositionPlayer() {
   const [step, setStep] = useState(0)
   const [userPaused, setUserPaused] = useState(false)
@@ -1178,6 +1193,7 @@ export function useCompositionPlayer() {
   }, [])
   useEffect(() => cancelWalk, [cancelWalk])
 
+  const [walking, setWalking] = useState(false)
   const goToStep = useCallback(
     (next: number) => {
       cancelWalk()
@@ -1192,13 +1208,19 @@ export function useCompositionPlayer() {
         between.length === 0 ||
         !between.every((s) => s.mid)
       ) {
+        setWalking(false)
         applyStep(next)
         return
       }
+      setWalking(true)
       const walk = () => {
         applyStep(stepRef.current + 1)
         if (stepRef.current < next) {
           walkTimerRef.current = setTimeout(walk, MANUAL_BEAT_MS)
+        } else {
+          // Clears in the same commit as the final step, so the arrival plays at
+          // full duration — nothing follows it to cut it off.
+          setWalking(false)
         }
       }
       walk()
@@ -1257,6 +1279,7 @@ export function useCompositionPlayer() {
     reducedMotion,
     paginated: paginatedSteps,
     activePaginated,
+    codeStaggerMs: walking ? WALK_CODE_STAGGER_MS : CODE_STAGGER_MS,
   }
 }
 
@@ -1416,8 +1439,8 @@ export function CompositionTransitionStyles({
 export function CompositionCode({
   code,
   reducedMotion,
-  duration = 700,
-  stagger = 2,
+  duration = CODE_DURATION_MS,
+  stagger = CODE_STAGGER_MS,
 }: {
   code: string
   reducedMotion: boolean
@@ -1434,6 +1457,8 @@ export function CompositionCode({
       options={{
         duration: reducedMotion ? 0 : duration,
         stagger,
+        // Pinned: CODE_SPAN is only correct if this is what the renderer uses.
+        delayEnter: CODE_ENTER_DELAY,
         containerStyle: false,
         // Snap edit boundaries to line breaks, else the raw char diff strands
         // `<` and `/>` on the old line and moves only the tag name.
@@ -1445,8 +1470,14 @@ export function CompositionCode({
 
 export function CompositionAnimation({ className }: { className?: string }) {
   const player = useCompositionPlayer()
-  const { mounted, containerRef, current, reducedMotion, setHoverPaused } =
-    player
+  const {
+    mounted,
+    containerRef,
+    current,
+    reducedMotion,
+    setHoverPaused,
+    codeStaggerMs,
+  } = player
 
   return (
     <div
@@ -1474,6 +1505,7 @@ export function CompositionAnimation({ className }: { className?: string }) {
             <CompositionCode
               code={current.code}
               reducedMotion={reducedMotion}
+              stagger={codeStaggerMs}
             />
           ) : (
             <pre className="whitespace-pre">{current.code}</pre>

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -22,6 +22,7 @@ export function CompositionSection() {
     containerRef,
     current,
     reducedMotion,
+    codeStaggerMs,
   } = player
 
   // Keep the active step centered in the fixed-height rail as the loop runs.
@@ -143,7 +144,9 @@ export function CompositionSection() {
         </div>
 
         {/* Code with its rendered result below — one card, no window chrome */}
-        <div {...pauseHandlers}>
+        {/* min-w-0: grid items floor at min-content, so the code would widen the
+            column past the viewport instead of scrolling inside the card. */}
+        <div className="min-w-0" {...pauseHandlers}>
           {/* Stands in for the step rail, which is desktop-only. */}
           <div className="mb-3 flex items-center justify-between gap-2 lg:hidden">
             <span className="truncate font-mono text-xs text-fg-muted">
@@ -175,12 +178,13 @@ export function CompositionSection() {
             >
               <div
                 ref={codeInnerRef}
-                className="no-scrollbar overflow-x-auto p-6 font-mono text-[0.8125rem] leading-normal"
+                className="no-scrollbar scroll-fade-x overflow-x-auto p-6 font-mono text-[0.8125rem] leading-normal"
               >
                 {mounted ? (
                   <CompositionCode
                     code={current.code}
                     reducedMotion={reducedMotion}
+                    stagger={codeStaggerMs}
                   />
                 ) : (
                   <pre className="whitespace-pre">{current.code}</pre>


### PR DESCRIPTION
## What changed

- Manual walks through mid steps (clicking a step in the rail/dots) now play the **exact same code transition as auto-play** — same 700ms duration, same enter delay. The only difference is a smaller magic-move stagger (`0.5ms` vs `2ms` per token).
- The walk beat grew from 500ms to ~1250ms, derived from the transition's full span (`CODE_SPAN × duration`) plus the stagger tail of the longest snippet — a 500ms beat would cut a 700ms transition off mid-flight.
- `delayEnter` is now pinned explicitly on `ShikiMagicMove` so `CODE_SPAN` (used to validate authored dwells) matches what the renderer actually runs; the Modal mid beat's dwell bumped 1300 → 1500ms to clear the real span.
- Since the code duration no longer varies, the `duration` prop threading was dropped from the player and both call sites — only `stagger` is threaded.
- Landing composition section: `min-w-0` on the code grid column so long snippets scroll inside the card instead of widening the page, plus a `scroll-fade-x` hint.

## Why

Walked mid steps looked visibly different from auto-play — rushed, with tokens moving in lockstep. The ask was to make them identical to normal steps with only a very small stagger; the beat length change follows from that.

## Reviewer notes

- Verified live on a worktree dev server: mid-walk the container runs at `--smm-duration: 700ms` with `--smm-stagger` in 0.5ms increments, and the walk lands on the target headline on schedule.
- Trade-off: clicking ahead through mid steps is slower now (a 3-mid walk takes ~3.7s). If that feels too slow the lever is `WALK_CODE_STAGGER_MS` or accepting a slightly clipped tail with a smaller beat.
- `pnpm typecheck` and `pnpm check` pass. No registry files touched.