### PR TITLE
fix(www): stop lone brackets flying in composition code morph

### DIFF
--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -1,6 +1,6 @@
 import 'shiki-magic-move/style.css'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
 import { parseDate } from '@internationalized/date'
 import {
@@ -11,7 +11,13 @@ import {
   type Diff,
 } from 'diff-match-patch-es'
 import { PauseIcon, PlayIcon } from 'lucide-react'
-import { ShikiMagicMove } from 'shiki-magic-move/react'
+import {
+  codeToKeyedTokens,
+  syncTokenKeys,
+  toKeyedTokens,
+} from 'shiki-magic-move/core'
+import { ShikiMagicMoveRenderer } from 'shiki-magic-move/react'
+import type { KeyedToken, KeyedTokensInfo } from 'shiki-magic-move/types'
 import { useTheme } from 'starter-themes'
 
 import {
@@ -1559,6 +1565,83 @@ function cleanupCodeDiff(diffs: Diff[]): Diff[] {
   return out
 }
 
+// A bracket belongs to its tag name — `<`/`</` to the name after it, the
+// closing `>`/`/>` to the name before it. The char diff doesn't know that:
+// wrapping `<Input />` in `<TextField>` matches old `<Input`'s bracket to new
+// `<TextField`'s, so the `<` stays behind while `Input` slides away. After the
+// library syncs keys, rebind every surviving tag name's brackets to its own —
+// stealing the key back when the diff gave it to another tag — and unmatch any
+// leftover punctuation pair that still jumps lines. Same-line leftovers stay:
+// a swapped-in-place tag (Popover → Modal) keeps its brackets still.
+const TAG_NAME = /^[A-Za-z][\w.]*$/
+
+function lockTagPunctuation(from: KeyedTokensInfo, to: KeyedTokensInfo) {
+  const fromByKey = new Map(from.tokens.map((t) => [t.key, t]))
+  const toByKey = new Map(to.tokens.map((t) => [t.key, t]))
+  const bound = new Set<KeyedToken>()
+  let freed = 0
+
+  const bind = (target: KeyedToken, key: string) => {
+    bound.add(target)
+    if (target.key === key) return
+    const holder = toByKey.get(key)
+    if (holder) {
+      holder.key = `${to.hash}-freed-${freed++}`
+      toByKey.set(holder.key, holder)
+    }
+    toByKey.delete(target.key)
+    target.key = key
+    toByKey.set(key, target)
+  }
+
+  // The tag's closing bracket: first `>`-bearing token after the name, as
+  // long as no other tag opens first (tags in the snippets are single-line).
+  const closeOf = (tokens: KeyedToken[], nameIdx: number) => {
+    for (const token of tokens.slice(nameIdx + 1)) {
+      const c = token.content
+      if (c === '\n' || c.includes('<')) return undefined
+      if (c.includes('>')) return token
+    }
+    return undefined
+  }
+
+  for (let i = 1; i < to.tokens.length; i++) {
+    const name = to.tokens[i]
+    const bracket = to.tokens[i - 1]
+    if (!name || !bracket) continue
+    if (bracket.content !== '<' && bracket.content !== '</') continue
+    if (!TAG_NAME.test(name.content)) continue
+    const fromName = fromByKey.get(name.key)
+    if (!fromName) continue
+    const fromIdx = from.tokens.indexOf(fromName)
+    const fromBracket = fromIdx > 0 ? from.tokens[fromIdx - 1] : undefined
+    if (fromBracket?.content !== bracket.content) continue
+    bind(bracket, fromBracket.key)
+    const toClose = closeOf(to.tokens, i)
+    const fromClose = closeOf(from.tokens, fromIdx)
+    if (toClose && fromClose && toClose.content === fromClose.content) {
+      bind(toClose, fromClose.key)
+    }
+  }
+
+  const lineOf = (source: string, offset: number) =>
+    source.slice(0, offset).split('\n').length
+  for (const token of to.tokens) {
+    if (bound.has(token)) continue
+    const partner = fromByKey.get(token.key)
+    if (!partner) continue
+    const c = token.content
+    if (c.trim() === '' || WORD.test(c)) continue
+    if (lineOf(from.code, partner.offset) !== lineOf(to.code, token.offset)) {
+      toByKey.delete(token.key)
+      token.key = `${to.hash}-freed-${freed++}`
+      toByKey.set(token.key, token)
+    }
+  }
+}
+
+const EMPTY_TOKENS = toKeyedTokens('', [])
+
 export function CompositionCode({
   code,
   reducedMotion,
@@ -1571,19 +1654,37 @@ export function CompositionCode({
   stagger?: number
 }) {
   const { resolvedTheme } = useTheme()
+  const theme = resolvedTheme === 'light' ? 'github-light' : 'github-dark'
+  // Inlined ShikiMagicMove machine so lockTagPunctuation can rewrite the
+  // synced keys before they reach the renderer. The code/theme guard keeps a
+  // strict-mode double render from committing the same step twice (which
+  // would make from === to and swallow the transition).
+  const cache = useRef<{ from: KeyedTokensInfo; to: KeyedTokensInfo } | null>(
+    null,
+  )
+  const step = useMemo(() => {
+    const previous = cache.current?.to ?? EMPTY_TOKENS
+    if (previous.code === code && previous.themeName === theme) {
+      return cache.current!
+    }
+    const next = codeToKeyedTokens(highlighter, code, { lang: 'tsx', theme })
+    const { from, to } = syncTokenKeys(previous, next, {
+      diffCleanup: cleanupCodeDiff,
+    })
+    lockTagPunctuation(from, to)
+    cache.current = { from, to }
+    return cache.current
+  }, [code, theme])
   return (
-    <ShikiMagicMove
-      highlighter={highlighter}
-      lang="tsx"
-      theme={resolvedTheme === 'light' ? 'github-light' : 'github-dark'}
-      code={code}
+    <ShikiMagicMoveRenderer
+      tokens={step.to}
+      previous={step.from}
       options={{
         duration: reducedMotion ? 0 : duration,
         stagger,
         // Pinned: CODE_SPAN is only correct if this is what the renderer uses.
         delayEnter: CODE_ENTER_DELAY,
         containerStyle: false,
-        diffCleanup: cleanupCodeDiff,
       }}
     />
   )

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -3,7 +3,13 @@ import 'shiki-magic-move/style.css'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
 import { parseDate } from '@internationalized/date'
-import { diffCleanupSemanticLossless } from 'diff-match-patch-es'
+import {
+  DIFF_DELETE,
+  DIFF_EQUAL,
+  DIFF_INSERT,
+  diffCleanupSemanticLossless,
+  type Diff,
+} from 'diff-match-patch-es'
 import { PauseIcon, PlayIcon } from 'lucide-react'
 import { ShikiMagicMove } from 'shiki-magic-move/react'
 import { useTheme } from 'starter-themes'
@@ -1491,6 +1497,68 @@ export function CompositionTransitionStyles({
   )
 }
 
+// The char diff happily matches stray punctuation across unrelated tags, so a
+// lone `<` or `/>` slides across the pane while the tag it belonged to fades.
+// After snapping boundaries to line breaks, demote every matched run that
+// lands on a different line but holds no whole word — it fades with its tag
+// instead of flying. Runs that keep words slide as blocks, and same-line runs
+// stay matched, so anchored brackets (the Popover → Modal one-word swap) hold
+// still. A word *fragment* at a run's edge (`Field>` shared by `</TextField>`
+// and `</SearchField>`) doesn't count: it can never match a whole token, so
+// only its punctuation would fly.
+const WORD = /[A-Za-z0-9]/
+
+function cleanupCodeDiff(diffs: Diff[]): Diff[] {
+  diffCleanupSemanticLossless(diffs)
+  let from = ''
+  let to = ''
+  for (const [op, text] of diffs) {
+    if (op !== DIFF_INSERT) from += text
+    if (op !== DIFF_DELETE) to += text
+  }
+  const out: Diff[] = []
+  let offFrom = 0
+  let offTo = 0
+  let lineFrom = 0
+  let lineTo = 0
+  for (const [op, text] of diffs) {
+    let demote = false
+    if (op === DIFF_EQUAL && lineFrom !== lineTo) {
+      let core = text
+      const end = text.length
+      if (
+        WORD.test(core[0] ?? '') &&
+        (WORD.test(from[offFrom - 1] ?? '') || WORD.test(to[offTo - 1] ?? ''))
+      ) {
+        core = core.replace(/^[A-Za-z0-9]+/, '')
+      }
+      if (
+        WORD.test(core[core.length - 1] ?? '') &&
+        (WORD.test(from[offFrom + end] ?? '') ||
+          WORD.test(to[offTo + end] ?? ''))
+      ) {
+        core = core.replace(/[A-Za-z0-9]+$/, '')
+      }
+      demote = !WORD.test(core)
+    }
+    if (demote) {
+      out.push([DIFF_DELETE, text], [DIFF_INSERT, text])
+    } else {
+      out.push([op, text])
+    }
+    const lines = text.split('\n').length - 1
+    if (op !== DIFF_INSERT) {
+      offFrom += text.length
+      lineFrom += lines
+    }
+    if (op !== DIFF_DELETE) {
+      offTo += text.length
+      lineTo += lines
+    }
+  }
+  return out
+}
+
 export function CompositionCode({
   code,
   reducedMotion,
@@ -1515,9 +1583,7 @@ export function CompositionCode({
         // Pinned: CODE_SPAN is only correct if this is what the renderer uses.
         delayEnter: CODE_ENTER_DELAY,
         containerStyle: false,
-        // Snap edit boundaries to line breaks, else the raw char diff strands
-        // `<` and `/>` on the old line and moves only the tag name.
-        diffCleanup: diffCleanupSemanticLossless,
+        diffCleanup: cleanupCodeDiff,
       }}
     />
   )


### PR DESCRIPTION
## Problem

In the home page composition section, the step-to-step code morph detached brackets from their component names: a lone `<`, `/>`, or `</` would fly across the pane on its own while the tag it belonged to faded — or stay behind when its tag moved (step 1 → 2: `<Input />` slides to line 2 but its `<` stays on line 1, stolen by the incoming `<TextField>`). The char diff behind `shiki-magic-move` has no concept of tag structure.

## Fix

Two layers, one rule: **a bracket belongs to its tag name.**

1. **Diff cleanup** (`cleanupCodeDiff`): after `diffCleanupSemanticLossless`, demote every matched run that lands on a different line but holds no whole word, so stray punctuation fades with its tag instead of flying. Word *fragments* at a run's edge (`Field>` shared by `</TextField>`/`</SearchField>`) don't count as words — they can never match a whole token.
2. **Token lock** (`lockTagPunctuation`): the `<ShikiMagicMove>` wrapper is replaced with the library's exported primitives (`codeToKeyedTokens` + `syncTokenKeys` + `ShikiMagicMoveRenderer`) so a post-pass can rewrite the synced keys: every tag name that survives a step re-binds its `<`/`</` and closing `>`/`/>` to its own from-side brackets — stealing the key back when the diff gave it to another tag — and any leftover punctuation match that still jumps lines is unmatched. Same-line leftovers stay, so a swapped-in-place tag (`Popover` → `Modal`) keeps its brackets perfectly still.

## Verification

Real pipeline (shiki highlighter + `syncTokenKeys`, both functions extracted from the committed source) over all 27 consecutive step pairs including the loop wrap:

- Lone flying punctuation tokens: **5 → 0**
- Bracket-ownership violations (surviving tag name whose bracket key isn't its own): **5 → 0**
- Matched word tokens (the good block slides): **347 → 347** — zero collateral damage
- Token keys stay unique after key stealing (renderer invariant) on every pair
- Step 1 → 2: `<` now carries the old `Input` bracket key and travels line 1 → 2 with it; `<TextField>`'s bracket enters fresh
- `Popover` → `Modal`: both brackets stay anchored (matched, same line)
- Live dev server: walked every headline step through the new machine — no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)