### PR TITLE
style(www): left-align home footer with section content

### DIFF
--- a/www/src/components/layout/footer.tsx
+++ b/www/src/components/layout/footer.tsx
@@ -1,6 +1,6 @@
 export function Footer() {
   return (
-    <footer className="mx-auto flex w-full max-w-[calc(1500px+16rem)] items-center justify-start px-4 py-10 sm:px-6 lg:px-32 lg:py-6">
+    <footer className="mx-auto flex h-24 w-full max-w-[calc(1500px+16rem)] items-center justify-start px-4 sm:px-6 lg:px-32">
       <p className="text-sm text-fg-muted">
         Built with passion by{' '}
         <a

--- a/www/src/components/layout/footer.tsx
+++ b/www/src/components/layout/footer.tsx
@@ -1,6 +1,6 @@
 export function Footer() {
   return (
-    <footer className="mx-auto flex w-full max-w-[calc(1500px+16rem)] items-center justify-start px-4 py-10 sm:px-6 lg:px-32">
+    <footer className="mx-auto flex w-full max-w-[calc(1500px+16rem)] items-center justify-start px-4 py-6 sm:px-6 lg:px-32">
       <p className="text-sm text-fg-muted">
         Built with passion by{' '}
         <a

--- a/www/src/components/layout/footer.tsx
+++ b/www/src/components/layout/footer.tsx
@@ -1,6 +1,6 @@
 export function Footer() {
   return (
-    <footer className="container flex items-center justify-center py-10">
+    <footer className="mx-auto flex w-full max-w-[calc(1500px+16rem)] items-center justify-start px-4 py-10 sm:px-6 lg:px-32">
       <p className="text-sm text-fg-muted">
         Built with passion by{' '}
         <a

--- a/www/src/components/layout/footer.tsx
+++ b/www/src/components/layout/footer.tsx
@@ -1,6 +1,6 @@
 export function Footer() {
   return (
-    <footer className="mx-auto flex w-full max-w-[calc(1500px+16rem)] items-center justify-start px-4 py-6 sm:px-6 lg:px-32">
+    <footer className="mx-auto flex w-full max-w-[calc(1500px+16rem)] items-center justify-start px-4 py-10 sm:px-6 lg:px-32 lg:py-6">
       <p className="text-sm text-fg-muted">
         Built with passion by{' '}
         <a

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -73,9 +73,7 @@ export function HomePage() {
 
       <CompositionSection />
 
-      <div className="mt-10 md:mt-14">
-        <Footer />
-      </div>
+      <Footer />
     </div>
   )
 }

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -73,7 +73,9 @@ export function HomePage() {
 
       <CompositionSection />
 
-      <Footer />
+      <div className="mt-10 md:mt-14 lg:mt-0">
+        <Footer />
+      </div>
     </div>
   )
 }

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -73,9 +73,7 @@ export function HomePage() {
 
       <CompositionSection />
 
-      <div className="mt-10 md:mt-14 lg:mt-0">
-        <Footer />
-      </div>
+      <Footer />
     </div>
   )
 }


### PR DESCRIPTION
## What

Left-aligns the home page footer text so it lines up with the page's section content instead of being centered.

## Why

The footer text ("Built with passion by @mehdibha") was centered, which didn't match the left-aligned layout of the sections above it. On large screens it now shares the same left content edge as the Composition section title.

## How

- Changed `justify-center` → `justify-start`.
- Swapped the `container` wrapper for the same width/padding wrapper the Composition section uses (`max-w-[calc(1500px+16rem)]` with `px-4 sm:px-6 lg:px-32`), so the text aligns with the "Composition" title on large screens.

## Notes

`footer.tsx` is only used on the home page, so no other page is affected.