### PR TITLE
feat(www): add export section, closing CTA, and footer nav to landing

### DIFF
--- a/www/src/components/layout/footer.tsx
+++ b/www/src/components/layout/footer.tsx
@@ -1,18 +1,73 @@
+import { Link as RouterLink } from '@tanstack/react-router'
+
+import { navItems, siteConfig } from '@/config/site'
+import { DiscordIcon } from '@/components/icons/discord'
+import { GitHubIcon } from '@/components/icons/github'
+import { TwitterIcon } from '@/components/icons/twitter'
+
+const SOCIALS = [
+  {
+    label: 'GitHub',
+    href: siteConfig.links.github,
+    icon: <GitHubIcon className="size-4" />,
+  },
+  {
+    label: 'X (Twitter)',
+    href: siteConfig.links.twitter,
+    icon: <TwitterIcon className="size-3.5" />,
+  },
+  {
+    label: 'Discord',
+    href: siteConfig.links.discord,
+    icon: <DiscordIcon className="size-4" />,
+  },
+]
+
 export function Footer() {
   return (
-    <footer className="container flex items-center justify-center py-10">
-      <p className="text-sm text-fg-muted">
-        Built with passion by{' '}
-        <a
-          href="https://x.com/mehdibha"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline underline-offset-4"
+    <footer className="border-t">
+      <div className="container flex flex-col items-center justify-between gap-6 py-10 sm:flex-row">
+        <p className="text-sm text-fg-muted">
+          Built with passion by{' '}
+          <a
+            href="https://x.com/mehdibha"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-4 hover:text-fg"
+          >
+            @mehdibha
+          </a>
+          .
+        </p>
+        <nav
+          aria-label="Footer"
+          className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2"
         >
-          @mehdibha
-        </a>
-        .
-      </p>
+          {navItems.map((item) => (
+            <RouterLink
+              key={item.name}
+              to={item.to}
+              params={item.params}
+              className="text-sm text-fg-muted transition-colors hover:text-fg"
+            >
+              {item.name}
+            </RouterLink>
+          ))}
+          <span aria-hidden className="h-4 w-px bg-border" />
+          {SOCIALS.map((social) => (
+            <a
+              key={social.label}
+              href={social.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={social.label}
+              className="text-fg-muted transition-colors hover:text-fg"
+            >
+              {social.icon}
+            </a>
+          ))}
+        </nav>
+      </div>
     </footer>
   )
 }

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -97,14 +97,14 @@ export function CompositionSection() {
       >
         {/* Copy + step rail */}
         <div className="flex flex-col items-start gap-4">
-          <h2 className="font-mono text-sm tracking-wide text-fg-muted">
+          <p className="font-mono text-sm tracking-wide text-fg-muted">
             Composition
-          </h2>
-          <p className="text-3xl font-semibold tracking-tighter text-balance sm:text-4xl">
+          </p>
+          <h2 className="text-3xl font-semibold tracking-tighter text-balance sm:text-4xl">
             Compose components.
             <br />
             <span className="text-fg-muted">Create your own patterns.</span>
-          </p>
+          </h2>
           <p className="text-base text-fg-muted lg:max-w-md">
             One compositional API across the library — the same parts combine
             into anything, from a simple field to a complex pattern.

--- a/www/src/modules/marketing/export-section.tsx
+++ b/www/src/modules/marketing/export-section.tsx
@@ -1,0 +1,140 @@
+import { CheckIcon, CopyIcon } from 'lucide-react'
+
+import { siteConfig } from '@/config/site'
+import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
+import { Button, LinkButton } from '@/registry/ui/button'
+import { V0Icon } from '@/components/icons/v0'
+
+const INIT_COMMAND = `npx shadcn init ${siteConfig.url}/r/init`
+const ADD_COMMAND = 'npx shadcn add @dotui/button'
+
+const V0_URL = `https://v0.dev/chat/api/open?url=${encodeURIComponent(`${siteConfig.url}/r/v0`)}`
+
+const STEPS = [
+  { title: 'Compose', detail: 'tune every axis in the editor' },
+  { title: 'Preview', detail: 'every change live, on real components' },
+  { title: 'Export', detail: 'into your codebase, or straight to v0' },
+]
+
+// What `shadcn add` actually lands in a consumer repo — real targets from the
+// registry items, kept short.
+const FILES = [
+  'ui/button.tsx',
+  'ui/menu.tsx',
+  'ui/tooltip.tsx',
+  'lib/utils.ts',
+  'theme.css',
+]
+
+export function ExportSection() {
+  return (
+    // Width mirrors the composition section, so the two read as one system.
+    <section className="mx-auto mt-24 w-full max-w-[calc(1500px+16rem)] px-4 sm:px-6 md:mt-32 lg:px-32">
+      <div className="grid items-start gap-12 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)] lg:gap-16">
+        {/* Copy + step list */}
+        <div className="flex flex-col items-start gap-4">
+          <p className="font-mono text-sm tracking-wide text-fg-muted">
+            Export
+          </p>
+          <h2 className="text-3xl font-semibold tracking-tighter text-balance sm:text-4xl">
+            Leave with code.
+            <br />
+            <span className="text-fg-muted">Not a dependency.</span>
+          </h2>
+          <p className="text-base text-fg-muted lg:max-w-md">
+            One command scaffolds your design system into your repo — real
+            files, styled your way, with no runtime dependency on us. Edit
+            anything; it&rsquo;s yours.
+          </p>
+          <ol className="mt-2 flex flex-col">
+            {STEPS.map((step, index) => (
+              <li
+                key={step.title}
+                className="flex gap-3 border-l py-1.5 pl-4 text-sm"
+              >
+                <span className="font-mono text-xs leading-5 text-fg-muted/50 tabular-nums">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <span>
+                  {step.title}{' '}
+                  <span className="text-fg-muted">— {step.detail}</span>
+                </span>
+              </li>
+            ))}
+          </ol>
+          <div className="flex flex-wrap gap-2 pt-2">
+            <LinkButton href="/create" variant="primary">
+              Launch the editor
+            </LinkButton>
+            <LinkButton
+              href={V0_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="default"
+            >
+              Open in <V0Icon className="h-3 w-auto" />
+            </LinkButton>
+          </div>
+        </div>
+
+        {/* Terminal card: the real commands, then what lands in the repo. */}
+        <div className="min-w-0">
+          <div className="overflow-hidden rounded-xl border bg-card shadow-xs">
+            <div className="flex flex-col gap-4 p-6">
+              <CommandLine
+                label="Initialize with your theme"
+                command={INIT_COMMAND}
+              />
+              <CommandLine label="Add components" command={ADD_COMMAND} />
+            </div>
+            <div className="border-t p-6">
+              <p className="font-mono text-xs text-fg-muted/70">
+                {'//'} what lands in your repo
+              </p>
+              <ul className="mt-3 flex flex-col gap-1.5 font-mono text-[0.8125rem]">
+                {FILES.map((file) => (
+                  <li key={file} className="flex items-center gap-2">
+                    <CheckIcon
+                      aria-hidden
+                      className="size-3.5 text-fg-muted/70"
+                    />
+                    {file}
+                  </li>
+                ))}
+                <li className="text-fg-muted">…and every component you add.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function CommandLine({ label, command }: { label: string; command: string }) {
+  const { isCopied, copyToClipboard } = useCopyToClipboard()
+
+  return (
+    <div>
+      <p className="mb-1.5 font-mono text-xs text-fg-muted/70">
+        {'//'} {label}
+      </p>
+      <div className="flex items-center gap-2">
+        <code className="no-scrollbar grow overflow-x-auto font-mono text-[0.8125rem] whitespace-nowrap">
+          <span className="text-fg-muted select-none">$ </span>
+          {command}
+        </code>
+        <Button
+          variant="quiet"
+          size="sm"
+          isIconOnly
+          className="shrink-0"
+          onPress={() => copyToClipboard(command)}
+          aria-label={isCopied ? 'Copied' : `Copy: ${command}`}
+        >
+          {isCopied ? <CheckIcon /> : <CopyIcon />}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -1,9 +1,11 @@
 import { Link } from 'react-aria-components'
 
+import { siteConfig } from '@/config/site'
 import { LinkButton } from '@/registry/ui/button'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
 import { Announcement } from '@/components/announcement'
 import { BaseUiIcon } from '@/components/icons/base-ui'
+import { GitHubIcon } from '@/components/icons/github'
 import { ReactAriaIcon } from '@/components/icons/react-aria'
 import { ReactJsIcon } from '@/components/icons/react-js'
 import { ShadcnIcon } from '@/components/icons/shadcn'
@@ -12,6 +14,7 @@ import { TypeScriptIcon } from '@/components/icons/typescript'
 import { Footer } from '@/components/layout/footer'
 import Cards from '@/modules/marketing/cards'
 import { CompositionSection } from '@/modules/marketing/composition-section'
+import { ExportSection } from '@/modules/marketing/export-section'
 
 export function HomePage() {
   return (
@@ -28,8 +31,9 @@ export function HomePage() {
             not someone else&rsquo;s.
           </h1>
           <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
-            Beautiful components, accessibility out of the box, composition, and
-            more.
+            Tune colors, typography, density, and component styles. Preview
+            every choice live on accessible React components. Export it as code
+            you own.
           </p>
           <div className="mt-9 flex items-center gap-3">
             <LinkButton href="/create" variant="primary" size="lg">
@@ -59,7 +63,7 @@ export function HomePage() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={label}
-                  className="flex items-center justify-center opacity-60 grayscale-100 transition-opacity hover:opacity-100 hover:grayscale-0"
+                  className="flex items-center justify-center rounded-md opacity-60 focus-reset grayscale-100 transition-[opacity,filter] hover:opacity-100 hover:grayscale-0 focus-visible:focus-ring"
                   href={href}
                 >
                   {icon}
@@ -68,14 +72,43 @@ export function HomePage() {
               </Tooltip>
             ))}
           </div>
+          <p className="max-w-xl text-center text-sm text-balance text-fg-muted">
+            Keyboard, focus, and screen-reader behavior come from React Aria and
+            Base UI — accessible by default, on every component.
+          </p>
         </div>
       </section>
 
       <CompositionSection />
 
-      <div className="mt-10 md:mt-14">
-        <Footer />
-      </div>
+      <ExportSection />
+
+      {/* Closing CTA */}
+      <section className="container flex flex-col items-center py-24 text-center md:py-32">
+        <h2 className="text-3xl font-semibold tracking-tighter text-balance sm:text-4xl">
+          Start building your design system.
+        </h2>
+        <p className="mt-3 text-base text-balance text-fg-muted">
+          Free and open source. Yours from the first component.
+        </p>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+          <LinkButton href="/create" variant="primary" size="lg">
+            Launch the editor
+          </LinkButton>
+          <LinkButton
+            href={siteConfig.links.github}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="default"
+            size="lg"
+          >
+            <GitHubIcon className="size-4.5" />
+            Star on GitHub
+          </LinkButton>
+        </div>
+      </section>
+
+      <Footer />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **New export section** — "Leave with code. Not a dependency." Mirrors the composition section's layout: a Compose → Preview → Export step rail on the left; on the right a terminal card with the real commands (`npx shadcn init https://dotui.org/r/init`, `npx shadcn add @dotui/button`) with copy buttons, a "what lands in your repo" file list using real registry target paths, and an "Open in v0" button on the real deeplink.
- **Closing CTA** — "Start building your design system." with Launch the editor + Star on GitHub, so the page no longer dead-ends after the composition demo.
- **Footer** — keeps the credit line, adds site nav (from `navItems`) and GitHub/X/Discord icon links, with a top border. Charts and presets pages pick this up too.
- **Hero subheadline** — replaces "Beautiful components, accessibility out of the box, composition, and more" with the actual pitch: tune axes, preview live, export code you own.
- **Heading semantics** — the composition section's visible statement is now the `h2` and the mono eyebrow a `p` (was inverted); new sections follow the same pattern.
- **Tools strip** — one muted line backing the accessibility claim (React Aria + Base UI provide keyboard/focus/screen-reader behavior); logo hover now transitions the grayscale filter instead of snapping; logos get visible focus rings.

Out of scope on purpose: presets (WIP on another branch), composition steps (kept all 17), an editor showcase (worth revisiting after the /create rewrite), and landing perf (build-pipeline work from the July audit, not markup).

Verified at desktop and 375 px (no horizontal overflow anywhere); `pnpm check` and `pnpm typecheck` pass; no registry files touched.