### PR TITLE
fix(registry): fix type errors in emitted component code

### DIFF
--- a/www/src/publisher/publish-smoke.test.ts
+++ b/www/src/publisher/publish-smoke.test.ts
@@ -113,24 +113,7 @@ async function buildFixture(): Promise<void> {
  * fails the test; an allowlisted component that starts compiling is stale and
  * also fails, forcing the entry's removal once the bug is fixed.
  */
-const KNOWN_BROKEN = new Map<string, string>([
-  [
-    'radio-group',
-    'transform renames the source `radioGroupStyles` tv to `radioGroupVariants`, colliding with the generated tv (duplicate declaration).',
-  ],
-  [
-    'toggle-button-group',
-    'imports `toggleButtonStyles` from toggle-button, but the transform renames that export to `toggleButtonVariants`.',
-  ],
-  [
-    'toast',
-    'ships `import type { … } from "./types"` but toast/types.ts is not in meta.files, so the type module is missing.',
-  ],
-  [
-    'time-picker',
-    'ships `import type { … } from "./types"` but time-picker/types.ts is not in meta.files, so the type module is missing.',
-  ],
-])
+const KNOWN_BROKEN = new Map<string, string>([])
 
 const DIAGNOSTIC_RE = /^(src\/.+?)\((\d+),\d+\): error TS/
 

--- a/www/src/registry/ui/button/base.tsx
+++ b/www/src/registry/ui/button/base.tsx
@@ -8,10 +8,12 @@ import type { VariantProps } from 'tailwind-variants'
 
 import { Loader } from '@/registry/ui/loader'
 
-import { buttonStyles, useStyles } from './styles'
+import { useStyles } from './styles'
 import type { ButtonStyles } from './styles'
 
 // MARK: buttonStyles
+
+export { buttonStyles } from './styles'
 
 type ButtonVariants = VariantProps<ButtonStyles>
 
@@ -112,4 +114,4 @@ const LinkButton = ({
 // MARK: Separator
 
 export type { ButtonProps, LinkButtonProps }
-export { Button, buttonStyles, LinkButton }
+export { Button, LinkButton }

--- a/www/src/registry/ui/radio-group/base.tsx
+++ b/www/src/registry/ui/radio-group/base.tsx
@@ -7,7 +7,6 @@ import { LabelContext } from 'react-aria-components/Label'
 import * as RadioGroupPrimitives from 'react-aria-components/RadioGroup'
 import { Provider, useSlottedContext } from 'react-aria-components/slots'
 import { useSlotId } from 'react-aria/private/utils/useId'
-import { tv } from 'tailwind-variants'
 
 import { Label } from '@/registry/ui/field'
 
@@ -15,18 +14,15 @@ import { useStyles } from './styles'
 
 // MARK: radioGroupStyles
 
-const radioGroupStyles = tv({
-  base: 'flex flex-col gap-3',
-})
-
 const RadioGroup = ({
   className,
   ...props
 }: RadioGroupPrimitives.RadioGroupProps) => {
+  const { group } = useStyles()()
   return (
     <RadioGroupPrimitives.RadioGroup
       className={composeRenderProps(className, (className) =>
-        radioGroupStyles({ className }),
+        group({ className }),
       )}
       {...props}
     />

--- a/www/src/registry/ui/radio-group/styles.ts
+++ b/www/src/registry/ui/radio-group/styles.ts
@@ -5,6 +5,7 @@ import radioGroupMeta from './meta'
 const { useStyles, styles } = createStyles(radioGroupMeta, {
   base: {
     slots: {
+      group: ['flex flex-col gap-3'],
       root: ['flex items-center has-data-description:items-start'],
       control: [
         'relative flex items-center gap-2 rounded-(--radio-radius) focus-reset not-has-data-label:after:absolute not-has-data-label:after:-inset-x-3 not-has-data-label:after:-inset-y-2 read-only:cursor-default focus-visible:focus-ring disabled:cursor-disabled has-data-description:items-start has-data-label:rounded-(--radio-card-radius)',

--- a/www/src/registry/ui/time-picker/base.tsx
+++ b/www/src/registry/ui/time-picker/base.tsx
@@ -27,7 +27,30 @@ import { useTimeFieldState } from 'react-stately/useTimeFieldState'
 import { useStyles as useFieldStyles } from '@/registry/ui/field/styles'
 
 import { useStyles } from './styles'
-import type { TimePickerColumnsProps, TimePickerProps } from './types'
+
+/**
+ * A time picker combines a TimeField and a scrollable time-column popover to
+ * allow users to enter or select a time value.
+ */
+interface TimePickerProps<T extends TimeFieldPrimitive.TimeValue> extends Omit<
+  TimeFieldPrimitive.TimeFieldProps<T>,
+  'className' | 'children'
+> {
+  className?: string
+  children?: React.ReactNode
+  /** Whether the popover is open by default (uncontrolled). */
+  defaultOpen?: boolean
+  /** Whether the popover is open (controlled). */
+  isOpen?: boolean
+  /** Handler that is called when the popover's open state changes. */
+  onOpenChange?: (isOpen: boolean) => void
+}
+
+/**
+ * The scrollable hour / minute / second / day-period columns rendered inside a
+ * TimePicker popover. Reads and writes the value from the enclosing TimePicker.
+ */
+interface TimePickerColumnsProps extends React.ComponentProps<'div'> {}
 
 // MARK: timePickerStyles
 

--- a/www/src/registry/ui/toast/base.tsx
+++ b/www/src/registry/ui/toast/base.tsx
@@ -11,7 +11,33 @@ import {
 } from '@/registry/icons'
 
 import { useStyles } from './styles'
-import type { ToastData, ToastPosition, ToastVariant } from './types'
+
+type ToastVariant =
+  | 'neutral'
+  | 'success'
+  | 'error'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'loading'
+
+type ToastPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right'
+
+interface ToastData {
+  /**
+   * Props forwarded to the root toast element.
+   */
+  rootProps?: Omit<
+    ToastPrimitive.Root.Props,
+    'children' | 'className' | 'swipeDirection' | 'toast'
+  >
+}
 
 type ToastObject = ToastPrimitive.Root.ToastObject<ToastData>
 

--- a/www/src/registry/ui/toggle-button/base.tsx
+++ b/www/src/registry/ui/toggle-button/base.tsx
@@ -7,10 +7,12 @@ import type { VariantProps } from 'tailwind-variants'
 
 import { createVariantsContext } from '@/registry/lib/context'
 
-import { toggleButtonStyles, useStyles } from './styles'
+import { useStyles } from './styles'
 import type { ToggleButtonStyles } from './styles'
 
 // MARK: toggleButtonStyles
+
+export { toggleButtonStyles } from './styles'
 
 type ToggleButtonVariants = VariantProps<ToggleButtonStyles>
 
@@ -75,4 +77,4 @@ const ToggleButton = (localProps: ToggleButtonProps) => {
 // MARK: Separator
 
 export type { ToggleButtonProps }
-export { ToggleButton, ToggleButtonProvider, toggleButtonStyles }
+export { ToggleButton, ToggleButtonProvider }


### PR DESCRIPTION
Part 3 of #495 (emitted code that doesn't compile). Registry-source fixes only — zero publisher/transform changes. `KNOWN_BROKEN` in the publish+compile smoke test is now **empty**; its staleness guard keeps it that way.

## Fixes

- **radio-group** — base.tsx had a local `const radioGroupStyles = tv(...)` for the group container alongside the styles-config import; the publisher's `*Styles`→`*Variants` rename collided it with the injected `radioGroupVariants` (duplicate declaration). Folded the container classes into the styles config as a base-only `group` slot (identical classes, density untouched — container spacing unchanged at every density).
- **toggle-button-group** — imported `toggleButtonStyles` from toggle-button, whose plain value re-export got renamed away by the transform. toggle-button now uses the canonical `export { toggleButtonStyles } from './styles'` pattern (as `field` does), which the transform rewrites to `export { toggleButtonVariants as toggleButtonStyles }`, keeping the stable public name. Applied identically to `button` per the Button ⇄ ToggleButton synced-group rule.
- **toast**, **time-picker** — imported types from `./types`, which is never shipped. Inlined the needed types into base.tsx (character-identical to the `types.ts` originals, JSDoc preserved); `types.ts` untouched, so API reference docs are unaffected (`build:references` produces zero drift).

## Verification (independent adversarial review)

- Fixture diff vs merge-base: **exactly 5 emitted files changed** (`button`, `radio-group`, `time-picker`, `toast`, `toggle-button`); `toggle-button-group.tsx` byte-identical (fix is producer-side); all other ~73 files byte-identical.
- www-side clear: site consumers of `buttonStyles`/`toggleButtonStyles` import via `index.tsx` → `./styles`, decoupled from the base.tsx change; `radioGroupStyles` had no consumers.
- Smoke test passes with empty `KNOWN_BROKEN`; `build:registry` no drift; `pnpm check` 0 errors; `pnpm typecheck`; `pnpm test` 231/231.

## Notes

- `button`'s emitted public export renames `buttonVariants` → `buttonStyles` (matching `field`'s convention). No internal consumer used the old name; external consumers who previously installed `button` and referenced `buttonVariants` would see the new name on reinstall.
- Consistency candidate (not done here): `checkbox-group`/`avatar`/`color-swatch` still keep a local `tv(...)` in base.tsx — safe today (no styles-config to collide with), worth folding in a future pass.
