### PR TITLE
fix(www): keep the page interactive during view transitions

### DIFF
--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -1464,11 +1464,9 @@ export function CompositionTransitionStyles({
 }: { morphMs?: number } = {}) {
   return (
     <style>{`
-      /* Keep the page interactive while a transition runs, and confine the
-         animation to the named preview parts — everything else swaps instantly. */
-      ::view-transition { pointer-events: none; }
-      ::view-transition-old(root) { display: none; }
-      ::view-transition-new(root) { animation: none; }
+      /* Only the named preview parts animate — everything else is live DOM
+         and swaps instantly (:root is opted out of transitions globally, see
+         styles.css, which also keeps the page interactive during morphs). */
       ::view-transition-group(cmp-field),
       ::view-transition-group(cmp-label),
       ::view-transition-group(cmp-desc),
@@ -1478,15 +1476,8 @@ export function CompositionTransitionStyles({
         animation-duration: ${morphMs}ms;
         animation-timing-function: cubic-bezier(0.645, 0.045, 0.355, 1);
       }
-      ::view-transition-old(cmp-code) { display: none; }
-      ::view-transition-new(cmp-code) { animation: none; }
       @keyframes cmp-progress-x { from { transform: translateX(-100%); } to { transform: translateX(0); } }
       @keyframes cmp-progress-y { from { transform: translateY(-100%); } to { transform: translateY(0); } }
-      @media (prefers-reduced-motion: reduce) {
-        ::view-transition-group(*),
-        ::view-transition-old(*),
-        ::view-transition-new(*) { animation: none; }
-      }
     `}</style>
   )
 }
@@ -1555,7 +1546,7 @@ export function CompositionAnimation({ className }: { className?: string }) {
         </div>
       </div>
       <div className="grid sm:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
-        <div className="no-scrollbar h-88 overflow-auto p-4 font-mono text-[0.8125rem] leading-relaxed [view-transition-name:cmp-code]">
+        <div className="no-scrollbar h-88 overflow-auto p-4 font-mono text-[0.8125rem] leading-relaxed">
           {mounted ? (
             <CompositionCode
               code={current.code}

--- a/www/src/modules/docs/demo.tsx
+++ b/www/src/modules/docs/demo.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react'
-import { flushSync } from 'react-dom'
 import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
+import type { PressEvent } from 'react-aria-components'
 
 import { Button } from '@/registry/ui/button'
 
 import { CodeBlock, Pre } from './code-block'
 import { DemoPreset } from './demo-preset'
 import { PreviewControls, PreviewPanel } from './preview-controls'
+import { toggleCodeBlock } from './toggle-code-block'
 
 // ============================================================================
 // Slot Components
@@ -60,16 +61,8 @@ export function Demo({ component: Component, children, ...props }: DemoProps) {
   // nothing instead. (Placed after all hooks so the early return doesn't break hook order.)
   if (!Component) return null
 
-  const handleToggle = () => {
-    if (document.startViewTransition) {
-      document.startViewTransition(() => {
-        flushSync(() => {
-          setExpanded((prev) => !prev)
-        })
-      })
-    } else {
-      setExpanded((prev) => !prev)
-    }
+  const handleToggle = (e: PressEvent) => {
+    toggleCodeBlock(e.target, () => setExpanded((prev) => !prev))
   }
 
   return (

--- a/www/src/modules/docs/interactive-demo/interactive-demo.tsx
+++ b/www/src/modules/docs/interactive-demo/interactive-demo.tsx
@@ -5,13 +5,13 @@ import {
   useState,
   type ComponentType,
 } from 'react'
-import { flushSync } from 'react-dom'
 import {
   ChevronDownIcon,
   ChevronUpIcon,
   SlidersHorizontalIcon,
   XIcon,
 } from 'lucide-react'
+import type { PressEvent } from 'react-aria-components'
 
 import { cn } from '@/registry/lib/utils'
 import { Button } from '@/registry/ui/button'
@@ -22,6 +22,7 @@ import type { CodeTemplate } from '@/modules/docs/codegen/code-template'
 import { DemoPreset } from '@/modules/docs/demo-preset'
 import { DynamicPre } from '@/modules/docs/dynamic-pre'
 import { PreviewControls, PreviewPanel } from '@/modules/docs/preview-controls'
+import { toggleCodeBlock } from '@/modules/docs/toggle-code-block'
 
 import { defaultControlValues } from './control-defaults'
 import { availableIcons, Controls } from './controls'
@@ -101,16 +102,8 @@ export function InteractiveDemo({
     [codeTemplate, values, isExpanded],
   )
 
-  const handleToggle = () => {
-    if (document.startViewTransition) {
-      document.startViewTransition(() => {
-        flushSync(() => {
-          setIsExpanded((prev) => !prev)
-        })
-      })
-    } else {
-      setIsExpanded((prev) => !prev)
-    }
+  const handleToggle = (e: PressEvent) => {
+    toggleCodeBlock(e.target, () => setIsExpanded((prev) => !prev))
   }
 
   return (

--- a/www/src/modules/docs/toggle-code-block.ts
+++ b/www/src/modules/docs/toggle-code-block.ts
@@ -1,0 +1,21 @@
+import { flushSync } from 'react-dom'
+
+// Expand/collapse morph scoped to one code block. :root is opted out of view
+// transitions globally (see styles.css) so the page never loses hit-testing;
+// only the block itself morphs. It's named just for the transition's duration —
+// a static name would duplicate across a page's demos and abort the transition.
+export function toggleCodeBlock(target: Element, update: () => void) {
+  const block = target.closest('figure')
+  if (!block || !document.startViewTransition) {
+    update()
+    return
+  }
+  block.style.viewTransitionName = 'docs-code-block'
+  document
+    .startViewTransition(() => {
+      flushSync(update)
+    })
+    .finished.finally(() => {
+      block.style.viewTransitionName = ''
+    })
+}

--- a/www/src/modules/docs/toggle-code-block.ts
+++ b/www/src/modules/docs/toggle-code-block.ts
@@ -1,21 +1,35 @@
-import { flushSync } from 'react-dom'
-
-// Expand/collapse morph scoped to one code block. :root is opted out of view
-// transitions globally (see styles.css) so the page never loses hit-testing;
-// only the block itself morphs. It's named just for the transition's duration —
-// a static name would duplicate across a page's demos and abort the transition.
+// Animates a code block's expand/collapse as a height tween. Deliberately not
+// a view transition: snapshotting pauses input document-wide (long for a big
+// highlighted file) and participating elements skip hit-testing, so even a
+// transition scoped to the block reads as a frozen page.
 export function toggleCodeBlock(target: Element, update: () => void) {
   const block = target.closest('figure')
-  if (!block || !document.startViewTransition) {
+  if (!block || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
     update()
     return
   }
-  block.style.viewTransitionName = 'docs-code-block'
-  document
-    .startViewTransition(() => {
-      flushSync(update)
-    })
-    .finished.finally(() => {
-      block.style.viewTransitionName = ''
-    })
+  const from = block.getBoundingClientRect().height
+  update()
+  // The re-render can land after the current task (DynamicPre defers
+  // re-highlighting), so tween on the resulting height change instead of
+  // measuring synchronously.
+  const ro = new ResizeObserver(() => {
+    const to = block.getBoundingClientRect().height
+    if (to === from) return
+    ro.disconnect()
+    clearTimeout(bail)
+    for (const animation of block.getAnimations()) animation.cancel()
+    block.style.overflow = 'hidden'
+    block
+      .animate([{ height: `${from}px` }, { height: `${to}px` }], {
+        duration: 250,
+        easing: 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+      })
+      .finished.finally(() => {
+        block.style.overflow = ''
+      })
+  })
+  ro.observe(block)
+  // A no-op toggle (same height) would leave the observer running forever.
+  const bail = setTimeout(() => ro.disconnect(), 500)
 }

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -197,7 +197,7 @@ export function CompositionSection() {
               />
             </div>
             <div
-              className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out [view-transition-name:cmp-code] motion-reduce:transition-none max-lg:min-h-(--code-min)"
+              className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out motion-reduce:transition-none max-lg:min-h-(--code-min)"
               style={
                 {
                   height: codeHeight ?? 'auto',

--- a/www/src/styles.css
+++ b/www/src/styles.css
@@ -23,6 +23,26 @@
   --radius-full: calc(infinity * 1px);
 }
 
+/* View transitions must never freeze the page. Two defaults conspire to: the
+   snapshot overlay eats pointer events, and any participating element skips
+   hit-testing while a transition runs (its pixels render in the overlay, not
+   at its DOM position) — and :root participates by default, taking the whole
+   page with it. Pass clicks through the overlay and keep the root out of
+   transitions; call sites name exactly the elements they morph. */
+::view-transition {
+  pointer-events: none;
+}
+:root {
+  view-transition-name: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none;
+  }
+}
+
 @utility container {
   @apply mx-auto max-w-[1440px] px-4 sm:px-6 lg:px-10 3xl:max-w-screen-2xl;
 }


### PR DESCRIPTION
Closes <!-- no tracked issue -->

## Summary

- Every view transition on the site froze the whole page's interactivity for its duration — the composition morphs on the landing page (every 1.3–4s while in view) and the docs code-block expand/collapse. Two platform defaults cause this: the `::view-transition` overlay captures pointer events, and any element participating in a transition skips hit-testing at its DOM position — and `:root` participates by default, taking the entire page with it. The composition section's existing `pointer-events: none` rule only addressed the first half, which is why it still blocked. (Reference: [Bramus — Keeping the page interactive while a View Transition is running](https://www.bram.us/2025/01/29/view-transitions-page-interactivity/).)
- `styles.css` now carries the global fix: `::view-transition { pointer-events: none }` plus `:root { view-transition-name: none }`, so the page itself never participates and never loses hit-testing; call sites name exactly the elements they morph. The global block also includes the `prefers-reduced-motion` kill for all view-transition pseudos (previously only mounted with the composition section).
- Composition styles simplified accordingly: the `old(root)`/`new(root)` rules and the duplicated reduced-motion block are dead once root is opted out, and the `cmp-code` transition name is removed (it existed only to isolate the code pane from the root snapshot, which no longer exists). The `cmp-*` preview morphs are visually unchanged.
- The docs toggles drop `startViewTransition` entirely in favor of a height tween (`toggle-code-block.ts`). Even a transition scoped to the block still froze docs pages: snapshot capture pauses input document-wide (long for a big highlighted file), and `DynamicPre`'s deferred re-highlight lands mid-animation as one long main-thread chunk. A height tween needs no snapshots — no input pause, no hit-test skip, no `flushSync` in the click handler. It observes the block's height change via `ResizeObserver` because the expanded content can commit after the current task (deferred highlighting), then tweens border-box height with the Web Animations API. Skipped under `prefers-reduced-motion`.

## Review notes

- Manual check: on the landing page, click rail steps / links while a composition morph runs; on a docs page, expand a large code block and immediately click the sidebar — both should respond instantly.
- Verified the `:root` opt-out is live and computed (`view-transition-name: none` on `html`) via an in-page probe. Mid-animation feel needs a visible tab (browsers skip view transitions in hidden documents), so the manual pass above is the meaningful check.
- `pnpm check` and `pnpm typecheck` pass. No registry files touched.