### PR TITLE
feat(www): add named local preset saves to the /create builder

### DIFF
--- a/www/src/modules/create/customizer-panel.tsx
+++ b/www/src/modules/create/customizer-panel.tsx
@@ -56,6 +56,7 @@ import {
   RadiusConfig,
 } from './layout'
 import { encodePreset, useDesignSystem } from './preset'
+import { SavePresetDialog } from './save-preset-dialog'
 import { TypographyConfig, TypographySummary } from './typography'
 
 /* -------------------------------- Types -------------------------------- */
@@ -212,6 +213,18 @@ export function CustomizerPanel({ className }: { className?: string }) {
       search: (prev) => ({
         ...prev,
         preset: encodePreset(picked.designSystem),
+        gallery: undefined,
+      }),
+    })
+  }
+
+  // A saved preset's `state` is already an encoded `?preset=` value — apply it
+  // directly (no re-encode) and close the gallery in one navigation.
+  function applySavedPreset(state: string) {
+    navigate({
+      search: (prev) => ({
+        ...prev,
+        preset: state || undefined,
         gallery: undefined,
       }),
     })
@@ -535,9 +548,10 @@ export function CustomizerPanel({ className }: { className?: string }) {
       </div>
 
       {/* Footer */}
-      <div className="border-t p-3">
+      <div className="flex items-center gap-2 border-t p-3">
+        <SavePresetDialog />
         <ExportDialog>
-          <Button variant="primary" size="sm" className="w-full">
+          <Button variant="primary" size="sm" className="flex-1">
             Export
           </Button>
         </ExportDialog>
@@ -546,7 +560,9 @@ export function CustomizerPanel({ className }: { className?: string }) {
       <PresetGalleryModal
         isOpen={gallery === true}
         onOpenChange={setGalleryOpen}
+        currentState={preset ?? ''}
         onApply={applyPreset}
+        onApplySaved={applySavedPreset}
       />
     </div>
   )

--- a/www/src/modules/create/customizer-panel.tsx
+++ b/www/src/modules/create/customizer-panel.tsx
@@ -9,9 +9,9 @@ import {
 import { getRouteApi } from '@tanstack/react-router'
 import {
   ChevronLeftIcon,
+  ChevronsUpDownIcon,
   MousePointer2Icon,
   ShuffleIcon,
-  SwatchBookIcon,
   Undo2Icon,
 } from 'lucide-react'
 import { AnimatePresence, motion, type Transition } from 'motion/react'
@@ -55,7 +55,8 @@ import {
   RADIUS_FACTOR_VAR,
   RadiusConfig,
 } from './layout'
-import { encodePreset, useDesignSystem } from './preset'
+import { encodePreset, useDesignSystem, useMyPresets } from './preset'
+import { saveDesignSystemName, useDesignSystemName } from './preset/storage'
 import { SavePresetDialog } from './save-preset-dialog'
 import { TypographyConfig, TypographySummary } from './typography'
 
@@ -156,6 +157,14 @@ export function CustomizerPanel({ className }: { className?: string }) {
 
   const navStack = useMemo(() => (panel ? panel.split('.') : []), [panel])
 
+  // The header names what's being edited: the active saved preset (dotted when
+  // edited past its snapshot), else the standalone design-system name.
+  const { presets, activeId, setActive } = useMyPresets()
+  const storedName = useDesignSystemName()
+  const activeSaved = presets.find((p) => p.id === activeId)
+  const isDirty = activeSaved ? activeSaved.state !== (preset ?? '') : false
+  const displayName = activeSaved?.name ?? storedName
+
   // Undo history. Every design change is encoded into the `?preset=` search param
   // with `replace: true`, so the browser back button can't step through edits — we
   // keep our own stack of past preset values and walk back through it. Watching
@@ -209,6 +218,8 @@ export function CustomizerPanel({ className }: { className?: string }) {
   // updates (setDesignSystem + closing) would race on the functional `prev`.
   // The `?preset=` change lands in the undo history like any other edit.
   function applyPreset(picked: Preset) {
+    setActive(undefined)
+    saveDesignSystemName(picked.name)
     navigate({
       search: (prev) => ({
         ...prev,
@@ -469,13 +480,23 @@ export function CustomizerPanel({ className }: { className?: string }) {
     >
       {/* Header */}
       <div className="relative overflow-hidden border-b p-2">
-        <div className="flex w-full items-center justify-between gap-2 pl-1">
-          <span className="text-sm font-medium">Customize</span>
+        <div className="flex w-full items-center justify-between gap-2">
+          <Button
+            variant="quiet"
+            size="sm"
+            onPress={() => setGalleryOpen(true)}
+            className="min-w-0 justify-start gap-1.5 font-medium"
+          >
+            <span className="truncate">{displayName}</span>
+            {isDirty ? (
+              <span
+                aria-label="Unsaved changes"
+                className="size-1.5 shrink-0 rounded-full bg-fg-muted"
+              />
+            ) : null}
+            <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-muted" />
+          </Button>
           <div className="flex items-center gap-1">
-            <Button size="sm" onPress={() => setGalleryOpen(true)}>
-              <SwatchBookIcon />
-              Presets
-            </Button>
             <Button size="sm" isIconOnly aria-label="Shuffle" onPress={shuffle}>
               <ShuffleIcon />
             </Button>

--- a/www/src/modules/create/preset/index.ts
+++ b/www/src/modules/create/preset/index.ts
@@ -1,5 +1,6 @@
 export { decodePreset, encodePreset } from './codec'
 export { DEFAULTS } from './defaults'
+export { type SavedPreset, useMyPresets } from './my-presets'
 export {
   type PreviewMode,
   sendPreviewMode,

--- a/www/src/modules/create/preset/my-presets.ts
+++ b/www/src/modules/create/preset/my-presets.ts
@@ -1,0 +1,114 @@
+'use client'
+
+import { createPersistedStore } from '@/lib/persisted-store'
+
+/** A named design-system snapshot the user saved from /create. */
+export interface SavedPreset {
+  id: string
+  name: string
+  /** `encodePreset()` output — the compact string, never the expanded object. */
+  state: string
+  createdAt: number
+  updatedAt: number
+}
+
+const presetsStore = createPersistedStore<SavedPreset[]>(
+  'dotui:my-presets',
+  [],
+  {
+    decode: (raw) => {
+      try {
+        const parsed = JSON.parse(raw)
+        return Array.isArray(parsed) ? (parsed as SavedPreset[]) : []
+      } catch {
+        return []
+      }
+    },
+    encode: (presets) => (presets.length > 0 ? JSON.stringify(presets) : null),
+  },
+)
+
+/** The preset last saved or applied — highlighted in the gallery, targeted by Save's update path. */
+const activeStore = createPersistedStore<string | undefined>(
+  'dotui:active-saved-preset',
+  undefined,
+  {
+    decode: (raw) => raw || undefined,
+    encode: (id) => id ?? null,
+  },
+)
+
+export function useMyPresets() {
+  const presets = presetsStore.useValue()
+  const activeId = activeStore.useValue()
+
+  function save(name: string, state: string): string {
+    const id = crypto.randomUUID()
+    const now = Date.now()
+    presetsStore.set([
+      ...presetsStore.get(),
+      { id, name, state, createdAt: now, updatedAt: now },
+    ])
+    activeStore.set(id)
+    return id
+  }
+
+  function update(id: string, state: string, name?: string) {
+    presetsStore.set(
+      presetsStore
+        .get()
+        .map((p) =>
+          p.id === id
+            ? { ...p, state, name: name ?? p.name, updatedAt: Date.now() }
+            : p,
+        ),
+    )
+    activeStore.set(id)
+  }
+
+  function rename(id: string, name: string) {
+    presetsStore.set(
+      presetsStore
+        .get()
+        .map((p) => (p.id === id ? { ...p, name, updatedAt: Date.now() } : p)),
+    )
+  }
+
+  function duplicate(id: string): string | undefined {
+    const source = presetsStore.get().find((p) => p.id === id)
+    if (!source) return undefined
+    const newId = crypto.randomUUID()
+    const now = Date.now()
+    presetsStore.set([
+      ...presetsStore.get(),
+      {
+        id: newId,
+        name: `${source.name} copy`,
+        state: source.state,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+    return newId
+  }
+
+  function remove(id: string) {
+    presetsStore.set(presetsStore.get().filter((p) => p.id !== id))
+    if (activeStore.get() === id) activeStore.set(undefined)
+  }
+
+  function setActive(id: string | undefined) {
+    activeStore.set(id)
+  }
+
+  return {
+    presets,
+    activeId,
+    save,
+    update,
+    rename,
+    duplicate,
+    remove,
+    setActive,
+  }
+}

--- a/www/src/modules/create/save-preset-dialog.tsx
+++ b/www/src/modules/create/save-preset-dialog.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/registry/ui/button'
+import {
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { Input } from '@/registry/ui/input'
+import { Modal } from '@/registry/ui/modal'
+import { TextField } from '@/registry/ui/text-field'
+
+import { encodePreset, useDesignSystem, useMyPresets } from './preset'
+import { useDesignSystemName } from './preset/storage'
+
+/**
+ * Snapshots the current design system to a named localStorage preset ("Save as").
+ * When an active saved preset has diverged it also offers to update it in place.
+ */
+export function SavePresetDialog() {
+  const [isOpen, setIsOpen] = useState(false)
+  const { designSystem } = useDesignSystem()
+  const { presets, activeId, save, update } = useMyPresets()
+  const storedName = useDesignSystemName()
+
+  const currentState = encodePreset(designSystem) ?? ''
+  const active = presets.find((p) => p.id === activeId)
+  const isDirty = active ? active.state !== currentState : false
+
+  const [name, setName] = useState('')
+  useEffect(() => {
+    if (isOpen) setName(active?.name ?? storedName)
+  }, [isOpen, active?.name, storedName])
+
+  const trimmed = name.trim()
+
+  function saveAsNew() {
+    save(trimmed || storedName, currentState)
+    setIsOpen(false)
+  }
+
+  function updateActive() {
+    if (active) update(active.id, currentState, trimmed || undefined)
+    setIsOpen(false)
+  }
+
+  return (
+    <>
+      <Button size="sm" className="shrink-0" onPress={() => setIsOpen(true)}>
+        Save
+      </Button>
+      <Modal
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        className="w-full sm:max-w-sm"
+      >
+        <DialogContent aria-label="Save preset" className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <DialogTitle className="text-base font-semibold">
+              Save preset
+            </DialogTitle>
+            <DialogDescription className="text-sm text-fg-muted">
+              Store the current system as a named preset you can reapply later.
+            </DialogDescription>
+          </div>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (!trimmed) return
+              if (active && isDirty) updateActive()
+              else saveAsNew()
+            }}
+          >
+            <TextField
+              autoFocus
+              aria-label="Preset name"
+              value={name}
+              onChange={setName}
+            >
+              <Label>Name</Label>
+              <Input placeholder="Untitled" />
+            </TextField>
+          </form>
+          <div className="flex justify-end gap-2">
+            {active && isDirty ? (
+              <>
+                <Button size="sm" onPress={saveAsNew}>
+                  Save as new
+                </Button>
+                <Button size="sm" variant="primary" onPress={updateActive}>
+                  Update “{active.name}”
+                </Button>
+              </>
+            ) : (
+              <Button
+                size="sm"
+                variant="primary"
+                onPress={saveAsNew}
+                isDisabled={!trimmed}
+              >
+                Save
+              </Button>
+            )}
+          </div>
+        </DialogContent>
+      </Modal>
+    </>
+  )
+}

--- a/www/src/modules/presets/preset-gallery-modal.tsx
+++ b/www/src/modules/presets/preset-gallery-modal.tsx
@@ -9,27 +9,38 @@ import {
   DialogTitle,
 } from '@/registry/ui/dialog'
 import { Modal } from '@/registry/ui/modal'
+import { useMyPresets } from '@/modules/create/preset'
 
 import { PresetCard } from './preset-card'
 import { PRESETS, type Preset } from './presets-data'
+import { SavedPresetCard } from './saved-preset-card'
 
 interface PresetGalleryModalProps {
   isOpen: boolean
   onOpenChange: (open: boolean) => void
-  /** Called with the picked preset; the caller applies it and closes. */
+  /** The current working system, encoded — used to flag the active saved preset. */
+  currentState: string
+  /** Called with the picked built-in preset; the caller applies it and closes. */
   onApply: (preset: Preset) => void
+  /** Called with a saved preset's (already encoded) state; the caller navigates. */
+  onApplySaved: (state: string) => void
 }
 
 /**
- * The preset gallery: a grid of live preset thumbnails in a modal over the
- * editor. Picking one loads it as the editor's starting point — the change goes
- * through the regular `?preset=` update, so Undo can revert it.
+ * The preset gallery: the user's saved systems above a grid of built-in preset
+ * thumbnails. Picking one loads it as the editor's starting point — the change
+ * goes through the regular `?preset=` update, so Undo can revert it.
  */
 export function PresetGalleryModal({
   isOpen,
   onOpenChange,
+  currentState,
   onApply,
+  onApplySaved,
 }: PresetGalleryModalProps) {
+  const { presets, activeId, setActive, rename, duplicate, remove } =
+    useMyPresets()
+
   return (
     <Modal
       isOpen={isOpen}
@@ -61,18 +72,57 @@ export function PresetGalleryModal({
             brings your current system back.
           </DialogDescription>
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto p-5">
-          <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {PRESETS.map((preset) => (
-              <PresetCard
-                key={preset.id}
-                preset={preset}
-                onSelect={() => onApply(preset)}
-              />
-            ))}
-          </div>
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-5">
+          <section className="space-y-3">
+            <SectionHeading>My presets</SectionHeading>
+            {presets.length > 0 ? (
+              <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                {presets.map((saved) => (
+                  <SavedPresetCard
+                    key={saved.id}
+                    saved={saved}
+                    isActive={
+                      saved.id === activeId && saved.state === currentState
+                    }
+                    onApply={() => {
+                      setActive(saved.id)
+                      onApplySaved(saved.state)
+                    }}
+                    onRename={(name) => rename(saved.id, name)}
+                    onDuplicate={() => duplicate(saved.id)}
+                    onDelete={() => remove(saved.id)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="rounded-2xl border border-dashed p-6 text-center text-sm text-fg-muted">
+                No saved presets yet — save your current system from the panel.
+              </p>
+            )}
+          </section>
+
+          <section className="space-y-3">
+            <SectionHeading>Built-in</SectionHeading>
+            <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+              {PRESETS.map((preset) => (
+                <PresetCard
+                  key={preset.id}
+                  preset={preset}
+                  onSelect={() => onApply(preset)}
+                />
+              ))}
+            </div>
+          </section>
         </div>
       </DialogContent>
     </Modal>
+  )
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="px-1 text-[10px] tracking-widest text-fg-muted uppercase">
+      {children}
+    </h3>
   )
 }

--- a/www/src/modules/presets/saved-preset-card.tsx
+++ b/www/src/modules/presets/saved-preset-card.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { MoreHorizontalIcon } from 'lucide-react'
+
+import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
+import { cn } from '@/registry/lib/utils'
+import { Button } from '@/registry/ui/button'
+import { DialogContent, DialogTitle } from '@/registry/ui/dialog'
+import { Label } from '@/registry/ui/field'
+import { Input } from '@/registry/ui/input'
+import { Menu, MenuContent, MenuItem } from '@/registry/ui/menu'
+import { Modal } from '@/registry/ui/modal'
+import { Popover } from '@/registry/ui/popover'
+import { TextField } from '@/registry/ui/text-field'
+import { ShowcaseCard } from '@/components/showcase-card'
+import { decodePreset, type SavedPreset } from '@/modules/create/preset'
+
+import { PresetThumbnail } from './preset-thumbnail'
+
+/**
+ * A user-saved preset in the gallery — the same framed live preview as a
+ * built-in card, plus an actions menu (rename / duplicate / copy link / delete)
+ * in the header slot and an accent ring when it's the active preset.
+ */
+export function SavedPresetCard({
+  saved,
+  isActive,
+  onApply,
+  onRename,
+  onDuplicate,
+  onDelete,
+}: {
+  saved: SavedPreset
+  isActive: boolean
+  onApply: () => void
+  onRename: (name: string) => void
+  onDuplicate: () => void
+  onDelete: () => void
+}) {
+  const designSystem = useMemo(() => decodePreset(saved.state), [saved.state])
+  const { copyToClipboard } = useCopyToClipboard()
+  const [renameOpen, setRenameOpen] = useState(false)
+
+  function onAction(key: string) {
+    if (key === 'rename') setRenameOpen(true)
+    else if (key === 'duplicate') onDuplicate()
+    else if (key === 'copy') {
+      copyToClipboard(`${window.location.origin}/create?preset=${saved.state}`)
+    } else if (key === 'delete') onDelete()
+  }
+
+  return (
+    <>
+      <ShowcaseCard
+        label={saved.name}
+        action={
+          <Menu>
+            <Button
+              variant="quiet"
+              size="sm"
+              isIconOnly
+              aria-label={`Actions for ${saved.name}`}
+              className="-my-1"
+            >
+              <MoreHorizontalIcon />
+            </Button>
+            <Popover placement="bottom end">
+              <MenuContent onAction={(key) => onAction(String(key))}>
+                <MenuItem id="rename">Rename</MenuItem>
+                <MenuItem id="duplicate">Duplicate</MenuItem>
+                <MenuItem id="copy">Copy link</MenuItem>
+                <MenuItem id="delete" variant="danger">
+                  Delete
+                </MenuItem>
+              </MenuContent>
+            </Popover>
+          </Menu>
+        }
+        className={cn(
+          'transition hover:border-border-hover hover:shadow-md has-[button:focus-visible]:border-border-hover',
+          isActive && 'ring-2 ring-border-focus ring-offset-2 ring-offset-bg',
+        )}
+      >
+        <PresetThumbnail designSystem={designSystem} />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-card to-transparent" />
+        <button
+          type="button"
+          onClick={onApply}
+          aria-label={`Apply the ${saved.name} preset`}
+          className="absolute inset-0 z-10 rounded-2xl focus-visible:focus-ring"
+        />
+      </ShowcaseCard>
+      <RenamePresetDialog
+        isOpen={renameOpen}
+        onOpenChange={setRenameOpen}
+        currentName={saved.name}
+        onRename={onRename}
+      />
+    </>
+  )
+}
+
+function RenamePresetDialog({
+  isOpen,
+  onOpenChange,
+  currentName,
+  onRename,
+}: {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  currentName: string
+  onRename: (name: string) => void
+}) {
+  const [name, setName] = useState(currentName)
+
+  function submit() {
+    const trimmed = name.trim()
+    if (trimmed) onRename(trimmed)
+    onOpenChange(false)
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (open) setName(currentName)
+        onOpenChange(open)
+      }}
+      className="w-full sm:max-w-sm"
+    >
+      <DialogContent aria-label="Rename preset" className="flex flex-col gap-4">
+        <DialogTitle className="text-base font-semibold">
+          Rename preset
+        </DialogTitle>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            submit()
+          }}
+        >
+          <TextField
+            autoFocus
+            aria-label="Preset name"
+            value={name}
+            onChange={setName}
+          >
+            <Label>Name</Label>
+            <Input placeholder="Untitled" />
+          </TextField>
+        </form>
+        <div className="flex justify-end gap-2">
+          <Button size="sm" onPress={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            variant="primary"
+            onPress={submit}
+            isDisabled={!name.trim()}
+          >
+            Rename
+          </Button>
+        </div>
+      </DialogContent>
+    </Modal>
+  )
+}


### PR DESCRIPTION
Adds "My presets" — named localStorage saves of the user's design systems — the zero-auth tier of user-saved presets (the GitHub-registry tier is #503).

## Changes

- **`my-presets.ts`**: `SavedPreset { id, name, state, createdAt, updatedAt }` where `state` is the existing `encodePreset()` output — saved presets share the exact codec/versioning path as share links. Two `createPersistedStore`-backed keys (`dotui:my-presets`, `dotui:active-saved-preset`), cross-tab reactive. Surface: `useMyPresets()` → save / update / rename / duplicate / remove / setActive. This module is the single storage seam a future GitHub-backed store plugs in behind.
- **Header preset selector**: the panel's static "Customize" label is replaced by the current system's identity — the active saved preset's name (else the design-system name), a dirty dot when edited past the last save, and a chevron; pressing it opens the gallery. The separate Presets button is gone. Applying a built-in clears the active save and takes the preset's name.
- **Save dialog**: a secondary **Save** button beside Export in the customizer footer. Name prefills from the active saved preset, else the stored design-system name. Save is a snapshot ("Save as"); when the active saved preset has diverged (plain string inequality between current encoded state and its `state`), the dialog offers **Update "name"** (also applies an edited name) and **Save as new**.
- **Gallery**: the preset modal now has a "My presets" section (with empty-state hint) above "Built-in". Saved cards reuse the card/thumbnail pipeline via `decodePreset`, show an accent ring when active-and-in-sync, and carry an actions menu: Rename, Duplicate, Copy link (`/create?preset=<state>` — shareable today), Delete.
- Applying a saved preset uses the same single-navigation pattern as built-ins (state is already encoded), so **Undo reverts it**.

## Verification

- `pnpm check` (0 errors) and `pnpm typecheck` pass.
- Browser-verified end to end on the dev server: save with custom name → stored + active; header shows the name and opens the gallery; apply built-in → header renames, active clears; edit → dirty dot appears, Update clears it and syncs state (byte-equality between stored state and the `?preset=` param confirmed on both the edit and built-in-apply paths); Duplicate, Apply (URL matches stored state, active follows), Delete (active id cleared) all confirmed via localStorage inspection.

## Notes

- Local-only by design; clearing browser data loses saves (the per-preset Copy link is the escape hatch). Durable storage is #503.
- Implemented by an Opus executor agent from a written spec; reviewed, one defect fixed in review (Update discarded an edited name), and re-verified. The header selector was a follow-up design iteration.