### PR TITLE
docs: polish accordion and alert demos

### DIFF
--- a/www/content/docs/components/accordion.mdx
+++ b/www/content/docs/components/accordion.mdx
@@ -56,8 +56,8 @@ Expanded items are tracked by each `Disclosure`'s `id`. Give the group `defaultE
 
 ## Examples
 
-<Examples className="sm:grid-cols-2 lg:grid-cols-3">
-  <Example name="accordion/demos/basic" title="FAQ" />
+<Examples className="lg:grid-cols-2">
+  <Example name="accordion/demos/basic" title="FAQ" className="lg:col-span-2" />
   <Example name="accordion/demos/product-features" title="Product Features" />
   <Example name="accordion/demos/settings-panel" title="Settings Panel" />
 </Examples>

--- a/www/content/docs/components/alert.mdx
+++ b/www/content/docs/components/alert.mdx
@@ -5,16 +5,22 @@ description: Alerts display a short, important message in a way that attracts th
 
 <InteractiveDemo
   name="alert"
-  fallback={`<Alert className="max-w-md">
-<AlertTitle>Alert Title</AlertTitle>
-<AlertDescription>This is an alert description.</AlertDescription>
-
-</Alert>`}
   controls={[
-    { name: "title", type: "string", defaultValue: "Alert Title", alwaysShow: true },
-    { name: "description", type: "string", defaultValue: "This is an alert description.", alwaysShow: true },
-    "variant",
-    { name: "icon", type: "icon" },
+    {
+      name: 'title',
+      type: 'string',
+      defaultValue: 'Update available',
+      alwaysShow: true,
+    },
+    {
+      name: 'description',
+      type: 'string',
+      defaultValue:
+        'A new version is ready to install. Restart the app to apply it.',
+      alwaysShow: true,
+    },
+    'variant',
+    { name: 'icon', type: 'icon', defaultValue: 'InfoIcon' },
   ]}
 />
 
@@ -51,7 +57,10 @@ import {
   AlertAction,
 } from '@/components/ui/alert'
 import { CircleAlert } from 'lucide-react'
-;<Alert>
+```
+
+```tsx
+<Alert>
   <CircleAlert />
   <AlertTitle>Title</AlertTitle>
   <AlertDescription>Description</AlertDescription>
@@ -63,7 +72,7 @@ import { CircleAlert } from 'lucide-react'
 
 ## Examples
 
-<Examples className="sm:grid-cols-2">
+<Examples>
   <Example name="alert/demos/default" title="Default" />
   <Example name="alert/demos/action" title="With Action" />
   <Example name="alert/demos/dismissible" title="Dismissible" />

--- a/www/src/modules/docs/interactive-demo/control-defaults.ts
+++ b/www/src/modules/docs/interactive-demo/control-defaults.ts
@@ -17,7 +17,7 @@ export function getDefaultControlValue(
     case 'enum':
       return control.defaultValue ?? control.options[0]
     case 'icon':
-      return null
+      return control.defaultValue ?? null
     default:
       return undefined
   }

--- a/www/src/modules/docs/interactive-demo/process-controls.ts
+++ b/www/src/modules/docs/interactive-demo/process-controls.ts
@@ -14,6 +14,7 @@ import type {
   Control,
   ControlInput,
   EnumControl,
+  IconControl,
   NumberControl,
   SerializableControl,
   StringControl,
@@ -386,6 +387,7 @@ function buildControlWithOverrides(
         type: 'icon',
         name,
         alwaysShow: overrides.alwaysShow,
+        defaultValue: (overrides as Partial<IconControl>).defaultValue,
       }
 
     default:

--- a/www/src/modules/docs/interactive-demo/types.ts
+++ b/www/src/modules/docs/interactive-demo/types.ts
@@ -52,6 +52,8 @@ export interface EnumControl extends BaseControl {
 
 export interface IconControl extends BaseControl {
   type: 'icon'
+  /** Key of `availableIcons`; the picker's initial selection. */
+  defaultValue?: string
 }
 
 export type Control =
@@ -122,6 +124,7 @@ export interface SerializableEnumControl extends SerializableBaseControl {
 
 export interface SerializableIconControl extends SerializableBaseControl {
   type: 'icon'
+  defaultValue?: string
 }
 
 /**

--- a/www/src/modules/docs/preview-controls.tsx
+++ b/www/src/modules/docs/preview-controls.tsx
@@ -141,7 +141,7 @@ function PresetSelector() {
           <PresetSwatch color={swatchFor(selected)} />
           <SelectValue />
         </SelectTrigger>
-        <SelectContent placement="bottom">
+        <SelectContent placement="bottom start">
           <SelectItem id={YOURS} textValue={yoursName}>
             <span className="flex items-center gap-2">
               <PresetSwatch color={yoursSwatch} className="size-2.5" />

--- a/www/src/registry/ui/accordion/demos/allows-multiple.tsx
+++ b/www/src/registry/ui/accordion/demos/allows-multiple.tsx
@@ -7,7 +7,11 @@ import {
 
 export default function Demo() {
   return (
-    <Accordion allowsMultipleExpanded>
+    <Accordion
+      allowsMultipleExpanded
+      className="max-w-xs"
+      defaultExpandedKeys={['getting-started']}
+    >
       <Disclosure id="getting-started">
         <DisclosureTrigger>How do I get started with DotUI?</DisclosureTrigger>
         <DisclosurePanel>

--- a/www/src/registry/ui/accordion/demos/basic.tsx
+++ b/www/src/registry/ui/accordion/demos/basic.tsx
@@ -7,21 +7,25 @@ import {
 
 const items = [
   {
+    id: 'getting-started',
     question: 'How do I get started with DotUI?',
     answer:
       'Getting started is simple! Install the package using your preferred package manager, then import the components you need. All components are built on React Aria Components and follow accessibility best practices out of the box.',
   },
   {
+    id: 'free-to-use',
     question: 'Is DotUI free to use?',
     answer:
       'Yes, DotUI is completely free and open source. You can use it in any project, whether personal or commercial, without any restrictions or licensing fees.',
   },
   {
+    id: 'customization',
     question: 'Can I customize the components?',
     answer:
       'Absolutely! All components use Tailwind Variants for styling, making it easy to customize colors, sizes, and other visual properties. You can pass custom className props or extend the default variants to match your design system.',
   },
   {
+    id: 'typescript',
     question: 'Does DotUI support TypeScript?',
     answer:
       'Yes, DotUI is built with TypeScript and provides full type definitions for all components. This ensures type safety and excellent developer experience with autocomplete and IntelliSense support in your IDE.',
@@ -30,9 +34,9 @@ const items = [
 
 export default function Demo() {
   return (
-    <Accordion className="max-w-md">
+    <Accordion className="max-w-lg" defaultExpandedKeys={['getting-started']}>
       {items.map((item) => (
-        <Disclosure key={item.question}>
+        <Disclosure id={item.id} key={item.id}>
           <DisclosureTrigger>{item.question}</DisclosureTrigger>
           <DisclosurePanel>{item.answer}</DisclosurePanel>
         </Disclosure>

--- a/www/src/registry/ui/accordion/demos/controlled.tsx
+++ b/www/src/registry/ui/accordion/demos/controlled.tsx
@@ -15,7 +15,7 @@ export default function Demo() {
   )
 
   return (
-    <div className="space-y-4">
+    <div className="max-w-xs space-y-4">
       <p className="text-sm text-fg-muted">
         Expanded: {[...expandedKeys].join(', ') || 'none'}
       </p>

--- a/www/src/registry/ui/accordion/demos/custom-trigger.tsx
+++ b/www/src/registry/ui/accordion/demos/custom-trigger.tsx
@@ -7,21 +7,25 @@ import {
 
 const items = [
   {
+    id: 'getting-started',
     question: 'How do I get started with DotUI?',
     answer:
       'Getting started is simple! Install the package using your preferred package manager, then import the components you need. All components are built on React Aria Components and follow accessibility best practices out of the box.',
   },
   {
+    id: 'free-to-use',
     question: 'Is DotUI free to use?',
     answer:
       'Yes, DotUI is completely free and open source. You can use it in any project, whether personal or commercial, without any restrictions or licensing fees.',
   },
   {
+    id: 'customization',
     question: 'Can I customize the components?',
     answer:
       'Absolutely! All components use Tailwind Variants for styling, making it easy to customize colors, sizes, and other visual properties. You can pass custom className props or extend the default variants to match your design system.',
   },
   {
+    id: 'typescript',
     question: 'Does DotUI support TypeScript?',
     answer:
       'Yes, DotUI is built with TypeScript and provides full type definitions for all components. This ensures type safety and excellent developer experience with autocomplete and IntelliSense support in your IDE.',
@@ -30,9 +34,9 @@ const items = [
 
 export default function Demo() {
   return (
-    <Accordion className="max-w-md">
+    <Accordion className="max-w-xs" defaultExpandedKeys={['getting-started']}>
       {items.map((item) => (
-        <Disclosure key={item.question}>
+        <Disclosure id={item.id} key={item.id}>
           <DisclosureTrigger>{item.question}</DisclosureTrigger>
           <DisclosurePanel>{item.answer}</DisclosurePanel>
         </Disclosure>

--- a/www/src/registry/ui/accordion/demos/default-expanded.tsx
+++ b/www/src/registry/ui/accordion/demos/default-expanded.tsx
@@ -7,7 +7,7 @@ import {
 
 export default function Demo() {
   return (
-    <Accordion defaultExpandedKeys={['getting-started']}>
+    <Accordion className="max-w-xs" defaultExpandedKeys={['getting-started']}>
       <Disclosure id="getting-started">
         <DisclosureTrigger>How do I get started with DotUI?</DisclosureTrigger>
         <DisclosurePanel>

--- a/www/src/registry/ui/accordion/demos/disabled.tsx
+++ b/www/src/registry/ui/accordion/demos/disabled.tsx
@@ -7,7 +7,11 @@ import {
 
 export default function Demo() {
   return (
-    <Accordion isDisabled>
+    <Accordion
+      className="max-w-xs"
+      defaultExpandedKeys={['getting-started']}
+      isDisabled
+    >
       <Disclosure id="getting-started">
         <DisclosureTrigger>How do I get started with DotUI?</DisclosureTrigger>
         <DisclosurePanel>

--- a/www/src/registry/ui/accordion/demos/playground.tsx
+++ b/www/src/registry/ui/accordion/demos/playground.tsx
@@ -36,7 +36,7 @@ export default function Demo({
     <Accordion
       allowsMultipleExpanded={allowsMultipleExpanded}
       isDisabled={isDisabled}
-      className="max-w-2xl"
+      className="max-w-sm"
     >
       {items.map((item) => (
         <Disclosure id={item.id} key={item.id}>

--- a/www/src/registry/ui/accordion/demos/product-features.tsx
+++ b/www/src/registry/ui/accordion/demos/product-features.tsx
@@ -34,7 +34,10 @@ const categories = [
 
 export default function Demo() {
   return (
-    <Accordion className="w-full max-w-sm">
+    <Accordion
+      className="w-full max-w-xs"
+      defaultExpandedKeys={['Collaboration']}
+    >
       {categories.map((category) => (
         <Disclosure key={category.name} id={category.name}>
           <DisclosureTrigger>{category.name}</DisclosureTrigger>

--- a/www/src/registry/ui/accordion/demos/settings-panel.tsx
+++ b/www/src/registry/ui/accordion/demos/settings-panel.tsx
@@ -42,7 +42,10 @@ const sections = [
 
 export default function Demo() {
   return (
-    <Accordion className="w-full max-w-sm">
+    <Accordion
+      className="w-full max-w-xs"
+      defaultExpandedKeys={['Notifications']}
+    >
       {sections.map((section) => (
         <Disclosure key={section.name} id={section.name}>
           <DisclosureTrigger>{section.name}</DisclosureTrigger>

--- a/www/src/registry/ui/alert/demos/playground.tsx
+++ b/www/src/registry/ui/alert/demos/playground.tsx
@@ -10,8 +10,8 @@ import {
 } from '@/registry/ui/alert'
 
 export default function Demo({
-  title = 'Alert Title',
-  description = 'This is an alert description.',
+  title = 'Update available',
+  description = 'A new version is ready to install. Restart the app to apply it.',
   variant = 'neutral',
   icon,
 }: {


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## Summary

- **Alert playground**: defaults to a realistic alert — "Update available" with an Info icon — instead of "Alert Title" placeholder text. Removed the dead `fallback` attribute (the rehype transform strips it; it rendered nowhere).
- **Icon control defaults**: `IconControl` now supports `defaultValue` (previously hard-coded to `null` in `getDefaultControlValue`), so a playground can start with an icon preselected. Backwards-compatible; alert is the only icon control in the docs.
- **Accordion demos**: constrain widths (`max-w-xs`/`max-w-lg`), default-expand the first item so demos aren't a wall of collapsed rows, and give items stable string ids. Examples grid reworked (`lg:grid-cols-2` with FAQ spanning both).
- **Alert docs**: examples grid to single column; anatomy code block split so imports and JSX render as separate fences (fixes the stray `;` artifact).
- **Preset selector**: popover opens `bottom start` instead of centered.

## Notes for review

- The `controls` block in alert.mdx was reformatted wholesale by oxfmt — the removed backtick template literal had been suppressing formatting of that JSX expression. Only the `title`/`description`/`icon` defaults are real changes.
- All 49 playground-fidelity tests pass (the icon default now appears in generated code, which must import it and stay oxfmt-stable); full www suite 192/192, `pnpm check` + `typecheck` clean, no registry or references drift.