### PR TITLE
fix(create): rewire preview display-mode into root ThemeProvider

### DIFF
--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import { ThemeProvider } from 'starter-themes'
 import { siteConfig } from '@/config/site'
 import { truncateOnWord } from '@/lib/text'
 import { ToastProvider } from '@/registry/ui/toast'
+import { usePreviewForcedTheme } from '@/modules/create/preset'
 
 import appCss from '@/styles.css?url'
 
@@ -95,8 +96,12 @@ function RootComponent() {
     }
   }, [])
 
+  // In the /create preview iframe, the customizer owns the displayed mode — force it so
+  // the provider's own system / storage listeners can't revert it. `undefined` elsewhere.
+  const forcedTheme = usePreviewForcedTheme()
+
   return (
-    <ThemeProvider>
+    <ThemeProvider forcedTheme={forcedTheme}>
       <RootDocument>
         <ToastProvider>
           <Outlet />


### PR DESCRIPTION
## Summary

- The /create preview toolbar's sun/moon toggle changed its icon but the iframe never switched between light and dark, while design-system changes applied live — so the postMessage handshake was alive, only the mode path was dead.
- Root cause: `usePreviewForcedTheme()` — the iframe-side hook that consumes `preview-mode` messages and hands the result to the root `ThemeProvider` as `forcedTheme` — had **zero consumers**. #191 wired it into the root route; 6e58b9c5 ("simplify root shell and global styles") deleted that wiring while trimming the root, orphaning the hook. Messages arrived and set state nobody read.
- Fix: restore the hook call in `RootComponent` and pass it as `<ThemeProvider forcedTheme={…}>`. It returns `undefined` outside the preview iframe, so the main site's theme behavior is unchanged.

## Verification

Browser-verified against the iframe's real DOM: initial mode seeds from the site theme; toggling flips the root class and the rendered background (`oklch(0.985 0 0)` ⇄ `oklch(0.13 0 0)`) in both directions; the forced mode holds against the provider's system/storage listeners; a remounted iframe (switching the previewed component) honors the mode immediately. Console clean throughout — the reported "state update on a component that hasn't mounted yet" warning did not reproduce before or after the fix (fresh loads, SPA navigations, rapid toggling during iframe load). `pnpm check` + `pnpm typecheck` green.

## Suggested follow-ups (not in this diff)

- No regression-test seam exists: the repo has no jsdom/Playwright infra, so nothing can assert the root route keeps this wiring. A small e2e smoke test of the /create preview channels (mode + design-system) would lock it down.
- An unused-export check (e.g. knip) in CI would have flagged the orphaned hook the moment the refactor dropped its only consumer.