### PR TITLE
feat(www): add light-only Paper writing preset

### DIFF
--- a/www/src/modules/docs/preview-controls.tsx
+++ b/www/src/modules/docs/preview-controls.tsx
@@ -62,10 +62,18 @@ function usePreviewMode(): PreviewMode | undefined {
     : undefined
 }
 
+/** True when the selected docs preset supports light mode only. */
+function useSelectedPresetLightOnly(): boolean {
+  const selected = presetStore.useValue()
+  return Boolean(PRESETS.find((p) => p.id === selected)?.lightOnly)
+}
+
 /** The mode previews must pin, or undefined when the site theme already provides it. */
 export function useForcedPreviewMode(): PreviewMode | undefined {
   const mode = usePreviewMode()
   const { resolvedTheme } = useTheme()
+  const lightOnly = useSelectedPresetLightOnly()
+  if (lightOnly) return resolvedTheme === 'light' ? undefined : 'light'
   return mode === undefined || mode === resolvedTheme ? undefined : mode
 }
 
@@ -163,9 +171,27 @@ function PresetSelector() {
 }
 
 function PreviewModeToggle({ className }: { className?: string }) {
-  const mode = usePreviewMode() ?? 'light'
+  const storedMode = usePreviewMode() ?? 'light'
+  const lightOnly = useSelectedPresetLightOnly()
+  const mode = lightOnly ? 'light' : storedMode
   const next = mode === 'light' ? 'dark' : 'light'
   const Icon = mode === 'light' ? SunIcon : MoonIcon
+
+  // A light-only preset has no dark rendering to switch to.
+  if (lightOnly) {
+    return (
+      <Button
+        variant="quiet"
+        size="sm"
+        isIconOnly
+        isDisabled
+        aria-label="Light-only preset"
+        className={cn('text-fg-muted', className)}
+      >
+        <SunIcon />
+      </Button>
+    )
+  }
 
   return (
     <Tooltip>

--- a/www/src/modules/marketing/cards.tsx
+++ b/www/src/modules/marketing/cards.tsx
@@ -9,7 +9,10 @@ import { PRESETS } from '@/modules/presets/presets-data'
 
 export function Cards() {
   const [selected, setSelected] = useState(0)
-  const preset = PRESETS[selected]?.designSystem ?? DEFAULTS
+  const active = PRESETS[selected]
+  const preset = active?.designSystem ?? DEFAULTS
+  // A light-only preset pins its scope to light even under the dark site theme.
+  const forcedMode = active?.lightOnly ? ('light' as const) : undefined
 
   // Re-theming the grid re-renders every styled component in it; as a transition
   // that render is interruptible and doesn't block the click.
@@ -26,7 +29,7 @@ export function Cards() {
           nested masks instead of mask-composite for browser compatibility.
           --preset-wash-bg is registered as a <color> in styles.css so it
           tweens on preset switch. */}
-      <DesignSystemProvider scoped color={preset.color}>
+      <DesignSystemProvider scoped color={preset.color} forcedMode={forcedMode}>
         <div
           aria-hidden
           className="pointer-events-none absolute inset-x-0 -top-56 bottom-0 -z-20 [mask-image:linear-gradient(to_bottom,transparent,black_24rem)]"
@@ -47,6 +50,7 @@ export function Cards() {
           density={preset.density}
           color={preset.color}
           icons={preset.icons}
+          forcedMode={forcedMode}
         >
           <CardsGrid className="relative z-20 w-[max(52rem,150vw)] max-w-none shrink-0 [zoom:0.8] [mask-image:linear-gradient(to_right,black_calc(125vw_-_1.25*var(--crop-pl)_-_1.25*var(--edge-fade)),transparent_calc(125vw_-_1.25*var(--crop-pl)))] [--edge-fade:2.5rem] lg:w-full lg:max-w-(--grid-max) lg:min-w-0 lg:shrink lg:[zoom:1] lg:[mask-image:none]" />
         </DesignSystemProvider>

--- a/www/src/modules/presets/preset-card.tsx
+++ b/www/src/modules/presets/preset-card.tsx
@@ -50,7 +50,10 @@ export function PresetCard({
       action={<PaletteSwatches preset={preset} />}
       className="transition hover:border-border-hover hover:shadow-md has-[button:focus-visible]:border-border-hover"
     >
-      <PresetThumbnail designSystem={preset.designSystem} />
+      <PresetThumbnail
+        designSystem={preset.designSystem}
+        forcedMode={preset.lightOnly ? 'light' : undefined}
+      />
       {/* Fade the clipped bottom edge into the card chrome. */}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-card to-transparent" />
       <button

--- a/www/src/modules/presets/preset-modal.tsx
+++ b/www/src/modules/presets/preset-modal.tsx
@@ -95,6 +95,7 @@ function PresetModalBody({ preset }: { preset: Preset }) {
   const { resolvedTheme } = useTheme()
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [previewMode, setPreviewMode] = useState<PreviewMode>('light')
+  const lightOnly = Boolean(preset.lightOnly)
 
   const encoded = useMemo(
     () => encodePreset(preset.designSystem),
@@ -107,8 +108,9 @@ function PresetModalBody({ preset }: { preset: Preset }) {
   // Seed the preview's light / dark from the site theme on open, then it's
   // independent (mirrors the /create PreviewPanel: the SSR'd server can't know
   // the client's stored theme, so seed after mount rather than during render).
+  // Light-only presets stay pinned to light regardless.
   useEffect(() => {
-    setPreviewMode(resolvedTheme === 'dark' ? 'dark' : 'light')
+    setPreviewMode(!lightOnly && resolvedTheme === 'dark' ? 'dark' : 'light')
     // oxlint-disable-next-line react/exhaustive-deps -- seed once at open; preview mode is independent thereafter
   }, [])
 
@@ -229,22 +231,29 @@ function PresetModalBody({ preset }: { preset: Preset }) {
       {/* RIGHT: the live showcase, themed by this preset. */}
       <div className="relative flex min-h-0 flex-1 flex-col bg-bg">
         <div className="flex h-11 shrink-0 items-center justify-end gap-1 border-b px-2">
-          <Tooltip>
-            <Button
-              size="sm"
-              variant="quiet"
-              isIconOnly
-              onPress={() =>
-                setPreviewMode((m) => (m === 'dark' ? 'light' : 'dark'))
-              }
-              aria-label="Toggle preview mode"
-            >
-              {previewMode === 'dark' ? <SunIcon /> : <MoonIcon />}
-            </Button>
-            <TooltipContent>
-              {previewMode === 'dark' ? 'Light mode' : 'Dark mode'}
-            </TooltipContent>
-          </Tooltip>
+          {lightOnly ? (
+            <span className="flex items-center gap-1.5 px-1.5 text-xs font-medium text-fg-muted">
+              <SunIcon className="size-3.5" />
+              Light only
+            </span>
+          ) : (
+            <Tooltip>
+              <Button
+                size="sm"
+                variant="quiet"
+                isIconOnly
+                onPress={() =>
+                  setPreviewMode((m) => (m === 'dark' ? 'light' : 'dark'))
+                }
+                aria-label="Toggle preview mode"
+              >
+                {previewMode === 'dark' ? <SunIcon /> : <MoonIcon />}
+              </Button>
+              <TooltipContent>
+                {previewMode === 'dark' ? 'Light mode' : 'Dark mode'}
+              </TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip>
             <Button
               size="sm"

--- a/www/src/modules/presets/preset-thumbnail.tsx
+++ b/www/src/modules/presets/preset-thumbnail.tsx
@@ -23,8 +23,11 @@ const BASE_WIDTH = 720
  */
 export function PresetThumbnail({
   designSystem,
+  forcedMode,
 }: {
   designSystem: DesignSystem
+  /** Pin the scoped theme to one mode (light-only presets), ignoring the site theme. */
+  forcedMode?: 'light' | 'dark'
 }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [width, setWidth] = useState(0)
@@ -50,6 +53,7 @@ export function PresetThumbnail({
           density={designSystem.density}
           color={designSystem.color}
           icons={designSystem.icons}
+          forcedMode={forcedMode}
         >
           {/* Canvas, themed by the scope so the cards sit on the preset's own bg. */}
           <div aria-hidden className="absolute inset-0 bg-bg" />

--- a/www/src/modules/presets/presets-data.ts
+++ b/www/src/modules/presets/presets-data.ts
@@ -25,6 +25,8 @@ export type Preset = {
    * near-black accent would vanish; it shows as a monochrome light dot).
    */
   swatch: string
+  /** Supports light mode only — previews pin light and drop the mode toggle. */
+  lightOnly?: boolean
   designSystem: DesignSystem
 }
 
@@ -38,6 +40,10 @@ function makeDesignSystem(opts: {
   primary?: ColorConfig['primary']
   /** Chroma-curve scale (1 = engine default). */
   vividness?: ColorConfig['vividness']
+  /** App-background lightness per mode (e.g. a dimmer paper-cream light). */
+  background?: ColorConfig['background']
+  /** Neutral whisper-tint scale (1 = engine default). */
+  neutralTint?: ColorConfig['neutralTint']
   /** Google font families for the typography tokens (default Geist / match body). */
   fonts?: { heading?: string; body?: string; mono?: string }
   /** Per-component param overrides on top of the builder defaults. */
@@ -66,6 +72,10 @@ function makeDesignSystem(opts: {
       seeds: { accent, neutral },
       ...(opts.primary ? { primary: opts.primary } : {}),
       ...(opts.vividness !== undefined ? { vividness: opts.vividness } : {}),
+      ...(opts.background ? { background: opts.background } : {}),
+      ...(opts.neutralTint !== undefined
+        ? { neutralTint: opts.neutralTint }
+        : {}),
     },
   }
 }
@@ -234,6 +244,29 @@ export const PRESETS: Preset[] = [
         badge: { radius: '--radius-full' },
         input: { style: 'filled' },
       },
+    }),
+  },
+  {
+    id: 'paper',
+    name: 'Paper',
+    description: 'Bookish serif on warm paper, light-only.',
+    swatch: '#e3d9c6',
+    lightOnly: true,
+    // A writing mood, not a brand replica: reading serifs, cream paper, ink
+    // actions. Dark mode is deliberately unsupported — paper has one side.
+    designSystem: makeDesignSystem({
+      // Warm stone ink; the boosted whisper tint plus a dimmer background
+      // lightness turn the neutral ramp into cream paper.
+      neutral: '#7a7265',
+      // Russet ink — deep enough to read as ink, warm enough to sit on cream.
+      accent: '#8f4731',
+      neutralTint: 2,
+      background: { light: 97 },
+      radiusFactor: '0.75',
+      density: 'comfortable',
+      fonts: { heading: 'Lora', body: 'Literata' },
+      // Printed-page hairlines: soft rules, not UI borders.
+      tokens: { '--color-border': 'var(--neutral-200)' },
     }),
   },
 ]


### PR DESCRIPTION
## Summary

- Adds a **Paper** preset — a writing mood, not a brand replica: Literata body / Lora headings, cream paper background (warm stone neutral, boosted whisper tint, light lightness 97), neutral ink primary with a russet accent, comfortable density, 0.75 radius, soft hairlines.
- Introduces a `lightOnly` flag on `Preset` — the first preset with no dark variant. Every surface that renders presets pins its scoped theme to light via the provider's existing `forcedMode`:
  - **Presets gallery**: card thumbnail stays light under the dark site theme; the modal preview pins light and swaps the mode toggle for a "Light only" label.
  - **Landing showcase**: selecting Paper pins the cards grid and background wash to light.
  - **Docs previews**: `useForcedPreviewMode` pins light even over a stored dark preview preference; the mode toggle renders disabled.
- `makeDesignSystem` gains `background` and `neutralTint` passthroughs (existing `ColorConfig` axes, needed for the paper look).

Verified live (DOM inspection, dark site theme) on all three surfaces: scopes carry `data-mode="light"` and resolve `--color-bg` to the cream value; the preview iframe pins `light`. `pnpm check` and `pnpm typecheck` pass; no registry files touched.

**Known limitation:** "Open in editor" doesn't carry light-only into /create — the builder and exported CSS have no supported-modes axis (export still emits `.dark` blocks). That's a product axis touching the codec, builder UI, and the publisher (queued for rewrite), so it's deliberately out of scope here.