### PR TITLE
ci: run Claude PR review at high effort

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,5 +39,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: '--effort high'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## What changed

Adds `claude_args: '--effort high'` to the Claude Code Review workflow.

## Why

The automatic PR review delegates to `code-review@claude-code-plugins`, which has no effort setting of its own — its only sensitivity knob is a hardcoded confidence threshold of 80. Raising the CLI session effort is what widens the review's coverage: `high` and above add a sweep stage and let lower-confidence findings survive.

## Notes for the reviewer

**This path is undocumented.** `--effort <level>` is a real CLI flag and `claude_args` forwards arbitrary flags to the CLI, but `claude-code-action` doesn't document effort as a supported input — nothing guarantees the two compose. If the action pins a CLI without the flag, the job fails rather than ignoring it. This PR exercises the workflow on itself, so **the review run on this PR is the test** — if it completes, the flag survived the handoff.

**This does not make the review always comment.** Step 6 of the plugin's command filters out findings scoring below 80 and then says "do not proceed", which returns before the commenting step. The plugin defines a "No issues found" template, but it's unreachable — clean PRs stay silent. Higher effort means more findings survive, so the review will speak up more often, but it still says nothing when it finds nothing.

## Suggested refactors

Vendoring the plugin's command into `.claude/commands/` and pointing `prompt` at it would let us fix the unreachable LGTM branch, tune the confidence threshold, and add dotUI-specific checks — at the cost of owning the review prompt ourselves. Not done here to keep this diff to one line. The unreachable template also looks like an upstream bug worth filing against `anthropics/claude-code`.