### PR TITLE
fix(www): render scoped design-system themes during SSR

### DIFF
--- a/www/src/lib/root-closure-data.ts
+++ b/www/src/lib/root-closure-data.ts
@@ -1,0 +1,10 @@
+import type { RootClosure } from './root-closure'
+
+/**
+ * Placeholder swapped by the `dotui-root-closure` plugin (vite.config.ts): in
+ * server environments this module's content becomes the root closure parsed
+ * from the compiled stylesheet, so scoped themes can render during
+ * SSR/prerender. On the client (and under vitest, which resolves the file
+ * as-is) it stays null and the provider harvests the live CSSOM instead.
+ */
+export default null as RootClosure | null

--- a/www/src/lib/root-closure.ts
+++ b/www/src/lib/root-closure.ts
@@ -1,0 +1,149 @@
+/**
+ * The "root closure" is the set of custom-property declarations the document
+ * authors at `:root` (light) and `.dark` — the token closure scoped theming
+ * clones onto a subtree so every var recomputes from the scope's own primitives
+ * (see `DesignSystemProvider`'s scoped mode in `@/lib/styles`).
+ *
+ * Two harvesters produce it from the same compiled stylesheet:
+ *   - the client walks the live CSSOM (`harvestRootClosure` in `@/lib/styles`);
+ *   - the server parses the compiled CSS text with `parseRootClosure` below —
+ *     wired up by the `dotui-root-closure` plugin in vite.config.ts, which swaps
+ *     `./root-closure-data` for the parsed closure in server environments so
+ *     scoped themes render during SSR/prerender instead of flashing in after
+ *     hydration.
+ *
+ * Both apply the same shape rules, shared here: which selectors count as
+ * root/dark, and which properties are excluded from the harvest.
+ */
+
+import { DEFAULT_SEMANTICS } from '@/registry/theme'
+
+export interface RootClosure {
+  light: string
+  dark: string
+}
+
+// Simple selectors whose declarations make up the document's theme closure. `.dark` is the
+// palette's dark override (it targets `<html>`, the same element as `:root`).
+export const ROOT_SELECTOR_TOKENS = new Set([
+  ':root',
+  ':host',
+  'html',
+  ':where(:root)',
+])
+export const DARK_SELECTOR_TOKENS = new Set([
+  '.dark',
+  ':root.dark',
+  'html.dark',
+  ':where(.dark)',
+])
+
+/** A grouped selector (`:root, :host`) counts if any of its simple parts is in `tokens`. */
+export function selectorIn(selectorText: string, tokens: Set<string>): boolean {
+  return selectorText.split(',').some((part) => tokens.has(part.trim()))
+}
+
+// The semantic vocabulary's exact prop names. Excluded from the harvest by KEY, not by the
+// `--color-` prefix: component surface vars share the prefix (`--color-area-radius`,
+// `--color-swatch-picker-item-radius`) and must be harvested like any other token, or they
+// stay frozen at `:root` values inside the scope.
+const SEMANTIC_COLOR_PROPS = new Set(
+  Object.keys(DEFAULT_SEMANTICS).map((name) => `--${name}`),
+)
+
+/**
+ * Excluded from the closure: non-custom props; `--radius-factor` (rides inline
+ * on the scope element so the cloned radius scale recomputes there); and the
+ * semantic vocabulary (emitted from `DEFAULT_SEMANTICS` instead — it's the
+ * typed source of truth, and its targets may be authored as `color-mix()`,
+ * whose CSSOM read-back is unreliable).
+ */
+export function isHarvestedProp(prop: string): boolean {
+  return (
+    prop.startsWith('--') &&
+    prop !== '--radius-factor' &&
+    !SEMANTIC_COLOR_PROPS.has(prop)
+  )
+}
+
+/** Serialize a harvested declaration map to the closure's CSS-block text. */
+export function closureText(decls: Map<string, string>): string {
+  return [...decls].map(([prop, value]) => `\t${prop}: ${value};`).join('\n')
+}
+
+/**
+ * Harvest the root closure from raw compiled CSS text — the server-side twin of
+ * the client's CSSOM walk, applying the same rules: collect the top-level
+ * declarations of any `:root`/`.dark` style rule, descending grouping at-rules
+ * (`@layer`, `@media`) unconditionally like the CSSOM walk does. A hand-rolled
+ * single pass (comment- and string-aware) is enough here: the input is
+ * machine-generated Tailwind output, and the client harvest stays the
+ * authority at runtime.
+ */
+export function parseRootClosure(css: string): RootClosure {
+  const light = new Map<string, string>()
+  const dark = new Map<string, string>()
+  const n = css.length
+  let i = 0
+
+  const skipComment = (): void => {
+    i += 2
+    while (i < n && !(css[i] === '*' && css[i + 1] === '/')) i++
+    i += 2
+  }
+  const readString = (): string => {
+    const start = i
+    const quote = css[i]
+    i++
+    while (i < n && css[i] !== quote) i += css[i] === '\\' ? 2 : 1
+    i++
+    return css.slice(start, i)
+  }
+  const collect = (decl: string, into: Map<string, string>): void => {
+    const colon = decl.indexOf(':')
+    if (colon === -1) return
+    const prop = decl.slice(0, colon).trim()
+    if (!isHarvestedProp(prop)) return
+    into.set(prop, decl.slice(colon + 1).trim())
+  }
+
+  // Parse one rule body (or, at top level, the whole sheet). `into` is set
+  // inside a `:root`/`.dark` style rule — its own declarations are collected;
+  // nested rules never are (matching the CSSOM walk, where a nested rule is a
+  // separate CSSStyleRule whose `&`-selector isn't in the token sets).
+  const parseBody = (into: Map<string, string> | null): void => {
+    let buf = ''
+    while (i < n) {
+      const ch = css[i]
+      if (ch === '/' && css[i + 1] === '*') {
+        skipComment()
+      } else if (ch === '"' || ch === "'") {
+        buf += readString()
+      } else if (ch === ';') {
+        if (into) collect(buf, into)
+        buf = ''
+        i++
+      } else if (ch === '}') {
+        if (into) collect(buf, into)
+        i++
+        return
+      } else if (ch === '{') {
+        const prelude = buf.trim()
+        buf = ''
+        i++
+        let child: Map<string, string> | null = null
+        if (!prelude.startsWith('@')) {
+          if (selectorIn(prelude, ROOT_SELECTOR_TOKENS)) child = light
+          else if (selectorIn(prelude, DARK_SELECTOR_TOKENS)) child = dark
+        }
+        parseBody(child)
+      } else {
+        buf += ch
+        i++
+      }
+    }
+  }
+
+  parseBody(null)
+  return { light: closureText(light), dark: closureText(dark) }
+}

--- a/www/src/lib/styles.tsx
+++ b/www/src/lib/styles.tsx
@@ -9,13 +9,21 @@ import type { ClassValue, TVReturnType, VariantProps } from 'tailwind-variants'
 import { ensureFontStylesheets, fontFamiliesFromTokens } from '@/lib/fonts'
 import { resolveColorConfigCached } from '@/lib/resolve-color'
 import {
+  closureText,
+  DARK_SELECTOR_TOKENS,
+  isHarvestedProp,
+  ROOT_SELECTOR_TOKENS,
+  selectorIn,
+} from '@/lib/root-closure'
+import type { RootClosure } from '@/lib/root-closure'
+import serverRootClosure from '@/lib/root-closure-data'
+import {
   IconLibraryContext,
   IconWeightContext,
 } from '@/registry/icons/create-icon'
 import { phosphorWeights } from '@/registry/icons/icon-map'
 import type { IconLibraryName, PhosphorWeight } from '@/registry/icons/icon-map'
 import {
-  DEFAULT_SEMANTICS,
   emitCss,
   emitDarkOverridesCss,
   emitPrimitivesCss,
@@ -97,55 +105,33 @@ const useIsomorphicLayoutEffect =
  * components added later — then recomputes from the scope's own tokens.
  */
 
-// Simple selectors whose declarations make up the document's theme closure. `.dark` is the
-// palette's dark override (it targets `<html>`, the same element as `:root`).
-const ROOT_SELECTOR_TOKENS = new Set([
-  ':root',
-  ':host',
-  'html',
-  ':where(:root)',
-])
-const DARK_SELECTOR_TOKENS = new Set([
-  '.dark',
-  ':root.dark',
-  'html.dark',
-  ':where(.dark)',
-])
-
-/** A grouped selector (`:root, :host`) counts if any of its simple parts is in `tokens`. */
-function selectorIn(selectorText: string, tokens: Set<string>): boolean {
-  return selectorText.split(',').some((part) => tokens.has(part.trim()))
-}
-
-interface RootClosure {
-  light: string
-  dark: string
-}
 let rootClosureCache: RootClosure | null = null
 
-// The semantic vocabulary's exact prop names. Excluded from the harvest by KEY, not by the
-// `--color-` prefix: component surface vars share the prefix (`--color-area-radius`,
-// `--color-swatch-picker-item-radius`) and must be harvested like any other token, or they
-// stay frozen at `:root` values inside the scope.
-const SEMANTIC_COLOR_PROPS = new Set(
-  Object.keys(DEFAULT_SEMANTICS).map((name) => `--${name}`),
-)
-
 /**
- * Harvest, as raw CSS text, the authored custom-property declarations the document defines at
- * `:root` (light) and `.dark`. Reading from `cssRules` (not `getComputedStyle`) preserves the
- * `var()` / `calc()` references, so re-emitting the result under a scope selector lets each
- * token recompute from that scope's primitives + `--radius-factor`. Cached — the closure is
- * static (scoped mode never writes `:root`); cross-origin sheets are skipped.
+ * The root closure, from whichever source this environment has (shape rules —
+ * selector sets, excluded props — live in `@/lib/root-closure`):
  *
- * The semantic `--color-*` vocabulary is deliberately EXCLUDED here and emitted from
- * `DEFAULT_SEMANTICS` instead (see `buildScopedThemeCss`): it's the typed source of truth, and
- * its targets may be authored as `color-mix()` (the vocabulary supports it), whose CSSOM
- * read-back is unreliable.
+ * On the server, the closure parsed from the compiled stylesheet at build time
+ * (see `root-closure-data`), so scoped themes render during SSR/prerender and
+ * the first paint is already themed.
+ *
+ * On the client, harvest the authored custom-property declarations the
+ * document defines at `:root` (light) and `.dark`, as raw CSS text. Reading
+ * from `cssRules` (not `getComputedStyle`) preserves the `var()` / `calc()`
+ * references, so re-emitting the result under a scope selector lets each token
+ * recompute from that scope's primitives + `--radius-factor`. Cached — the
+ * closure is static (scoped mode never writes `:root`); cross-origin sheets
+ * are skipped.
+ *
+ * The semantic `--color-*` vocabulary is deliberately EXCLUDED here and emitted
+ * from `DEFAULT_SEMANTICS` instead (see `buildScopedThemeCss`): it's the typed
+ * source of truth, and its targets may be authored as `color-mix()` (the
+ * vocabulary supports it), whose CSSOM read-back is unreliable.
  */
-function harvestRootClosure(): RootClosure {
+function getRootClosure(): RootClosure {
+  if (typeof document === 'undefined')
+    return serverRootClosure ?? { light: '', dark: '' }
   if (rootClosureCache) return rootClosureCache
-  if (typeof document === 'undefined') return { light: '', dark: '' }
 
   const light = new Map<string, string>()
   const dark = new Map<string, string>()
@@ -153,15 +139,7 @@ function harvestRootClosure(): RootClosure {
     const { style } = rule
     for (let i = 0; i < style.length; i++) {
       const prop = style.item(i)
-      // Skip: non-custom props; `--radius-factor` (rides inline on the scope element so the
-      // cloned radius scale recomputes there); and the semantic vocabulary (emitted from
-      // DEFAULT_SEMANTICS — see SEMANTIC_COLOR_PROPS for why it's an exact-key match).
-      if (
-        !prop.startsWith('--') ||
-        prop === '--radius-factor' ||
-        SEMANTIC_COLOR_PROPS.has(prop)
-      )
-        continue
+      if (!isHarvestedProp(prop)) continue
       into.set(prop, style.getPropertyValue(prop).trim())
     }
   }
@@ -185,9 +163,7 @@ function harvestRootClosure(): RootClosure {
     }
   }
 
-  const toText = (map: Map<string, string>) =>
-    [...map].map(([prop, value]) => `\t${prop}: ${value};`).join('\n')
-  const closure = { light: toText(light), dark: toText(dark) }
+  const closure = { light: closureText(light), dark: closureText(dark) }
   // An empty harvest means the stylesheets weren't parsed yet — don't cache it, or scoped
   // theming would stay off for the whole session.
   if (closure.light || closure.dark) rootClosureCache = closure
@@ -197,7 +173,7 @@ function harvestRootClosure(): RootClosure {
 /**
  * Build the `<style>` text that themes only `selector`'s subtree: clone `:root`'s token closure
  * onto the scope (primitives + component vars, so they recompute there), add the semantic
- * `--color-*` layer from `DEFAULT_SEMANTICS` (the reliable source — see `harvestRootClosure`),
+ * `--color-*` layer from `DEFAULT_SEMANTICS` (the reliable source — see `getRootClosure`),
  * then, when a `color` is given, override the primitive ramps with the scoped palette.
  * `--radius-factor` + param vars ride inline on the scope element.
  *
@@ -212,11 +188,10 @@ function buildScopedThemeCss(
   color: ColorConfig | undefined,
   forcedMode: 'light' | 'dark' | undefined,
 ): string | null {
-  const { light, dark } = harvestRootClosure()
-  // No closure to clone — we're on the server, or the document's stylesheets aren't
-  // parsed yet. Scoped theming is inherently client-only (it mirrors the live `:root`
-  // closure), so emit nothing here; it applies once mounted on the client. Rendering a
-  // partial closure now would also mismatch the client during hydration.
+  const { light, dark } = getRootClosure()
+  // No closure to clone — the document's stylesheets aren't parsed yet (client) or the
+  // server closure is missing. Emit nothing rather than a partial closure; the caller
+  // retries on a later render.
   if (!light && !dark) return null
 
   const base = forcedMode === 'dark' ? `${light}\n${dark}` : light
@@ -261,23 +236,24 @@ function buildScopedThemeCss(
 
 /*
  * The closure-clone stylesheet is ~10KB and fully determined by `color` + `forcedMode`,
- * so scoped providers on the same theme share one scope token and one injected <style>
- * instead of each carrying their own — a docs page rendering N demos in the user's
- * stored preset injects one style node, not N. Entries are refcounted; the node is
- * removed when the last provider using it unmounts or moves to a different theme.
- * Client-only, like buildScopedThemeCss (null during SSR).
+ * so it renders as a React hoistable <style href precedence>: every provider on the
+ * same theme renders the same href and React dedupes them to one node in <head> — a
+ * docs page rendering N demos in the user's stored preset gets one style node, not N.
+ * Rendering (instead of imperatively injecting) is what makes SSR work: the server has
+ * the closure too (see `root-closure-data`), so the style streams with the shell and
+ * scoped themes paint correctly before hydration. Hydration adopts hoistables by href
+ * without diffing content, so cosmetic serialization differences between the
+ * server-parsed and CSSOM-harvested closure are harmless. React never removes
+ * hoistables, so styles outlive their last provider — fine: they're keyed by content
+ * hash and inert without a matching scope attribute on the page.
  */
 
-interface SharedThemeEntry {
-  refs: number
-  el: HTMLStyleElement
-}
-const sharedThemes = new Map<string, SharedThemeEntry>()
+const scopedThemeCssCache = new Map<string, string>()
 
 /**
  * djb2 over the theme key. Deterministic from content — the token renders as the
- * `data-dotui-scope` attribute on the server too, so it must hydrate identically
- * (a session counter would drift between server and client).
+ * `data-dotui-scope` attribute and the style's href on the server too, so it must
+ * hydrate identically (a session counter would drift between server and client).
  */
 function themeTokenFor(key: string): string {
   let hash = 5381
@@ -288,66 +264,49 @@ function themeTokenFor(key: string): string {
 }
 
 /**
- * Join (or create) the shared <style> for a scoped theme and return its scope token —
- * the value the provider renders as `data-dotui-scope`. `undefined` when the provider
- * doesn't diverge from the page theme (nothing to inject).
+ * The scoped theme's scope token — the value the provider renders as
+ * `data-dotui-scope` — and its stylesheet as a hoistable <style> element for the
+ * provider to render. Both `undefined`/null when the provider doesn't diverge
+ * from the page theme (nothing to emit).
  */
-function useSharedScopedTheme(
+function useScopedTheme(
   color: ColorConfig | undefined,
   forcedMode: 'light' | 'dark' | undefined,
   enabled: boolean,
-): string | undefined {
+): { token: string | undefined; sheet: React.ReactNode } {
   // Content key = everything the stylesheet is built from (color config + pinned mode).
   // Token-only divergence (inline vars, no palette) shares a per-mode colorless entry.
+  // `color`/`forcedMode` enter only through the key: an identity-only `color` change
+  // must not rebuild, and the cache below keys on content.
   const [key, token] = React.useMemo(() => {
     if (!enabled) return [null, undefined] as const
     const k = `${forcedMode ?? 'auto'}:${color ? JSON.stringify(color) : 'default'}`
     return [k, themeTokenFor(k)] as const
   }, [enabled, color, forcedMode])
 
-  useIsomorphicLayoutEffect(() => {
-    if (key === null || token === undefined) return
-    // Layout effect, so the style lands in the same frame as the commit that rendered
-    // the scope attribute — before paint, no flash of the page theme.
-    let acquired = false
-    const entry = sharedThemes.get(key)
-    if (entry) {
-      entry.refs += 1
-      acquired = true
-    } else {
-      const css = buildScopedThemeCss(
+  let css: string | null = null
+  if (key !== null && token !== undefined) {
+    css = scopedThemeCssCache.get(key) ?? null
+    if (css === null) {
+      css = buildScopedThemeCss(
         `[data-dotui-scope="${token}"]`,
         color,
         forcedMode,
       )
-      // null: no closure to harvest yet — skip; a later theme change re-runs this.
-      if (css) {
-        const el = document.createElement('style')
-        el.setAttribute('data-dotui-color', token)
-        el.textContent = css
-        document.head.append(el)
-        sharedThemes.set(key, { refs: 1, el })
-        acquired = true
-      }
+      // null: no closure available yet — don't cache, a later render retries.
+      if (css !== null) scopedThemeCssCache.set(key, css)
     }
-    return () => {
-      // Only release what this effect actually acquired — a skipped (css: null)
-      // acquire must not decrement an entry another instance created since.
-      if (!acquired) return
-      const current = sharedThemes.get(key)
-      if (!current) return
-      current.refs -= 1
-      if (current.refs === 0) {
-        current.el.remove()
-        sharedThemes.delete(key)
-      }
-    }
-    // `color`/`forcedMode` are deliberately not deps: `key` pins their content, and an
-    // identity-only `color` change must not release/re-acquire — a sole holder would
-    // remove and rebuild the shared node every render.
-  }, [key, token])
+  }
 
-  return token
+  return {
+    token,
+    sheet:
+      css !== null && token !== undefined ? (
+        <style href={token} precedence="dotui-scope">
+          {css}
+        </style>
+      ) : null,
+  }
 }
 
 interface DesignSystemProviderProps {
@@ -424,7 +383,7 @@ function DesignSystemProvider({
   }, [tokens, params])
 
   // Per-instance id for the overlay portal target (only used in `scoped` mode). The
-  // scope *selector* is no longer per-instance — see useSharedScopedTheme.
+  // scope *selector* is no longer per-instance — see useScopedTheme.
   const scopeId = React.useId()
 
   // Apply the global token vars to :root so values that reference each other via calc() +
@@ -458,16 +417,16 @@ function DesignSystemProvider({
   // Warm the closure cache off the critical path: built lazily, the first divergence would pay
   // the full-document CSSOM walk synchronously inside the render of the user's first drag tick.
   React.useEffect(() => {
-    if (scoped) harvestRootClosure()
+    if (scoped) getRootClosure()
   }, [scoped])
 
-  // Scoped mode: join the shared closure-clone stylesheet, but only once something
+  // Scoped mode: render the shared closure-clone stylesheet, but only once something
   // actually diverges (a color, or a token like --radius-factor); an untouched preview
-  // injects nothing and inherits the page defaults. `cssVars` ride inline on the scope
+  // emits nothing and inherits the page defaults. `cssVars` ride inline on the scope
   // element and never enter the CSS text, so divergence keys on whether any override
   // EXISTS (a boolean), not object identity — else every radius tick rebuilds identical CSS.
   const hasTokenOverrides = Object.keys(cssVars).length > 0
-  const scopeToken = useSharedScopedTheme(
+  const { token: scopeToken, sheet: scopeSheet } = useScopedTheme(
     color,
     forcedMode,
     scoped && (Boolean(color) || hasTokenOverrides || Boolean(forcedMode)),
@@ -549,6 +508,7 @@ function DesignSystemProvider({
       data-mode={forcedMode}
       style={{ display: 'contents', ...scopeStyle }}
     >
+      {scopeSheet}
       <UNSAFE_PortalProvider
         getContainer={() => document.getElementById(portalDomId)}
       >

--- a/www/vite.config.ts
+++ b/www/vite.config.ts
@@ -6,6 +6,31 @@ import viteReact from '@vitejs/plugin-react'
 import mdx from 'fumadocs-mdx/vite'
 import { nitro } from 'nitro/vite'
 import { defineConfig } from 'vite'
+import type { Plugin } from 'vite'
+
+// Scoped design-system themes must paint before hydration, but the server has
+// no CSSOM to harvest the root token closure from. In server environments,
+// swap the root-closure-data placeholder for the closure parsed out of the
+// compiled stylesheet — see src/lib/root-closure.ts.
+const rootClosureDataId = path.resolve(
+  import.meta.dirname,
+  'src/lib/root-closure-data.ts',
+)
+function rootClosure(): Plugin {
+  return {
+    name: 'dotui-root-closure',
+    enforce: 'pre',
+    load(id) {
+      if (id.split('?')[0] !== rootClosureDataId) return
+      if (this.environment.name === 'client') return
+      return [
+        `import cssText from '../styles.css?inline'`,
+        `import { parseRootClosure } from './root-closure'`,
+        `export default parseRootClosure(cssText)`,
+      ].join('\n')
+    },
+  }
+}
 
 export default defineConfig({
   server: {
@@ -31,6 +56,7 @@ export default defineConfig({
     noExternal: ['@tabler/icons-react'],
   },
   plugins: [
+    rootClosure(),
     mdx(await import('./source.config')),
     nitro({
       preset: process.env.VERCEL ? 'vercel' : 'node',


### PR DESCRIPTION
## Problem

On the landing page, the preset cards (and the background wash) painted with the default page theme first — the selected preset's colors, radii, and density-scoped styles only appeared after hydration.

Root cause: a scoped `DesignSystemProvider` builds its theme stylesheet by harvesting the document's `:root`/`.dark` token closure **from the live CSSOM** and injecting a `<style>` **in a layout effect**. Both are impossible on the server, so SSR/prerender shipped the `data-dotui-scope` markup with zero theme CSS.

## Fix

- **`lib/root-closure.ts`** — the closure's shape rules (root/dark selector sets, excluded props) extracted from `styles.tsx`, plus `parseRootClosure()`: a text-parsing twin of the CSSOM walk.
- **`lib/root-closure-data.ts` + a small vite plugin** — the placeholder is `null` on the client; in server environments the plugin swaps its content for the closure parsed from the compiled `styles.css?inline`. Same compiled artifact the browser harvests, so it stays self-maintaining (new component vars/tokens are picked up automatically) with zero client-bundle cost. Vitest resolves the real file, so tests need no special handling.
- **Scoped styles are now rendered, not imperatively injected** — a React 19 hoistable `<style href={token} precedence="dotui-scope">`. It streams with the SSR shell (first paint is themed), and React's dedupe-by-href replaces the refcounted `sharedThemes` machinery (net simplification). Hydration adopts hoistables by href without diffing content, so cosmetic serialization differences between the two harvesters are harmless.

This fixes the same flash everywhere scoped theming SSRs — docs demos and preset thumbnails too, not just the landing.

## Reviewer notes

- **Behavior change:** hoistable styles persist for the session (React never removes them), where the old refcounting removed the node when the last provider left. They're inert without a matching scope attribute — memory-only, bounded by distinct themes viewed.
- Verified: dev SSR and the prod prerender both ship one deduped ~23KB `<style>` in `<head>` after the main stylesheet (specificity ties resolve by order); no hydration errors; preset switching still builds new styles client-side and the wash tween still runs; client JS bundles contain neither the parser nor the CSS string.
- `pnpm check` / `pnpm typecheck` / `pnpm test` (223) pass; no registry changes, so no generated drift.