### PR TITLE
feat(www): add line numbers to code blocks

### DIFF
--- a/www/src/modules/create/code-options/preview.tsx
+++ b/www/src/modules/create/code-options/preview.tsx
@@ -68,7 +68,14 @@ export function CodeOptionsPreview() {
           {isCopied ? <CheckIcon /> : <CopyIcon />}
         </Button>
       </div>
-      <div className="relative min-h-0 flex-1 overflow-auto">
+      {/* This view has its own chrome instead of CodeBlock, so it opts the
+          line-number gutter in itself: the attribute activates it, the counter
+          reset scopes it. */}
+      <div
+        className="relative min-h-0 flex-1 overflow-auto"
+        data-line-numbers
+        style={{ counterReset: 'line' }}
+      >
         {code ? (
           <DynamicPre lang="tsx">{code}</DynamicPre>
         ) : (

--- a/www/src/modules/docs/code-block.tsx
+++ b/www/src/modules/docs/code-block.tsx
@@ -14,6 +14,8 @@ export interface CodeBlockProps extends React.ComponentProps<'figure'> {
   icon?: string | React.ReactNode
   /** Extra classes for the scrollable code container, e.g. to make it a modal's scroller. */
   contentClassName?: string
+  /** Line-number gutter, on by default. Only renders on shiki `.line` spans, so
+   *  plain-text blocks (CLI commands) show nothing regardless. */
   'data-line-numbers'?: boolean
 }
 
@@ -24,6 +26,7 @@ export function CodeBlock({
   children,
   className,
   contentClassName,
+  'data-line-numbers': lineNumbers = true,
   ...props
 }: CodeBlockProps) {
   const containerRef = useRef<HTMLElement>(null)
@@ -41,6 +44,8 @@ export function CodeBlock({
       <figure
         ref={containerRef}
         className={cn('rounded-md border bg-card', className)}
+        // Presence, not value, drives the CSS — so opt out by omitting it.
+        {...(lineNumbers ? { 'data-line-numbers': true } : {})}
         {...props}
       >
         {title && (

--- a/www/src/modules/docs/code-block.tsx
+++ b/www/src/modules/docs/code-block.tsx
@@ -108,7 +108,7 @@ export function Pre({
         "**:[.diff.add]:bg-success/15 **:[.diff.add]:before:text-success **:[.diff.add]:before:content-['+']",
         "**:[.diff.remove]:bg-danger/20 **:[.diff.remove]:before:text-danger **:[.diff.remove]:before:content-['-']",
         // line numbers
-        '**:[.line]:[counter-increment:line] **:[.line]:after:absolute **:[.line]:after:left-2 **:[.line]:after:text-fg-muted in-data-line-numbers:**:[.line]:pl-9! in-data-line-numbers:**:[.line]:after:content-[counter(line)]',
+        '**:[.line]:[counter-increment:line] **:[.line]:after:absolute **:[.line]:after:left-2 **:[.line]:after:text-fg-muted/50 in-data-line-numbers:**:[.line]:pl-9! in-data-line-numbers:**:[.line]:after:content-[counter(line)]',
         className,
       )}
       {...props}

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -38,7 +38,10 @@ function LineNumbers({
     <div
       aria-hidden
       className={cn(
-        'shrink-0 text-right text-fg-muted/50 tabular-nums select-none',
+        // 2ch: the widest step reaches line 19, so pinning the gutter to two
+        // digits keeps its right edge — and the code beside it — from shifting
+        // between single- and double-digit steps.
+        'w-[2ch] shrink-0 text-right text-fg-muted/50 tabular-nums select-none',
         className,
       )}
     >

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { cn } from '@/registry/lib/utils'
 import { LinkButton } from '@/registry/ui/button'
@@ -13,25 +13,19 @@ import {
   useCompositionPlayer,
 } from '@/modules/docs/composition-animation'
 
-// The code pane's border-box height at a given line count: p-6 padding plus
-// lines at text-[0.8125rem]/leading-normal. Its border-t takes its 1px out of
-// the bottom padding, which is why the pane isn't a line taller than the gutter.
+// The code pane's height at a given line count: p-6 padding plus lines at
+// text-[0.8125rem]/leading-normal.
 const codePaneHeight = (lines: number) =>
   `calc(3rem + ${lines} * 0.8125rem * 1.5)`
 
-// The pane is pinned to the longest snippet in the loop, so only the code
-// inside it ever moves — the card holds still from the first step to the last.
-// Below lg the section stacks and plays the shorter compact loop; that one is a
-// floor, not a fixed height, because the breakpoint flips in CSS while the loop
-// swaps in an effect — a full-loop step caught at that width must overflow the
-// pane rather than be clipped by it.
-const codeHeight = codePaneHeight(maxCodeLines)
+// Pinning the pane below lg (where the section stacks) keeps the page from
+// moving between compact-loop steps.
 const compactCodeMinHeight = codePaneHeight(compactMaxCodeLines)
 
 // The right panel at its tallest step: preview area (min-h-56) + code pane +
-// the card's own y-borders. Reserving it on the panel's container keeps a
-// taller preview from moving the page.
-const panelMaxHeight = `calc(14rem + 2px + ${codeHeight})`
+// the card's own y-borders. Reserving it on the panel's container keeps the
+// animating card from ever moving the page.
+const panelMaxHeight = `calc(14rem + 2px + ${codePaneHeight(maxCodeLines)})`
 
 function LineNumbers({
   lines,
@@ -82,6 +76,32 @@ export function CompositionSection() {
       behavior: reducedMotion ? 'auto' : 'smooth',
     })
   }, [activePaginated, reducedMotion])
+
+  // The code pane hugs its content. The target height is computed from the
+  // step's line count (calibrated once against the first rendered snippet) so
+  // the tween starts in the same commit as the token animation — observing the
+  // DOM instead would only fire after departing tokens are removed, i.e. late.
+  // Until calibration the height stays auto (auto→px doesn't tween). The gutter
+  // shares the row's line count and line-height, so measuring the padded row
+  // stays valid.
+  const codeInnerRef = useRef<HTMLDivElement>(null)
+  const codeMetrics = useRef<{ line: number; pad: number } | null>(null)
+  const [codeHeight, setCodeHeight] = useState<number | null>(null)
+  const lineCount = current.code.split('\n').length
+  useEffect(() => {
+    const el = codeInnerRef.current
+    if (!el || !mounted) return
+    if (!codeMetrics.current) {
+      const style = getComputedStyle(el)
+      const pad = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom)
+      // Rect, not offsetHeight — the integer rounding inflates the per-line
+      // metric (67.5 → 68 reads as 20px/line instead of 19.5).
+      const height = el.getBoundingClientRect().height
+      codeMetrics.current = { line: (height - pad) / lineCount, pad }
+    }
+    const { line, pad } = codeMetrics.current
+    setCodeHeight(lineCount * line + pad)
+  }, [mounted, lineCount])
 
   const pauseHandlers = {
     onMouseEnter: () => setHoverPaused(true),
@@ -201,24 +221,22 @@ export function CompositionSection() {
               />
             </div>
             <div
-              className="min-h-(--code-min) overflow-hidden border-t lg:h-(--code-full)"
+              className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out motion-reduce:transition-none max-lg:min-h-(--code-min)"
               style={
                 {
-                  '--code-full': codeHeight,
+                  height: codeHeight ?? 'auto',
+                  transitionDuration: '500ms',
                   '--code-min': compactCodeMinHeight,
                 } as React.CSSProperties
               }
             >
-              <div className="flex gap-4 p-6 font-mono text-[0.8125rem] leading-normal">
-                {/* The gutter numbers the whole pane, not the current snippet —
-                    it's the ruled page the code is written on, so it holds still
-                    while steps come and go. One per loop, picked by the same
-                    breakpoint that sets the pane height. */}
-                <LineNumbers
-                  lines={compactMaxCodeLines}
-                  className="lg:hidden"
-                />
-                <LineNumbers lines={maxCodeLines} className="max-lg:hidden" />
+              <div
+                ref={codeInnerRef}
+                className="flex gap-4 p-6 font-mono text-[0.8125rem] leading-normal"
+              >
+                {/* The gutter tracks the current step — it grows and shrinks with
+                    the pane rather than reserving the tallest step's rows. */}
+                <LineNumbers lines={lineCount} />
                 <div className="no-scrollbar min-w-0 flex-1 scroll-fade-x overflow-x-auto">
                   {mounted ? (
                     <CompositionCode

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { cn } from '@/registry/lib/utils'
 import { LinkButton } from '@/registry/ui/button'
@@ -13,19 +13,47 @@ import {
   useCompositionPlayer,
 } from '@/modules/docs/composition-animation'
 
-// The code pane's height at a given line count: p-6 padding plus lines at
-// text-[0.8125rem]/leading-normal.
+// The code pane's border-box height at a given line count: p-6 padding plus
+// lines at text-[0.8125rem]/leading-normal. Its border-t takes its 1px out of
+// the bottom padding, which is why the pane isn't a line taller than the gutter.
 const codePaneHeight = (lines: number) =>
   `calc(3rem + ${lines} * 0.8125rem * 1.5)`
 
-// Pinning the pane below lg (where the section stacks) keeps the page from
-// moving between compact-loop steps.
+// The pane is pinned to the longest snippet in the loop, so only the code
+// inside it ever moves — the card holds still from the first step to the last.
+// Below lg the section stacks and plays the shorter compact loop; that one is a
+// floor, not a fixed height, because the breakpoint flips in CSS while the loop
+// swaps in an effect — a full-loop step caught at that width must overflow the
+// pane rather than be clipped by it.
+const codeHeight = codePaneHeight(maxCodeLines)
 const compactCodeMinHeight = codePaneHeight(compactMaxCodeLines)
 
 // The right panel at its tallest step: preview area (min-h-56) + code pane +
-// the card's own y-borders. Reserving it on the panel's container keeps the
-// animating card from ever moving the page.
-const panelMaxHeight = `calc(14rem + 2px + ${codePaneHeight(maxCodeLines)})`
+// the card's own y-borders. Reserving it on the panel's container keeps a
+// taller preview from moving the page.
+const panelMaxHeight = `calc(14rem + 2px + ${codeHeight})`
+
+function LineNumbers({
+  lines,
+  className,
+}: {
+  lines: number
+  className?: string
+}) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'shrink-0 text-right text-fg-muted/50 tabular-nums select-none',
+        className,
+      )}
+    >
+      {Array.from({ length: lines }, (_, i) => (
+        <div key={i}>{i + 1}</div>
+      ))}
+    </div>
+  )
+}
 
 export function CompositionSection() {
   const player = useCompositionPlayer({ compactBelowLg: true })
@@ -54,30 +82,6 @@ export function CompositionSection() {
       behavior: reducedMotion ? 'auto' : 'smooth',
     })
   }, [activePaginated, reducedMotion])
-
-  // The code pane hugs its content. The target height is computed from the
-  // step's line count (calibrated once against the first rendered snippet) so
-  // the tween starts in the same commit as the token animation — observing the
-  // DOM instead would only fire after departing tokens are removed, i.e. late.
-  // Until calibration the height stays auto (auto→px doesn't tween).
-  const codeInnerRef = useRef<HTMLDivElement>(null)
-  const codeMetrics = useRef<{ line: number; pad: number } | null>(null)
-  const [codeHeight, setCodeHeight] = useState<number | null>(null)
-  useEffect(() => {
-    const el = codeInnerRef.current
-    if (!el || !mounted) return
-    const lines = current.code.split('\n').length
-    if (!codeMetrics.current) {
-      const style = getComputedStyle(el)
-      const pad = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom)
-      // Rect, not offsetHeight — the integer rounding inflates the per-line
-      // metric (67.5 → 68 reads as 20px/line instead of 19.5).
-      const height = el.getBoundingClientRect().height
-      codeMetrics.current = { line: (height - pad) / lines, pad }
-    }
-    const { line, pad } = codeMetrics.current
-    setCodeHeight(lines * line + pad)
-  }, [mounted, current.code])
 
   const pauseHandlers = {
     onMouseEnter: () => setHoverPaused(true),
@@ -163,8 +167,8 @@ export function CompositionSection() {
         </div>
 
         {/* Code with its rendered result below — one card, no window chrome.
-            On lg the container reserves the tallest step's height so the
-            animating card resizes inside it without moving the page. */}
+            On lg the container reserves the tallest step's height so a taller
+            preview can't move the page. */}
         {/* min-w-0: grid items floor at min-content, so the code would widen the
             column past the viewport instead of scrolling inside the card. */}
         <div
@@ -197,28 +201,35 @@ export function CompositionSection() {
               />
             </div>
             <div
-              className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out motion-reduce:transition-none max-lg:min-h-(--code-min)"
+              className="min-h-(--code-min) overflow-hidden border-t lg:h-(--code-full)"
               style={
                 {
-                  height: codeHeight ?? 'auto',
-                  transitionDuration: '500ms',
+                  '--code-full': codeHeight,
                   '--code-min': compactCodeMinHeight,
                 } as React.CSSProperties
               }
             >
-              <div
-                ref={codeInnerRef}
-                className="no-scrollbar scroll-fade-x overflow-x-auto p-6 font-mono text-[0.8125rem] leading-normal"
-              >
-                {mounted ? (
-                  <CompositionCode
-                    code={current.code}
-                    reducedMotion={reducedMotion}
-                    stagger={codeStaggerMs}
-                  />
-                ) : (
-                  <pre className="whitespace-pre">{current.code}</pre>
-                )}
+              <div className="flex gap-4 p-6 font-mono text-[0.8125rem] leading-normal">
+                {/* The gutter numbers the whole pane, not the current snippet —
+                    it's the ruled page the code is written on, so it holds still
+                    while steps come and go. One per loop, picked by the same
+                    breakpoint that sets the pane height. */}
+                <LineNumbers
+                  lines={compactMaxCodeLines}
+                  className="lg:hidden"
+                />
+                <LineNumbers lines={maxCodeLines} className="max-lg:hidden" />
+                <div className="no-scrollbar min-w-0 flex-1 scroll-fade-x overflow-x-auto">
+                  {mounted ? (
+                    <CompositionCode
+                      code={current.code}
+                      reducedMotion={reducedMotion}
+                      stagger={codeStaggerMs}
+                    />
+                  ) : (
+                    <pre className="whitespace-pre">{current.code}</pre>
+                  )}
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What

Adds line-number gutters to code blocks across the site.

- **Site-wide code blocks** — the shared `Pre`/`CodeBlock` already carried a full CSS-counter line-number gutter, but no call site ever switched it on. `CodeBlock` now defaults `data-line-numbers` on, so docs fences, demos, the playground, and both code modals all get numbers from one change. Numbers render only on shiki `.line` spans, so the plain-text install/CLI command tabs stay unnumbered automatically.
- **/create export view** — this view renders `DynamicPre` with its own chrome rather than a `CodeBlock`, so it opts the gutter in directly (the activation attribute plus a counter reset to scope it).
- **Composition showcase** — pins the code pane to its tallest step's height and numbers it with a static gutter, instead of measuring and tweening the pane height on every step. The measurement effect and height transition are removed. Per discussion, the gutter tops out at 20 (one transient auto-play frame is 20 lines; every clickable step is ≤19) — the demos are left untouched.

## Verification

Drove it live at both breakpoints:
- Docs fences (installation, button pages) and component snippets — numbered, gutter offset applied.
- `/create` export view — 142-line file numbered, counter correctly scoped.
- Composition pane holds a constant height across all steps at desktop (20 lines) and below `lg` (13 lines); gutter numbers align to code lines.
- CLI command tabs — excluded (no `.line` spans to number).

`pnpm check` and `pnpm typecheck` pass. No registry changes, so no regeneration needed.