### PR TITLE
fix(registry): register context and use-image-loading-status deps

### DIFF
--- a/www/scripts/registry-build.ts
+++ b/www/scripts/registry-build.ts
@@ -413,8 +413,6 @@ ${arrayBlock('registryLib', 'lib', lib)}
  *   ui/react-hook-form   WIP — name:"form"; meta points to a base.tsx that does
  *                         not exist yet.
  *   ui/tanstack-form     WIP — name:"form"; stub (index.tsx + meta only).
- *   lib/context          Real runtime dep (avatar/tabs/toggle-button) but not yet
- *                         a registered item.
  *
  * NOTE: react-hook-form and tanstack-form both declare name:"form"; they never
  * collide because both are excluded here (and bare ui/form has no meta.ts).
@@ -422,7 +420,6 @@ ${arrayBlock('registryLib', 'lib', lib)}
 const ORPHAN_ALLOWLIST = new Set<string>([
   'ui/react-hook-form',
   'ui/tanstack-form',
-  'lib/context',
 ])
 
 /**
@@ -498,17 +495,14 @@ function checkAllowlistReadiness(): void {
 }
 
 /**
- * Derived dep names whose target is NOT a registered item yet — a known packaging gap
- * (lib/context + the use-image-loading-status hook are unregistered). Skipped so the
- * drift check doesn't demand a dep `shadcn add` couldn't resolve. Keyed by DEP-NAME and
- * covers the hooks scope, so it is deliberately DISTINCT from ORPHAN_ALLOWLIST (folder-
- * path keyed, ui|lib only) — do not unify them. Drop an entry once its target is a
- * registered item, and the guard will then require consumers to declare it.
+ * Derived dep names whose target is NOT a registered item yet — a known packaging gap.
+ * Skipped so the drift check doesn't demand a dep `shadcn add` couldn't resolve. Keyed
+ * by DEP-NAME and covers the hooks scope, so it is deliberately DISTINCT from
+ * ORPHAN_ALLOWLIST (folder-path keyed, ui|lib only) — do not unify them. Drop an entry
+ * once its target is a registered item, and the guard will then require consumers to
+ * declare it. Currently empty — every derived dep resolves to a registered item.
  */
-const UNREGISTERED_DEP_ALLOWLIST = new Set([
-  'context',
-  'use-image-loading-status',
-])
+const UNREGISTERED_DEP_ALLOWLIST = new Set<string>()
 
 /**
  * Asserts each registered ui item DECLARES every registry dependency its shipped base

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -1,6 +1,7 @@
 // AUTO-GENERATED - DO NOT EDIT
 // Run "tsx scripts/registry-build.ts" to regenerate
 
+import LibContext from "@/registry/lib/context/meta";
 import LibFocusStyles from "@/registry/lib/focus-styles/meta";
 import LibReactAriaTokenField from "@/registry/lib/react-aria-token-field/meta";
 import LibResponsive from "@/registry/lib/responsive/meta";
@@ -161,6 +162,7 @@ export const registryUi: RegistryItem[] = [
 ];
 
 export const registryLib: RegistryItem[] = [
+	LibContext,
 	LibFocusStyles,
 	LibReactAriaTokenField,
 	LibResponsive,

--- a/www/src/registry/hooks/registry.ts
+++ b/www/src/registry/hooks/registry.ts
@@ -2,6 +2,17 @@ import type { RegistryItem } from '@/registry/types'
 
 export const registryHooks: RegistryItem[] = [
   {
+    name: 'use-image-loading-status',
+    type: 'registry:hook',
+    files: [
+      {
+        type: 'registry:hook',
+        path: 'hooks/use-image-loading-status.ts',
+        target: 'hooks/use-image-loading-status.ts',
+      },
+    ],
+  },
+  {
     name: 'use-mobile',
     type: 'registry:hook',
     files: [

--- a/www/src/registry/hooks/use-image-loading-status.ts
+++ b/www/src/registry/hooks/use-image-loading-status.ts
@@ -2,9 +2,6 @@
 
 import * as React from 'react'
 
-// import { useIsoLayoutEffect } from '@base-ui-components/utils/useIsoLayoutEffect';
-// import { NOOP } from '../../utils/noop';
-
 export type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error'
 
 interface UseImageLoadingStatusOptions {

--- a/www/src/registry/ui/avatar/meta.ts
+++ b/www/src/registry/ui/avatar/meta.ts
@@ -11,6 +11,7 @@ const avatarMeta = {
       target: 'ui/avatar.tsx',
     },
   ],
+  registryDependencies: ['context', 'use-image-loading-status'],
   params: {
     radius: {
       kind: 'scalar',

--- a/www/src/registry/ui/sidebar/meta.ts
+++ b/www/src/registry/ui/sidebar/meta.ts
@@ -13,6 +13,7 @@ const sidebarMeta = {
   ],
   registryDependencies: [
     'button',
+    'context',
     'drawer',
     'separator',
     'skeleton',

--- a/www/src/registry/ui/tabs/meta.ts
+++ b/www/src/registry/ui/tabs/meta.ts
@@ -10,15 +10,8 @@ const tabsMeta = {
       path: 'ui/tabs/base.tsx',
       target: 'ui/tabs.tsx',
     },
-    // base.tsx imports @/lib/context, which has no installable registry item —
-    // ship the file with tabs until lib items become publishable.
-    {
-      type: 'registry:lib',
-      path: 'lib/context/index.tsx',
-      target: 'lib/context.tsx',
-    },
   ],
-  registryDependencies: ['focus-styles'],
+  registryDependencies: ['context', 'focus-styles'],
 } satisfies RegistryItem
 
 export default tabsMeta

--- a/www/src/registry/ui/toggle-button/meta.ts
+++ b/www/src/registry/ui/toggle-button/meta.ts
@@ -11,7 +11,7 @@ const toggleButtonMeta = {
       target: 'ui/toggle-button.tsx',
     },
   ],
-  registryDependencies: ['focus-styles'],
+  registryDependencies: ['context', 'focus-styles'],
 } satisfies RegistryItem
 
 export default toggleButtonMeta


### PR DESCRIPTION
Follow-up to #499 (part 2 of the #495 dangling-deps class). Replaces the original inline-files approach of this PR, which #499 superseded.

## Problem

`lib/context` (imported by avatar, sidebar, tabs, toggle-button) and `hooks/use-image-loading-status` (avatar) were the last unregistered runtime deps — excused via `UNREGISTERED_DEP_ALLOWLIST`, so:

- **avatar** and **sidebar** installs were broken: their emitted code imports `@/lib/context` (and the hook) but nothing ships or declares it.
- **tabs** still shipped `lib/context.tsx` inline via `meta.files` — the pre-#499 pattern, duplicating the file per consumer.

## Fix

- Register `context` (drop `lib/context` from `ORPHAN_ALLOWLIST`) and add `use-image-loading-status` to `registryHooks` — both now emit style-less publishables and serve at `/r/<name>`.
- Declare `context` in avatar, sidebar, tabs, toggle-button metas (+ `use-image-loading-status` in avatar); drop tabs' inline file.
- Empty `UNREGISTERED_DEP_ALLOWLIST` — every derived dep now resolves to a registered item, so the drift guard enforces declaration everywhere.

Verified: `build:registry` guards, publisher suite (77 tests incl. publish smoke), `check`, `typecheck` all green.
