### PR TITLE
fix(www): keep composition section height stable across steps

### DIFF
--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -520,7 +520,7 @@ const steps: Step[] = [
     preview: (
       <Select className="w-full max-w-xs">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
-        <SelectTrigger className="[view-transition-name:cmp-trigger]" />
+        <SelectTrigger className="[view-transition-name:cmp-field]" />
       </Select>
     ),
   },
@@ -542,7 +542,7 @@ const steps: Step[] = [
     preview: (
       <Select className="w-full max-w-xs" defaultSelectedKey="cara">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
-        <SelectTrigger className="[view-transition-name:cmp-trigger]" />
+        <SelectTrigger className="[view-transition-name:cmp-field]" />
         <Popover>
           <ListBox className="[view-transition-name:cmp-list]">
             <ListBoxItem id="cara">Cara</ListBoxItem>
@@ -575,7 +575,7 @@ const steps: Step[] = [
     preview: (
       <Select className="w-full max-w-xs" defaultSelectedKey="cara">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
-        <SelectTrigger className="[view-transition-name:cmp-trigger]" />
+        <SelectTrigger className="[view-transition-name:cmp-field]" />
         <Popover>
           <ListBox className="[view-transition-name:cmp-list]">
             <ListBoxSection>

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -72,7 +72,7 @@ const firstStep: Step = {
     <Input
       aria-label="Email"
       placeholder="hello@example.com"
-      className="w-56 [view-transition-name:cmp-field]"
+      className="w-full max-w-xs [view-transition-name:cmp-field]"
     />
   ),
 }
@@ -86,7 +86,7 @@ const steps: Step[] = [
   <Input placeholder="hello@example.com" />
 </TextField>`,
     preview: (
-      <TextField aria-label="Email" className="w-56">
+      <TextField aria-label="Email" className="w-full max-w-xs">
         <Input
           placeholder="hello@example.com"
           className="[view-transition-name:cmp-field]"
@@ -103,7 +103,7 @@ const steps: Step[] = [
   <Description>No spam, unsubscribe anytime.</Description>
 </TextField>`,
     preview: (
-      <TextField className="w-56">
+      <TextField className="w-full max-w-xs">
         <Label className="[view-transition-name:cmp-label]">Email</Label>
         <Input
           placeholder="hello@example.com"
@@ -128,7 +128,7 @@ const steps: Step[] = [
   <Description>No spam, unsubscribe anytime.</Description>
 </TextField>`,
     preview: (
-      <TextField className="w-72">
+      <TextField className="w-full max-w-xs">
         <Label className="[view-transition-name:cmp-label]">Email</Label>
         <InputGroup className="[view-transition-name:cmp-field]">
           <Input placeholder="hello@example.com" />
@@ -155,7 +155,7 @@ const steps: Step[] = [
   <Description>No spam, unsubscribe anytime.</Description>
 </TextField>`,
     preview: (
-      <TextField className="w-72">
+      <TextField className="w-full max-w-xs">
         <Label className="[view-transition-name:cmp-label]">Email</Label>
         <InputGroup className="[view-transition-name:cmp-field]">
           <InputGroupAddon>
@@ -187,7 +187,7 @@ const steps: Step[] = [
   <Description>No spam, unsubscribe anytime.</Description>
 </TextField>`,
     preview: (
-      <TextField className="w-72">
+      <TextField className="w-full max-w-xs">
         <Label className="[view-transition-name:cmp-label]">Email</Label>
         <InputGroup className="[view-transition-name:cmp-field]">
           <InputGroupAddon>
@@ -224,7 +224,7 @@ const steps: Step[] = [
   </InputGroup>
 </SearchField>`,
     preview: (
-      <SearchField className="w-72">
+      <SearchField className="w-full max-w-xs">
         <Label className="[view-transition-name:cmp-label]">Search</Label>
         <InputGroup className="[view-transition-name:cmp-field]">
           <InputGroupAddon>
@@ -251,7 +251,10 @@ const steps: Step[] = [
   </InputGroup>
 </DateField>`,
     preview: (
-      <DateField className="w-56" defaultValue={parseDate('2026-07-10')}>
+      <DateField
+        className="w-full max-w-xs"
+        defaultValue={parseDate('2026-07-10')}
+      >
         <Label className="[view-transition-name:cmp-label]">Meeting date</Label>
         <InputGroup className="[view-transition-name:cmp-field]">
           <InputGroupAddon>
@@ -280,7 +283,10 @@ const steps: Step[] = [
   </InputGroup>
 </DatePicker>`,
     preview: (
-      <DatePicker className="w-56" defaultValue={parseDate('2026-07-10')}>
+      <DatePicker
+        className="w-full max-w-xs"
+        defaultValue={parseDate('2026-07-10')}
+      >
         <Label className="[view-transition-name:cmp-label]">Meeting date</Label>
         <InputGroup className="[view-transition-name:cmp-field]">
           <DateInput />
@@ -318,7 +324,10 @@ const steps: Step[] = [
   </Popover>
 </DatePicker>`,
     preview: (
-      <DatePicker className="w-56" defaultValue={parseDate('2026-07-10')}>
+      <DatePicker
+        className="w-full max-w-xs"
+        defaultValue={parseDate('2026-07-10')}
+      >
         <Label className="[view-transition-name:cmp-label]">Meeting date</Label>
         <InputGroup className="[view-transition-name:cmp-field]">
           <DateInput />
@@ -363,7 +372,7 @@ const steps: Step[] = [
 </DateRangePicker>`,
     preview: (
       <DateRangePicker
-        className="w-64"
+        className="w-full max-w-xs"
         defaultValue={{
           start: parseDate('2026-07-10'),
           end: parseDate('2026-07-17'),
@@ -418,7 +427,7 @@ const steps: Step[] = [
 </DateRangePicker>`,
     preview: (
       <DateRangePicker
-        className="w-64"
+        className="w-full max-w-xs"
         defaultValue={{
           start: parseDate('2026-07-10'),
           end: parseDate('2026-07-17'),
@@ -470,7 +479,7 @@ const steps: Step[] = [
 </DateRangePicker>`,
     preview: (
       <DateRangePicker
-        className="w-64"
+        className="w-full max-w-xs"
         defaultValue={{
           start: parseDate('2026-07-10'),
           end: parseDate('2026-07-17'),
@@ -509,7 +518,7 @@ const steps: Step[] = [
   <SelectTrigger />
 </Select>`,
     preview: (
-      <Select className="w-56">
+      <Select className="w-full max-w-xs">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
         <SelectTrigger className="[view-transition-name:cmp-trigger]" />
       </Select>
@@ -531,7 +540,7 @@ const steps: Step[] = [
   </Popover>
 </Select>`,
     preview: (
-      <Select className="w-56" defaultSelectedKey="cara">
+      <Select className="w-full max-w-xs" defaultSelectedKey="cara">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
         <SelectTrigger className="[view-transition-name:cmp-trigger]" />
         <Popover>
@@ -564,7 +573,7 @@ const steps: Step[] = [
   </Popover>
 </Select>`,
     preview: (
-      <Select className="w-56" defaultSelectedKey="cara">
+      <Select className="w-full max-w-xs" defaultSelectedKey="cara">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
         <SelectTrigger className="[view-transition-name:cmp-trigger]" />
         <Popover>
@@ -603,7 +612,7 @@ const steps: Step[] = [
   </Popover>
 </Combobox>`,
     preview: (
-      <Combobox className="w-64">
+      <Combobox className="w-full max-w-xs">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
         <InputGroup className="[view-transition-name:cmp-field]">
           <Input placeholder="Search people…" />
@@ -651,7 +660,7 @@ const steps: Step[] = [
   </Popover>
 </Combobox>`,
     preview: (
-      <Combobox className="w-64">
+      <Combobox className="w-full max-w-xs">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
         <TagGroup aria-label="Invitees">
           <TagList>
@@ -829,7 +838,7 @@ const steps: Step[] = [
   </Popover>
 </ContextMenu>`,
     preview: (
-      <ContextMenu className="bg-bg-muted flex h-24 w-64 items-center justify-center rounded-md border border-dashed text-sm text-fg-muted">
+      <ContextMenu className="bg-bg-muted flex h-24 w-full max-w-xs items-center justify-center rounded-md border border-dashed text-sm text-fg-muted">
         Right click here
         <Popover>
           <MenuContent className="[view-transition-name:cmp-list]">
@@ -868,7 +877,7 @@ const steps: Step[] = [
   </Popover>
 </Mention>`,
     preview: (
-      <Mention className="w-64">
+      <Mention className="w-full max-w-xs">
         <TextField>
           <Label className="[view-transition-name:cmp-label]">Comment</Label>
           <TextArea placeholder="Type @ to mention…" />
@@ -906,7 +915,7 @@ const steps: Step[] = [
   </Popover>
 </Mention>`,
     preview: (
-      <Mention className="w-64">
+      <Mention className="w-full max-w-xs">
         <TextField>
           <Label className="[view-transition-name:cmp-label]">Comment</Label>
           <TextArea placeholder="Type @ to mention…" />
@@ -946,7 +955,7 @@ const steps: Step[] = [
   </SearchField>
 </Command>`,
     preview: (
-      <div className="w-72 overflow-hidden rounded-md border bg-bg">
+      <div className="w-full max-w-xs overflow-hidden rounded-md border bg-bg">
         <Command aria-label="Command menu">
           <SearchField aria-label="Search">
             <InputGroup className="[view-transition-name:cmp-field]">
@@ -981,7 +990,7 @@ const steps: Step[] = [
   </ListBox>
 </Command>`,
     preview: (
-      <div className="w-72 overflow-hidden rounded-md border bg-bg">
+      <div className="w-full max-w-xs overflow-hidden rounded-md border bg-bg">
         <Command aria-label="Command menu">
           <SearchField aria-label="Search">
             <InputGroup className="[view-transition-name:cmp-field]">
@@ -1027,7 +1036,7 @@ const steps: Step[] = [
   </ListBox>
 </Command>`,
     preview: (
-      <div className="w-72 overflow-hidden rounded-md border bg-bg">
+      <div className="w-full max-w-xs overflow-hidden rounded-md border bg-bg">
         <Command aria-label="Command menu">
           <SearchField aria-label="Search">
             <InputGroup className="[view-transition-name:cmp-field]">

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -62,6 +62,10 @@ interface Step {
   // clickable stop in the pagination (e.g. building an InputGroup addon by
   // addon before landing on the headline step).
   mid?: boolean
+  // Part of the compact loop played when the home section stacks vertically —
+  // only steps within a few code lines of each other, so the pane height
+  // barely moves (see compactSteps).
+  compact?: boolean
 }
 
 const firstStep: Step = {
@@ -172,6 +176,7 @@ const steps: Step[] = [
   {
     // Headline step: add the trailing addon — the full InputGroup.
     title: 'InputGroup',
+    compact: true,
     durationMs: 3600,
     code: `<TextField>
   <Label>Email</Label>
@@ -210,6 +215,7 @@ const steps: Step[] = [
     // Same anatomy, different field: swap in SearchField, a search icon, and a
     // ⌘K hint that reappears in the command palette finale.
     title: 'SearchField',
+    compact: true,
     durationMs: 2800,
     code: `<SearchField>
   <Label>Search</Label>
@@ -240,6 +246,7 @@ const steps: Step[] = [
   },
   {
     title: 'DateField',
+    compact: true,
     durationMs: 3000,
     code: `<DateField>
   <Label>Meeting date</Label>
@@ -527,6 +534,7 @@ const steps: Step[] = [
   {
     // Headline: attach the options list.
     title: 'Select',
+    compact: true,
     durationMs: 3200,
     code: `<Select>
   <Label>Assignee</Label>
@@ -721,6 +729,7 @@ const steps: Step[] = [
   {
     // Headline: the items gain keyboard shortcuts.
     title: 'Menu',
+    compact: true,
     durationMs: 2800,
     code: `<Menu>
   <Button size="sm" isIconOnly>
@@ -826,6 +835,7 @@ const steps: Step[] = [
     // Headline: the same menu, now opened by right-click — the trigger becomes
     // the target surface.
     title: 'ContextMenu',
+    compact: true,
     durationMs: 3000,
     code: `<ContextMenu>
   Right click here
@@ -1069,12 +1079,22 @@ const steps: Step[] = [
   },
 ]
 
+const maxLines = (list: Step[]) =>
+  Math.max(...list.map((s) => s.code.split('\n').length))
+
+const compactSteps = steps.filter((s) => s.compact)
+export const maxCodeLines = maxLines(steps)
+export const compactMaxCodeLines = maxLines(compactSteps)
+
 // Pagination lists only the headline steps; mid steps play during auto-advance
-// but aren't clickable stops. Each entry keeps its index into `steps` so the
+// but aren't clickable stops. Each entry keeps its index into its list so the
 // rail/dots can jump straight to it.
-const paginatedSteps = steps
-  .map((s, index) => ({ title: s.title, index, mid: s.mid }))
-  .filter((s) => !s.mid)
+const paginate = (list: Step[]) =>
+  list
+    .map((s, index) => ({ title: s.title, index, mid: s.mid }))
+    .filter((s) => !s.mid)
+const paginatedSteps = paginate(steps)
+const compactPaginatedSteps = paginate(compactSteps)
 
 export type CompositionPlayer = ReturnType<typeof useCompositionPlayer>
 
@@ -1100,8 +1120,12 @@ const MANUAL_BEAT_MS = Math.ceil(
 // drift. Hovering or focusing the showcase pauses; the play/pause button is a
 // sticky override. Every step change routes through a view transition so the
 // preview's named parts (field shell, label, trigger…) morph instead of swap.
-export function useCompositionPlayer() {
+// `compactBelowLg` swaps in the compact loop when the viewport is under the
+// lg breakpoint. It flips after mount only, so server and hydration markup
+// always show the full list's first step.
+export function useCompositionPlayer({ compactBelowLg = false } = {}) {
   const [step, setStep] = useState(0)
+  const [compact, setCompact] = useState(false)
   const [userPaused, setUserPaused] = useState(false)
   const [hoverPaused, setHoverPausedState] = useState(false)
   const [hidden, setHidden] = useState(false)
@@ -1116,6 +1140,16 @@ export function useCompositionPlayer() {
       setUserPaused(true)
     }
   }, [])
+
+  useEffect(() => {
+    if (!compactBelowLg) return
+    const mq = window.matchMedia('(min-width: 64rem)')
+    const update = () => setCompact(!mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [compactBelowLg])
+  const activeSteps = compact ? compactSteps : steps
 
   // Only animate while on screen — the clock parks itself otherwise.
   useEffect(() => {
@@ -1202,12 +1236,20 @@ export function useCompositionPlayer() {
   }, [])
   useEffect(() => cancelWalk, [cancelWalk])
 
+  // Restart from the top when the step list swaps (breakpoint cross) — the
+  // current index points into the other list.
+  useEffect(() => {
+    cancelWalk()
+    stepRef.current = 0
+    setStep(0)
+  }, [compact, cancelWalk])
+
   const [walking, setWalking] = useState(false)
   const goToStep = useCallback(
     (next: number) => {
       cancelWalk()
       const from = stepRef.current
-      const between = steps.slice(from + 1, next)
+      const between = activeSteps.slice(from + 1, next)
       const reduce = window.matchMedia(
         '(prefers-reduced-motion: reduce)',
       ).matches
@@ -1234,12 +1276,12 @@ export function useCompositionPlayer() {
       }
       walk()
     },
-    [applyStep, cancelWalk],
+    [applyStep, cancelWalk, activeSteps],
   )
 
   const advance = useCallback(
-    () => applyStep((stepRef.current + 1) % steps.length),
-    [applyStep],
+    () => applyStep((stepRef.current + 1) % activeSteps.length),
+    [applyStep, activeSteps],
   )
 
   // Hovering is a real pause to the reader, so the button reads and toggles
@@ -1253,12 +1295,16 @@ export function useCompositionPlayer() {
   }, [paused])
 
   const playing = mounted && inView && !hidden && !paused
-  const current = steps[step] ?? firstStep
+  const paginated = compact ? compactPaginatedSteps : paginatedSteps
+  // The index may briefly outlive a list swap — the reset effect above hasn't
+  // run yet on that render.
+  const current =
+    activeSteps[Math.min(step, activeSteps.length - 1)] ?? firstStep
   // A mid step maps to the headline step it's building toward (the next
   // paginated entry), so that entry stays lit while the beats play.
   const activePaginated = Math.max(
     0,
-    paginatedSteps.findIndex((p) => p.index >= step),
+    paginated.findIndex((p) => p.index >= step),
   )
   const stepDurationMs = current.durationMs
   const reducedMotion =
@@ -1273,7 +1319,7 @@ export function useCompositionPlayer() {
   }, [playing, reducedMotion, step, stepDurationMs, advance])
 
   return {
-    steps,
+    steps: activeSteps,
     step,
     goToStep,
     advance,
@@ -1286,7 +1332,7 @@ export function useCompositionPlayer() {
     current,
     stepDurationMs,
     reducedMotion,
-    paginated: paginatedSteps,
+    paginated,
     activePaginated,
     codeStaggerMs: walking ? WALK_CODE_STAGGER_MS : CODE_STAGGER_MS,
   }

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -3,16 +3,32 @@ import { useEffect, useRef, useState } from 'react'
 import { cn } from '@/registry/lib/utils'
 import { LinkButton } from '@/registry/ui/button'
 import {
+  compactMaxCodeLines,
   CompositionCode,
   CompositionTransitionStyles,
+  maxCodeLines,
   PlayPauseButton,
   StepDots,
   StepTimer,
   useCompositionPlayer,
 } from '@/modules/docs/composition-animation'
 
+// The code pane's height at a given line count: p-6 padding plus lines at
+// text-[0.8125rem]/leading-normal.
+const codePaneHeight = (lines: number) =>
+  `calc(3rem + ${lines} * 0.8125rem * 1.5)`
+
+// Pinning the pane below lg (where the section stacks) keeps the page from
+// moving between compact-loop steps.
+const compactCodeMinHeight = codePaneHeight(compactMaxCodeLines)
+
+// The right panel at its tallest step: preview area (min-h-56) + code pane +
+// the card's own y-borders. Reserving it on the panel's container keeps the
+// animating card from ever moving the page.
+const panelMaxHeight = `calc(14rem + 2px + ${codePaneHeight(maxCodeLines)})`
+
 export function CompositionSection() {
-  const player = useCompositionPlayer()
+  const player = useCompositionPlayer({ compactBelowLg: true })
   const {
     paginated,
     activePaginated,
@@ -54,7 +70,10 @@ export function CompositionSection() {
     if (!codeMetrics.current) {
       const style = getComputedStyle(el)
       const pad = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom)
-      codeMetrics.current = { line: (el.offsetHeight - pad) / lines, pad }
+      // Rect, not offsetHeight — the integer rounding inflates the per-line
+      // metric (67.5 → 68 reads as 20px/line instead of 19.5).
+      const height = el.getBoundingClientRect().height
+      codeMetrics.current = { line: (height - pad) / lines, pad }
     }
     const { line, pad } = codeMetrics.current
     setCodeHeight(lines * line + pad)
@@ -143,10 +162,16 @@ export function CompositionSection() {
           </div>
         </div>
 
-        {/* Code with its rendered result below — one card, no window chrome */}
+        {/* Code with its rendered result below — one card, no window chrome.
+            On lg the container reserves the tallest step's height so the
+            animating card resizes inside it without moving the page. */}
         {/* min-w-0: grid items floor at min-content, so the code would widen the
             column past the viewport instead of scrolling inside the card. */}
-        <div className="min-w-0" {...pauseHandlers}>
+        <div
+          className="min-w-0 lg:min-h-(--panel-max)"
+          style={{ '--panel-max': panelMaxHeight } as React.CSSProperties}
+          {...pauseHandlers}
+        >
           {/* Stands in for the step rail, which is desktop-only. */}
           <div className="mb-3 flex items-center justify-between gap-2 lg:hidden">
             <span className="truncate font-mono text-xs text-fg-muted">
@@ -172,11 +197,14 @@ export function CompositionSection() {
               />
             </div>
             <div
-              className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out [view-transition-name:cmp-code] motion-reduce:transition-none"
-              style={{
-                height: codeHeight ?? 'auto',
-                transitionDuration: '500ms',
-              }}
+              className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out [view-transition-name:cmp-code] motion-reduce:transition-none max-lg:min-h-(--code-min)"
+              style={
+                {
+                  height: codeHeight ?? 'auto',
+                  transitionDuration: '500ms',
+                  '--code-min': compactCodeMinHeight,
+                } as React.CSSProperties
+              }
             >
               <div
                 ref={codeInnerRef}

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -163,7 +163,9 @@ export function CompositionSection() {
                 aria-hidden
                 className="absolute inset-0 bg-[radial-gradient(var(--color-border)_1px,transparent_1px)] [mask-image:radial-gradient(ellipse_70%_80%_at_50%_50%,black,transparent)] bg-[size:14px_14px]"
               />
-              <div className="relative">{current.preview}</div>
+              <div className="relative flex w-full justify-center">
+                {current.preview}
+              </div>
               <PlayPauseButton
                 player={player}
                 className="absolute right-2 bottom-2 max-lg:hidden"


### PR DESCRIPTION
## Summary

The home composition section reflowed the whole page while the code pane's height tweened between steps (1 → 20 lines). Two fixes, one per layout:

- **Desktop (`lg+`):** the preview+code column reserves the tallest step's height (`min-height` computed from the longest snippet: preview area + code pane at max lines + card borders), so the card animates inside a fixed box and the section height never changes. Verified by sampling every 100ms while stepping through all 16 stops (mid-beats included): a single constant 664px, with the tallest step filling the reservation exactly.
- **Below `lg` (stacked):** reserving the desktop max would leave a large blank under short steps, so the player instead swaps to a compact loop of six steps with similar code sizes (9–13 lines): InputGroup, SearchField, DateField, Select, Menu, ContextMenu. The code pane is pinned to the tallest of them, making the card height a constant 527.5px across the loop. The swap happens post-mount via `matchMedia`, so SSR/hydration markup is unchanged (server always renders the full list's first step; console is clean).

Also fixes a latent measurement bug: the per-line height calibration used `el.offsetHeight`, whose integer rounding (67.5 → 68) inflated the metric to 20px/line instead of the true 19.5px, making every tweened pane height up to 10px too tall. It now measures via `getBoundingClientRect()`.

The docs `CompositionAnimation` shares the player but doesn't opt into the compact mode — still all 16 steps at any width (its code pane already has a fixed height).

## Reviewer notes

- The reserved height and the mobile pin are `calc()` expressions derived from the step data at module scope (line count × `text-[0.8125rem]`/`leading-normal` + `p-6`), so they're SSR-deterministic; the comments note the coupling to those classes.
- Crossing the `lg` breakpoint restarts the loop from its first step — indices don't map across the two lists.