### PR TITLE
fix(registry): serve lib/hook deps as publishables

### DIFF
--- a/www/scripts/registry-build.ts
+++ b/www/scripts/registry-build.ts
@@ -659,20 +659,7 @@ function checkPublishableSkips(build: PublishablesBuild): string[] {
  * and UNREGISTERED_DEP_ALLOWLIST (derived-import gaps). Drop an entry once the
  * dep is inlined or becomes a publishable, and the guard requires it to resolve.
  */
-const KNOWN_UNSERVABLE_DEPS = new Map<string, string>([
-  [
-    'responsive',
-    'lib/responsive — declared by ui/dialog, ui/menu; not inlined, not servable.',
-  ],
-  [
-    'react-aria-token-field',
-    'lib/react-aria-token-field — declared by ui/mention, ui/token-field; not inlined, not servable.',
-  ],
-  [
-    'use-mobile',
-    'hooks/use-mobile — declared by ui/sidebar; not inlined, not servable.',
-  ],
-])
+const KNOWN_UNSERVABLE_DEPS = new Map<string, string>()
 
 /**
  * Guard 2: every publishable's `registryDependencies` must resolve to something
@@ -843,11 +830,11 @@ interface PublishablesBuild {
 }
 
 async function buildShadcnPublishables(
-  registryUi: RegistryItem[],
+  items: RegistryItem[],
 ): Promise<PublishablesBuild> {
   const { written, skipped } = await buildPublishables({
     registryDir: REGISTRY_DIR,
-    items: registryUi,
+    items,
   })
   for (const filePath of written) {
     console.log(`  ✓ ${path.relative(REGISTRY_DIR, filePath)}`)
@@ -921,7 +908,14 @@ async function main() {
     await buildInternalExamples()
 
     console.log('\nGenerating shadcn publishables')
-    const publishablesBuild = await buildShadcnPublishables(registryUi)
+    // lib/hook items publish too (as verbatim files) so registryDependencies
+    // like `responsive` / `use-mobile` resolve at /r/<name> instead of falling
+    // through to shadcn's default registry.
+    const publishablesBuild = await buildShadcnPublishables([
+      ...registryUi,
+      ...registryLib,
+      ...registryHooks,
+    ])
 
     console.log('\nChecking publishable integrity')
     await checkPublishableIntegrity(registryUi, publishablesBuild)

--- a/www/src/publisher/build-time/build-publishables.ts
+++ b/www/src/publisher/build-time/build-publishables.ts
@@ -159,7 +159,8 @@ interface BuildOneInput {
 
 /**
  * Build one publishable. Returns the file path written, "skipped" when the
- * component has no base.tsx (non-ui registry entries), or throws.
+ * item has no shippable files, or throws. Style-less lib/hook items (no
+ * `base.tsx`) ship their files verbatim so `/r/<name>` serves them too.
  */
 async function buildOne({
   meta,
@@ -167,7 +168,9 @@ async function buildOne({
   outDir,
 }: BuildOneInput): Promise<string | 'skipped'> {
   const baseFiles = collectBaseFiles(meta)
-  if (baseFiles.length === 0) return 'skipped'
+  if (baseFiles.length === 0) {
+    return buildStylelessPublishable({ meta, registryDir, outDir })
+  }
 
   // Extract the styles config once per component (it's shared across enum-file variants).
   const componentDir = path.join(registryDir, 'ui', meta.name)
@@ -212,6 +215,33 @@ async function buildOne({
     templates,
     extraFiles,
   })
+  await fs.writeFile(outPath, source, 'utf8')
+  return outPath
+}
+
+/**
+ * Build a style-less publishable (registry:lib / registry:hook) — no tv config,
+ * no template transform. Every file ships verbatim (registry import paths
+ * rewritten) as an `extraFile`, so `publish()` emits each one unchanged.
+ */
+async function buildStylelessPublishable({
+  meta,
+  registryDir,
+  outDir,
+}: BuildOneInput): Promise<string | 'skipped'> {
+  const files = meta.files ?? []
+  if (files.length === 0) return 'skipped'
+
+  const extraFiles: Record<string, string> = {}
+  for (const file of files) {
+    extraFiles[file.path] = await transformExtraFile(
+      path.join(registryDir, file.path),
+      meta.name,
+    )
+  }
+
+  const outPath = path.join(outDir, `${meta.name}.ts`)
+  const source = await renderStylelessPublishableSource({ meta, extraFiles })
   await fs.writeFile(outPath, source, 'utf8')
   return outPath
 }
@@ -332,6 +362,44 @@ interface RenderInput {
   stylesConfig: StylesConfig
   templates: Array<{ file: RegistryItemFile; template: string }>
   extraFiles: Record<string, string>
+}
+
+/** Render a style-less publishable: empty template, all files as extraFiles. */
+async function renderStylelessPublishableSource({
+  meta,
+  extraFiles,
+}: {
+  meta: RegistryItem
+  extraFiles: Record<string, string>
+}): Promise<string> {
+  const metaLiteral = JSON.stringify(meta, null, 2)
+  const lines: string[] = [
+    `// AUTO-GENERATED — do not edit. Source: ${meta.type} "${meta.name}"`,
+    `// Run \`pnpm build:registry\` to regenerate.`,
+    ``,
+    `import type { Publishable } from "@/publisher/types";`,
+    ``,
+    `const meta = ${metaLiteral} as const;`,
+    ``,
+    `export const publishable: Publishable = {`,
+    `\ttemplate: "",`,
+    `\tstylesConfig: { base: {} } as unknown as Publishable["stylesConfig"],`,
+    `\tmeta: meta as unknown as Publishable["meta"],`,
+    `\textraFiles: ${renderExtraFilesLiteral(extraFiles, 1)},`,
+    `};`,
+    ``,
+  ]
+
+  const raw = lines.join('\n')
+  try {
+    const { code } = await format('publishable.ts', raw, {
+      printWidth: 120,
+      useTabs: true,
+    })
+    return code
+  } catch {
+    return raw
+  }
 }
 
 async function renderPublishableSource({


### PR DESCRIPTION
Part 1 of #495 (dangling `registryDependencies`).

## Problem

`dialog`/`menu` declare `responsive`, `mention`/`token-field` declare `react-aria-token-field`, and `sidebar` declares `use-mobile` — all registered lib/hook items, but none servable at `/r/<name>`. The dep rewriter leaves unknown names bare, so `shadcn add` resolved them against shadcn's **default registry** (the #477 failure mode). They were excused via `KNOWN_UNSERVABLE_DEPS`.

## Fix

The publishables builder only handled `ui/` items with a `base.tsx`. It now also emits publishables for style-less items: their `meta.files` ship verbatim through the existing `extraFiles` path (so registry import rewriting like `@/registry/hooks/use-mobile` → `@/hooks/use-mobile` applies), and `buildShadcnPublishables` receives ui + lib + hooks items. Uniform rule — every registered lib/hook item is now servable (74 → 80 publishables; `utils`/`focus-styles` are dead-but-correct endpoints since `BUNDLED_INTO_INIT` names are dropped from deps before rewriting). `KNOWN_UNSERVABLE_DEPS` is now **empty**; its staleness guard keeps it that way.

## Verification (independent adversarial review)

- All five consumer components now emit **zero bare deps** — the three names rewrite to absolute `https://dotui.org/r/<name>` URLs (including the transitive `responsive` → `use-mobile`).
- All 74 pre-existing publishables **byte-identical** to main (built both, diffed); index changes purely additive.
- Emitted lib/hook items: correct `registry:lib`/`registry:hook` types, imports rewritten, no www-only leaks; all 80 items compile together in the publish+compile smoke test.
- `build:registry` guards green, `pnpm check` 0 errors, `pnpm typecheck`, `pnpm test` 231/231.

## Notes (pre-existing, not regressions)

- `react-aria-token-field` doesn't list `react-aria-components` in emitted `dependencies` — same init contract as every ui component (init's `DEFAULT_DEPENDENCIES` installs it); a standalone add without dotui init wouldn't resolve it. Uniform fix would be adding `react-aria-components` to `FILE_IMPORT_NPM_DEPS`.
- `// MARK:` section markers ship verbatim in extraFiles regardless of `codeOptions.sectionComments` — pre-existing for all secondary files, cosmetic.
