### PR TITLE
fix(publisher): evaluate style refs and preserve empty slots

### DIFF
--- a/www/src/publisher/build-time/build.test.ts
+++ b/www/src/publisher/build-time/build.test.ts
@@ -68,6 +68,47 @@ describe('extractStylesConfig', () => {
       'shimmer',
     ])
   })
+
+  test('input: resolves module-level const string refs (compactText)', () => {
+    const cfg = extractStylesConfig(path.join(REGISTRY_UI, 'input/styles.ts'))
+    // `inputGroup: compactText` — the identifier resolves to its const literal.
+    expect(cfg.density?.compact?.slots?.inputGroup).toBe(
+      'text-base sm:text-xs/relaxed',
+    )
+  })
+
+  test('input: resolves local tv() factory calls (tokens, outlineField)', () => {
+    const cfg = extractStylesConfig(path.join(REGISTRY_UI, 'input/styles.ts'))
+    // `tokens({ h: 6 })` in density.compact size.sm → the h=6 token string.
+    const sm = cfg.density?.compact?.variants?.size?.sm as Record<
+      string,
+      string
+    >
+    expect(sm.input).toContain('[--input-h:--spacing(6)]')
+    // `outlineField({ focus: 'self' })` in params.style.outline.
+    const outline = cfg.params?.style?.outline?.slots?.input as string
+    expect(outline).toContain('focus:ring-2')
+    expect(outline).toContain('border-border-field')
+  })
+
+  test('otp-field: composes field styles via fieldStyles().field(...)', () => {
+    const cfg = extractStylesConfig(
+      path.join(REGISTRY_UI, 'otp-field/styles.ts'),
+    )
+    const root = cfg.base.slots?.root as string[]
+    expect(Array.isArray(root)).toBe(true)
+    // The composed field slot classes + the passed className, all merged by tv.
+    expect(root[0]).toContain('group/otp-field')
+    expect(root[0]).toContain('w-full flex-col gap-2')
+  })
+
+  test('slider: composes field styles via fieldStyles().field()', () => {
+    const cfg = extractStylesConfig(path.join(REGISTRY_UI, 'slider/styles.ts'))
+    // Same default-composed field slot the app renders (no className arg).
+    expect(cfg.base.slots?.root).toBe(
+      'flex invalid:has-data-[slot=field-error]:**:data-[slot=description]:hidden w-full flex-col gap-2',
+    )
+  })
 })
 
 /* ============================================================ */
@@ -207,5 +248,39 @@ describe('end-to-end (extract + transform → publish)', () => {
 
     expect(rawContent).toContain('rounded-md')
     expect(rawContent).not.toContain('rounded-(--alert-radius)')
+  })
+
+  test('field: declared-but-empty slots (fieldset/legend) survive to the emitted tv config', () => {
+    const stylesConfig = extractStylesConfig(
+      path.join(REGISTRY_UI, 'field/styles.ts'),
+    )
+    const { template } = transformBase({
+      baseTsxPath: path.join(REGISTRY_UI, 'field/base.tsx'),
+      componentName: 'field',
+    })
+
+    const { rawContent } = publish({
+      publishable: {
+        template,
+        stylesConfig,
+        meta: {
+          name: 'field',
+          type: 'registry:ui',
+          files: [
+            {
+              type: 'registry:ui',
+              path: 'ui/field/base.tsx',
+              target: 'ui/field.tsx',
+            },
+          ],
+        },
+      },
+      preset: { density: 'default', componentParams: {} },
+    })
+
+    // The base file destructures `fieldset` / `legend` from the tv slots — if
+    // flatten drops the empty slot keys, those become undefined slot functions.
+    expect(rawContent).toMatch(/fieldset:\s*""/)
+    expect(rawContent).toMatch(/legend:\s*""/)
   })
 })

--- a/www/src/publisher/build-time/extract-config.ts
+++ b/www/src/publisher/build-time/extract-config.ts
@@ -18,10 +18,32 @@
  * Build-time only. Imports ts-morph.
  */
 
+import path from 'node:path'
+import { tv } from 'tailwind-variants'
 import { Node, Project, SyntaxKind } from 'ts-morph'
-import type { Expression, SourceFile } from 'ts-morph'
+import type { CallExpression, Expression, SourceFile } from 'ts-morph'
 
+import type { RegistryItem } from '@/registry/types'
+
+import { flatten } from '../flatten'
 import type { StylesConfig } from '../types'
+
+/**
+ * Threaded through `exprToValue` so runtime helpers used in `styles.ts` values
+ * — module-level `const` string refs, local `tv()` factory calls, and
+ * `<importedStyles>().<slot>()` compositions — resolve to the same class
+ * strings the app renders (evaluated with the real `tv`), not just plain
+ * literals.
+ */
+interface ExtractCtx {
+  sourceFile: SourceFile
+  filePath: string
+}
+
+/** `.../registry/ui/<name>/styles.ts` → `.../registry/ui`. */
+function registryUiDirOf(stylesTsPath: string): string {
+  return path.dirname(path.dirname(stylesTsPath))
+}
 
 /* ---------------------------- expression → value ---------------------------- */
 
@@ -41,7 +63,8 @@ function unwrap(expr: Expression): Expression {
   return expr
 }
 
-function exprToValue(expr: Expression, filePath: string): unknown {
+function exprToValue(expr: Expression, ctx: ExtractCtx): unknown {
+  const { filePath } = ctx
   const node = unwrap(expr)
 
   if (
@@ -56,15 +79,22 @@ function exprToValue(expr: Expression, filePath: string): unknown {
   if (node.isKind(SyntaxKind.TrueKeyword)) return true
   if (node.isKind(SyntaxKind.FalseKeyword)) return false
   if (node.isKind(SyntaxKind.NullKeyword)) return null
-  if (node.isKind(SyntaxKind.Identifier) && node.getText() === 'undefined')
-    return undefined
+  if (node.isKind(SyntaxKind.Identifier)) {
+    if (node.getText() === 'undefined') return undefined
+    // Module-level `const x = <literal>` reference (e.g. input's `compactText`).
+    return exprToValue(resolveLocalConst(node.getText(), ctx), ctx)
+  }
+
+  if (node.isKind(SyntaxKind.CallExpression)) {
+    return evaluateCall(node, ctx)
+  }
 
   if (node.isKind(SyntaxKind.PrefixUnaryExpression)) {
     const text = node.getText()
     // Allow e.g. `-1`
     if (text.startsWith('-') || text.startsWith('+')) {
       const inner = node.getOperand()
-      const innerVal = exprToValue(inner, filePath)
+      const innerVal = exprToValue(inner, ctx)
       if (typeof innerVal === 'number')
         return text.startsWith('-') ? -innerVal : innerVal
     }
@@ -80,7 +110,7 @@ function exprToValue(expr: Expression, filePath: string): unknown {
           `[publisher/extract] spread elements are not supported (${filePath})`,
         )
       }
-      return exprToValue(el, filePath)
+      return exprToValue(el, ctx)
     })
   }
 
@@ -95,10 +125,7 @@ function exprToValue(expr: Expression, filePath: string): unknown {
             `[publisher/extract] property without initializer in ${filePath}`,
           )
         }
-        obj[propertyKey(nameNode, filePath)] = exprToValue(
-          initializer,
-          filePath,
-        )
+        obj[propertyKey(nameNode, filePath)] = exprToValue(initializer, ctx)
         continue
       }
       if (property.isKind(SyntaxKind.ShorthandPropertyAssignment)) {
@@ -143,6 +170,173 @@ function propertyKey(nameNode: Node, filePath: string): string {
   )
 }
 
+/* ------------------------- runtime-helper resolution ------------------------- */
+
+/** Initializer of a module-level `const <name> = …` in the current file. */
+function resolveLocalConst(name: string, ctx: ExtractCtx): Expression {
+  const decl = ctx.sourceFile.getVariableDeclaration(name)
+  const init = decl?.getInitializer()
+  if (!init) {
+    throw new Error(
+      `[publisher/extract] cannot resolve identifier "${name}" — no local const in ${ctx.filePath}`,
+    )
+  }
+  return init
+}
+
+/**
+ * Evaluate a call used as a class value. Two shapes appear in `styles.ts`:
+ *   - `localFactory(args)` — a same-file `const f = tv({…})` invoked (input's
+ *     `tokens({ h: 6 })`, `outlineField({ focus: 'group' })`).
+ *   - `importedStyles().slot(args)` — another component's styles composed in
+ *     (otp-field / slider / progress-bar's `fieldStyles().field(…)`).
+ * Both run through the real `tv`, so the extracted string matches the app.
+ */
+function evaluateCall(call: CallExpression, ctx: ExtractCtx): string {
+  const callee = call.getExpression()
+  const args = call.getArguments().map((arg) => {
+    if (!Node.isExpression(arg)) {
+      throw new Error(
+        `[publisher/extract] non-expression call argument in ${ctx.filePath}`,
+      )
+    }
+    return exprToValue(arg, ctx)
+  })
+
+  // `importedStyles().slot(args)`
+  if (callee.isKind(SyntaxKind.PropertyAccessExpression)) {
+    const slotName = callee.getName()
+    const factoryCall = callee.getExpression()
+    const factoryId = factoryCall.isKind(SyntaxKind.CallExpression)
+      ? factoryCall.getExpression()
+      : undefined
+    if (!factoryId?.isKind(SyntaxKind.Identifier)) {
+      throw new Error(
+        `[publisher/extract] unsupported call "${call.getText()}" in ${ctx.filePath}`,
+      )
+    }
+    const stylesFn = resolveImportedStyles(factoryId.getText(), ctx)
+    const slots = stylesFn() as Record<string, (...a: unknown[]) => string>
+    const slotFn = slots[slotName]
+    if (typeof slotFn !== 'function') {
+      throw new Error(
+        `[publisher/extract] "${factoryId.getText()}().${slotName}()" — no such slot (${ctx.filePath})`,
+      )
+    }
+    return asClassString(slotFn(...args), call, ctx)
+  }
+
+  // `localFactory(args)`
+  if (callee.isKind(SyntaxKind.Identifier)) {
+    const factory = resolveLocalTvFactory(callee.getText(), ctx)
+    return asClassString(factory(...args), call, ctx)
+  }
+
+  throw new Error(
+    `[publisher/extract] unsupported call "${call.getText()}" in ${ctx.filePath}`,
+  )
+}
+
+function asClassString(
+  value: unknown,
+  call: CallExpression,
+  ctx: ExtractCtx,
+): string {
+  if (typeof value !== 'string') {
+    throw new Error(
+      `[publisher/extract] call "${call.getText()}" did not resolve to a class string (${ctx.filePath})`,
+    )
+  }
+  return value
+}
+
+/** A same-file `const <name> = tv({…})` rebuilt with the real `tv`. */
+function resolveLocalTvFactory(
+  name: string,
+  ctx: ExtractCtx,
+): (...args: unknown[]) => unknown {
+  const init = resolveLocalConst(name, ctx)
+  if (
+    !init.isKind(SyntaxKind.CallExpression) ||
+    init.getExpression().getText() !== 'tv'
+  ) {
+    throw new Error(
+      `[publisher/extract] "${name}" is not a tv() factory in ${ctx.filePath}`,
+    )
+  }
+  const configArg = init.getArguments()[0]
+  if (!configArg || !Node.isExpression(configArg)) {
+    throw new Error(
+      `[publisher/extract] tv() config missing for "${name}" in ${ctx.filePath}`,
+    )
+  }
+  return tv(exprToValue(configArg, ctx) as Parameters<typeof tv>[0]) as (
+    ...args: unknown[]
+  ) => unknown
+}
+
+const importedStylesCache = new Map<string, () => unknown>()
+
+/**
+ * Rebuild another component's default `styles` (the value of `<x>Styles`) so
+ * `<x>Styles().slot()` resolves to the same class the app renders. `styles.ts`
+ * exports `compose('default', paramDefaults)`; we mirror that with `flatten`
+ * (base ← default density ← param defaults) fed to the real `tv`.
+ */
+function resolveImportedStyles(name: string, ctx: ExtractCtx): () => unknown {
+  const spec = importSpecifierFor(name, ctx)
+  const match = spec.match(/^@\/registry\/ui\/([a-z0-9-]+)(?:\/styles)?$/)
+  if (!match) {
+    throw new Error(
+      `[publisher/extract] "${name}" imported from unsupported module "${spec}" in ${ctx.filePath}`,
+    )
+  }
+  const componentName = match[1]!
+  const stylesTsPath = path.join(
+    registryUiDirOf(ctx.filePath),
+    componentName,
+    'styles.ts',
+  )
+  const cached = importedStylesCache.get(stylesTsPath)
+  if (cached) return cached
+
+  const config = extractStylesConfig(stylesTsPath)
+  if (config.params && Object.keys(config.params).length > 0) {
+    // Composing a parameterized component's styles would need its meta param
+    // defaults; no current source does, so fail loudly rather than emit a
+    // silently-wrong default.
+    throw new Error(
+      `[publisher/extract] cannot compose "${name}" (${componentName} has params) in ${ctx.filePath}`,
+    )
+  }
+  const layer = flatten({
+    stylesConfig: config,
+    meta: {
+      name: componentName,
+      type: 'registry:ui',
+      params: {},
+    } as RegistryItem,
+    density: 'default',
+    paramSelections: {},
+  })
+  const stylesFn = () => tv(layer as Parameters<typeof tv>[0])()
+  importedStylesCache.set(stylesTsPath, stylesFn)
+  return stylesFn
+}
+
+/** Module specifier of the import that binds `name` in the current file. */
+function importSpecifierFor(name: string, ctx: ExtractCtx): string {
+  for (const imp of ctx.sourceFile.getImportDeclarations()) {
+    for (const named of imp.getNamedImports()) {
+      const local = named.getAliasNode()?.getText() ?? named.getName()
+      if (local === name) return imp.getModuleSpecifierValue()
+    }
+  }
+  throw new Error(
+    `[publisher/extract] no import found for "${name}" in ${ctx.filePath}`,
+  )
+}
+
 /* ---------------------------- entry ---------------------------- */
 
 /**
@@ -180,7 +374,7 @@ function extractFromSourceFile(sourceFile: SourceFile): StylesConfig {
     )
   }
 
-  const value = exprToValue(configArg, filePath)
+  const value = exprToValue(configArg, { sourceFile, filePath })
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new Error(
       `[publisher/extract] createStyles() config must be an object literal in ${filePath}`,

--- a/www/src/publisher/flatten.ts
+++ b/www/src/publisher/flatten.ts
@@ -100,8 +100,11 @@ function mergeSlots(
     ...Object.keys(b ?? {}),
   ])
   for (const key of keys) {
-    const merged = mergeClass(a?.[key], b?.[key])
-    if (merged !== undefined) result[key] = merged
+    // Every iterated key is declared in a source layer, so preserve it even
+    // when its merged class list is empty ('') — the shipped base file
+    // destructures and calls every declared slot, and a dropped key becomes an
+    // undefined slot function at runtime (e.g. field's `fieldset` / `legend`).
+    result[key] = mergeClass(a?.[key], b?.[key]) ?? ''
   }
   return Object.keys(result).length > 0 ? result : undefined
 }

--- a/www/src/publisher/publish.test.ts
+++ b/www/src/publisher/publish.test.ts
@@ -114,6 +114,22 @@ describe('flatten', () => {
     expect(dangerSlots.root).toMatch(/text-fg-danger/)
   })
 
+  test('preserves declared-but-empty slots when a density layer merges', () => {
+    // A slot declared empty in base (like field's `fieldset`/`legend`) must
+    // survive the merge as "" — the shipped base file calls every declared slot.
+    const layer = flatten({
+      stylesConfig: {
+        base: { slots: { fieldset: '', field: 'flex gap-2' } },
+        density: { default: { slots: { field: 'text-sm' } } },
+      },
+      meta: { name: 'x', type: 'registry:ui' } as never,
+      density: 'default',
+      paramSelections: {},
+    })
+    expect(layer.slots).toHaveProperty('fieldset', '')
+    expect(layer.slots?.field).toBeDefined()
+  })
+
   test('alert: undefined density layer leaves base untouched', () => {
     // density compact entry is an empty object — should be a no-op.
     const compact = flatten({
@@ -239,6 +255,39 @@ describe('publish', () => {
 
     expect(item.registryDependencies).toEqual([
       'https://dotui.com/r/loader?preset=abc',
+    ])
+  })
+
+  test('text-field: rewrites BOTH deps (field + input) to absolute URLs, none bare', () => {
+    // Regression for #477: `input` used to pass through bare (it had no
+    // publishable), so `shadcn add` resolved it against shadcn's default
+    // registry. With `input` publishable, both deps rewrite to dotui URLs.
+    setKnownDotuiNames(['field', 'input'])
+    setDotuiDepResolver('https://dotui.org')
+
+    const { item } = publish({
+      publishable: {
+        template: TV_CONFIG_PLACEHOLDER,
+        stylesConfig: { base: {} },
+        meta: {
+          name: 'text-field',
+          type: 'registry:ui',
+          registryDependencies: ['field', 'input'],
+          files: [
+            {
+              type: 'registry:ui',
+              path: 'ui/text-field/base.tsx',
+              target: 'ui/text-field.tsx',
+            },
+          ],
+        },
+      },
+      preset: { density: 'default', componentParams: {} },
+    })
+
+    expect(item.registryDependencies).toEqual([
+      'https://dotui.org/r/field',
+      'https://dotui.org/r/input',
     ])
   })
 


### PR DESCRIPTION
Closes #477. Closes #466.

## Problem

`pnpm build:registry` silently skipped 4 components (`input`, `otp-field`, `progress-bar`, `slider`) because the static extractor couldn't evaluate three expression shapes in `styles.ts`, then printed "✅ Registry built successfully!" anyway. Since `__generated__/publishables/` is built per deploy, those components never existed in production → `/r/input` 404'd (for months, while the docs advertise `shadcn add @dotui/input`). Two cascades:

- `text-field` declares `registryDependencies: ['field', 'input']`; the dep rewriter only rewrites *known* publishable names to `https://dotui.org/r/<name>` URLs, so the bare `input` fell through to shadcn's default registry — `shadcn add @dotui/text-field` installed **shadcn's Input**, overwriting a dotUI `input.tsx`.
- Independently, declared-but-empty slots (`fieldset: ''`, `legend: ''` in field) were dropped during flatten/serialize, so the served `field.tsx` destructures and calls slot functions that don't exist in its own `fieldVariants` config.

## Fix

- `extract-config.ts`: targeted static evaluation, routed through the **real** `tv`, for the three shapes present in registry source: module-level const string refs (`compactText`), local `tv()` factory calls (`tokens({h:6})`, `outlineField({focus})`), and imported composed calls (`fieldStyles().field(...)` — resolved from the referenced component's `styles.ts`, folded with base ← default density, never hand-inlined so field composition stays in sync). Unsupported patterns throw loudly with precise messages instead of producing output.
- `flatten.ts`: declared slot keys survive as `""` when their merged class list is empty — general, not field-specific. This also repairs `menu` (`itemLabel`), which was serving broken code on main, plus empty base slots in `card`/`list-box`/`pagination`.
- No change needed for the text-field dep cascade — publishing `input` fixes it; covered by a unit test asserting both deps emit as absolute URLs.

## Verification

- `build:registry`: 0 skipped (was 4), 75 publishables; all 71 pre-existing generated files **byte-identical** to main; served `publish()` output diffed for button/select/menu/checkbox/table/toast/field — only additive empty-slot repairs.
- Extracted composed styles diffed against hand-built runtime `tv` output for slider: identical string.
- Invariant "every slot referenced in emitted code exists in the emitted config" checked programmatically across 11 components: holds.
- 7 new unit tests; publisher suite 72/72; `pnpm check`, `pnpm typecheck` clean.
- Adversarial fixtures (parameterized composition, unresolvable const, object-returning `tv()` as class, non-registry import) all fail the build loudly.

## Suggested refactors

- Extractor errors are still swallowed into silent build-passing skips (`build-publishables.ts` catch → `registry-build.ts` logs and exits 0) — a future unsupported pattern would 404 again. Hardening lands separately in the follow-up guards PR (build fails on unexplained skips, dep-closure assertion, docs↔registry check, publish+compile smoke test).
- `resolveImportedStyles` deliberately throws on composing a *parameterized* component's styles (none do today); the planned publisher rewrite should compose these properly from the referenced component's meta defaults.

