### PR TITLE
docs: align install instructions with real registry routes

### DIFF
--- a/www/content/docs/(root)/installation.mdx
+++ b/www/content/docs/(root)/installation.mdx
@@ -28,10 +28,12 @@ This writes the `@dotui` registry into `components.json`:
 ```json title="components.json"
 {
   "registries": {
-    "@dotui": "https://dotui.org/r/{name}"
+    "@dotui": "https://dotui.org/r/{name}?preset="
   }
 }
 ```
+
+The empty `?preset=` is a placeholder — a style exported from the [editor](/create) fills it in so every component installs pre-themed.
 
 <Alert>
   Building a style in the [editor](/create)? Its export dialog gives you an

--- a/www/content/docs/(root)/installation.mdx
+++ b/www/content/docs/(root)/installation.mdx
@@ -15,45 +15,36 @@ Before you begin, make sure your project meets these requirements:
 
 <Steps>
 
-### Initialize shadcn CLI
+### Initialize
 
-Start by setting up the shadcn CLI in your project:
+Run this in your project root. It scaffolds the shadcn CLI, installs the design tokens, and registers dotUI in your `components.json` so components resolve to it.
 
 ```npm
-npx shadcn@latest init --no-base-style
+npx shadcn@latest init https://dotui.org/r/init
 ```
 
-### Configure your registry
-
-Choose or create a style, then update your `components.json` file to use the selected style.
+This writes the `@dotui` registry into `components.json`:
 
 ```json title="components.json"
 {
-  "style": "minimalist", // or "mehdibha/minimalist"
   "registries": {
-    "@dotui": "https://dotui.org/r/{style}/{name}"
+    "@dotui": "https://dotui.org/r/{name}"
   }
 }
 ```
 
-### Init your style
-
-```npm
-npx shadcn@latest add @dotui/base
-```
+<Alert>
+  Building a style in the [editor](/create)? Its export dialog gives you an
+  `init` command with your theme baked in, so every component installs
+  pre-styled to your system.
+</Alert>
 
 ### Add components
 
-You can now add components to your project.
+You can now add any component to your project.
 
 ```npm
 npx shadcn@latest add @dotui/button
-```
-
-To add all the components at once, you can use the `@dotui/all`.
-
-```npm
-npx shadcn@latest add @dotui/all
 ```
 
 ### You're done!

--- a/www/content/docs/components/form.mdx
+++ b/www/content/docs/components/form.mdx
@@ -11,9 +11,9 @@ wip: true
 
 ## Installation
 
-```npm
-npx shadcn@latest add @dotui/form
-```
+<Alert>
+  `Form` isn't published as a standalone item yet — it's on the way.
+</Alert>
 
 ## Usage
 

--- a/www/content/docs/components/text-area.mdx
+++ b/www/content/docs/components/text-area.mdx
@@ -50,8 +50,10 @@ wip: true
 
 ## Installation
 
+`TextArea` ships with the input primitives, so install `text-field`.
+
 ```npm
-npx shadcn@latest add @dotui/text-area
+npx shadcn@latest add @dotui/text-field
 ```
 
 ## Usage

--- a/www/scripts/registry-build.ts
+++ b/www/scripts/registry-build.ts
@@ -723,22 +723,20 @@ function checkDependencyClosure(
 
 /**
  * Non-component `@dotui/<name>` install targets docs may advertise, name →
- * reason. `base`/`all` are the init + aggregate targets from installation.mdx;
- * `form`/`text-area` are WIP components (docs pages carry `wip: true`) with no
- * publishable yet. A component name here is stale once it starts publishing.
+ * reason. Starts EMPTY: every install name in the docs must resolve to a
+ * publishable or a served route (see SERVED_ROUTE_NAMES). An entry here is a
+ * standing excuse for a name that 404s, so add one only for a genuinely
+ * unservable target, with a reason; a name that starts publishing makes it stale.
  */
-const DOCS_INSTALL_NAME_ALLOWLIST = new Map<string, string>([
-  [
-    'base',
-    'installation.mdx — the `registry:base` init target served by /r/init.',
-  ],
-  ['all', 'installation.mdx — the aggregate "add every component" target.'],
-  [
-    'form',
-    'components/form.mdx (wip) — react-hook-form/tanstack-form not yet publishable.',
-  ],
-  ['text-area', 'components/text-area.mdx (wip) — no registered item yet.'],
-])
+const DOCS_INSTALL_NAME_ALLOWLIST = new Map<string, string>()
+
+/**
+ * Names that resolve to a real `/r/<name>` route but aren't components, so they
+ * never appear in `builtNames`. `init` serves the `registry:base` item that
+ * `shadcn init https://dotui.org/r/init` consumes (see routes/r/init.tsx). Docs
+ * may advertise these; the guard treats them as served, not dangling.
+ */
+const SERVED_ROUTE_NAMES = new Set(['init'])
 
 /** `@dotui/<name>` install targets, excluding import paths like `@dotui/registry/ui/x` (trailing slash). */
 const DOCS_INSTALL_RE = /@dotui\/([a-z0-9][a-z0-9-]*)(?![/a-z0-9-])/g
@@ -749,8 +747,9 @@ const DOCS_REGISTRY_URL_RE =
 /**
  * Guard 3: every install name advertised in the docs must ship. Scans
  * content/docs for `@dotui/<name>` install targets and `dotui.org/r/<name>`
- * URLs; each must be a publishable or an allowlisted non-component. This is what
- * would have caught `@dotui/text-field` advertising a component that 404'd.
+ * URLs; each must be a publishable, a served route (SERVED_ROUTE_NAMES), or an
+ * allowlisted non-component. This is what would have caught `@dotui/text-field`
+ * advertising a component that 404'd.
  */
 async function checkDocsRegistryConsistency(
   build: PublishablesBuild,
@@ -771,6 +770,7 @@ async function checkDocsRegistryConsistency(
           const name = match[1]
           if (!name) continue
           if (build.builtNames.has(name)) continue
+          if (SERVED_ROUTE_NAMES.has(name)) continue
           if (DOCS_INSTALL_NAME_ALLOWLIST.has(name)) {
             seen.add(name)
             continue


### PR DESCRIPTION
Part 2 of #495 (docs advertising installs that 404). `DOCS_INSTALL_NAME_ALLOWLIST` is now **empty**; its staleness guard keeps it that way.

## Changes

- **installation.mdx** — the setup guide was structurally wrong: a `registries` mapping template of `/r/{style}/{name}` (never matches the real `/r/$name` route), a `@dotui/base` init step (404), and a `@dotui/all` "add everything" step (404). Now a 2-step flow mirroring the app's own export dialog: `npx shadcn@latest init https://dotui.org/r/init` (the real `registry:base` endpoint, which itself writes the `@dotui` mapping), then `add @dotui/<component>`. The shown components.json snippet matches what init writes byte-for-byte (including the `?preset=` placeholder, with a one-line explanation). `@dotui/all` dropped — no aggregate endpoint exists today. Added an Alert pointing to /create for a theme-baked init command.
- **text-area.mdx** — advertised `@dotui/text-area` (no such item). Now installs `@dotui/text-field`, whose dep chain (`field`, `input`, `text`) ships everything the page uses (`TextArea`, `InputGroup`, `InputGroupAddon` are exported by the input item).
- **form.mdx** — advertised `@dotui/form` (WIP, excluded from the registry). Install command replaced with an Alert stating Form isn't published as a standalone item yet; rest of the page untouched.
- **registry-build.ts** — allowlist emptied; small `SERVED_ROUTE_NAMES = {'init'}` added so the docs guard recognizes `/r/init` as a genuinely served route rather than re-allowlisting it as a 404 excuse.

## Verification (independent adversarial review, incl. real-CLI test)

- In a scratch Next.js project: `npx shadcn@latest init https://dotui.org/r/init` succeeded and wrote the `@dotui` mapping exactly as the docs now show; `npx shadcn@latest add @dotui/button` resolved via that mapping and installed. `add @dotui/text-field` installed text-field + field + input + text with all the exports the text-area page imports.
- Injected violations still fail the build (fake `dotui.org/r/bogus-thing` → guard error; stale allowlist entry → staleness error); `SERVED_ROUTE_NAMES` only matches exact `init`.
- `build:registry` guards green, no generated drift; `pnpm check` 0 errors; `pnpm typecheck`; `pnpm test` 231/231.

## Follow-up candidates (pre-existing, out of scope)

- Every component doc's Usage block imports `@/components/ui/<name>` while installs land at the literal target `ui/<name>.tsx` (→ `@/ui/<name>`) — uniform repo-wide mismatch, deserves its own pass.
- An "install everything" aggregate endpoint (`/r/all`) if that UX is still wanted — the old claim had no backing route.
- `SERVED_ROUTE_NAMES` has no existence check against actual route files (its sibling allowlists have staleness checks) — fine for one entry, asymmetric.
