### PR TITLE
feat(create): progressive preview toolbar blur themed by preset

### DIFF
--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -33,7 +33,7 @@ export function Header({ className, items = [] }: HeaderProps) {
   return (
     <header
       className={cn(
-        'sticky top-0 z-30 flex h-(--header-height) w-full items-center justify-between header-blur-fallback pr-3 pl-4 md:pr-4 md:pl-6',
+        'sticky top-0 z-30 flex h-(--header-height) w-full items-center justify-between blur-reveal-fallback pr-3 pl-4 md:pr-4 md:pl-6',
         className,
       )}
     >
@@ -46,7 +46,7 @@ export function Header({ className, items = [] }: HeaderProps) {
       <div
         key={pathname}
         aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] header-blur-reveal"
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] blur-reveal"
       >
         <ProgressiveBlur />
       </div>

--- a/www/src/components/layout/header.tsx
+++ b/www/src/components/layout/header.tsx
@@ -9,40 +9,10 @@ import { Separator } from '@/registry/ui/separator'
 import { GitHubIcon } from '@/components/icons/github'
 import { Logo } from '@/components/layout/logo'
 import { MobileNav } from '@/components/layout/mobile-nav'
+import { ProgressiveBlur } from '@/components/progressive-blur'
 import { SearchCommand } from '@/components/search-command'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { DocsTocSelect } from '@/modules/docs/docs-toc-select'
-
-// iOS-style progressive blur: each layer adds a larger backdrop blur over an
-// overlapping gradient window. Where the windows overlap the blurs compound,
-// ramping smoothly from sharp (bottom edge) to heavily blurred (top). The
-// `to top` direction puts the strongest blur under the nav content. The wrapper
-// must stay mask-free — a mask there establishes a backdrop root and kills the
-// cross-layer compounding that makes the ramp smooth.
-const BLUR_LAYERS = [
-  {
-    blur: 0.5,
-    mask: 'linear-gradient(to top, transparent 0%, #000 10%, #000 30%, transparent 40%)',
-  },
-  {
-    blur: 1,
-    mask: 'linear-gradient(to top, transparent 10%, #000 20%, #000 40%, transparent 50%)',
-  },
-  {
-    blur: 2,
-    mask: 'linear-gradient(to top, transparent 15%, #000 30%, #000 50%, transparent 60%)',
-  },
-  {
-    blur: 4,
-    mask: 'linear-gradient(to top, transparent 20%, #000 40%, #000 60%, transparent 70%)',
-  },
-  {
-    blur: 8,
-    mask: 'linear-gradient(to top, transparent 40%, #000 60%, #000 80%, transparent 90%)',
-  },
-  { blur: 16, mask: 'linear-gradient(to top, transparent 60%, #000 80%)' },
-  { blur: 24, mask: 'linear-gradient(to top, transparent 70%, #000 100%)' },
-]
 
 interface HeaderProps {
   className?: string
@@ -78,36 +48,7 @@ export function Header({ className, items = [] }: HeaderProps) {
         aria-hidden
         className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] header-blur-reveal"
       >
-        {BLUR_LAYERS.map(({ blur, mask }) => (
-          <div
-            key={blur}
-            className="absolute inset-0"
-            style={{
-              backdropFilter: `blur(calc(var(--blur-progress, 0) * ${blur}px))`,
-              WebkitBackdropFilter: `blur(calc(var(--blur-progress, 0) * ${blur}px))`,
-              maskImage: mask,
-              WebkitMaskImage: mask,
-            }}
-          />
-        ))}
-        <div
-          className="absolute inset-0"
-          style={{
-            // Darkness rides this element's opacity (0.9 at full scroll) — never the
-            // backdrop-filter layers, which would form an opacity group and drop the
-            // blur. The gradient peaks at full --color-bg at the top.
-            opacity: 'calc(var(--blur-progress, 0) * 0.9)',
-            background:
-              'linear-gradient(to top, transparent 0%, color-mix(in oklab, var(--color-bg) 76%, transparent) 55%, var(--color-bg) 100%)',
-          }}
-        />
-        <div
-          aria-hidden
-          className="absolute inset-0 header-blur-dither"
-          style={{
-            opacity: 'calc(var(--blur-progress, 0) * 0.035)',
-          }}
-        />
+        <ProgressiveBlur />
       </div>
       <div className="flex items-center gap-3 md:gap-6">
         <Logo />

--- a/www/src/components/progressive-blur.tsx
+++ b/www/src/components/progressive-blur.tsx
@@ -33,8 +33,10 @@ const BLUR_LAYERS = [
  * The layered blur + `--color-bg` tint stack behind the app header and the
  * create preview toolbar. Fills its positioned parent; strongest at the top,
  * dissolving to sharp at the bottom. Intensity rides `--blur-progress`
- * (registered in styles.css, initial 0): the header animates it with a scroll
- * timeline, always-on overlays pin `[--blur-progress:1]` on their wrapper.
+ * (registered in styles.css, initial 0): drive it with the `blur-reveal` /
+ * `blur-reveal-nearest` utilities (scroll timelines) or pin it manually
+ * (inline style / JS writes) — never both on one wrapper, since an animated
+ * custom property outranks inline style.
  */
 export function ProgressiveBlur() {
   return (

--- a/www/src/components/progressive-blur.tsx
+++ b/www/src/components/progressive-blur.tsx
@@ -1,0 +1,74 @@
+// iOS-style progressive blur: each layer adds a larger backdrop blur over an
+// overlapping gradient window. Where the windows overlap the blurs compound,
+// ramping smoothly from sharp (bottom edge) to heavily blurred (top). The
+// `to top` direction puts the strongest blur under the overlaid content. The
+// positioned parent must stay mask-free — a mask there establishes a backdrop
+// root and kills the cross-layer compounding that makes the ramp smooth.
+const BLUR_LAYERS = [
+  {
+    blur: 0.5,
+    mask: 'linear-gradient(to top, transparent 0%, #000 10%, #000 30%, transparent 40%)',
+  },
+  {
+    blur: 1,
+    mask: 'linear-gradient(to top, transparent 10%, #000 20%, #000 40%, transparent 50%)',
+  },
+  {
+    blur: 2,
+    mask: 'linear-gradient(to top, transparent 15%, #000 30%, #000 50%, transparent 60%)',
+  },
+  {
+    blur: 4,
+    mask: 'linear-gradient(to top, transparent 20%, #000 40%, #000 60%, transparent 70%)',
+  },
+  {
+    blur: 8,
+    mask: 'linear-gradient(to top, transparent 40%, #000 60%, #000 80%, transparent 90%)',
+  },
+  { blur: 16, mask: 'linear-gradient(to top, transparent 60%, #000 80%)' },
+  { blur: 24, mask: 'linear-gradient(to top, transparent 70%, #000 100%)' },
+]
+
+/**
+ * The layered blur + `--color-bg` tint stack behind the app header and the
+ * create preview toolbar. Fills its positioned parent; strongest at the top,
+ * dissolving to sharp at the bottom. Intensity rides `--blur-progress`
+ * (registered in styles.css, initial 0): the header animates it with a scroll
+ * timeline, always-on overlays pin `[--blur-progress:1]` on their wrapper.
+ */
+export function ProgressiveBlur() {
+  return (
+    <>
+      {BLUR_LAYERS.map(({ blur, mask }) => (
+        <div
+          key={blur}
+          className="absolute inset-0"
+          style={{
+            backdropFilter: `blur(calc(var(--blur-progress, 0) * ${blur}px))`,
+            WebkitBackdropFilter: `blur(calc(var(--blur-progress, 0) * ${blur}px))`,
+            maskImage: mask,
+            WebkitMaskImage: mask,
+          }}
+        />
+      ))}
+      <div
+        className="absolute inset-0"
+        style={{
+          // Darkness rides this element's opacity (0.9 at full progress) — never the
+          // backdrop-filter layers, which would form an opacity group and drop the
+          // blur. The gradient peaks at full --color-bg at the top.
+          opacity: 'calc(var(--blur-progress, 0) * 0.9)',
+          background:
+            'linear-gradient(to top, transparent 0%, color-mix(in oklab, var(--color-bg) 76%, transparent) 55%, var(--color-bg) 100%)',
+        }}
+      />
+      <div
+        aria-hidden
+        className="absolute inset-0 progressive-blur-dither"
+        style={{
+          opacity: 'calc(var(--blur-progress, 0) * 0.035)',
+        }}
+      />
+    </>
+  )
+}

--- a/www/src/modules/create/preset/iframe-sync.ts
+++ b/www/src/modules/create/preset/iframe-sync.ts
@@ -12,9 +12,7 @@ type ParentToIframeMessage =
   | { type: 'design-system'; data: DesignSystem }
   | { type: 'preview-mode'; mode: PreviewMode }
 
-type IframeToParentMessage =
-  | { type: 'preview-ready' }
-  | { type: 'preview-scrolled'; scrolled: boolean }
+type IframeToParentMessage = { type: 'preview-ready' }
 
 /* ------------------------------ Send (parent) ------------------------------ */
 
@@ -103,29 +101,4 @@ export function usePreviewForcedTheme(): PreviewMode | undefined {
   }, [])
 
   return mode
-}
-
-/**
- * Inside the preview iframe: report whether the document is scrolled past the top, so
- * the embedding toolbar can reveal its bottom border. Sends only on threshold crossings,
- * plus once on mount — which also resets the parent after an iframe reload.
- */
-export function useReportPreviewScrolled() {
-  React.useEffect(() => {
-    if (!isInIframe()) return
-
-    let last: boolean | undefined
-    const report = () => {
-      const scrolled = window.scrollY > 0
-      if (scrolled === last) return
-      last = scrolled
-      window.parent.postMessage(
-        { type: 'preview-scrolled', scrolled } satisfies IframeToParentMessage,
-        '*',
-      )
-    }
-    report()
-    window.addEventListener('scroll', report, { passive: true })
-    return () => window.removeEventListener('scroll', report)
-  }, [])
 }

--- a/www/src/modules/create/preset/iframe-sync.ts
+++ b/www/src/modules/create/preset/iframe-sync.ts
@@ -12,6 +12,10 @@ type ParentToIframeMessage =
   | { type: 'design-system'; data: DesignSystem }
   | { type: 'preview-mode'; mode: PreviewMode }
 
+type IframeToParentMessage =
+  | { type: 'preview-ready' }
+  | { type: 'preview-scrolled'; scrolled: boolean }
+
 /* ------------------------------ Send (parent) ------------------------------ */
 
 export function sendToIframe(
@@ -91,9 +95,37 @@ export function usePreviewForcedTheme(): PreviewMode | undefined {
     window.addEventListener('message', handleMessage)
     // Signal readiness so the parent (re)sends the current mode — its load-event send can
     // race ahead of this listener mounting.
-    window.parent.postMessage({ type: 'preview-ready' }, '*')
+    window.parent.postMessage(
+      { type: 'preview-ready' } satisfies IframeToParentMessage,
+      '*',
+    )
     return () => window.removeEventListener('message', handleMessage)
   }, [])
 
   return mode
+}
+
+/**
+ * Inside the preview iframe: report whether the document is scrolled past the top, so
+ * the embedding toolbar can reveal its bottom border. Sends only on threshold crossings,
+ * plus once on mount — which also resets the parent after an iframe reload.
+ */
+export function useReportPreviewScrolled() {
+  React.useEffect(() => {
+    if (!isInIframe()) return
+
+    let last: boolean | undefined
+    const report = () => {
+      const scrolled = window.scrollY > 0
+      if (scrolled === last) return
+      last = scrolled
+      window.parent.postMessage(
+        { type: 'preview-scrolled', scrolled } satisfies IframeToParentMessage,
+        '*',
+      )
+    }
+    report()
+    window.addEventListener('scroll', report, { passive: true })
+    return () => window.removeEventListener('scroll', report)
+  }, [])
 }

--- a/www/src/modules/create/preset/iframe-sync.ts
+++ b/www/src/modules/create/preset/iframe-sync.ts
@@ -12,7 +12,9 @@ type ParentToIframeMessage =
   | { type: 'design-system'; data: DesignSystem }
   | { type: 'preview-mode'; mode: PreviewMode }
 
-type IframeToParentMessage = { type: 'preview-ready' }
+type IframeToParentMessage =
+  | { type: 'preview-ready' }
+  | { type: 'preview-scroll'; progress: number }
 
 /* ------------------------------ Send (parent) ------------------------------ */
 
@@ -101,4 +103,32 @@ export function usePreviewForcedTheme(): PreviewMode | undefined {
   }, [])
 
   return mode
+}
+
+/**
+ * Inside the preview iframe: report scroll progress (0 at rest → 1 at `range` px)
+ * so the embedding toolbar can reveal its blur the way the app header does. CSS
+ * scroll timelines can't cross the document boundary — the parent's CSS cannot
+ * observe this document's scroller — so the progress travels by postMessage
+ * instead: one message per scroll frame, only while the value actually changes.
+ * The mount-time report also resets the parent after an iframe reload.
+ */
+export function useReportScrollProgress(range: number) {
+  React.useEffect(() => {
+    if (!isInIframe()) return
+
+    let last = -1
+    const report = () => {
+      const progress = Math.min(1, Math.max(0, window.scrollY / range))
+      if (progress === last) return
+      last = progress
+      window.parent.postMessage(
+        { type: 'preview-scroll', progress } satisfies IframeToParentMessage,
+        '*',
+      )
+    }
+    report()
+    window.addEventListener('scroll', report, { passive: true })
+    return () => window.removeEventListener('scroll', report)
+  }, [range])
 }

--- a/www/src/modules/create/preset/index.ts
+++ b/www/src/modules/create/preset/index.ts
@@ -6,6 +6,7 @@ export {
   sendToIframe,
   useIframeMessageListener,
   usePreviewForcedTheme,
+  useReportPreviewScrolled,
 } from './iframe-sync'
 export { useDesignSystem } from './use-design-system'
 export type {

--- a/www/src/modules/create/preset/index.ts
+++ b/www/src/modules/create/preset/index.ts
@@ -6,6 +6,7 @@ export {
   sendToIframe,
   useIframeMessageListener,
   usePreviewForcedTheme,
+  useReportScrollProgress,
 } from './iframe-sync'
 export { useDesignSystem } from './use-design-system'
 export type {

--- a/www/src/modules/create/preset/index.ts
+++ b/www/src/modules/create/preset/index.ts
@@ -6,7 +6,6 @@ export {
   sendToIframe,
   useIframeMessageListener,
   usePreviewForcedTheme,
-  useReportPreviewScrolled,
 } from './iframe-sync'
 export { useDesignSystem } from './use-design-system'
 export type {

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -73,6 +73,7 @@ export function PreviewPanel({ className }: { className?: string }) {
 
   const panelRef = useRef<HTMLDivElement>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const blurRef = useRef<HTMLDivElement>(null)
   const [previewMode, setPreviewMode] = useState<PreviewMode>('light')
   const [size, setSize] = useState<DeviceSize>('desktop')
   const [zoom, setZoom] = useState(1)
@@ -139,6 +140,24 @@ export function PreviewPanel({ className }: { className?: string }) {
     }
   }, [previewMode])
 
+  // The iframe reports its scroll progress (0→1 over the first toolbar-height of
+  // scroll — see useReportScrollProgress); write it straight onto the blur wrapper's
+  // --blur-progress, bypassing React state: this fires every scroll frame and a
+  // re-render per frame would be waste. Gives the toolbar the app header's smooth
+  // scroll reveal, which a CSS scroll timeline can't do across the iframe boundary.
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'preview-scroll') {
+        blurRef.current?.style.setProperty(
+          '--blur-progress',
+          String(event.data.progress),
+        )
+      }
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [])
+
   // Keep the fullscreen toggle's icon in sync with the actual state — exiting via Esc
   // (not just the button) still flips it back.
   useEffect(() => {
@@ -192,12 +211,12 @@ export function PreviewPanel({ className }: { className?: string }) {
       </div>
 
       {/* Toolbar — overlays the top of the stage with the app header's progressive
-          blur (pinned always-on via [--blur-progress:1] — no scroll reveal here), so
-          the preview dissolves into a blurred tint beneath the controls. Scoped to
-          the previewed design system's palette + mode so the tint's --color-bg
-          matches the iframe's background, not the site's. The wrapper is
-          pointer-events-none so empty areas click through to the preview; each
-          control cluster re-enables pointer events. */}
+          blur, revealed by the iframe's scroll progress (written onto --blur-progress
+          above), so the preview dissolves into a blurred tint as content slides under
+          the controls. Scoped to the previewed design system's palette + mode so the
+          tint's --color-bg matches the iframe's background, not the site's. The
+          wrapper is pointer-events-none so empty areas click through to the preview;
+          each control cluster re-enables pointer events. */}
       <div className="pointer-events-none absolute inset-x-0 top-0 z-20">
         <DesignSystemProvider
           scoped
@@ -205,8 +224,9 @@ export function PreviewPanel({ className }: { className?: string }) {
           forcedMode={previewMode}
         >
           <div
+            ref={blurRef}
             aria-hidden
-            className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] [--blur-progress:1]"
+            className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%]"
           >
             <ProgressiveBlur />
           </div>

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -31,6 +31,7 @@ import { Select, SelectValue } from '@/registry/ui/select'
 import { ToggleButton } from '@/registry/ui/toggle-button'
 import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+import { ProgressiveBlur } from '@/components/progressive-blur'
 import {
   sendPreviewMode,
   sendToIframe,
@@ -38,6 +39,7 @@ import {
 } from '@/modules/create/preset'
 import type { PreviewMode } from '@/modules/create/preset'
 import { componentsData } from '@/modules/docs/components-list/components-data'
+import { useTweak } from '@/dev/tweaker'
 
 type DeviceSize = 'mobile' | 'tablet' | 'desktop'
 
@@ -64,6 +66,11 @@ const ZOOM_LEVELS = [0.5, 0.75, 1, 1.25, 1.5, 2]
 
 const routeApi = getRouteApi('/_app/create')
 
+// dev-tweak scaffolding: the create page's tweaker drives the iframe's scrollbar
+// mode through localStorage — cross-document `storage` events make it live without
+// touching the postMessage protocol. Key duplicated in routes/preview/$slug.tsx.
+const DEV_SCROLLBAR_TWEAK_KEY = 'dotui:dev-preview-scrollbar'
+
 export function PreviewPanel({ className }: { className?: string }) {
   const { preview, preset } = routeApi.useSearch()
   const navigate = routeApi.useNavigate()
@@ -77,6 +84,25 @@ export function PreviewPanel({ className }: { className?: string }) {
   const [zoom, setZoom] = useState(1)
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
+
+  // dev-tweak scaffolding (remove once picked)
+  const blurTweak = useTweak('Blur', {
+    type: 'select',
+    options: ['frosted', 'progressive'],
+    default: 'frosted',
+    group: 'Preview toolbar',
+  })
+  const scrollbarTweak = useTweak('Scrollbar', {
+    type: 'select',
+    options: ['custom', 'auto-hide', 'none', 'native'],
+    default: 'custom',
+    group: 'Preview toolbar',
+  })
+  useEffect(() => {
+    if (import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview') {
+      localStorage.setItem(DEV_SCROLLBAR_TWEAK_KEY, scrollbarTweak)
+    }
+  }, [scrollbarTweak])
 
   const effectivePreview = preview
   const constrained = size !== 'desktop'
@@ -217,13 +243,22 @@ export function PreviewPanel({ className }: { className?: string }) {
           color={designSystem.color}
           forcedMode={previewMode}
         >
-          <div
-            aria-hidden
-            className={cn(
-              'pointer-events-none absolute inset-x-0 top-0 -z-10 h-(--header-height) border-b bg-bg/75 backdrop-blur-md transition-colors duration-300',
-              scrolled ? 'border-border' : 'border-transparent',
-            )}
-          />
+          {blurTweak === 'progressive' ? (
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] [--blur-progress:1]"
+            >
+              <ProgressiveBlur />
+            </div>
+          ) : (
+            <div
+              aria-hidden
+              className={cn(
+                'pointer-events-none absolute inset-x-0 top-0 -z-10 h-(--header-height) border-b bg-bg/75 backdrop-blur-md transition-colors duration-300',
+                scrolled ? 'border-border' : 'border-transparent',
+              )}
+            />
+          )}
         </DesignSystemProvider>
 
         <div className="relative flex h-(--header-height) items-center gap-2 px-3">

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -31,7 +31,6 @@ import { Select, SelectValue } from '@/registry/ui/select'
 import { ToggleButton } from '@/registry/ui/toggle-button'
 import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
-import { ProgressiveBlur } from '@/components/progressive-blur'
 import {
   sendPreviewMode,
   sendToIframe,
@@ -77,6 +76,7 @@ export function PreviewPanel({ className }: { className?: string }) {
   const [size, setSize] = useState<DeviceSize>('desktop')
   const [zoom, setZoom] = useState(1)
   const [isFullscreen, setIsFullscreen] = useState(false)
+  const [scrolled, setScrolled] = useState(false)
 
   const effectivePreview = preview
   const constrained = size !== 'desktop'
@@ -139,6 +139,19 @@ export function PreviewPanel({ className }: { className?: string }) {
     }
   }, [previewMode])
 
+  // The iframe reports whether its document is scrolled past the top (threshold
+  // crossings only); the toolbar reveals its bottom border while it is. A reloaded
+  // iframe re-reports on mount, which also resets the state.
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'preview-scrolled') {
+        setScrolled(Boolean(event.data.scrolled))
+      }
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [])
+
   // Keep the fullscreen toggle's icon in sync with the actual state — exiting via Esc
   // (not just the button) still flips it back.
   useEffect(() => {
@@ -165,7 +178,7 @@ export function PreviewPanel({ className }: { className?: string }) {
       )}
     >
       {/* Stage — holds the iframe at full height for every device size; the toolbar's
-          progressive blur overlays its top edge. Smaller sizes narrow the iframe and center
+          frosted bar overlays its top edge. Smaller sizes narrow the iframe and center
           it on a muted backdrop. Scrolls when zoomed past fit. */}
       <div
         className={cn(
@@ -191,11 +204,11 @@ export function PreviewPanel({ className }: { className?: string }) {
         </div>
       </div>
 
-      {/* Toolbar — overlays the top of the stage with the app header's progressive
-          blur, so the preview dissolves into a blurred tint beneath the controls.
-          Pinned always-on ([--blur-progress:1] — no scroll reveal here), and scoped
-          to the previewed design system's palette + mode so the tint's --color-bg
-          matches the iframe's background, not the site's. The wrapper is
+      {/* Toolbar — a frosted bar overlaying the top of the stage: uniform blur + a
+          translucent background, with a bottom border that fades in once the preview
+          is scrolled (reported by the iframe — see useReportPreviewScrolled). Scoped
+          to the previewed design system's palette + mode so the tint and border
+          resolve the preset's tokens, not the site's. The wrapper is
           pointer-events-none so empty areas click through to the preview; each
           control cluster re-enables pointer events. */}
       <div className="pointer-events-none absolute inset-x-0 top-0 z-20">
@@ -206,10 +219,11 @@ export function PreviewPanel({ className }: { className?: string }) {
         >
           <div
             aria-hidden
-            className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] [--blur-progress:1]"
-          >
-            <ProgressiveBlur />
-          </div>
+            className={cn(
+              'pointer-events-none absolute inset-x-0 top-0 -z-10 h-(--header-height) border-b bg-bg/75 backdrop-blur-md transition-colors duration-300',
+              scrolled ? 'border-border' : 'border-transparent',
+            )}
+          />
         </DesignSystemProvider>
 
         <div className="relative flex h-(--header-height) items-center gap-2 px-3">

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -39,7 +39,6 @@ import {
 } from '@/modules/create/preset'
 import type { PreviewMode } from '@/modules/create/preset'
 import { componentsData } from '@/modules/docs/components-list/components-data'
-import { useTweak } from '@/dev/tweaker'
 
 type DeviceSize = 'mobile' | 'tablet' | 'desktop'
 
@@ -66,11 +65,6 @@ const ZOOM_LEVELS = [0.5, 0.75, 1, 1.25, 1.5, 2]
 
 const routeApi = getRouteApi('/_app/create')
 
-// dev-tweak scaffolding: the create page's tweaker drives the iframe's scrollbar
-// mode through localStorage — cross-document `storage` events make it live without
-// touching the postMessage protocol. Key duplicated in routes/preview/$slug.tsx.
-const DEV_SCROLLBAR_TWEAK_KEY = 'dotui:dev-preview-scrollbar'
-
 export function PreviewPanel({ className }: { className?: string }) {
   const { preview, preset } = routeApi.useSearch()
   const navigate = routeApi.useNavigate()
@@ -83,26 +77,6 @@ export function PreviewPanel({ className }: { className?: string }) {
   const [size, setSize] = useState<DeviceSize>('desktop')
   const [zoom, setZoom] = useState(1)
   const [isFullscreen, setIsFullscreen] = useState(false)
-  const [scrolled, setScrolled] = useState(false)
-
-  // dev-tweak scaffolding (remove once picked)
-  const blurTweak = useTweak('Blur', {
-    type: 'select',
-    options: ['frosted', 'progressive'],
-    default: 'frosted',
-    group: 'Preview toolbar',
-  })
-  const scrollbarTweak = useTweak('Scrollbar', {
-    type: 'select',
-    options: ['custom', 'auto-hide', 'none', 'native'],
-    default: 'custom',
-    group: 'Preview toolbar',
-  })
-  useEffect(() => {
-    if (import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview') {
-      localStorage.setItem(DEV_SCROLLBAR_TWEAK_KEY, scrollbarTweak)
-    }
-  }, [scrollbarTweak])
 
   const effectivePreview = preview
   const constrained = size !== 'desktop'
@@ -165,19 +139,6 @@ export function PreviewPanel({ className }: { className?: string }) {
     }
   }, [previewMode])
 
-  // The iframe reports whether its document is scrolled past the top (threshold
-  // crossings only); the toolbar reveals its bottom border while it is. A reloaded
-  // iframe re-reports on mount, which also resets the state.
-  useEffect(() => {
-    const onMessage = (event: MessageEvent) => {
-      if (event.data?.type === 'preview-scrolled') {
-        setScrolled(Boolean(event.data.scrolled))
-      }
-    }
-    window.addEventListener('message', onMessage)
-    return () => window.removeEventListener('message', onMessage)
-  }, [])
-
   // Keep the fullscreen toggle's icon in sync with the actual state — exiting via Esc
   // (not just the button) still flips it back.
   useEffect(() => {
@@ -204,7 +165,7 @@ export function PreviewPanel({ className }: { className?: string }) {
       )}
     >
       {/* Stage — holds the iframe at full height for every device size; the toolbar's
-          frosted bar overlays its top edge. Smaller sizes narrow the iframe and center
+          progressive blur overlays its top edge. Smaller sizes narrow the iframe and center
           it on a muted backdrop. Scrolls when zoomed past fit. */}
       <div
         className={cn(
@@ -230,11 +191,11 @@ export function PreviewPanel({ className }: { className?: string }) {
         </div>
       </div>
 
-      {/* Toolbar — a frosted bar overlaying the top of the stage: uniform blur + a
-          translucent background, with a bottom border that fades in once the preview
-          is scrolled (reported by the iframe — see useReportPreviewScrolled). Scoped
-          to the previewed design system's palette + mode so the tint and border
-          resolve the preset's tokens, not the site's. The wrapper is
+      {/* Toolbar — overlays the top of the stage with the app header's progressive
+          blur (pinned always-on via [--blur-progress:1] — no scroll reveal here), so
+          the preview dissolves into a blurred tint beneath the controls. Scoped to
+          the previewed design system's palette + mode so the tint's --color-bg
+          matches the iframe's background, not the site's. The wrapper is
           pointer-events-none so empty areas click through to the preview; each
           control cluster re-enables pointer events. */}
       <div className="pointer-events-none absolute inset-x-0 top-0 z-20">
@@ -243,22 +204,12 @@ export function PreviewPanel({ className }: { className?: string }) {
           color={designSystem.color}
           forcedMode={previewMode}
         >
-          {blurTweak === 'progressive' ? (
-            <div
-              aria-hidden
-              className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] [--blur-progress:1]"
-            >
-              <ProgressiveBlur />
-            </div>
-          ) : (
-            <div
-              aria-hidden
-              className={cn(
-                'pointer-events-none absolute inset-x-0 top-0 -z-10 h-(--header-height) border-b bg-bg/75 backdrop-blur-md transition-colors duration-300',
-                scrolled ? 'border-border' : 'border-transparent',
-              )}
-            />
-          )}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] [--blur-progress:1]"
+          >
+            <ProgressiveBlur />
+          </div>
         </DesignSystemProvider>
 
         <div className="relative flex h-(--header-height) items-center gap-2 px-3">

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react'
 import { useTheme } from 'starter-themes'
 
+import { DesignSystemProvider } from '@/lib/styles'
 import { cn } from '@/registry/lib/utils'
 import { Button } from '@/registry/ui/button'
 import { Command } from '@/registry/ui/command'
@@ -30,6 +31,7 @@ import { Select, SelectValue } from '@/registry/ui/select'
 import { ToggleButton } from '@/registry/ui/toggle-button'
 import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
 import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
+import { ProgressiveBlur } from '@/components/progressive-blur'
 import {
   sendPreviewMode,
   sendToIframe,
@@ -163,7 +165,7 @@ export function PreviewPanel({ className }: { className?: string }) {
       )}
     >
       {/* Stage — holds the iframe at full height for every device size; the toolbar's
-          background fade overlays its top edge. Smaller sizes narrow the iframe and center
+          progressive blur overlays its top edge. Smaller sizes narrow the iframe and center
           it on a muted backdrop. Scrolls when zoomed past fit. */}
       <div
         className={cn(
@@ -189,19 +191,26 @@ export function PreviewPanel({ className }: { className?: string }) {
         </div>
       </div>
 
-      {/* Toolbar — overlays the top of the stage. A background-to-transparent fade (no
-          blur), the height of the app header, lets the preview dissolve into the page
-          color beneath the controls. The wrapper is pointer-events-none so empty areas
-          click through to the preview; each control cluster re-enables pointer events. */}
+      {/* Toolbar — overlays the top of the stage with the app header's progressive
+          blur, so the preview dissolves into a blurred tint beneath the controls.
+          Pinned always-on ([--blur-progress:1] — no scroll reveal here), and scoped
+          to the previewed design system's palette + mode so the tint's --color-bg
+          matches the iframe's background, not the site's. The wrapper is
+          pointer-events-none so empty areas click through to the preview; each
+          control cluster re-enables pointer events. */}
       <div className="pointer-events-none absolute inset-x-0 top-0 z-20">
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-(--header-height)"
-          style={{
-            background:
-              'linear-gradient(to bottom, var(--color-bg) 0%, var(--color-bg) 25%, transparent 100%)',
-          }}
-        />
+        <DesignSystemProvider
+          scoped
+          color={designSystem.color}
+          forcedMode={previewMode}
+        >
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] [--blur-progress:1]"
+          >
+            <ProgressiveBlur />
+          </div>
+        </DesignSystemProvider>
 
         <div className="relative flex h-(--header-height) items-center gap-2 px-3">
           {/* Preview selector */}

--- a/www/src/routeTree.gen.ts
+++ b/www/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as RNameRouteImport } from './routes/r/$name'
 import { Route as PreviewSlugRouteImport } from './routes/preview/$slug'
 import { Route as InternalColorsRouteImport } from './routes/internal.colors'
 import { Route as InternalColorLabRouteImport } from './routes/internal.color-lab'
+import { Route as InternalBlurRevealRouteImport } from './routes/internal.blur-reveal'
 import { Route as DemosSlugRouteImport } from './routes/demos/$slug'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 import { Route as AppPresetsRouteImport } from './routes/_app/presets'
@@ -109,6 +110,11 @@ const InternalColorLabRoute = InternalColorLabRouteImport.update({
   path: '/internal/color-lab',
   getParentRoute: () => rootRouteImport,
 } as any)
+const InternalBlurRevealRoute = InternalBlurRevealRouteImport.update({
+  id: '/internal/blur-reveal',
+  path: '/internal/blur-reveal',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DemosSlugRoute = DemosSlugRouteImport.update({
   id: '/demos/$slug',
   path: '/demos/$slug',
@@ -177,6 +183,7 @@ export interface FileRoutesByFullPath {
   '/presets': typeof AppPresetsRoute
   '/api/search': typeof ApiSearchRoute
   '/demos/$slug': typeof DemosSlugRoute
+  '/internal/blur-reveal': typeof InternalBlurRevealRoute
   '/internal/color-lab': typeof InternalColorLabRoute
   '/internal/colors': typeof InternalColorsRoute
   '/preview/$slug': typeof PreviewSlugRoute
@@ -202,6 +209,7 @@ export interface FileRoutesByTo {
   '/presets': typeof AppPresetsRoute
   '/api/search': typeof ApiSearchRoute
   '/demos/$slug': typeof DemosSlugRoute
+  '/internal/blur-reveal': typeof InternalBlurRevealRoute
   '/internal/color-lab': typeof InternalColorLabRoute
   '/internal/colors': typeof InternalColorsRoute
   '/preview/$slug': typeof PreviewSlugRoute
@@ -230,6 +238,7 @@ export interface FileRoutesById {
   '/_app/presets': typeof AppPresetsRoute
   '/api/search': typeof ApiSearchRoute
   '/demos/$slug': typeof DemosSlugRoute
+  '/internal/blur-reveal': typeof InternalBlurRevealRoute
   '/internal/color-lab': typeof InternalColorLabRoute
   '/internal/colors': typeof InternalColorsRoute
   '/preview/$slug': typeof PreviewSlugRoute
@@ -259,6 +268,7 @@ export interface FileRouteTypes {
     | '/presets'
     | '/api/search'
     | '/demos/$slug'
+    | '/internal/blur-reveal'
     | '/internal/color-lab'
     | '/internal/colors'
     | '/preview/$slug'
@@ -284,6 +294,7 @@ export interface FileRouteTypes {
     | '/presets'
     | '/api/search'
     | '/demos/$slug'
+    | '/internal/blur-reveal'
     | '/internal/color-lab'
     | '/internal/colors'
     | '/preview/$slug'
@@ -311,6 +322,7 @@ export interface FileRouteTypes {
     | '/_app/presets'
     | '/api/search'
     | '/demos/$slug'
+    | '/internal/blur-reveal'
     | '/internal/color-lab'
     | '/internal/colors'
     | '/preview/$slug'
@@ -334,6 +346,7 @@ export interface RootRouteChildren {
   DotwellKnownApiCatalogRoute: typeof DotwellKnownApiCatalogRoute
   ApiSearchRoute: typeof ApiSearchRoute
   DemosSlugRoute: typeof DemosSlugRoute
+  InternalBlurRevealRoute: typeof InternalBlurRevealRoute
   InternalColorLabRoute: typeof InternalColorLabRoute
   InternalColorsRoute: typeof InternalColorsRoute
   PreviewSlugRoute: typeof PreviewSlugRoute
@@ -448,6 +461,13 @@ declare module '@tanstack/react-router' {
       path: '/internal/color-lab'
       fullPath: '/internal/color-lab'
       preLoaderRoute: typeof InternalColorLabRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/internal/blur-reveal': {
+      id: '/internal/blur-reveal'
+      path: '/internal/blur-reveal'
+      fullPath: '/internal/blur-reveal'
+      preLoaderRoute: typeof InternalBlurRevealRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/demos/$slug': {
@@ -570,6 +590,7 @@ const rootRouteChildren: RootRouteChildren = {
   DotwellKnownApiCatalogRoute: DotwellKnownApiCatalogRoute,
   ApiSearchRoute: ApiSearchRoute,
   DemosSlugRoute: DemosSlugRoute,
+  InternalBlurRevealRoute: InternalBlurRevealRoute,
   InternalColorLabRoute: InternalColorLabRoute,
   InternalColorsRoute: InternalColorsRoute,
   PreviewSlugRoute: PreviewSlugRoute,

--- a/www/src/routes/internal.blur-reveal.tsx
+++ b/www/src/routes/internal.blur-reveal.tsx
@@ -1,0 +1,83 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { ProgressiveBlur } from '@/components/progressive-blur'
+
+export const Route = createFileRoute('/internal/blur-reveal')({
+  component: BlurRevealDemo,
+})
+
+// Internal demo of the blur-reveal utilities (styles.css) paired with
+// ProgressiveBlur: the root-scroll driver on a page header, and the
+// nearest-scroller driver with a custom range on a sticky bar inside an
+// overflow-auto card.
+function BlurRevealDemo() {
+  return (
+    <div className="min-h-screen bg-bg text-fg">
+      {/* Root-scroll driver — same anatomy as the app header: the utility rides
+          the mask-free wrapper, the fallback rides the bar itself. */}
+      <header className="sticky top-0 z-10 flex h-14 items-center blur-reveal-fallback px-6">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] blur-reveal"
+        >
+          <ProgressiveBlur />
+        </div>
+        <span className="text-sm font-medium">
+          blur-reveal — document scroll
+        </span>
+      </header>
+
+      <div className="space-y-8 px-6 pb-24">
+        <p className="max-w-md text-sm text-fg-muted">
+          Scroll the page — the header's blur ramps in over the first header
+          height of scroll, exactly like the app navbar.
+        </p>
+
+        {/* Colorful rows so the blur ramp is visible under the bars. */}
+        <div className="grid grid-cols-3 gap-4">
+          {Array.from({ length: 9 }, (_, i) => (
+            <div
+              key={i}
+              className={
+                ['bg-primary', 'bg-accent-muted', 'bg-muted'][i % 3] +
+                ' h-28 rounded-lg'
+              }
+            />
+          ))}
+        </div>
+
+        {/* Nearest-scroller driver — the sticky bar's timeline binds to the
+            overflow-y-auto card, with a shortened 3rem reveal range. */}
+        <div className="max-w-sm">
+          <h2 className="mb-2 text-sm font-medium">
+            blur-reveal-nearest — card scroller, 3rem range
+          </h2>
+          <div className="h-96 overflow-y-auto rounded-xl border">
+            <div className="sticky top-0 z-10 flex h-12 items-center blur-reveal-fallback px-4">
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[140%] blur-reveal-nearest [--blur-reveal-range:3rem]"
+              >
+                <ProgressiveBlur />
+              </div>
+              <span className="text-sm font-medium">Card header</span>
+            </div>
+            <div className="space-y-3 p-4">
+              {Array.from({ length: 24 }, (_, i) => (
+                <div
+                  key={i}
+                  className={
+                    (i % 4 === 0 ? 'bg-primary/60' : 'bg-muted') +
+                    ' h-9 rounded-md'
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="h-[60vh]" />
+      </div>
+    </div>
+  )
+}

--- a/www/src/routes/preview/$slug.tsx
+++ b/www/src/routes/preview/$slug.tsx
@@ -11,6 +11,7 @@ import {
   DEFAULTS,
   decodePreset,
   useIframeMessageListener,
+  useReportPreviewScrolled,
 } from '@/modules/create/preset'
 import type { DesignSystem } from '@/modules/create/preset'
 import { PresetOverview } from '@/modules/create/preview/overview'
@@ -34,6 +35,31 @@ function getExamplesPromise(slug: string) {
   return promise
 }
 
+// Embedded, the /create toolbar overlays the top 3.5rem of the viewport; the native
+// viewport scrollbar would run beneath it and get caught in its blur. Styling the
+// scrollbar (WebKit classic mode) lets the track start below the toolbar via a
+// margin, so the thumb only ever travels in the visible area. Firefox has no track
+// margin — it falls back to a thin full-height scrollbar.
+const EMBEDDED_SCROLLBAR_CSS = `
+html::-webkit-scrollbar { width: 10px; }
+html::-webkit-scrollbar-track { margin-block-start: 3.5rem; }
+html::-webkit-scrollbar-thumb {
+  background-color: color-mix(in oklab, var(--color-fg) 28%, transparent);
+  background-clip: padding-box;
+  border: 3px solid transparent;
+  border-radius: 999px;
+}
+html::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in oklab, var(--color-fg) 45%, transparent);
+}
+@supports not selector(::-webkit-scrollbar) {
+  html {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in oklab, var(--color-fg) 35%, transparent) transparent;
+  }
+}
+`
+
 export const Route = createFileRoute('/preview/$slug')({
   validateSearch: z.object({ preset: z.string().optional().catch(undefined) }),
   ssr: false,
@@ -53,6 +79,7 @@ function PreviewPage() {
   useIframeMessageListener(
     useCallback((ds: DesignSystem) => setDesignSystem(ds), []),
   )
+  useReportPreviewScrolled()
 
   // The "overview" slug isn't a component/group example — it's a bespoke style-guide
   // view that needs the raw designSystem (for the generated color ramps), so it's
@@ -88,6 +115,7 @@ function PreviewPage() {
       color={designSystem.color}
       icons={designSystem.icons}
     >
+      {embedded && <style>{EMBEDDED_SCROLLBAR_CSS}</style>}
       <div className={embedded ? 'pt-11' : undefined}>{content}</div>
     </DesignSystemProvider>
   )

--- a/www/src/routes/preview/$slug.tsx
+++ b/www/src/routes/preview/$slug.tsx
@@ -11,6 +11,7 @@ import {
   DEFAULTS,
   decodePreset,
   useIframeMessageListener,
+  useReportScrollProgress,
 } from '@/modules/create/preset'
 import type { DesignSystem } from '@/modules/create/preset'
 import { PresetOverview } from '@/modules/create/preview/overview'
@@ -63,6 +64,8 @@ function PreviewPage() {
   useIframeMessageListener(
     useCallback((ds: DesignSystem) => setDesignSystem(ds), []),
   )
+  // Ramp range mirrors the app header's reveal: one toolbar height (3.5rem) of scroll.
+  useReportScrollProgress(56)
 
   // The "overview" slug isn't a component/group example — it's a bespoke style-guide
   // view that needs the raw designSystem (for the generated color ramps), so it's

--- a/www/src/routes/preview/$slug.tsx
+++ b/www/src/routes/preview/$slug.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, use, useCallback, useEffect, useState } from 'react'
+import { type ReactNode, use, useCallback, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 
@@ -11,7 +11,6 @@ import {
   DEFAULTS,
   decodePreset,
   useIframeMessageListener,
-  useReportPreviewScrolled,
 } from '@/modules/create/preset'
 import type { DesignSystem } from '@/modules/create/preset'
 import { PresetOverview } from '@/modules/create/preview/overview'
@@ -36,96 +35,14 @@ function getExamplesPromise(slug: string) {
 }
 
 // Embedded, the /create toolbar overlays the top 3.5rem of the viewport; the native
-// viewport scrollbar would run beneath it and get caught in its blur. Styling the
-// scrollbar (WebKit classic mode) lets the track start below the toolbar via a
-// margin, so the thumb only ever travels in the visible area. Firefox has no track
-// margin — it falls back to a thin full-height scrollbar.
+// viewport scrollbar would run beneath it and get caught in its blur, and a styled
+// (classic-mode) scrollbar can't match the native overlay look. Hide it instead —
+// wheel/trackpad scrolling is unaffected. Standalone (open-in-new-tab) previews
+// keep the native scrollbar.
 const EMBEDDED_SCROLLBAR_CSS = `
-html::-webkit-scrollbar { width: 10px; }
-html::-webkit-scrollbar-track { margin-block-start: 3.5rem; }
-html::-webkit-scrollbar-thumb {
-  background-color: color-mix(in oklab, var(--color-fg) 28%, transparent);
-  background-clip: padding-box;
-  border: 3px solid transparent;
-  border-radius: 999px;
-}
-html::-webkit-scrollbar-thumb:hover {
-  background-color: color-mix(in oklab, var(--color-fg) 45%, transparent);
-}
-@supports not selector(::-webkit-scrollbar) {
-  html {
-    scrollbar-width: thin;
-    scrollbar-color: color-mix(in oklab, var(--color-fg) 35%, transparent) transparent;
-  }
-}
-`
-
-/* ---- dev-tweak scaffolding (remove once picked) ----
-   Scrollbar mode driven from the create page's tweaker via localStorage (key
-   duplicated from preview-panel.tsx); cross-document storage events make it live. */
-const DEV_SCROLLBAR_TWEAK_KEY = 'dotui:dev-preview-scrollbar'
-type DevScrollbarMode = 'custom' | 'auto-hide' | 'none' | 'native'
-const DEV_TWEAKS_ENABLED =
-  import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview'
-
-const DEV_SCROLLBAR_CSS: Record<DevScrollbarMode, string> = {
-  custom: EMBEDDED_SCROLLBAR_CSS,
-  // Custom below-toolbar track, but invisible at rest — the thumb shows only while
-  // scrolling (data attr set below) or hovered, mimicking macOS overlay behavior.
-  'auto-hide': `${EMBEDDED_SCROLLBAR_CSS}
-html:not([data-dev-scrolling])::-webkit-scrollbar-thumb { background-color: transparent; }
-html:not([data-dev-scrolling])::-webkit-scrollbar-thumb:hover {
-  background-color: color-mix(in oklab, var(--color-fg) 45%, transparent);
-}
-`,
-  none: `
 html { scrollbar-width: none; }
 html::-webkit-scrollbar { display: none; }
-`,
-  native: '',
-}
-
-function useDevScrollbarMode(): DevScrollbarMode {
-  const [mode, setMode] = useState<DevScrollbarMode>('custom')
-
-  useEffect(() => {
-    if (!DEV_TWEAKS_ENABLED) return
-    const read = () => {
-      const stored = localStorage.getItem(DEV_SCROLLBAR_TWEAK_KEY)
-      setMode(
-        stored && stored in DEV_SCROLLBAR_CSS
-          ? (stored as DevScrollbarMode)
-          : 'custom',
-      )
-    }
-    read()
-    window.addEventListener('storage', read)
-    return () => window.removeEventListener('storage', read)
-  }, [])
-
-  // auto-hide: flag the root while scrolling so the thumb shows only then.
-  useEffect(() => {
-    if (mode !== 'auto-hide') return
-    let timer: ReturnType<typeof setTimeout>
-    const onScroll = () => {
-      document.documentElement.setAttribute('data-dev-scrolling', '')
-      clearTimeout(timer)
-      timer = setTimeout(
-        () => document.documentElement.removeAttribute('data-dev-scrolling'),
-        800,
-      )
-    }
-    window.addEventListener('scroll', onScroll, { passive: true })
-    return () => {
-      clearTimeout(timer)
-      window.removeEventListener('scroll', onScroll)
-      document.documentElement.removeAttribute('data-dev-scrolling')
-    }
-  }, [mode])
-
-  return mode
-}
-/* ---- end dev-tweak scaffolding ---- */
+`
 
 export const Route = createFileRoute('/preview/$slug')({
   validateSearch: z.object({ preset: z.string().optional().catch(undefined) }),
@@ -146,8 +63,6 @@ function PreviewPage() {
   useIframeMessageListener(
     useCallback((ds: DesignSystem) => setDesignSystem(ds), []),
   )
-  useReportPreviewScrolled()
-  const devScrollbarMode = useDevScrollbarMode()
 
   // The "overview" slug isn't a component/group example — it's a bespoke style-guide
   // view that needs the raw designSystem (for the generated color ramps), so it's
@@ -183,9 +98,7 @@ function PreviewPage() {
       color={designSystem.color}
       icons={designSystem.icons}
     >
-      {embedded && DEV_SCROLLBAR_CSS[devScrollbarMode] && (
-        <style>{DEV_SCROLLBAR_CSS[devScrollbarMode]}</style>
-      )}
+      {embedded && <style>{EMBEDDED_SCROLLBAR_CSS}</style>}
       <div className={embedded ? 'pt-11' : undefined}>{content}</div>
     </DesignSystemProvider>
   )

--- a/www/src/routes/preview/$slug.tsx
+++ b/www/src/routes/preview/$slug.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, use, useCallback, useState } from 'react'
+import { type ReactNode, use, useCallback, useEffect, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 
@@ -60,6 +60,73 @@ html::-webkit-scrollbar-thumb:hover {
 }
 `
 
+/* ---- dev-tweak scaffolding (remove once picked) ----
+   Scrollbar mode driven from the create page's tweaker via localStorage (key
+   duplicated from preview-panel.tsx); cross-document storage events make it live. */
+const DEV_SCROLLBAR_TWEAK_KEY = 'dotui:dev-preview-scrollbar'
+type DevScrollbarMode = 'custom' | 'auto-hide' | 'none' | 'native'
+const DEV_TWEAKS_ENABLED =
+  import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview'
+
+const DEV_SCROLLBAR_CSS: Record<DevScrollbarMode, string> = {
+  custom: EMBEDDED_SCROLLBAR_CSS,
+  // Custom below-toolbar track, but invisible at rest — the thumb shows only while
+  // scrolling (data attr set below) or hovered, mimicking macOS overlay behavior.
+  'auto-hide': `${EMBEDDED_SCROLLBAR_CSS}
+html:not([data-dev-scrolling])::-webkit-scrollbar-thumb { background-color: transparent; }
+html:not([data-dev-scrolling])::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in oklab, var(--color-fg) 45%, transparent);
+}
+`,
+  none: `
+html { scrollbar-width: none; }
+html::-webkit-scrollbar { display: none; }
+`,
+  native: '',
+}
+
+function useDevScrollbarMode(): DevScrollbarMode {
+  const [mode, setMode] = useState<DevScrollbarMode>('custom')
+
+  useEffect(() => {
+    if (!DEV_TWEAKS_ENABLED) return
+    const read = () => {
+      const stored = localStorage.getItem(DEV_SCROLLBAR_TWEAK_KEY)
+      setMode(
+        stored && stored in DEV_SCROLLBAR_CSS
+          ? (stored as DevScrollbarMode)
+          : 'custom',
+      )
+    }
+    read()
+    window.addEventListener('storage', read)
+    return () => window.removeEventListener('storage', read)
+  }, [])
+
+  // auto-hide: flag the root while scrolling so the thumb shows only then.
+  useEffect(() => {
+    if (mode !== 'auto-hide') return
+    let timer: ReturnType<typeof setTimeout>
+    const onScroll = () => {
+      document.documentElement.setAttribute('data-dev-scrolling', '')
+      clearTimeout(timer)
+      timer = setTimeout(
+        () => document.documentElement.removeAttribute('data-dev-scrolling'),
+        800,
+      )
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      clearTimeout(timer)
+      window.removeEventListener('scroll', onScroll)
+      document.documentElement.removeAttribute('data-dev-scrolling')
+    }
+  }, [mode])
+
+  return mode
+}
+/* ---- end dev-tweak scaffolding ---- */
+
 export const Route = createFileRoute('/preview/$slug')({
   validateSearch: z.object({ preset: z.string().optional().catch(undefined) }),
   ssr: false,
@@ -80,6 +147,7 @@ function PreviewPage() {
     useCallback((ds: DesignSystem) => setDesignSystem(ds), []),
   )
   useReportPreviewScrolled()
+  const devScrollbarMode = useDevScrollbarMode()
 
   // The "overview" slug isn't a component/group example — it's a bespoke style-guide
   // view that needs the raw designSystem (for the generated color ramps), so it's
@@ -115,7 +183,9 @@ function PreviewPage() {
       color={designSystem.color}
       icons={designSystem.icons}
     >
-      {embedded && <style>{EMBEDDED_SCROLLBAR_CSS}</style>}
+      {embedded && DEV_SCROLLBAR_CSS[devScrollbarMode] && (
+        <style>{DEV_SCROLLBAR_CSS[devScrollbarMode]}</style>
+      )}
       <div className={embedded ? 'pt-11' : undefined}>{content}</div>
     </DesignSystemProvider>
   )

--- a/www/src/styles.css
+++ b/www/src/styles.css
@@ -61,10 +61,11 @@
    technique as shadcn's scroll-fade utilities (scroll-driven animation of a
    registered @property), retargeted from a mask to backdrop-filter. The scroll timeline ramps
    --blur-progress 0 → 1 across the first header-height of scroll; the blur layers
-   scale their radius by it and the tint scales its opacity (see header.tsx), so the
-   container never carries a fractional opacity — which would make it an opacity
-   group and break backdrop sampling. Where scroll timelines are unsupported the blur
-   stays at 0 and the header falls back to a solid background (see header-blur-fallback). */
+   scale their radius by it and the tint scales its opacity (see ProgressiveBlur in
+   components/progressive-blur.tsx), so the container never carries a fractional
+   opacity — which would make it an opacity group and break backdrop sampling. Where
+   scroll timelines are unsupported the blur stays at 0 and the header falls back to
+   a solid background (see header-blur-fallback). */
 @property --blur-progress {
   syntax: '<number>';
   inherits: true;
@@ -99,11 +100,11 @@
   }
 }
 
-/* header-blur-dither — a low-opacity tiled noise that dithers the navbar tint's
-   near-black gradient so 8-bit color banding doesn't show as horizontal steps.
-   Opacity is ramped by --blur-progress inline (see header.tsx); masked to the upper
-   band where the tint sits. */
-@utility header-blur-dither {
+/* progressive-blur-dither — a low-opacity tiled noise that dithers the blur stack's
+   near-black tint gradient so 8-bit color banding doesn't show as horizontal steps.
+   Opacity is ramped by --blur-progress inline (see components/progressive-blur.tsx);
+   masked to the upper band where the tint sits. */
+@utility progressive-blur-dither {
   background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='140'%20height='140'%3E%3Cfilter%20id='n'%3E%3CfeTurbulence%20type='fractalNoise'%20baseFrequency='0.85'%20numOctaves='2'%20stitchTiles='stitch'/%3E%3CfeColorMatrix%20type='saturate'%20values='0'/%3E%3C/filter%3E%3Crect%20width='100%25'%20height='100%25'%20filter='url(%23n)'/%3E%3C/svg%3E");
   background-size: 140px 140px;
   mask-image: linear-gradient(to top, transparent 10%, #000 60%);

--- a/www/src/styles.css
+++ b/www/src/styles.css
@@ -57,15 +57,28 @@
   }
 }
 
-/* header-blur-reveal — reveals the nav's progressive blur on scroll with the same
-   technique as shadcn's scroll-fade utilities (scroll-driven animation of a
-   registered @property), retargeted from a mask to backdrop-filter. The scroll timeline ramps
-   --blur-progress 0 → 1 across the first header-height of scroll; the blur layers
-   scale their radius by it and the tint scales its opacity (see ProgressiveBlur in
-   components/progressive-blur.tsx), so the container never carries a fractional
-   opacity — which would make it an opacity group and break backdrop sampling. Where
-   scroll timelines are unsupported the blur stays at 0 and the header falls back to
-   a solid background (see header-blur-fallback). */
+/* blur-reveal — scroll-driven reveal for a ProgressiveBlur stack (see
+   components/progressive-blur.tsx): the same technique as shadcn's scroll-fade
+   utilities (a scroll timeline animating a registered @property), retargeted
+   from a mask to backdrop-filter. The timeline ramps --blur-progress 0 → 1
+   across the first --blur-reveal-range of scroll (default one header height);
+   the blur layers scale their radius by it and the tint scales its own opacity,
+   so these utilities add only an animation — the wrapper they land on must stay
+   mask-free and fully opaque (either would establish a backdrop root / opacity
+   group and kill cross-layer blur compounding). Two drivers:
+   - blur-reveal          — document scroll (the app header)
+   - blur-reveal-nearest  — nearest ancestor scroll container (a sticky bar
+                            inside an overflow-auto card). Beware: overflow-
+                            hidden ancestors count as scroll containers and
+                            capture the timeline; use blur-reveal when the
+                            document is the scroller.
+   Call sites that pin progress manually (create preview panel's inline
+   --blur-progress writes) must NOT carry these utilities — an animated custom
+   property outranks inline style. Shared gotcha: a timeline that turns inactive
+   (its scroller loses overflow) HOLDS the animation's last progress — remount
+   the wrapper to reset (see layout/header.tsx). Where scroll timelines are
+   unsupported the blur stays at 0 and the bar falls back to a solid background
+   (blur-reveal-fallback). */
 @property --blur-progress {
   syntax: '<number>';
   inherits: true;
@@ -81,20 +94,31 @@
   }
 }
 
-@utility header-blur-reveal {
+@utility blur-reveal {
   @supports (animation-timeline: scroll()) {
     animation: blur-reveal 1ms linear;
     animation-timeline: scroll(root y);
-    animation-range: 0 var(--header-height, calc(var(--spacing) * 14));
+    animation-range: 0
+      var(--blur-reveal-range, var(--header-height, calc(var(--spacing) * 14)));
     animation-fill-mode: both;
   }
 }
 
-/* header-blur-fallback — where scroll-driven animations are unsupported the blur
-   above can't track scroll; rather than pin the full blur on over the hero, give the
-   header a solid background. Lives on the header (not the taller blur wrapper) so it
-   covers exactly the bar. */
-@utility header-blur-fallback {
+@utility blur-reveal-nearest {
+  @supports (animation-timeline: scroll()) {
+    animation: blur-reveal 1ms linear;
+    animation-timeline: scroll(nearest y);
+    animation-range: 0
+      var(--blur-reveal-range, var(--header-height, calc(var(--spacing) * 14)));
+    animation-fill-mode: both;
+  }
+}
+
+/* blur-reveal-fallback — where scroll-driven animations are unsupported the
+   blur can't track scroll; rather than pin the full blur over the content
+   below, give the bar a solid background. Lives on the bar element (not the
+   taller blur wrapper) so it covers exactly the bar. */
+@utility blur-reveal-fallback {
   @supports not (animation-timeline: scroll()) {
     background-color: var(--color-bg);
   }


### PR DESCRIPTION
## Summary

- Replace the create preview toolbar's background fade with the app header's iOS-style progressive blur, revealed by scroll: the iframe reports scroll progress (0→1 over one toolbar height) via postMessage — CSS scroll timelines can't cross the document boundary — and the parent writes it onto `--blur-progress`, matching the navbar's smooth reveal.
- Theme the blur by the previewed design system: a scoped `DesignSystemProvider` with `color` + `forcedMode={previewMode}` resolves the tint's `--color-bg` from the preset's tokens in the preview's own light/dark mode.
- Hide the embedded preview's viewport scrollbar (it ran beneath the blur and looked smeared); wheel/trackpad scrolling is unaffected and standalone previews keep the native scrollbar.
- Extract the header's layered blur stack into a reusable `ProgressiveBlur` component, and generalize the scroll driver into utilities: `blur-reveal` (document scroll — the header, renamed drop-in), `blur-reveal-nearest` (nearest ancestor scroller, for sticky bars inside overflow-auto containers), `blur-reveal-fallback` (solid bg where scroll timelines are unsupported), with a `--blur-reveal-range` variable knob (default one header height). `header-blur-dither` renamed to `progressive-blur-dither`.
- Add an internal demo at `/internal/blur-reveal` exercising both drivers plus the range knob.

Design notes: root scroll keeps the unsuffixed name because `scroll(nearest y)` silently binds to any overflow-hidden ancestor; utilities and manually-pinned `--blur-progress` must never share an element (an animated custom property outranks inline style) — both documented in styles.css.

Verified in the browser: utilities compile and bind (`scroll(root y)` @ 56px, nearest @ 3rem via the knob); the preview toolbar's blur ramps 0→0.5→1 with iframe scroll and back; demo renders both drivers. `pnpm check` + `pnpm typecheck` pass.