### PR TITLE
feat(www): add DateRangePicker mid beat and refine composition steps

### DIFF
--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -58,7 +58,7 @@ import { Menu, MenuContent, MenuItem, MenuSub } from '@/registry/ui/menu'
 import { Modal } from '@/registry/ui/modal'
 import { Popover } from '@/registry/ui/popover'
 import { SearchField } from '@/registry/ui/search-field'
-import { Select, SelectTrigger } from '@/registry/ui/select'
+import { Select, SelectValue } from '@/registry/ui/select'
 import { Tag, TagGroup, TagList } from '@/registry/ui/tag-group'
 import { TextField } from '@/registry/ui/text-field'
 import { highlighter } from '@/modules/docs/highlight'
@@ -587,12 +587,21 @@ const steps: Step[] = [
     durationMs: 1300,
     code: `<Select>
   <Label>Assignee</Label>
-  <SelectTrigger />
+  <Button>
+    <SelectValue />
+    <ChevronDownIcon />
+  </Button>
 </Select>`,
     preview: (
-      <Select className="w-full max-w-xs">
+      // defaultSelectedKey is mount-only, and the headline's Select updates
+      // this same instance in place — so the selection must start here, even
+      // though there are no items to resolve it against yet.
+      <Select className="w-full max-w-xs" defaultSelectedKey="cara">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
-        <SelectTrigger className="[view-transition-name:cmp-field]" />
+        <Button className="[view-transition-name:cmp-field]">
+          <SelectValue />
+          <ChevronDownIcon />
+        </Button>
       </Select>
     ),
   },
@@ -603,7 +612,10 @@ const steps: Step[] = [
     durationMs: 3200,
     code: `<Select>
   <Label>Assignee</Label>
-  <SelectTrigger />
+  <Button>
+    <SelectValue />
+    <ChevronDownIcon />
+  </Button>
   <Popover>
     <ListBox>
       <ListBoxItem>Cara</ListBoxItem>
@@ -615,7 +627,10 @@ const steps: Step[] = [
     preview: (
       <Select className="w-full max-w-xs" defaultSelectedKey="cara">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
-        <SelectTrigger className="[view-transition-name:cmp-field]" />
+        <Button className="[view-transition-name:cmp-field]">
+          <SelectValue />
+          <ChevronDownIcon />
+        </Button>
         <Popover>
           <ListBox className="[view-transition-name:cmp-list]">
             <ListBoxItem id="cara">Cara</ListBoxItem>
@@ -633,7 +648,10 @@ const steps: Step[] = [
     durationMs: 1400,
     code: `<Select>
   <Label>Assignee</Label>
-  <SelectTrigger />
+  <Button>
+    <SelectValue />
+    <ChevronDownIcon />
+  </Button>
   <Popover>
     <ListBox>
       <ListBoxSection>
@@ -648,7 +666,10 @@ const steps: Step[] = [
     preview: (
       <Select className="w-full max-w-xs" defaultSelectedKey="cara">
         <Label className="[view-transition-name:cmp-label]">Assignee</Label>
-        <SelectTrigger className="[view-transition-name:cmp-field]" />
+        <Button className="[view-transition-name:cmp-field]">
+          <SelectValue />
+          <ChevronDownIcon />
+        </Button>
         <Popover>
           <ListBox className="[view-transition-name:cmp-list]">
             <ListBoxSection>

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -702,6 +702,11 @@ const steps: Step[] = [
   </TagGroup>
   <InputGroup>
     <Input placeholder="Add people…" />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <ChevronDownIcon />
+      </Button>
+    </InputGroupAddon>
   </InputGroup>
   <Popover>
     <ListBox>
@@ -722,6 +727,15 @@ const steps: Step[] = [
         </TagGroup>
         <InputGroup className="[view-transition-name:cmp-field]">
           <Input placeholder="Add people…" />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <ChevronDownIcon />
+            </Button>
+          </InputGroupAddon>
         </InputGroup>
         <Popover>
           <ListBox className="[view-transition-name:cmp-list]">

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -642,48 +642,6 @@ const steps: Step[] = [
     ),
   },
   {
-    // Mid beat: the same list gains a section header.
-    title: 'Sections',
-    mid: true,
-    durationMs: 1400,
-    code: `<Select>
-  <Label>Assignee</Label>
-  <Button>
-    <SelectValue />
-    <ChevronDownIcon />
-  </Button>
-  <Popover>
-    <ListBox>
-      <ListBoxSection>
-        <ListBoxSectionHeader>Team</ListBoxSectionHeader>
-        <ListBoxItem>Cara</ListBoxItem>
-        <ListBoxItem>Dan</ListBoxItem>
-        <ListBoxItem>Eve</ListBoxItem>
-      </ListBoxSection>
-    </ListBox>
-  </Popover>
-</Select>`,
-    preview: (
-      <Select className="w-full max-w-xs" defaultSelectedKey="cara">
-        <Label className="[view-transition-name:cmp-label]">Assignee</Label>
-        <Button className="[view-transition-name:cmp-field]">
-          <SelectValue />
-          <ChevronDownIcon />
-        </Button>
-        <Popover>
-          <ListBox className="[view-transition-name:cmp-list]">
-            <ListBoxSection>
-              <ListBoxSectionHeader>Team</ListBoxSectionHeader>
-              <ListBoxItem id="cara">Cara</ListBoxItem>
-              <ListBoxItem id="dan">Dan</ListBoxItem>
-              <ListBoxItem id="eve">Eve</ListBoxItem>
-            </ListBoxSection>
-          </ListBox>
-        </Popover>
-      </Select>
-    ),
-  },
-  {
     // Headline: same list, now a typeahead — swap the trigger for an input.
     title: 'Combobox',
     durationMs: 3200,

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -543,7 +543,7 @@ const steps: Step[] = [
       </Button>
     </InputGroupAddon>
   </InputGroup>
-  <Drawer placement="bottom">
+  <Drawer>
     <DialogContent>
       <RangeCalendar />
     </DialogContent>
@@ -572,7 +572,7 @@ const steps: Step[] = [
             </Button>
           </InputGroupAddon>
         </InputGroup>
-        <Drawer placement="bottom">
+        <Drawer>
           <DialogContent>
             <RangeCalendar />
           </DialogContent>

--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -369,6 +369,59 @@ const steps: Step[] = [
     ),
   },
   {
+    // Mid beat: promote to a range — Calendar → RangeCalendar, one input still.
+    // The snippet defers the slots to the headline beat; the preview needs
+    // slot="start" at runtime.
+    title: 'DateRangePicker',
+    mid: true,
+    durationMs: 1400,
+    code: `<DateRangePicker>
+  <Label>Trip dates</Label>
+  <InputGroup>
+    <DateInput />
+    <InputGroupAddon>
+      <Button size="sm" isIconOnly>
+        <CalendarIcon />
+      </Button>
+    </InputGroupAddon>
+  </InputGroup>
+  <Popover>
+    <DialogContent>
+      <RangeCalendar />
+    </DialogContent>
+  </Popover>
+</DateRangePicker>`,
+    preview: (
+      <DateRangePicker
+        className="w-full max-w-xs"
+        defaultValue={{
+          start: parseDate('2026-07-10'),
+          end: parseDate('2026-07-17'),
+        }}
+      >
+        <Label className="[view-transition-name:cmp-label]">Trip dates</Label>
+        <InputGroup className="[view-transition-name:cmp-field]">
+          <DateInput slot="start" />
+          <InputGroupAddon>
+            <Button
+              size="sm"
+              isIconOnly
+              className="[view-transition-name:cmp-trigger]"
+            >
+              <CalendarIcon />
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <Popover>
+          <DialogContent>
+            <RangeCalendar />
+          </DialogContent>
+        </Popover>
+      </DateRangePicker>
+    ),
+  },
+  {
+    // Headline: the field gains its end date.
     title: 'DateRangePicker',
     durationMs: 3400,
     code: `<DateRangePicker>


### PR DESCRIPTION
## Summary

Refines the home page composition walkthrough — one new mid beat plus a pass over the Select/Combobox stretch of the sequence.

- **DateRangePicker mid beat**: the DatePicker → DateRangePicker step landed everything in one large diff. A `mid: true` beat now plays the promotion to a range first (rename, "Trip dates" label, `Calendar` → `RangeCalendar`), and the headline adds the end input and separator. The mid snippet shows a plain `<DateInput />` — the slot props only appear in the headline beat; the preview keeps `slot="start"` internally since React Aria requires it (noted in a source comment).
- **Select trigger composed from parts**: the three Select steps show `<Button><SelectValue /><ChevronDownIcon /></Button>` instead of `<SelectTrigger />`, matching the section's compose-from-parts story. This surfaced a pre-existing bug: `defaultSelectedKey` is mount-only and the headline's Select updates the mid beat's instance in place, so the trigger showed the placeholder instead of "Cara" after a walk — fixed by seeding the key on the mid beat.
- **Dropped the Sections mid beat**: it added a `ListBoxSection` that the very next step (Combobox) silently removed — sections flashed in and out. They're still introduced properly in the Command palette finale.
- **Tags step keeps the trigger addon**: the Combobox → Tags transition silently dropped the chevron button; it's now carried over, so the diff reads purely as "selected people surface as tags". This makes Tags the longest snippet (24 lines), so the section's reserved panel height grows accordingly (automatic via `maxCodeLines`).
- Also removes `placement="bottom"` from the Drawer step — it's the Drawer's default.

Everything verified live at desktop width (manual walks and rendered previews, no console errors). The compact (mobile) loop is unaffected since mid steps aren't part of it. `pnpm check` and `pnpm typecheck` pass.