### PR TITLE
feat(command): add Vercel ⌘K style 3 and wire the Vercel preset

### DIFF
--- a/www/src/modules/presets/presets-data.ts
+++ b/www/src/modules/presets/presets-data.ts
@@ -40,6 +40,8 @@ function makeDesignSystem(opts: {
   vividness?: ColorConfig['vividness']
   /** Google font families for the typography tokens (default Geist / match body). */
   fonts?: { heading?: string; body?: string; mono?: string }
+  /** Per-component param overrides on top of the builder defaults. */
+  components?: Record<string, Record<string, string>>
 }): DesignSystem {
   const { neutral, accent, density = 'default' } = opts
   const tokens: Record<string, string> = {}
@@ -48,8 +50,13 @@ function makeDesignSystem(opts: {
     tokens[FONT_HEADING_VAR] = fontStack(opts.fonts.heading)
   if (opts.fonts?.body) tokens[FONT_SANS_VAR] = fontStack(opts.fonts.body)
   if (opts.fonts?.mono) tokens[FONT_MONO_VAR] = fontStack(opts.fonts.mono)
+  const componentParams = { ...DEFAULTS.componentParams }
+  for (const [component, overrides] of Object.entries(opts.components ?? {})) {
+    componentParams[component] = { ...componentParams[component], ...overrides }
+  }
   return {
     ...DEFAULTS,
+    componentParams,
     density,
     tokens,
     color: {
@@ -75,6 +82,7 @@ export const PRESETS: Preset[] = [
       // A pure-gray accent: zero vividness keeps the ramp from tinting back up
       // (Geist-style neutral primary).
       vividness: 0,
+      components: { command: { style: '3' } },
     }),
   },
   {

--- a/www/src/registry/ui/command/styles.ts
+++ b/www/src/registry/ui/command/styles.ts
@@ -31,7 +31,15 @@ const { useStyles, styles } = createStyles(commandMeta, {
           'in-data-modal:**:data-search-field:p-0.5',
         ],
       },
-      3: {},
+      3: {
+        base: [
+          // Vercel ⌘K: padded shell, frameless input on an inset hairline, flush list.
+          'gap-2 p-2 **:data-listbox:p-0',
+          '**:[[data-search-field]>[data-input-group]]:border-0 **:[[data-search-field]>[data-input-group]]:bg-transparent **:[[data-search-field]>[data-input-group]]:ring-0',
+          '**:data-search-field:border-b **:data-search-field:pb-1.5',
+          '**:data-listbox:**:data-separator:mx-0 **:data-listbox:**:data-separator:my-1.5',
+        ],
+      },
     },
   },
 })


### PR DESCRIPTION
## What

Fills the command component's empty `style: 3` slot with a Vercel-look command palette and points the Vercel preset at it.

- **`command/styles.ts`** — style 3 recreates Vercel's ⌘K menu (grounded in cmdk's canonical Vercel theme): padded shell (`p-2`, `gap-2`), frameless search input (border/bg/ring stripped), an **inset** hairline under the search row (vs style 2's full-bleed one), flush list (`p-0`), separators kept inset instead of bleeding to the edges.
- **`presets-data.ts`** — `makeDesignSystem` gains a `components` option merging per-component param overrides over the builder defaults; the Vercel preset sets `command: { style: '3' }`.

## Why

Part of the high-fidelity preset effort (#391): the Vercel preset should read like Geist, and its command palette is one of its most recognizable surfaces.

## Reviewer notes

- Verified live in the presets modal: Vercel preview renders the padded shell / frameless input / inset hairline; Supabase still gets default style 1, so the override doesn't leak. `pnpm check`, `pnpm typecheck`, `pnpm build:registry` all pass (publishables are gitignored, so the diff is just the two source files).
- In a ⌘K modal, dialog content already drops its own padding around a command (`has-data-command:p-0`), so the style-3 shell padding composes correctly.