### PR TITLE
feat(www): merge Input into the TextField composition step

### DIFF
--- a/www/src/modules/docs/composition-animation.tsx
+++ b/www/src/modules/docs/composition-animation.tsx
@@ -80,9 +80,12 @@ interface Step {
   compact?: boolean
 }
 
+// Opening mid beat: a bare Input, the seed the TextField builds around. It's
+// the first frame on load, so it dwells a touch longer than the mids after it.
 const firstStep: Step = {
-  title: 'Input',
-  durationMs: 2400,
+  title: 'TextField',
+  mid: true,
+  durationMs: 2000,
   code: `<Input placeholder="hello@example.com" />`,
   preview: (
     <Input


### PR DESCRIPTION
## What

On the home page's **Composition** section, the text-field build-up had two clickable rail stops — "Input" and "TextField". This merges them into a single **"TextField"** stop, with the bare-input beat folded in as an intermediate step.

## Why

"Input" and "TextField" aren't two separate patterns to a reader — the bare input is just the seed the field grows from. Collapsing them to one stop makes the rail read as one coherent field being composed, rather than implying `Input` is a peer destination alongside `TextField`, `InputGroup`, `SearchField`, etc.

## How

The bare-`<Input />` step (`firstStep`) is demoted from a headline (clickable) to a `mid` beat and retitled "TextField". Everything downstream — pagination, step dots, the walk-between-mids logic, active-step highlighting — already keys off the `mid` flag, so no other code changes were needed.

The build-up under the single "TextField" stop is now three mid beats arriving at the full field:

1. `<Input />` — bare (opening frame)
2. wrapped in `<TextField>`
3. `+ <Label>`
4. → **TextField** headline — full field with `<Label>`, `<Input>`, `<Description>`

The opening bare-input beat dwells 2000ms (vs the 1400ms mids after it) since it's the first frame on page load.

## Notes for reviewer

- The rail now opens on "TextField" instead of "Input"; the initial preview frame is still the bare input.
- `pnpm check` and `pnpm typecheck` pass (no new warnings/errors).