### PR TITLE
fix(registry): make every published component compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
 
+      # publish-smoke.test.ts imports the generated publishables (gitignored).
+      - run: pnpm build:registry
       - run: pnpm test
 
   registry-drift:

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 
 # Generated shadcn publishables — emitted by `pnpm build:registry`.
 www/src/registry/__generated__/publishables/
+
+# Publisher compile smoke-test fixture — emitted by publish-smoke.test.ts.
+www/.smoke-fixture/

--- a/www/scripts/registry-build.ts
+++ b/www/scripts/registry-build.ts
@@ -17,6 +17,7 @@ import {
   collectBaseFiles,
 } from '../src/publisher/build-time/build-publishables'
 import { deriveRegistryDeps } from '../src/publisher/build-time/derive-registry-deps'
+import { BUNDLED_INTO_INIT } from '../src/publisher/publish'
 import { registryBase } from '../src/registry/base/registry'
 import { registryHooks } from '../src/registry/hooks/registry'
 import { iconLibraries, registryIcons } from '../src/registry/icons/icon-map'
@@ -497,12 +498,6 @@ function checkAllowlistReadiness(): void {
 }
 
 /**
- * Deps that ship in the init bundle (base.css / theme.css / lib/utils), dropped at
- * publish by publish.ts BUNDLED_INTO_INIT — a base file importing them is not drift.
- */
-const BUNDLED_INTO_INIT = new Set(['utils', 'focus-styles', 'theme'])
-
-/**
  * Derived dep names whose target is NOT a registered item yet — a known packaging gap
  * (lib/context + the use-image-loading-status hook are unregistered). Skipped so the
  * drift check doesn't demand a dep `shadcn add` couldn't resolve. Keyed by DEP-NAME and
@@ -616,10 +611,240 @@ async function checkRegistryIntegrity(
 }
 
 // ============================================================================
+// Post-publish guards: the emitted publishable set is a CONTRACT — every skip
+// is explained, every declared dep resolves, every docs-advertised name ships.
+// These catch the #477 bug class (a component silently missing from /r/{name},
+// or a dep that falls through to shadcn's default registry) at build, not in
+// production. See www/src/publisher/publish-smoke.test.ts for the compile guard.
+// ============================================================================
+
+/**
+ * ui items allowed to NOT emit a publishable, name → reason. Mirrors
+ * ORPHAN_ALLOWLIST: a skip that is NOT listed here fails the build, and a listed
+ * name that DID publish is stale and also fails. Every registered ui item must
+ * publish, so this starts EMPTY — an extractor/transform error is a build break,
+ * never a silent skip (the original #477 failure).
+ */
+const SKIP_ALLOWLIST = new Map<string, string>()
+
+/** Guard 1: fails on any unexplained publishable skip and on stale allowlist entries. */
+function checkPublishableSkips(build: PublishablesBuild): string[] {
+  const errors: string[] = []
+  for (const { name, reason } of build.skipped) {
+    if (SKIP_ALLOWLIST.has(name)) continue
+    errors.push(
+      `Publishable "${name}" was skipped: ${reason}\n` +
+        `      Fix ui/${name} so it emits a publishable, or (only if intentional) add ` +
+        `"${name}" to SKIP_ALLOWLIST in scripts/registry-build.ts with a reason.`,
+    )
+  }
+  for (const name of SKIP_ALLOWLIST.keys()) {
+    if (build.builtNames.has(name)) {
+      errors.push(
+        `Stale SKIP_ALLOWLIST entry "${name}" — it now publishes fine. ` +
+          `Remove it from SKIP_ALLOWLIST in scripts/registry-build.ts.`,
+      )
+    }
+  }
+  return errors
+}
+
+/**
+ * Registered lib/hook items referenced as `registryDependencies` that are NOT
+ * independently servable at GET /r/{name} (only ui items become publishables).
+ * shadcn add would fall through to its DEFAULT registry for these bare names —
+ * the exact #477 failure. They are a KNOWN packaging gap: the fix is to ship the
+ * file inline (as ui/tabs does with lib/context) or make lib/hooks servable.
+ * name → reason. Keyed by DEP-NAME; distinct from ORPHAN_ALLOWLIST (folder-path)
+ * and UNREGISTERED_DEP_ALLOWLIST (derived-import gaps). Drop an entry once the
+ * dep is inlined or becomes a publishable, and the guard requires it to resolve.
+ */
+const KNOWN_UNSERVABLE_DEPS = new Map<string, string>([
+  [
+    'responsive',
+    'lib/responsive — declared by ui/dialog, ui/menu; not inlined, not servable.',
+  ],
+  [
+    'react-aria-token-field',
+    'lib/react-aria-token-field — declared by ui/mention, ui/token-field; not inlined, not servable.',
+  ],
+  [
+    'use-mobile',
+    'hooks/use-mobile — declared by ui/sidebar; not inlined, not servable.',
+  ],
+])
+
+/**
+ * Guard 2: every publishable's `registryDependencies` must resolve to something
+ * shadcn can fetch — another publishable, an init-bundled name, an absolute URL,
+ * or an `@namespace/…` dep. A bare unknown name silently resolves against
+ * shadcn's default registry (how text-field pulled shadcn's Input), so it fails.
+ */
+function checkDependencyClosure(
+  registryUi: RegistryItem[],
+  build: PublishablesBuild,
+): string[] {
+  const errors: string[] = []
+  const referenced = new Set<string>()
+  for (const meta of registryUi) {
+    if (!build.builtNames.has(meta.name)) continue
+    for (const dep of meta.registryDependencies ?? []) {
+      if (build.builtNames.has(dep)) continue
+      if (BUNDLED_INTO_INIT.has(dep)) continue
+      if (dep.includes('://') || dep.startsWith('@')) continue
+      if (KNOWN_UNSERVABLE_DEPS.has(dep)) {
+        referenced.add(dep)
+        continue
+      }
+      errors.push(
+        `Dangling registryDependency: "${meta.name}" declares "${dep}", which is not a ` +
+          `published component, not bundled into init, and not an absolute-URL / @namespace dep. ` +
+          `shadcn add would resolve "${dep}" against its DEFAULT registry (the #477 failure). ` +
+          `Publish "${dep}" (add ui/${dep}), fix the name in ui/${meta.name}/meta.ts, or — if it is a ` +
+          `known lib/hook gap — add it to KNOWN_UNSERVABLE_DEPS in scripts/registry-build.ts.`,
+      )
+    }
+  }
+  for (const [dep, reason] of KNOWN_UNSERVABLE_DEPS) {
+    if (build.builtNames.has(dep)) {
+      errors.push(
+        `Stale KNOWN_UNSERVABLE_DEPS entry "${dep}" — it now publishes and is servable. ` +
+          `Remove it from KNOWN_UNSERVABLE_DEPS in scripts/registry-build.ts.`,
+      )
+    } else if (!referenced.has(dep)) {
+      errors.push(
+        `Stale KNOWN_UNSERVABLE_DEPS entry "${dep}" — no publishable declares it anymore (${reason}). ` +
+          `Remove it from KNOWN_UNSERVABLE_DEPS in scripts/registry-build.ts.`,
+      )
+    }
+  }
+  return errors
+}
+
+/**
+ * Non-component `@dotui/<name>` install targets docs may advertise, name →
+ * reason. `base`/`all` are the init + aggregate targets from installation.mdx;
+ * `form`/`text-area` are WIP components (docs pages carry `wip: true`) with no
+ * publishable yet. A component name here is stale once it starts publishing.
+ */
+const DOCS_INSTALL_NAME_ALLOWLIST = new Map<string, string>([
+  [
+    'base',
+    'installation.mdx — the `registry:base` init target served by /r/init.',
+  ],
+  ['all', 'installation.mdx — the aggregate "add every component" target.'],
+  [
+    'form',
+    'components/form.mdx (wip) — react-hook-form/tanstack-form not yet publishable.',
+  ],
+  ['text-area', 'components/text-area.mdx (wip) — no registered item yet.'],
+])
+
+/** `@dotui/<name>` install targets, excluding import paths like `@dotui/registry/ui/x` (trailing slash). */
+const DOCS_INSTALL_RE = /@dotui\/([a-z0-9][a-z0-9-]*)(?![/a-z0-9-])/g
+/** `dotui.org/r/<name>` URLs, ignoring `{placeholder}` template segments. */
+const DOCS_REGISTRY_URL_RE =
+  /dotui\.org\/r\/([a-z0-9][a-z0-9-]*)(?![/a-z0-9-])/g
+
+/**
+ * Guard 3: every install name advertised in the docs must ship. Scans
+ * content/docs for `@dotui/<name>` install targets and `dotui.org/r/<name>`
+ * URLs; each must be a publishable or an allowlisted non-component. This is what
+ * would have caught `@dotui/text-field` advertising a component that 404'd.
+ */
+async function checkDocsRegistryConsistency(
+  build: PublishablesBuild,
+): Promise<string[]> {
+  const docsDir = path.join(process.cwd(), 'content/docs')
+  const files = await listMdxFiles(docsDir)
+  const errors: string[] = []
+  const seen = new Set<string>()
+
+  for (const file of files) {
+    const source = await fs.readFile(file, 'utf8')
+    const lines = source.split('\n')
+    lines.forEach((line, i) => {
+      for (const re of [DOCS_INSTALL_RE, DOCS_REGISTRY_URL_RE]) {
+        re.lastIndex = 0
+        let match: RegExpExecArray | null
+        while ((match = re.exec(line)) !== null) {
+          const name = match[1]
+          if (!name) continue
+          if (build.builtNames.has(name)) continue
+          if (DOCS_INSTALL_NAME_ALLOWLIST.has(name)) {
+            seen.add(name)
+            continue
+          }
+          errors.push(
+            `${path.relative(process.cwd(), file)}:${i + 1} advertises "@dotui/${name}", ` +
+              `which is not a published component. Publish "${name}" (add ui/${name}), fix the docs ` +
+              `name, or — if it is a known non-component target — add it to DOCS_INSTALL_NAME_ALLOWLIST ` +
+              `in scripts/registry-build.ts.`,
+          )
+        }
+      }
+    })
+  }
+
+  for (const [name, reason] of DOCS_INSTALL_NAME_ALLOWLIST) {
+    if (build.builtNames.has(name)) {
+      errors.push(
+        `Stale DOCS_INSTALL_NAME_ALLOWLIST entry "${name}" — it now publishes as a component. ` +
+          `Remove it from DOCS_INSTALL_NAME_ALLOWLIST in scripts/registry-build.ts.`,
+      )
+    } else if (!seen.has(name)) {
+      errors.push(
+        `Stale DOCS_INSTALL_NAME_ALLOWLIST entry "${name}" — no docs page advertises it anymore (${reason}). ` +
+          `Remove it from DOCS_INSTALL_NAME_ALLOWLIST in scripts/registry-build.ts.`,
+      )
+    }
+  }
+  return errors
+}
+
+async function listMdxFiles(dir: string): Promise<string[]> {
+  const out: string[] = []
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...(await listMdxFiles(full)))
+    else if (entry.name.endsWith('.mdx')) out.push(full)
+  }
+  return out.sort()
+}
+
+/** Runs the post-publish guards (skips, dep closure, docs); throws on any failure. */
+async function checkPublishableIntegrity(
+  registryUi: RegistryItem[],
+  build: PublishablesBuild,
+) {
+  const errors = [
+    ...checkPublishableSkips(build),
+    ...checkDependencyClosure(registryUi, build),
+    ...(await checkDocsRegistryConsistency(build)),
+  ]
+  if (errors.length > 0) {
+    throw new Error(
+      `Publishable integrity check failed:\n  - ${errors.join('\n  - ')}`,
+    )
+  }
+  console.log(
+    '  ✓ publishable integrity (no unexplained skips, deps resolve, docs names ship)',
+  )
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
-async function buildShadcnPublishables(registryUi: RegistryItem[]) {
+interface PublishablesBuild {
+  skipped: Array<{ name: string; reason: string }>
+  /** Names of items that emitted a publishable — the exact set GET /r/{name} serves. */
+  builtNames: Set<string>
+}
+
+async function buildShadcnPublishables(
+  registryUi: RegistryItem[],
+): Promise<PublishablesBuild> {
   const { written, skipped } = await buildPublishables({
     registryDir: REGISTRY_DIR,
     items: registryUi,
@@ -633,6 +858,15 @@ async function buildShadcnPublishables(registryUi: RegistryItem[]) {
       console.log(`    - ${name}: ${reason}`)
     }
   }
+
+  // A written path is `<name>.ts`, excluding the index/base-css helpers.
+  const builtNames = new Set(
+    written
+      .filter((p) => p.endsWith('.ts'))
+      .map((p) => path.basename(p, '.ts'))
+      .filter((n) => n !== 'index' && n !== 'base-css'),
+  )
+  return { skipped, builtNames }
 }
 
 /** Generate base/colors.css from the default ColorConfig (both modes solved independently by the engine). */
@@ -687,7 +921,10 @@ async function main() {
     await buildInternalExamples()
 
     console.log('\nGenerating shadcn publishables')
-    await buildShadcnPublishables(registryUi)
+    const publishablesBuild = await buildShadcnPublishables(registryUi)
+
+    console.log('\nChecking publishable integrity')
+    await checkPublishableIntegrity(registryUi, publishablesBuild)
 
     console.log('\n✅ Registry built successfully!')
   } catch (error) {

--- a/www/src/publisher/build-time/build.test.ts
+++ b/www/src/publisher/build-time/build.test.ts
@@ -68,6 +68,47 @@ describe('extractStylesConfig', () => {
       'shimmer',
     ])
   })
+
+  test('input: resolves module-level const string refs (compactText)', () => {
+    const cfg = extractStylesConfig(path.join(REGISTRY_UI, 'input/styles.ts'))
+    // `inputGroup: compactText` — the identifier resolves to its const literal.
+    expect(cfg.density?.compact?.slots?.inputGroup).toBe(
+      'text-base sm:text-xs/relaxed',
+    )
+  })
+
+  test('input: resolves local tv() factory calls (tokens, outlineField)', () => {
+    const cfg = extractStylesConfig(path.join(REGISTRY_UI, 'input/styles.ts'))
+    // `tokens({ h: 6 })` in density.compact size.sm → the h=6 token string.
+    const sm = cfg.density?.compact?.variants?.size?.sm as Record<
+      string,
+      string
+    >
+    expect(sm.input).toContain('[--input-h:--spacing(6)]')
+    // `outlineField({ focus: 'self' })` in params.style.outline.
+    const outline = cfg.params?.style?.outline?.slots?.input as string
+    expect(outline).toContain('focus:ring-2')
+    expect(outline).toContain('border-border-field')
+  })
+
+  test('otp-field: composes field styles via fieldStyles().field(...)', () => {
+    const cfg = extractStylesConfig(
+      path.join(REGISTRY_UI, 'otp-field/styles.ts'),
+    )
+    const root = cfg.base.slots?.root as string[]
+    expect(Array.isArray(root)).toBe(true)
+    // The composed field slot classes + the passed className, all merged by tv.
+    expect(root[0]).toContain('group/otp-field')
+    expect(root[0]).toContain('w-full flex-col gap-2')
+  })
+
+  test('slider: composes field styles via fieldStyles().field()', () => {
+    const cfg = extractStylesConfig(path.join(REGISTRY_UI, 'slider/styles.ts'))
+    // Same default-composed field slot the app renders (no className arg).
+    expect(cfg.base.slots?.root).toBe(
+      'flex invalid:has-data-[slot=field-error]:**:data-[slot=description]:hidden w-full flex-col gap-2',
+    )
+  })
 })
 
 /* ============================================================ */
@@ -207,5 +248,39 @@ describe('end-to-end (extract + transform → publish)', () => {
 
     expect(rawContent).toContain('rounded-md')
     expect(rawContent).not.toContain('rounded-(--alert-radius)')
+  })
+
+  test('field: declared-but-empty slots (fieldset/legend) survive to the emitted tv config', () => {
+    const stylesConfig = extractStylesConfig(
+      path.join(REGISTRY_UI, 'field/styles.ts'),
+    )
+    const { template } = transformBase({
+      baseTsxPath: path.join(REGISTRY_UI, 'field/base.tsx'),
+      componentName: 'field',
+    })
+
+    const { rawContent } = publish({
+      publishable: {
+        template,
+        stylesConfig,
+        meta: {
+          name: 'field',
+          type: 'registry:ui',
+          files: [
+            {
+              type: 'registry:ui',
+              path: 'ui/field/base.tsx',
+              target: 'ui/field.tsx',
+            },
+          ],
+        },
+      },
+      preset: { density: 'default', componentParams: {} },
+    })
+
+    // The base file destructures `fieldset` / `legend` from the tv slots — if
+    // flatten drops the empty slot keys, those become undefined slot functions.
+    expect(rawContent).toMatch(/fieldset:\s*""/)
+    expect(rawContent).toMatch(/legend:\s*""/)
   })
 })

--- a/www/src/publisher/build-time/extract-config.ts
+++ b/www/src/publisher/build-time/extract-config.ts
@@ -18,10 +18,32 @@
  * Build-time only. Imports ts-morph.
  */
 
+import path from 'node:path'
+import { tv } from 'tailwind-variants'
 import { Node, Project, SyntaxKind } from 'ts-morph'
-import type { Expression, SourceFile } from 'ts-morph'
+import type { CallExpression, Expression, SourceFile } from 'ts-morph'
 
+import type { RegistryItem } from '@/registry/types'
+
+import { flatten } from '../flatten'
 import type { StylesConfig } from '../types'
+
+/**
+ * Threaded through `exprToValue` so runtime helpers used in `styles.ts` values
+ * — module-level `const` string refs, local `tv()` factory calls, and
+ * `<importedStyles>().<slot>()` compositions — resolve to the same class
+ * strings the app renders (evaluated with the real `tv`), not just plain
+ * literals.
+ */
+interface ExtractCtx {
+  sourceFile: SourceFile
+  filePath: string
+}
+
+/** `.../registry/ui/<name>/styles.ts` → `.../registry/ui`. */
+function registryUiDirOf(stylesTsPath: string): string {
+  return path.dirname(path.dirname(stylesTsPath))
+}
 
 /* ---------------------------- expression → value ---------------------------- */
 
@@ -41,7 +63,8 @@ function unwrap(expr: Expression): Expression {
   return expr
 }
 
-function exprToValue(expr: Expression, filePath: string): unknown {
+function exprToValue(expr: Expression, ctx: ExtractCtx): unknown {
+  const { filePath } = ctx
   const node = unwrap(expr)
 
   if (
@@ -56,15 +79,22 @@ function exprToValue(expr: Expression, filePath: string): unknown {
   if (node.isKind(SyntaxKind.TrueKeyword)) return true
   if (node.isKind(SyntaxKind.FalseKeyword)) return false
   if (node.isKind(SyntaxKind.NullKeyword)) return null
-  if (node.isKind(SyntaxKind.Identifier) && node.getText() === 'undefined')
-    return undefined
+  if (node.isKind(SyntaxKind.Identifier)) {
+    if (node.getText() === 'undefined') return undefined
+    // Module-level `const x = <literal>` reference (e.g. input's `compactText`).
+    return exprToValue(resolveLocalConst(node.getText(), ctx), ctx)
+  }
+
+  if (node.isKind(SyntaxKind.CallExpression)) {
+    return evaluateCall(node, ctx)
+  }
 
   if (node.isKind(SyntaxKind.PrefixUnaryExpression)) {
     const text = node.getText()
     // Allow e.g. `-1`
     if (text.startsWith('-') || text.startsWith('+')) {
       const inner = node.getOperand()
-      const innerVal = exprToValue(inner, filePath)
+      const innerVal = exprToValue(inner, ctx)
       if (typeof innerVal === 'number')
         return text.startsWith('-') ? -innerVal : innerVal
     }
@@ -80,7 +110,7 @@ function exprToValue(expr: Expression, filePath: string): unknown {
           `[publisher/extract] spread elements are not supported (${filePath})`,
         )
       }
-      return exprToValue(el, filePath)
+      return exprToValue(el, ctx)
     })
   }
 
@@ -95,10 +125,7 @@ function exprToValue(expr: Expression, filePath: string): unknown {
             `[publisher/extract] property without initializer in ${filePath}`,
           )
         }
-        obj[propertyKey(nameNode, filePath)] = exprToValue(
-          initializer,
-          filePath,
-        )
+        obj[propertyKey(nameNode, filePath)] = exprToValue(initializer, ctx)
         continue
       }
       if (property.isKind(SyntaxKind.ShorthandPropertyAssignment)) {
@@ -143,6 +170,173 @@ function propertyKey(nameNode: Node, filePath: string): string {
   )
 }
 
+/* ------------------------- runtime-helper resolution ------------------------- */
+
+/** Initializer of a module-level `const <name> = …` in the current file. */
+function resolveLocalConst(name: string, ctx: ExtractCtx): Expression {
+  const decl = ctx.sourceFile.getVariableDeclaration(name)
+  const init = decl?.getInitializer()
+  if (!init) {
+    throw new Error(
+      `[publisher/extract] cannot resolve identifier "${name}" — no local const in ${ctx.filePath}`,
+    )
+  }
+  return init
+}
+
+/**
+ * Evaluate a call used as a class value. Two shapes appear in `styles.ts`:
+ *   - `localFactory(args)` — a same-file `const f = tv({…})` invoked (input's
+ *     `tokens({ h: 6 })`, `outlineField({ focus: 'group' })`).
+ *   - `importedStyles().slot(args)` — another component's styles composed in
+ *     (otp-field / slider / progress-bar's `fieldStyles().field(…)`).
+ * Both run through the real `tv`, so the extracted string matches the app.
+ */
+function evaluateCall(call: CallExpression, ctx: ExtractCtx): string {
+  const callee = call.getExpression()
+  const args = call.getArguments().map((arg) => {
+    if (!Node.isExpression(arg)) {
+      throw new Error(
+        `[publisher/extract] non-expression call argument in ${ctx.filePath}`,
+      )
+    }
+    return exprToValue(arg, ctx)
+  })
+
+  // `importedStyles().slot(args)`
+  if (callee.isKind(SyntaxKind.PropertyAccessExpression)) {
+    const slotName = callee.getName()
+    const factoryCall = callee.getExpression()
+    const factoryId = factoryCall.isKind(SyntaxKind.CallExpression)
+      ? factoryCall.getExpression()
+      : undefined
+    if (!factoryId?.isKind(SyntaxKind.Identifier)) {
+      throw new Error(
+        `[publisher/extract] unsupported call "${call.getText()}" in ${ctx.filePath}`,
+      )
+    }
+    const stylesFn = resolveImportedStyles(factoryId.getText(), ctx)
+    const slots = stylesFn() as Record<string, (...a: unknown[]) => string>
+    const slotFn = slots[slotName]
+    if (typeof slotFn !== 'function') {
+      throw new Error(
+        `[publisher/extract] "${factoryId.getText()}().${slotName}()" — no such slot (${ctx.filePath})`,
+      )
+    }
+    return asClassString(slotFn(...args), call, ctx)
+  }
+
+  // `localFactory(args)`
+  if (callee.isKind(SyntaxKind.Identifier)) {
+    const factory = resolveLocalTvFactory(callee.getText(), ctx)
+    return asClassString(factory(...args), call, ctx)
+  }
+
+  throw new Error(
+    `[publisher/extract] unsupported call "${call.getText()}" in ${ctx.filePath}`,
+  )
+}
+
+function asClassString(
+  value: unknown,
+  call: CallExpression,
+  ctx: ExtractCtx,
+): string {
+  if (typeof value !== 'string') {
+    throw new Error(
+      `[publisher/extract] call "${call.getText()}" did not resolve to a class string (${ctx.filePath})`,
+    )
+  }
+  return value
+}
+
+/** A same-file `const <name> = tv({…})` rebuilt with the real `tv`. */
+function resolveLocalTvFactory(
+  name: string,
+  ctx: ExtractCtx,
+): (...args: unknown[]) => unknown {
+  const init = resolveLocalConst(name, ctx)
+  if (
+    !init.isKind(SyntaxKind.CallExpression) ||
+    init.getExpression().getText() !== 'tv'
+  ) {
+    throw new Error(
+      `[publisher/extract] "${name}" is not a tv() factory in ${ctx.filePath}`,
+    )
+  }
+  const configArg = init.getArguments()[0]
+  if (!configArg || !Node.isExpression(configArg)) {
+    throw new Error(
+      `[publisher/extract] tv() config missing for "${name}" in ${ctx.filePath}`,
+    )
+  }
+  return tv(exprToValue(configArg, ctx) as Parameters<typeof tv>[0]) as (
+    ...args: unknown[]
+  ) => unknown
+}
+
+const importedStylesCache = new Map<string, () => unknown>()
+
+/**
+ * Rebuild another component's default `styles` (the value of `<x>Styles`) so
+ * `<x>Styles().slot()` resolves to the same class the app renders. `styles.ts`
+ * exports `compose('default', paramDefaults)`; we mirror that with `flatten`
+ * (base ← default density ← param defaults) fed to the real `tv`.
+ */
+function resolveImportedStyles(name: string, ctx: ExtractCtx): () => unknown {
+  const spec = importSpecifierFor(name, ctx)
+  const match = spec.match(/^@\/registry\/ui\/([a-z0-9-]+)(?:\/styles)?$/)
+  if (!match) {
+    throw new Error(
+      `[publisher/extract] "${name}" imported from unsupported module "${spec}" in ${ctx.filePath}`,
+    )
+  }
+  const componentName = match[1]!
+  const stylesTsPath = path.join(
+    registryUiDirOf(ctx.filePath),
+    componentName,
+    'styles.ts',
+  )
+  const cached = importedStylesCache.get(stylesTsPath)
+  if (cached) return cached
+
+  const config = extractStylesConfig(stylesTsPath)
+  if (config.params && Object.keys(config.params).length > 0) {
+    // Composing a parameterized component's styles would need its meta param
+    // defaults; no current source does, so fail loudly rather than emit a
+    // silently-wrong default.
+    throw new Error(
+      `[publisher/extract] cannot compose "${name}" (${componentName} has params) in ${ctx.filePath}`,
+    )
+  }
+  const layer = flatten({
+    stylesConfig: config,
+    meta: {
+      name: componentName,
+      type: 'registry:ui',
+      params: {},
+    } as RegistryItem,
+    density: 'default',
+    paramSelections: {},
+  })
+  const stylesFn = () => tv(layer as Parameters<typeof tv>[0])()
+  importedStylesCache.set(stylesTsPath, stylesFn)
+  return stylesFn
+}
+
+/** Module specifier of the import that binds `name` in the current file. */
+function importSpecifierFor(name: string, ctx: ExtractCtx): string {
+  for (const imp of ctx.sourceFile.getImportDeclarations()) {
+    for (const named of imp.getNamedImports()) {
+      const local = named.getAliasNode()?.getText() ?? named.getName()
+      if (local === name) return imp.getModuleSpecifierValue()
+    }
+  }
+  throw new Error(
+    `[publisher/extract] no import found for "${name}" in ${ctx.filePath}`,
+  )
+}
+
 /* ---------------------------- entry ---------------------------- */
 
 /**
@@ -180,7 +374,7 @@ function extractFromSourceFile(sourceFile: SourceFile): StylesConfig {
     )
   }
 
-  const value = exprToValue(configArg, filePath)
+  const value = exprToValue(configArg, { sourceFile, filePath })
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new Error(
       `[publisher/extract] createStyles() config must be an object literal in ${filePath}`,

--- a/www/src/publisher/flatten.ts
+++ b/www/src/publisher/flatten.ts
@@ -100,8 +100,11 @@ function mergeSlots(
     ...Object.keys(b ?? {}),
   ])
   for (const key of keys) {
-    const merged = mergeClass(a?.[key], b?.[key])
-    if (merged !== undefined) result[key] = merged
+    // Every iterated key is declared in a source layer, so preserve it even
+    // when its merged class list is empty ('') — the shipped base file
+    // destructures and calls every declared slot, and a dropped key becomes an
+    // undefined slot function at runtime (e.g. field's `fieldset` / `legend`).
+    result[key] = mergeClass(a?.[key], b?.[key]) ?? ''
   }
   return Object.keys(result).length > 0 ? result : undefined
 }

--- a/www/src/publisher/publish-smoke.test.ts
+++ b/www/src/publisher/publish-smoke.test.ts
@@ -107,30 +107,12 @@ async function buildFixture(): Promise<void> {
 
 /**
  * Publishables whose EMITTED code has a known pre-existing type error, name →
- * reason. All are publisher/packaging bugs unrelated to #477's fix; the
- * publisher is queued for a rewrite, so they are tolerated here (never
- * deepened) rather than blocking the guard. A NEW break in any other component
- * fails the test; an allowlisted component that starts compiling is stale and
- * also fails, forcing the entry's removal once the bug is fixed.
+ * reason. Tolerated here (never deepened) rather than blocking the guard. A
+ * NEW break in any other component fails the test; an allowlisted component
+ * that starts compiling is stale and also fails, forcing the entry's removal
+ * once the bug is fixed.
  */
-const KNOWN_BROKEN = new Map<string, string>([
-  [
-    'radio-group',
-    'transform renames the source `radioGroupStyles` tv to `radioGroupVariants`, colliding with the generated tv (duplicate declaration).',
-  ],
-  [
-    'toggle-button-group',
-    'imports `toggleButtonStyles` from toggle-button, but the transform renames that export to `toggleButtonVariants`.',
-  ],
-  [
-    'toast',
-    'ships `import type { … } from "./types"` but toast/types.ts is not in meta.files, so the type module is missing.',
-  ],
-  [
-    'time-picker',
-    'ships `import type { … } from "./types"` but time-picker/types.ts is not in meta.files, so the type module is missing.',
-  ],
-])
+const KNOWN_BROKEN = new Map<string, string>([])
 
 const DIAGNOSTIC_RE = /^(src\/.+?)\((\d+),\d+\): error TS/
 

--- a/www/src/publisher/publish-smoke.test.ts
+++ b/www/src/publisher/publish-smoke.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Compile smoke test — the load-bearing guard for the #477 bug class.
+ *
+ * Publishes EVERY publishable at the default preset (mimicking the /r/$name
+ * route), lays the emitted files out as a shadcn consumer would receive them,
+ * and runs ONE `tsc --noEmit` over the whole set. Cross-component imports
+ * (`@/components/ui/field`) resolve to OTHER emitted files, so the check proves
+ * the shipped code actually type-checks together — e.g. that every slot a base
+ * file destructures and calls exists in the emitted tv config (the
+ * field `fieldset`/`legend` regression). npm deps resolve from www/node_modules.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+
+import { defaultPreset } from '@/lib/registry-preset'
+import {
+  publishables,
+  PUBLISHABLE_NAMES,
+} from '@/registry/__generated__/publishables'
+
+import {
+  publish,
+  selectPublishable,
+  setDotuiDepResolver,
+  setKnownDotuiNames,
+} from './publish'
+
+// www/ — the fixture lives inside it so bare imports resolve via www/node_modules
+// and path aliases can reach registry source with plain relative specifiers.
+const WWW_DIR = path.resolve(import.meta.dirname, '../..')
+const FIXTURE_DIR = path.join(WWW_DIR, '.smoke-fixture')
+const TSC_BIN = path.join(WWW_DIR, 'node_modules', 'typescript', 'bin', 'tsc')
+
+/** Map a shipped `target` to its consumer-alias location under the fixture src. */
+function fixtureRelPath(target: string): string {
+  if (target.startsWith('ui/')) return `src/components/ui/${target.slice(3)}`
+  if (target.startsWith('lib/')) return `src/lib/${target.slice(4)}`
+  if (target.startsWith('hooks/')) return `src/hooks/${target.slice(6)}`
+  return `src/${target}`
+}
+
+function writeFixtureFile(relPath: string, content: string): void {
+  const abs = path.join(FIXTURE_DIR, relPath)
+  mkdirSync(path.dirname(abs), { recursive: true })
+  writeFileSync(abs, content, 'utf8')
+}
+
+async function buildFixture(): Promise<void> {
+  rmSync(FIXTURE_DIR, { recursive: true, force: true })
+  mkdirSync(FIXTURE_DIR, { recursive: true })
+
+  setKnownDotuiNames(PUBLISHABLE_NAMES)
+  setDotuiDepResolver('https://dotui.org')
+  const preset = defaultPreset()
+
+  for (const name of PUBLISHABLE_NAMES) {
+    const loader = publishables[name]
+    if (!loader) continue
+    const mod = await loader()
+    const { item } = publish({
+      publishable: selectPublishable(mod, preset),
+      preset,
+    })
+    for (const file of item.files ?? []) {
+      if (!file.target || file.content == null) continue
+      writeFixtureFile(fixtureRelPath(file.target), file.content)
+    }
+  }
+
+  // Init-bundled cn helper (ships in the registry:base item, not per-component).
+  writeFixtureFile('src/lib/utils.ts', `export { cn } from "cnfast";\n`)
+  // `@/components/icons` is resolved to a real library at publish; type it away
+  // in case any emitted file still references the marker.
+  writeFixtureFile('src/env.d.ts', `declare module "@/components/icons";\n`)
+
+  // Aliases mirror the consumer's components.json. `@/components/ui/*` MUST hit
+  // the emitted fixture files (cross-component type-checking); lib/hook deps not
+  // shipped inline fall back to registry source for real types.
+  const toRegistry = (sub: string) =>
+    path.relative(FIXTURE_DIR, path.join(WWW_DIR, 'src/registry', sub))
+  const tsconfig = {
+    extends: '@dotui/ts-config/base.json',
+    compilerOptions: {
+      lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+      jsx: 'react-jsx',
+      module: 'ESNext',
+      moduleResolution: 'Bundler',
+      noEmit: true,
+      skipLibCheck: true,
+      incremental: false,
+      checkJs: false,
+      types: [],
+      paths: {
+        '@/components/ui/*': ['./src/components/ui/*'],
+        '@/lib/*': ['./src/lib/*', `${toRegistry('lib')}/*`],
+        '@/hooks/*': ['./src/hooks/*', `${toRegistry('hooks')}/*`],
+        '@/registry/*': [`${toRegistry('')}/*`],
+      },
+    },
+    include: ['src/**/*.ts', 'src/**/*.tsx'],
+  }
+  writeFixtureFile('tsconfig.json', JSON.stringify(tsconfig, null, 2))
+}
+
+/**
+ * Publishables whose EMITTED code has a known pre-existing type error, name →
+ * reason. All are publisher/packaging bugs unrelated to #477's fix; the
+ * publisher is queued for a rewrite, so they are tolerated here (never
+ * deepened) rather than blocking the guard. A NEW break in any other component
+ * fails the test; an allowlisted component that starts compiling is stale and
+ * also fails, forcing the entry's removal once the bug is fixed.
+ */
+const KNOWN_BROKEN = new Map<string, string>([
+  [
+    'radio-group',
+    'transform renames the source `radioGroupStyles` tv to `radioGroupVariants`, colliding with the generated tv (duplicate declaration).',
+  ],
+  [
+    'toggle-button-group',
+    'imports `toggleButtonStyles` from toggle-button, but the transform renames that export to `toggleButtonVariants`.',
+  ],
+  [
+    'toast',
+    'ships `import type { … } from "./types"` but toast/types.ts is not in meta.files, so the type module is missing.',
+  ],
+  [
+    'time-picker',
+    'ships `import type { … } from "./types"` but time-picker/types.ts is not in meta.files, so the type module is missing.',
+  ],
+])
+
+const DIAGNOSTIC_RE = /^(src\/.+?)\((\d+),\d+\): error TS/
+
+/** Component slug that owns an errored diagnostic line, e.g. `…/time-picker.tsx(9,…)` → `time-picker`. */
+function ownerOf(line: string): string | undefined {
+  const filePath = line.match(DIAGNOSTIC_RE)?.[1]
+  return filePath ? path.basename(filePath).replace(/\.tsx?$/, '') : undefined
+}
+
+/** Run tsc over the fixture; returns diagnostic lines (only `path(line,col): error …`). */
+function runTsc(): string[] {
+  let output = ''
+  try {
+    execFileSync(process.execPath, [TSC_BIN, '--noEmit', '--pretty', 'false'], {
+      cwd: FIXTURE_DIR,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string }
+    output = `${e.stdout ?? ''}${e.stderr ?? ''}`
+  }
+  return output.split('\n').filter((l) => DIAGNOSTIC_RE.test(l))
+}
+
+test(
+  'every publishable emits code that type-checks together (default preset)',
+  { timeout: 180_000 },
+  async () => {
+    await buildFixture()
+    const diagnostics = runTsc()
+
+    const unexpected: string[] = []
+    const brokenSeen = new Set<string>()
+    for (const line of diagnostics) {
+      const owner = ownerOf(line)
+      if (owner && KNOWN_BROKEN.has(owner)) brokenSeen.add(owner)
+      else unexpected.push(line)
+    }
+
+    const stale = [...KNOWN_BROKEN.keys()].filter((n) => !brokenSeen.has(n))
+
+    if (unexpected.length > 0) {
+      const shown = unexpected.slice(0, 40).join('\n')
+      throw new Error(
+        `Emitted publishable code failed to type-check (${unexpected.length} error(s) in ` +
+          `non-allowlisted components). A component ships broken code — e.g. a base file ` +
+          `destructures a tv slot the emitted config dropped (the #477 field-slot regression). ` +
+          `Fix the component's source/styles, or (only if it is a known publisher-rewrite bug) ` +
+          `add it to KNOWN_BROKEN in publish-smoke.test.ts. First errors:\n\n${shown}`,
+      )
+    }
+    if (stale.length > 0) {
+      throw new Error(
+        `Stale KNOWN_BROKEN entr${stale.length === 1 ? 'y' : 'ies'} — now compiles clean: ` +
+          `${stale.join(', ')}. Remove from KNOWN_BROKEN in publish-smoke.test.ts.`,
+      )
+    }
+
+    expect(unexpected).toEqual([])
+    if (!process.env.KEEP_SMOKE_FIXTURE) {
+      rmSync(FIXTURE_DIR, { recursive: true, force: true })
+    }
+  },
+)

--- a/www/src/publisher/publish.test.ts
+++ b/www/src/publisher/publish.test.ts
@@ -114,6 +114,22 @@ describe('flatten', () => {
     expect(dangerSlots.root).toMatch(/text-fg-danger/)
   })
 
+  test('preserves declared-but-empty slots when a density layer merges', () => {
+    // A slot declared empty in base (like field's `fieldset`/`legend`) must
+    // survive the merge as "" — the shipped base file calls every declared slot.
+    const layer = flatten({
+      stylesConfig: {
+        base: { slots: { fieldset: '', field: 'flex gap-2' } },
+        density: { default: { slots: { field: 'text-sm' } } },
+      },
+      meta: { name: 'x', type: 'registry:ui' } as never,
+      density: 'default',
+      paramSelections: {},
+    })
+    expect(layer.slots).toHaveProperty('fieldset', '')
+    expect(layer.slots?.field).toBeDefined()
+  })
+
   test('alert: undefined density layer leaves base untouched', () => {
     // density compact entry is an empty object — should be a no-op.
     const compact = flatten({
@@ -239,6 +255,39 @@ describe('publish', () => {
 
     expect(item.registryDependencies).toEqual([
       'https://dotui.com/r/loader?preset=abc',
+    ])
+  })
+
+  test('text-field: rewrites BOTH deps (field + input) to absolute URLs, none bare', () => {
+    // Regression for #477: `input` used to pass through bare (it had no
+    // publishable), so `shadcn add` resolved it against shadcn's default
+    // registry. With `input` publishable, both deps rewrite to dotui URLs.
+    setKnownDotuiNames(['field', 'input'])
+    setDotuiDepResolver('https://dotui.org')
+
+    const { item } = publish({
+      publishable: {
+        template: TV_CONFIG_PLACEHOLDER,
+        stylesConfig: { base: {} },
+        meta: {
+          name: 'text-field',
+          type: 'registry:ui',
+          registryDependencies: ['field', 'input'],
+          files: [
+            {
+              type: 'registry:ui',
+              path: 'ui/text-field/base.tsx',
+              target: 'ui/text-field.tsx',
+            },
+          ],
+        },
+      },
+      preset: { density: 'default', componentParams: {} },
+    })
+
+    expect(item.registryDependencies).toEqual([
+      'https://dotui.org/r/field',
+      'https://dotui.org/r/input',
     ])
   })
 

--- a/www/src/publisher/publish.ts
+++ b/www/src/publisher/publish.ts
@@ -54,7 +54,7 @@ let dotuiDepQuery = ''
  * They're not separately fetchable URLs — drop them from per-component
  * `registryDependencies` so shadcn doesn't 404 looking for them.
  */
-const BUNDLED_INTO_INIT = new Set([
+export const BUNDLED_INTO_INIT = new Set([
   // focus-ring / focus-reset / focus-input utilities ship in base.css.
   'focus-styles',
   // @theme blocks ship in theme.css.

--- a/www/src/registry/ui/radio-group/base.tsx
+++ b/www/src/registry/ui/radio-group/base.tsx
@@ -13,9 +13,9 @@ import { Label } from '@/registry/ui/field'
 
 import { useStyles } from './styles'
 
-// MARK: radioGroupStyles
+// MARK: radioGroupRootStyles
 
-const radioGroupStyles = tv({
+const radioGroupRootStyles = tv({
   base: 'flex flex-col gap-3',
 })
 
@@ -26,7 +26,7 @@ const RadioGroup = ({
   return (
     <RadioGroupPrimitives.RadioGroup
       className={composeRenderProps(className, (className) =>
-        radioGroupStyles({ className }),
+        radioGroupRootStyles({ className }),
       )}
       {...props}
     />

--- a/www/src/registry/ui/time-picker/base.tsx
+++ b/www/src/registry/ui/time-picker/base.tsx
@@ -27,7 +27,6 @@ import { useTimeFieldState } from 'react-stately/useTimeFieldState'
 import { useStyles as useFieldStyles } from '@/registry/ui/field/styles'
 
 import { useStyles } from './styles'
-import type { TimePickerColumnsProps, TimePickerProps } from './types'
 
 // MARK: timePickerStyles
 
@@ -46,6 +45,20 @@ const useSlot = (
 }
 
 // MARK: TimePicker
+
+interface TimePickerProps<T extends TimeFieldPrimitive.TimeValue> extends Omit<
+  TimeFieldPrimitive.TimeFieldProps<T>,
+  'className' | 'children'
+> {
+  className?: string
+  children?: React.ReactNode
+  /** Whether the popover is open by default (uncontrolled). */
+  defaultOpen?: boolean
+  /** Whether the popover is open (controlled). */
+  isOpen?: boolean
+  /** Handler that is called when the popover's open state changes. */
+  onOpenChange?: (isOpen: boolean) => void
+}
 
 // There is no React Aria `TimePicker` primitive, so we compose one from the
 // same building blocks its `DatePicker` uses: a shared `TimeFieldState` drives
@@ -170,6 +183,8 @@ const range = (length: number, offset = 0): number[] =>
   Array.from({ length }, (_, i) => i + offset)
 
 const pad = (value: number): string => String(value).padStart(2, '0')
+
+interface TimePickerColumnsProps extends React.ComponentProps<'div'> {}
 
 const TimePickerColumns = ({ className, ...props }: TimePickerColumnsProps) => {
   const state = React.useContext(TimeFieldStateContext)

--- a/www/src/registry/ui/toast/base.tsx
+++ b/www/src/registry/ui/toast/base.tsx
@@ -11,7 +11,31 @@ import {
 } from '@/registry/icons'
 
 import { useStyles } from './styles'
-import type { ToastData, ToastPosition, ToastVariant } from './types'
+
+type ToastVariant =
+  | 'neutral'
+  | 'success'
+  | 'error'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'loading'
+
+type ToastPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right'
+
+interface ToastData {
+  /** Props forwarded to the root toast element. */
+  rootProps?: Omit<
+    ToastPrimitive.Root.Props,
+    'children' | 'className' | 'swipeDirection' | 'toast'
+  >
+}
 
 type ToastObject = ToastPrimitive.Root.ToastObject<ToastData>
 

--- a/www/src/registry/ui/toggle-button/base.tsx
+++ b/www/src/registry/ui/toggle-button/base.tsx
@@ -7,10 +7,11 @@ import type { VariantProps } from 'tailwind-variants'
 
 import { createVariantsContext } from '@/registry/lib/context'
 
-import { toggleButtonStyles, useStyles } from './styles'
+import { useStyles } from './styles'
 import type { ToggleButtonStyles } from './styles'
 
 // MARK: toggleButtonStyles
+export { toggleButtonStyles } from './styles'
 
 type ToggleButtonVariants = VariantProps<ToggleButtonStyles>
 
@@ -75,4 +76,4 @@ const ToggleButton = (localProps: ToggleButtonProps) => {
 // MARK: Separator
 
 export type { ToggleButtonProps }
-export { ToggleButton, ToggleButtonProvider, toggleButtonStyles }
+export { ToggleButton, ToggleButtonProvider }


### PR DESCRIPTION
Fixes the four publishables whose emitted code was type-broken, and empties the `KNOWN_BROKEN` allowlist in the compile smoke test.

> Stacked on #491 (which adds the smoke test + allowlist); retarget to `main` once it merges.

## What changed

- **radio-group** — renamed the local group-wrapper tv to `radioGroupRootStyles`. The transform renames the exact identifier `radioGroupStyles` → `radioGroupVariants`, which collided with the injected tv (duplicate `const`, TS2451). The other components with local `<name>Styles` tvs (avatar, checkbox-group, color-swatch) have no `styles.ts`, so the rename pass never touches them — radio-group was the only one with both.
- **toggle-button** — re-exports its styles via the pattern `field` already uses: `export { toggleButtonStyles } from './styles'`. The transform rewrites that to `export { toggleButtonVariants as toggleButtonStyles }`, keeping the public name stable, so toggle-button-group's emitted `import type { toggleButtonStyles } from '@/components/ui/toggle-button'` resolves (was TS2724). No change needed in toggle-button-group; www-side `index.tsx` re-exports are unaffected.
- **toast, time-picker** — inlined the prop types their `base.tsx` imported from `./types` (not a shipped file, TS2307). `types.ts` stays untouched as the API-reference source, matching the house pattern (button et al. declare prop types in `base.tsx` and duplicate them in `types.ts`). Shipping `types.ts` instead was ruled out: a `./types` relative import would have to land at `ui/types.ts`, which collides across components.
- **publish-smoke.test.ts** — `KNOWN_BROKEN` is now empty (the test fails on stale entries, so all four had to come out together with the fixes).

All fixes are shallow source/meta changes; `transform-base.ts` is untouched (publisher rewrite is queued).

## Verification

- Smoke test green with the empty allowlist; confirmed it isn't vacuous — the fixture `tsc` program contains all 75 emitted files and exits 0, and I inspected the four emitted files under `.smoke-fixture` to confirm each fix landed as intended.
- Full publisher suite (73 tests), `pnpm check`, `pnpm typecheck` all pass; `pnpm build:registry` clean (no tracked generated output changed — `publishables/` is gitignored).