### PR TITLE
feat(colors): add per-token semantic remapping

### DIFF
--- a/www/src/lib/styles.tsx
+++ b/www/src/lib/styles.tsx
@@ -8,12 +8,12 @@ import type { ClassValue, TVReturnType, VariantProps } from 'tailwind-variants'
 
 import { resolveColorConfigCached } from '@/lib/resolve-color'
 import {
-  ACCENT_PRIMARY_SEMANTICS,
   DEFAULT_SEMANTICS,
   emitCss,
   emitDarkOverridesCss,
   emitPrimitivesCss,
-  semanticsWithPrimary,
+  semanticDelta,
+  semanticsFor,
 } from '@/registry/theme'
 import type { ColorConfig } from '@/registry/theme'
 import type {
@@ -222,10 +222,9 @@ function buildScopedThemeCss(
     `${selector} {\n${base}\n\tcolor: var(--color-fg);\n}`,
     `.dark ${selector} {\n${darkOverrides}\n}`,
     // Mode-agnostic `--color-*` (they reference primitives that flip via the blocks above).
-    emitCss(semanticsWithPrimary(color?.primary), { selector }),
-    // Empty today (no semantic token declares per-mode targets), kept so a
-    // future per-mode token re-points inside scopes like it does globally.
-    emitDarkOverridesCss(semanticsWithPrimary(color?.primary), {
+    emitCss(semanticsFor(color), { selector }),
+    // `.dark` re-points for per-mode targets (per-mode token overrides).
+    emitDarkOverridesCss(semanticsFor(color), {
       selector: `.dark ${selector}`,
     }),
   ]
@@ -462,14 +461,15 @@ function DesignSystemProvider({
   const themeCss = React.useMemo(() => {
     if (scoped || !color) return null
     const primitives = emitPrimitivesCss(resolveColorConfigCached(color))
-    // An accent-sourced primary re-points the primary cluster on plain `:root`
-    // (beats the layered `@theme` declarations), plus any per-mode re-points
-    // on `.dark` (none today — the accent primitives flip with `.dark`).
-    if (color.primary !== 'accent') return primitives
+    // Tokens the config re-points (primary source, per-token overrides)
+    // re-declare on plain `:root` (beats the layered `@theme` declarations),
+    // plus their per-mode re-points on `.dark`.
+    const delta = semanticDelta(color)
+    if (Object.keys(delta).length === 0) return primitives
     return (
       primitives +
-      emitCss(ACCENT_PRIMARY_SEMANTICS, { selector: ':root' }) +
-      emitDarkOverridesCss(ACCENT_PRIMARY_SEMANTICS, { selector: '.dark' })
+      emitCss(delta, { selector: ':root' }) +
+      emitDarkOverridesCss(delta, { selector: '.dark' })
     )
   }, [scoped, color])
   const themeStyle = themeCss ? (

--- a/www/src/modules/create/colors/index.tsx
+++ b/www/src/modules/create/colors/index.tsx
@@ -31,6 +31,7 @@ import { ChartColorsSection, ChartSwatchStrip } from '../chart-colors'
 import { useDesignSystem } from '../preset'
 import { ContrastReadout } from './contrast'
 import { ColorBackgroundControls, ColorFineTuneControls } from './knobs'
+import { TokenOverridesSection } from './overrides'
 
 type GrayMode = 'auto' | 'pure' | 'custom'
 
@@ -250,6 +251,13 @@ export function ColorsConfig() {
         <DisclosureTrigger>Fine-tune</DisclosureTrigger>
         <DisclosurePanel>
           <ColorFineTuneControls seedDelta={theme.report.seedDelta.accent} />
+        </DisclosurePanel>
+      </Disclosure>
+
+      <Disclosure>
+        <DisclosureTrigger>Token overrides</DisclosureTrigger>
+        <DisclosurePanel>
+          <TokenOverridesSection />
         </DisclosurePanel>
       </Disclosure>
 

--- a/www/src/modules/create/colors/overrides.test.ts
+++ b/www/src/modules/create/colors/overrides.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Per-token remapping (T5 `overrides`, #457): the semantic resolver applies
+ * config remaps, delta re-emits carry them, and migration salvages them.
+ */
+
+import { describe, expect, test } from 'vitest'
+
+import {
+  applyTokenOverrides,
+  DEFAULT_COLOR_CONFIG,
+  DEFAULT_SEMANTICS,
+  emitCss,
+  emitDarkOverridesCss,
+  migrateColorConfig,
+  semanticDelta,
+  semanticsFor,
+} from '@/registry/theme'
+
+describe('applyTokenOverrides', () => {
+  test('a mode-agnostic remap re-points the token ref', () => {
+    const vocab = applyTokenOverrides(DEFAULT_SEMANTICS, {
+      'color-card': { palette: 'neutral', job: 'app-bg' },
+    })
+    expect(vocab['color-card']!.target).toEqual({
+      ref: { palette: 'neutral', step: '25' },
+    })
+    // Category and picker pool survive the remap.
+    expect(vocab['color-card']!.category).toBe('background')
+    expect(vocab['color-card']!.scales).toEqual(
+      DEFAULT_SEMANTICS['color-card']!.scales,
+    )
+  })
+
+  test('a per-mode remap keeps the default target on the other mode', () => {
+    // The Geist case: dark collapses the subtle background onto the app bg.
+    const vocab = applyTokenOverrides(DEFAULT_SEMANTICS, {
+      'color-card': { dark: { palette: 'neutral', job: 'app-bg' } },
+    })
+    expect(vocab['color-card']!.target).toEqual({
+      light: DEFAULT_SEMANTICS['color-card']!.target,
+      dark: { ref: { palette: 'neutral', step: '25' } },
+    })
+    const darkCss = emitDarkOverridesCss({ 'color-card': vocab['color-card']! })
+    expect(darkCss).toContain('--color-card: var(--neutral-25);')
+  })
+
+  test('unknown token names are inert', () => {
+    const vocab = applyTokenOverrides(DEFAULT_SEMANTICS, {
+      'color-does-not-exist': { palette: 'neutral', job: 'solid' },
+    })
+    expect(vocab).toEqual(DEFAULT_SEMANTICS)
+  })
+
+  test('remapped tokens emit the new var reference', () => {
+    const css = emitCss(
+      semanticsFor({
+        overrides: {
+          'color-border': { palette: 'accent', job: 'border-emphasized' },
+        },
+      }),
+    )
+    expect(css).toContain('--color-border: var(--accent-600);')
+  })
+})
+
+describe('semanticDelta', () => {
+  test('empty for the untouched default config', () => {
+    expect(semanticDelta(undefined)).toEqual({})
+    expect(semanticDelta(DEFAULT_COLOR_CONFIG)).toEqual({})
+  })
+
+  test('an accent primary yields exactly the diverging primary cluster', () => {
+    const delta = semanticDelta({ primary: 'accent' })
+    expect(Object.keys(delta).length).toBeGreaterThan(0)
+    for (const name of Object.keys(delta))
+      expect(
+        name.startsWith('color-primary') ||
+          name === 'color-fg-on-primary' ||
+          name === 'color-fg-primary-disabled',
+        name,
+      ).toBe(true)
+  })
+
+  test('an override yields exactly that token', () => {
+    const delta = semanticDelta({
+      overrides: { 'color-card': { palette: 'neutral', job: 'app-bg' } },
+    })
+    expect(Object.keys(delta)).toEqual(['color-card'])
+  })
+})
+
+describe('migrateColorConfig overrides salvage', () => {
+  test('valid overrides survive, junk entries drop field-by-field', () => {
+    const config = migrateColorConfig({
+      v: 2,
+      seeds: { accent: '#0070f7' },
+      overrides: {
+        'color-card': { palette: 'neutral', job: 'app-bg' },
+        'color-popover': { dark: { palette: 'neutral', job: 'app-bg' } },
+        'color-bad-job': { palette: 'neutral', job: 'nope' },
+        'color-bad-shape': 'neutral-25',
+        'color-empty': { light: { palette: '', job: 'solid' } },
+      },
+    })
+    expect(config.overrides).toEqual({
+      'color-card': { palette: 'neutral', job: 'app-bg' },
+      'color-popover': { dark: { palette: 'neutral', job: 'app-bg' } },
+    })
+  })
+
+  test('an all-junk table drops to undefined (default encoding)', () => {
+    const config = migrateColorConfig({
+      v: 2,
+      seeds: { accent: '#0070f7' },
+      overrides: { 'color-card': { job: 'app-bg' } },
+    })
+    expect(config.overrides).toBeUndefined()
+  })
+})

--- a/www/src/modules/create/colors/overrides.tsx
+++ b/www/src/modules/create/colors/overrides.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import { ChevronDownIcon, XIcon } from 'lucide-react'
+
+import {
+  DEFAULT_COLOR_CONFIG,
+  DEFAULT_SEMANTICS,
+  JOB_STEPS,
+  PALETTE_ORDER,
+} from '@/registry/theme'
+import type { JobName, SemanticToken, TokenTargetSpec } from '@/registry/theme'
+import { Button } from '@/registry/ui/button'
+import { Label } from '@/registry/ui/field'
+import { ListBox, ListBoxItem } from '@/registry/ui/list-box'
+import { Popover } from '@/registry/ui/popover'
+import { Select, SelectValue } from '@/registry/ui/select'
+
+import { useDesignSystem } from '../preset'
+
+const JOB_NAMES = Object.keys(JOB_STEPS) as JobName[]
+const STEP_JOBS = Object.fromEntries(
+  Object.entries(JOB_STEPS).map(([job, step]) => [step, job as JobName]),
+)
+
+/** Tokens the picker offers: those with a curated ramp pool (T7). */
+const REMAPPABLE = Object.entries(DEFAULT_SEMANTICS).filter(
+  ([, token]) => token.scales !== undefined,
+)
+
+/** Job a fresh override starts at when the default target isn't a plain ref. */
+const CATEGORY_JOBS: Record<SemanticToken['category'], JobName> = {
+  background: 'ui-rest',
+  foreground: 'text',
+  border: 'border-subtle',
+}
+
+/** A token's starting (palette, job): its own ref target, or a category guess. */
+function defaultSpec(
+  token: SemanticToken,
+  customPalettes: string[],
+): TokenTargetSpec | undefined {
+  const target = 'light' in token.target ? token.target.light : token.target
+  if ('ref' in target) {
+    const job = STEP_JOBS[target.ref.step]
+    if (job) return { palette: target.ref.palette, job }
+  }
+  const palette = palettePool(token, customPalettes)[0]
+  return palette ? { palette, job: CATEGORY_JOBS[token.category] } : undefined
+}
+
+/** The palettes a token's pool offers; `'..'` opens any config-added palette. */
+function palettePool(token: SemanticToken, customPalettes: string[]): string[] {
+  const pool = token.scales ?? []
+  const named = pool.filter((name) => name !== '..')
+  const open = pool.includes('..')
+  return [...new Set([...named, ...(open ? customPalettes : [])])]
+}
+
+/**
+ * Per-token remapping (T7 advanced tier): the `scales` picker pools as a UI.
+ * Rows write mode-agnostic `{ palette, job }` overrides; per-mode pairs stay
+ * expressible at the config/preset level.
+ */
+export function TokenOverridesSection() {
+  const { designSystem, setColorTokenOverride } = useDesignSystem()
+  const config = designSystem.color ?? DEFAULT_COLOR_CONFIG
+  const overrides = config.overrides ?? {}
+  const customPalettes = Object.keys(config.seeds).filter(
+    (name) => !(PALETTE_ORDER as readonly string[]).includes(name),
+  )
+  const available = REMAPPABLE.filter(([name]) => !(name in overrides))
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs text-fg-muted">
+        Re-point a semantic token at another ramp step. The contrast readout
+        below tracks the result.
+      </p>
+
+      {Object.entries(overrides).map(([name, override]) => {
+        const token = DEFAULT_SEMANTICS[name]
+        if (!token || !('palette' in override)) return null
+        const palettes = palettePool(token, customPalettes)
+        return (
+          <div key={name} className="flex flex-col gap-1">
+            <span className="pl-1 text-[10px] tracking-widest text-fg-muted uppercase">
+              {name.replace(/^color-/, '')}
+            </span>
+            <div className="flex items-center gap-2">
+              <Select
+                aria-label={`${name} palette`}
+                className="flex-1"
+                selectedKey={override.palette}
+                onSelectionChange={(key) =>
+                  setColorTokenOverride(name, {
+                    ...override,
+                    palette: String(key),
+                  })
+                }
+              >
+                <Button size="sm" className="w-full justify-between">
+                  <SelectValue className="truncate" />
+                  <ChevronDownIcon data-icon-end="" />
+                </Button>
+                <Popover>
+                  <ListBox>
+                    {palettes.map((palette) => (
+                      <ListBoxItem key={palette} id={palette}>
+                        {palette}
+                      </ListBoxItem>
+                    ))}
+                  </ListBox>
+                </Popover>
+              </Select>
+              <Select
+                aria-label={`${name} job`}
+                className="flex-1"
+                selectedKey={override.job}
+                onSelectionChange={(key) =>
+                  setColorTokenOverride(name, {
+                    ...override,
+                    job: key as JobName,
+                  })
+                }
+              >
+                <Button size="sm" className="w-full justify-between">
+                  <SelectValue className="truncate" />
+                  <ChevronDownIcon data-icon-end="" />
+                </Button>
+                <Popover>
+                  <ListBox>
+                    {JOB_NAMES.map((job) => (
+                      <ListBoxItem key={job} id={job}>
+                        {job}
+                      </ListBoxItem>
+                    ))}
+                  </ListBox>
+                </Popover>
+              </Select>
+              <Button
+                size="sm"
+                variant="quiet"
+                aria-label={`Reset ${name}`}
+                onPress={() => setColorTokenOverride(name, undefined)}
+              >
+                <XIcon />
+              </Button>
+            </div>
+          </div>
+        )
+      })}
+
+      {available.length > 0 && (
+        <Select
+          aria-label="Add token override"
+          className="w-full"
+          selectedKey={null}
+          onSelectionChange={(key) => {
+            const entry = REMAPPABLE.find(([name]) => name === key)
+            if (!entry) return
+            const spec = defaultSpec(entry[1], customPalettes)
+            if (spec) setColorTokenOverride(entry[0], spec)
+          }}
+        >
+          <Label>Add override</Label>
+          <Button size="sm" className="w-full justify-between">
+            <SelectValue className="truncate">
+              {() => 'Pick a token…'}
+            </SelectValue>
+            <ChevronDownIcon data-icon-end="" />
+          </Button>
+          <Popover>
+            <ListBox>
+              {available.map(([name]) => (
+                <ListBoxItem key={name} id={name}>
+                  {name.replace(/^color-/, '')}
+                </ListBoxItem>
+              ))}
+            </ListBox>
+          </Popover>
+        </Select>
+      )}
+    </div>
+  )
+}

--- a/www/src/modules/create/preset/use-design-system.ts
+++ b/www/src/modules/create/preset/use-design-system.ts
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { getRouteApi } from '@tanstack/react-router'
 
 import { DEFAULT_COLOR_CONFIG } from '@/registry/theme'
-import type { ColorConfig, PaletteSeeds } from '@/registry/theme'
+import type { ColorConfig, PaletteSeeds, TokenOverride } from '@/registry/theme'
 import { DEFAULT_CODE_OPTIONS } from '@/publisher/code-options'
 import type { CodeOptions } from '@/publisher/code-options'
 
@@ -129,6 +129,20 @@ export function useDesignSystem() {
     [setColor],
   )
 
+  /** Remap one semantic token; `undefined` deletes it (→ default target). */
+  const setColorTokenOverride = useCallback(
+    (token: string, value: TokenOverride | undefined) => {
+      setColor((base) => {
+        const overrides = { ...base.overrides }
+        if (value === undefined) delete overrides[token]
+        else overrides[token] = value
+        const { overrides: _drop, ...rest } = base
+        return Object.keys(overrides).length > 0 ? { ...rest, overrides } : rest
+      })
+    },
+    [setColor],
+  )
+
   /** Pin (or unpin) the accent seed verbatim at the solid step. */
   const setColorPreserveSeed = useCallback(
     (value: boolean) => {
@@ -175,6 +189,7 @@ export function useDesignSystem() {
     setColorSeed,
     setColorAxis,
     setColorBackground,
+    setColorTokenOverride,
     setColorPreserveSeed,
     setColorPrimary,
     setCodeOption,

--- a/www/src/publisher/emit-theme.ts
+++ b/www/src/publisher/emit-theme.ts
@@ -11,8 +11,9 @@
 
 import {
   resolveColorConfig,
+  resolveTarget,
   resolveTokenValue,
-  semanticVocabulary,
+  semanticsFor,
 } from '@/registry/theme'
 import type { Density, RegistryItem } from '@/registry/types'
 
@@ -205,12 +206,20 @@ export function mergePresetCssFields(
 
   // The shipped `@theme` block is resolved from the typed vocabulary, honoring
   // the preset's primary source (`--color-primary: var(--accent-700)` when the
-  // primary draws from the accent ramp).
+  // primary draws from the accent ramp) and any per-token overrides. Per-mode
+  // targets take their light value in `@theme` and re-point on `.dark`.
   const themeVars = (cssVars.theme ??= {})
-  for (const [name, token] of Object.entries(
-    semanticVocabulary(preset.color?.primary ?? 'neutral'),
-  )) {
+  const darkRepoints: Record<string, string> = {}
+  for (const [name, token] of Object.entries(semanticsFor(preset.color))) {
     themeVars[`--${name}`] = resolveTokenValue(token)
+    if ('light' in token.target)
+      darkRepoints[`--${name}`] = resolveTarget(token.target.dark)
+  }
+  if (Object.keys(darkRepoints).length > 0) {
+    css['.dark'] = {
+      ...(isPlainCssObject(css['.dark']) ? css['.dark'] : {}),
+      ...darkRepoints,
+    }
   }
 
   const lightVars = emitPresetLightVars(preset)

--- a/www/src/registry/theme/SPEC.md
+++ b/www/src/registry/theme/SPEC.md
@@ -141,8 +141,9 @@ the current flat section are both replaced):
 - Randomize-within-quality-rules + per-seed locks (lock-and-reroll)
 
 **Advanced** — the engine's real axes: `vividness`, `hueShift`,
-`neutralTint`, `preserveSeed`, per-token remapping (the `scales` picker
-pools finally get their UI), chart palette controls.
+`neutralTint`, `preserveSeed`, per-token remapping ✅ (the `scales` picker
+pools as a UI — mode-agnostic `{palette, job}` rows; per-mode pairs stay
+config/preset-level), chart palette controls.
 
 **Verification in the panel**: the contrast readout covers the actually-
 shipped guarantee pairings (engine D2) in both modes — not just fg-on-500 in

--- a/www/src/registry/theme/color-config.ts
+++ b/www/src/registry/theme/color-config.ts
@@ -10,7 +10,26 @@ import { z } from 'zod'
 
 import { STATUS_SEEDS, toOklch } from '@dotui/colors'
 
-import type { PrimaryColorSource } from './types'
+import type {
+  PrimaryColorSource,
+  TokenOverride,
+  TokenOverrides,
+  TokenTargetSpec,
+} from './types'
+import { JOB_STEPS, type JobName } from './types'
+
+const JOB_NAMES = Object.keys(JOB_STEPS) as [JobName, ...JobName[]]
+const tokenTargetSpec = z.object({
+  palette: z.string().min(1),
+  job: z.enum(JOB_NAMES),
+})
+const tokenOverride = z.union([
+  tokenTargetSpec,
+  z.object({
+    light: tokenTargetSpec.optional(),
+    dark: tokenTargetSpec.optional(),
+  }),
+])
 
 export const colorConfigSchema = z.object({
   v: z.literal(2),
@@ -44,6 +63,11 @@ export const colorConfigSchema = z.object({
    * (brand-colored primary); absent means the default neutral (black/white).
    */
   primary: z.literal('accent').optional(),
+  /**
+   * Per-token remaps (T5): token name → (palette, job), one destination or a
+   * per-mode pair. Applied by the semantic resolver; unknown names are inert.
+   */
+  overrides: z.record(z.string(), tokenOverride).optional(),
 })
 
 export type ColorConfig = z.infer<typeof colorConfigSchema>
@@ -99,6 +123,38 @@ const clamp = (value: number, min: number, max: number) =>
 const finite = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value)
 
+/** Salvage one remap destination: a non-empty palette + a known job name. */
+function salvageTargetSpec(raw: unknown): TokenTargetSpec | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const spec = raw as { palette?: unknown; job?: unknown }
+  if (typeof spec.palette !== 'string' || spec.palette.length === 0)
+    return undefined
+  if (typeof spec.job !== 'string' || !(spec.job in JOB_STEPS)) return undefined
+  return { palette: spec.palette, job: spec.job as JobName }
+}
+
+/** Salvage the per-token remap table: keep only valid entries, drop empties. */
+function salvageOverrides(raw: unknown): TokenOverrides | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const overrides: TokenOverrides = {}
+  for (const [token, value] of Object.entries(raw)) {
+    const both = salvageTargetSpec(value)
+    if (both) {
+      overrides[token] = both
+      continue
+    }
+    if (typeof value !== 'object' || value === null) continue
+    const pair = value as { light?: unknown; dark?: unknown }
+    const override: Exclude<TokenOverride, TokenTargetSpec> = {}
+    const light = salvageTargetSpec(pair.light)
+    const dark = salvageTargetSpec(pair.dark)
+    if (light) override.light = light
+    if (dark) override.dark = dark
+    if (light || dark) overrides[token] = override
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined
+}
+
 /**
  * Migrate any decoded color slice — v2 salvages field by field (a corrupt or
  * out-of-range axis is clamped or dropped, never taking valid siblings with
@@ -118,6 +174,7 @@ export function migrateColorConfig(input: unknown): ColorConfig {
     hueShift?: unknown
     neutralTint?: unknown
     preserveSeed?: unknown
+    overrides?: unknown
     algorithm?: string
     knobs?: Record<string, unknown>
     primary?: unknown
@@ -141,6 +198,8 @@ export function migrateColorConfig(input: unknown): ColorConfig {
     if (typeof raw.preserveSeed === 'boolean')
       config.preserveSeed = raw.preserveSeed
     if (raw.primary === 'accent') config.primary = 'accent'
+    const overrides = salvageOverrides(raw.overrides)
+    if (overrides) config.overrides = overrides
     return config
   }
 

--- a/www/src/registry/theme/index.ts
+++ b/www/src/registry/theme/index.ts
@@ -7,16 +7,23 @@
  */
 
 export type {
+  JobName,
   ModeName,
   PrimaryColorSource,
   SemanticCategory,
   SemanticTarget,
   SemanticToken,
   SemanticVocabulary,
+  TokenOverride,
+  TokenOverrides,
+  TokenTargetSpec,
 } from './types'
+export { JOB_STEPS } from './types'
 export {
-  ACCENT_PRIMARY_SEMANTICS,
+  applyTokenOverrides,
   DEFAULT_SEMANTICS,
+  semanticDelta,
+  semanticsFor,
   semanticsWithPrimary,
   semanticVocabulary,
 } from './semantics'

--- a/www/src/registry/theme/semantics.ts
+++ b/www/src/registry/theme/semantics.ts
@@ -15,7 +15,11 @@ import type {
   SemanticTarget,
   SemanticToken,
   SemanticVocabulary,
+  TokenOverride,
+  TokenOverrides,
+  TokenTargetSpec,
 } from './types'
+import { JOB_STEPS } from './types'
 
 /** Picker pools: the neutral backbone + any custom palette. */
 const NEUTRAL = ['neutral', '..'] as const
@@ -183,12 +187,74 @@ export function semanticsWithPrimary(
   return semanticVocabulary(source ?? 'neutral')
 }
 
-/** The primary-cluster overrides alone (accent source) — for scoped re-emits. */
-export const ACCENT_PRIMARY_SEMANTICS: SemanticVocabulary = Object.fromEntries(
-  Object.entries(semanticVocabulary('accent')).filter(
-    ([name]) =>
-      name.startsWith('color-primary') ||
-      name === 'color-fg-on-primary' ||
-      name === 'color-fg-primary-disabled',
-  ),
-)
+const specTarget = (spec: TokenTargetSpec): SemanticTarget => ({
+  ref: { palette: spec.palette, step: JOB_STEPS[spec.job] },
+})
+
+const modeTarget = (
+  target: SemanticToken['target'],
+  mode: 'light' | 'dark',
+): SemanticTarget => ('light' in target ? target[mode] : target)
+
+function overriddenTarget(
+  base: SemanticToken['target'],
+  override: TokenOverride,
+): SemanticToken['target'] {
+  if ('palette' in override) return specTarget(override)
+  return {
+    light: override.light
+      ? specTarget(override.light)
+      : modeTarget(base, 'light'),
+    dark: override.dark ? specTarget(override.dark) : modeTarget(base, 'dark'),
+  }
+}
+
+/**
+ * Apply per-token remaps (T5 `overrides`) to a vocabulary. Unknown token
+ * names are ignored (a stale preset must never break emission); category,
+ * picker pools, and descriptions survive the remap.
+ */
+export function applyTokenOverrides(
+  vocabulary: SemanticVocabulary,
+  overrides: TokenOverrides | undefined,
+): SemanticVocabulary {
+  if (!overrides || Object.keys(overrides).length === 0) return vocabulary
+  const out = { ...vocabulary }
+  for (const [name, override] of Object.entries(overrides)) {
+    const base = out[name]
+    if (!base) continue
+    out[name] = { ...base, target: overriddenTarget(base.target, override) }
+  }
+  return out
+}
+
+/** The one resolver every emitter goes through (T4): primary + overrides. */
+export function semanticsFor(
+  color:
+    | { primary?: PrimaryColorSource; overrides?: TokenOverrides }
+    | undefined,
+): SemanticVocabulary {
+  return applyTokenOverrides(
+    semanticVocabulary(color?.primary ?? 'neutral'),
+    color?.overrides,
+  )
+}
+
+/**
+ * The tokens whose target differs from the default vocabulary — for delta
+ * re-emits on plain `:root`/`.dark` (the v0 bundle, scoped previews), where
+ * the full `@theme` layer ships static and only divergences re-point.
+ */
+export function semanticDelta(
+  color:
+    | { primary?: PrimaryColorSource; overrides?: TokenOverrides }
+    | undefined,
+): SemanticVocabulary {
+  return Object.fromEntries(
+    Object.entries(semanticsFor(color)).filter(
+      ([name, token]) =>
+        JSON.stringify(token.target) !==
+        JSON.stringify(DEFAULT_SEMANTICS[name]?.target),
+    ),
+  )
+}

--- a/www/src/registry/theme/types.ts
+++ b/www/src/registry/theme/types.ts
@@ -51,3 +51,38 @@ export interface SemanticToken {
 
 /** The semantic vocabulary, keyed by token name WITHOUT the leading `--` (e.g. `"color-bg"`). */
 export type SemanticVocabulary = Record<string, SemanticToken>
+
+/** The engine's 12-job ladder by job name (T2) — the remap-facing vocabulary. */
+export const JOB_STEPS = {
+  'app-bg': '25',
+  'subtle-bg': '50',
+  'ui-rest': '100',
+  'ui-hover': '200',
+  'ui-active': '300',
+  'border-subtle': '400',
+  'border-interactive': '500',
+  'border-emphasized': '600',
+  solid: '700',
+  'solid-hover': '800',
+  'text-muted': '900',
+  text: '950',
+} as const satisfies Record<string, StepName>
+
+export type JobName = keyof typeof JOB_STEPS
+
+/** A remap destination: a palette + job, resolved to `ref(palette, step)`. */
+export interface TokenTargetSpec {
+  palette: string
+  job: JobName
+}
+
+/**
+ * A per-token remap (T5 `overrides`): one destination for both modes, or a
+ * per-mode pair — a missing mode keeps the token's default target there.
+ */
+export type TokenOverride =
+  | TokenTargetSpec
+  | { light?: TokenTargetSpec; dark?: TokenTargetSpec }
+
+/** Per-token remaps, keyed by token name (e.g. `"color-card"`). */
+export type TokenOverrides = Record<string, TokenOverride>


### PR DESCRIPTION
Closes #457.

Second axis from the fidelity-first roadmap. The Geist experiment ([#456's writeup](https://github.com/mehdibha/dotUI/issues/456#issuecomment-5016250126)) validated it concretely: Geist dark ships `background-100 = background-200 = #000` — a subtle-bg collapse (ΔEok 0.15, the largest single dark-gray delta) that no engine axis can express. It's a token-resolution decision: `color-card`/`color-popover` pointing at `app-bg` instead of `subtle-bg`, per mode. Token SPEC T5 already reserved `overrides`; this implements it.

## Semantic layer (`@/registry/theme`)

- `JOB_STEPS` / `JobName` — the 12-job ladder by job name (T2), the remap-facing vocabulary; overrides say `{ palette: 'neutral', job: 'app-bg' }`, never magic step numbers.
- `applyTokenOverrides(vocabulary, overrides)` — re-points token targets; unknown token names are inert (a stale preset never breaks emission); category/picker pools survive. A per-mode override (`{ dark: {...} }`) keeps the default target on the other mode.
- `semanticsFor(color)` — **the one resolver every emitter goes through** (the T4 direction): primary source + overrides. All call sites migrated: scoped preview, global preview, publisher `@theme` (which the rebuilt "Open in v0" path consumes via `mergePresetCssFields`, so v0 exports carry overrides with no extra work).
- `semanticDelta(color)` — tokens whose target diverges from the default vocabulary, for plain-`:root`/`.dark` re-emits in the live preview. Replaces the hand-maintained `ACCENT_PRIMARY_SEMANTICS` special case (deleted); an accent primary now falls out of the same diff.
- Publisher `@theme` emission now also routes per-mode targets: light value in `cssVars.theme`, dark re-point in `css['.dark']` (T3's "per-mode targets are first-class", previously unimplemented in the registry-JSON path).

## Config + /create

- `ColorConfig.overrides` (T5 shape): token name → `{ palette, job }` or per-mode pair; zod-validated, salvage-style migration (junk entries drop field-by-field, empty tables drop to `undefined`).
- New **Token overrides** section in the /create colors panel (T7 advanced tier — the `scales` picker pools as a UI): add-override flow, per-row palette select (constrained to the token's pool, `'..'` opening config-added palettes) + job select + reset. Rows write mode-agnostic overrides; per-mode pairs stay preset/config-level.

## Verification

- 11 new tests (resolver, per-mode re-points, delta semantics, migration salvage); www suite 150 passed, typecheck + lint clean; registry regenerated.
- End-to-end on the worktree's own vite server: added a `card → neutral/app-bg` override through the UI; the preview iframe's `--color-card` re-pointed from `--neutral-50` to `--neutral-25`, and the override survived a full reload through the preset URL (codec round-trip).
- Rebased onto #465 (the "Open in v0" rebuild): the old bundle emitter and showcase-bundle script this PR originally touched were deleted there; overrides now reach v0 through the publisher path above.

## Notes

- Dark-only `color-card`/`color-popover` collapse (the exact Geist recipe) is expressible in config today; the UI exposes the mode-agnostic tier. A Geist preset (#391) can pin the per-mode pair directly.
- Independent of #467 (border targets) — the two merge cleanly in either order.