### PR TITLE
ci: add post-deploy registry probe

### DIFF
--- a/.github/workflows/registry-probe.yml
+++ b/.github/workflows/registry-probe.yml
@@ -24,6 +24,10 @@ on:
         required: false
         default: 'https://dotui.org'
 
+# The probe only reads a public site; it needs nothing else from the token.
+permissions:
+  contents: read
+
 # Never run two probes at once; a newer deploy supersedes an in-flight probe.
 concurrency:
   group: registry-probe
@@ -39,6 +43,7 @@ jobs:
        github.event.deployment_status.environment == 'Production')
     runs-on: ubuntu-latest
     name: Probe production registry
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup

--- a/.github/workflows/registry-probe.yml
+++ b/.github/workflows/registry-probe.yml
@@ -1,0 +1,71 @@
+# Post-deploy probe (issue #496): checks what the DEPLOYED app serves at /r/*.
+#
+# CI (ci.yml) guards the registry build from source, but __generated__/publishables
+# is gitignored and rebuilt per deploy — so production can drift from a green CI
+# (this is how #477's /r/input 404 stayed invisible). This workflow probes the
+# live production app after each production deploy, and once daily as a safety net.
+#
+# Vercel's GitHub integration emits `deployment_status` events; we run on the
+# successful Production one. dotui.org is the stable production alias, so the
+# probe always targets it (the script cache-busts every request to dodge stale
+# CDN copies from the previous deploy).
+
+name: Registry probe
+
+on:
+  deployment_status:
+  schedule:
+    # Daily safety net — catches drift even without a deploy, or a missed event.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+    inputs:
+      origin:
+        description: 'Origin to probe'
+        required: false
+        default: 'https://dotui.org'
+
+# Never run two probes at once; a newer deploy supersedes an in-flight probe.
+concurrency:
+  group: registry-probe
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    # For deployment_status, only the successful Production deployment. Other
+    # triggers (schedule, manual) always run.
+    if: >-
+      github.event_name != 'deployment_status' ||
+      (github.event.deployment_status.state == 'success' &&
+       github.event.deployment_status.environment == 'Production')
+    runs-on: ubuntu-latest
+    name: Probe production registry
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+
+      # Give the production alias a moment to point at the new deployment before
+      # probing; deployment_status success can fire a beat before promotion.
+      - name: Wait for promotion
+        if: github.event_name == 'deployment_status'
+        run: sleep 30
+
+      - name: Probe
+        env:
+          PROBE_ORIGIN: ${{ github.event.inputs.origin || 'https://dotui.org' }}
+        # Retry a couple of times: a just-promoted deploy plus cache warming can
+        # briefly race. Three attempts, 20s apart, before we call it a failure.
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::probe attempt $attempt"
+            if pnpm probe:registry --origin "$PROBE_ORIGIN"; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "$attempt" -lt 3 ]; then
+              echo "attempt $attempt failed; retrying in 20s"
+              sleep 20
+            fi
+          done
+          echo "probe failed after 3 attempts"
+          exit 1

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:registry": "pnpm --filter=www build:registry",
     "preview:www": "pnpm --filter=www preview",
     "build:references": "pnpm --filter=www build:references",
+    "probe:registry": "pnpm --filter=www probe:registry",
     "clean": "git clean -xdf node_modules",
     "clean:workspaces": "turbo run clean",
     "check": "oxlint . && oxfmt --check .",

--- a/www/package.json
+++ b/www/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "typecheck": "pnpm build:registry && tsc --noEmit",
     "clean": "git clean -xdf .output .nitro .cache .turbo node_modules",
-    "build:references": "tsx scripts/api-docs-builder/src/index.ts"
+    "build:references": "tsx scripts/api-docs-builder/src/index.ts",
+    "probe:registry": "tsx scripts/registry-probe.ts"
   },
   "dependencies": {
     "@base-ui/react": "1.4.1",

--- a/www/scripts/registry-probe.ts
+++ b/www/scripts/registry-probe.ts
@@ -1,0 +1,247 @@
+/**
+ * Post-deploy registry probe.
+ *
+ * Verifies what a DEPLOYED dotui.org actually serves at /r/* — the one gap the
+ * CI guard suite can't cover. `www/src/registry/__generated__/publishables` is
+ * gitignored and rebuilt per deploy, so production depends on the deploy-time
+ * build: CI can be green while production drifts. That's how #477's /r/input
+ * 404 stayed invisible for months (see issue #496). This probe hits the live
+ * app so a bad deploy fails loudly.
+ *
+ * Steps, against --origin (default https://dotui.org):
+ *   1. GET /r/registry.json to learn the deployed component list. Never
+ *      hardcoded — the probe tracks whatever the deploy actually shipped.
+ *   2. GET /r/<name> for every item plus /r/init. Fail on any non-200 or
+ *      non-JSON response.
+ *   3. Assert no BARE registryDependencies in any served item: every entry must
+ *      be an absolute URL or an "@namespace/…" id. A bare name means the dep
+ *      rewriter didn't recognize it and shadcn would resolve it against its
+ *      default registry — exactly the #477 failure mode.
+ *   4. Shape spot-check on /r/field: every slot the code destructures from
+ *      fieldVariants() must be declared in the tv() slots:{} block. Cheap,
+ *      regex-level — catches a publish that emits code referencing a slot the
+ *      styles no longer define.
+ *
+ * Cache-awareness: /r/$name is served with
+ * `s-maxage=3600, stale-while-revalidate=86400` (see routes/r/$name.tsx), so a
+ * probe run right after a deploy can read STALE cached JSON built by the PREVIOUS
+ * deployment. Every request carries a unique cache-busting query param so we
+ * always hit the fresh deployment, not the CDN's copy.
+ *
+ * Usage:  tsx scripts/registry-probe.ts [--origin https://dotui.org]
+ * Exit 0 if everything passes; non-zero with a per-failure report otherwise.
+ */
+
+const DEFAULT_ORIGIN = 'https://dotui.org'
+const CONCURRENCY = 6
+// Extra names to probe that don't appear in registry.json's items list.
+const EXTRA_NAMES = ['init']
+
+interface Failure {
+  name: string
+  url: string
+  reason: string
+}
+
+function parseOrigin(argv: string[]): string {
+  const i = argv.indexOf('--origin')
+  const raw =
+    i !== -1 ? argv[i + 1] : (process.env.PROBE_ORIGIN ?? DEFAULT_ORIGIN)
+  if (!raw) {
+    console.error('error: --origin given without a value')
+    process.exit(2)
+  }
+  // Strip a trailing slash so `${origin}/r/x` never doubles up.
+  return raw.replace(/\/+$/, '')
+}
+
+/** Append a unique param so the CDN can't answer from a stale cached copy. */
+function bust(url: string): string {
+  const sep = url.includes('?') ? '&' : '?'
+  return `${url}${sep}_cb=${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+async function fetchJson(
+  url: string,
+): Promise<{ json?: unknown; error?: string }> {
+  let res: Response
+  try {
+    res = await fetch(bust(url), { headers: { accept: 'application/json' } })
+  } catch (err) {
+    return { error: `network error: ${(err as Error).message}` }
+  }
+  if (res.status !== 200) {
+    return { error: `HTTP ${res.status} ${res.statusText}` }
+  }
+  const contentType = res.headers.get('content-type') ?? ''
+  const body = await res.text()
+  if (!contentType.includes('application/json')) {
+    return { error: `non-JSON content-type: ${contentType || '(none)'}` }
+  }
+  try {
+    return { json: JSON.parse(body) }
+  } catch {
+    return { error: 'body did not parse as JSON' }
+  }
+}
+
+/** A minimal cross-worker task pool — no dependencies, native promises. */
+async function mapPool<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let next = 0
+  async function worker(): Promise<void> {
+    while (next < items.length) {
+      const idx = next++
+      results[idx] = await fn(items[idx]!)
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, worker),
+  )
+  return results
+}
+
+function isAbsoluteOrNamespaced(dep: string): boolean {
+  return /^https?:\/\//.test(dep) || dep.startsWith('@')
+}
+
+/** Check one served item for bare registryDependencies. */
+function checkDeps(name: string, url: string, item: unknown): Failure[] {
+  const deps = (item as { registryDependencies?: unknown }).registryDependencies
+  if (deps === undefined) return []
+  if (!Array.isArray(deps)) {
+    return [{ name, url, reason: 'registryDependencies is not an array' }]
+  }
+  const bare = deps.filter(
+    (d): d is string => typeof d === 'string' && !isAbsoluteOrNamespaced(d),
+  )
+  if (bare.length === 0) return []
+  return [
+    {
+      name,
+      url,
+      reason: `bare registryDependencies (dep rewriter didn't recognize): ${bare.join(', ')}`,
+    },
+  ]
+}
+
+/**
+ * Shape spot-check on /r/field: every slot destructured from fieldVariants()
+ * must be declared in the tv() slots:{} block of the emitted source.
+ */
+function checkFieldShape(origin: string, item: unknown): Failure[] {
+  const url = `${origin}/r/field`
+  const files = (item as { files?: Array<{ content?: string }> }).files
+  const content = files?.map((f) => f.content ?? '').join('\n') ?? ''
+  if (!content) {
+    return [{ name: 'field', url, reason: 'no file content to spot-check' }]
+  }
+
+  const slotsBlock = content.match(/slots:\s*\{([\s\S]*?)\n\s*\}/)
+  if (!slotsBlock) {
+    return [
+      {
+        name: 'field',
+        url,
+        reason: 'no slots:{} block found in emitted source',
+      },
+    ]
+  }
+  const declared = new Set(
+    [...slotsBlock[1]!.matchAll(/^\s*([A-Za-z][\w]*)\s*:/gm)].map((m) => m[1]!),
+  )
+
+  const destructured = [
+    ...content.matchAll(/const\s*\{\s*([\w]+)\s*\}\s*=\s*fieldVariants\(/g),
+  ].map((m) => m[1]!)
+
+  if (destructured.length === 0) {
+    return [
+      { name: 'field', url, reason: 'no fieldVariants() slot usage found' },
+    ]
+  }
+
+  const undeclared = destructured.filter((s) => !declared.has(s))
+  if (undeclared.length === 0) return []
+  return [
+    {
+      name: 'field',
+      url,
+      reason: `code destructures slots not declared in slots:{}: ${undeclared.join(', ')}`,
+    },
+  ]
+}
+
+async function main(): Promise<void> {
+  const origin = parseOrigin(process.argv.slice(2))
+  const started = Date.now()
+  console.log(`probing registry at ${origin}`)
+
+  // 1. Learn the component list from the deploy itself.
+  const indexUrl = `${origin}/r/registry.json`
+  const index = await fetchJson(indexUrl)
+  if (index.error || !index.json) {
+    console.error(`FAIL  ${indexUrl}  ${index.error ?? 'no body'}`)
+    console.error('\ncannot determine component list; aborting')
+    process.exit(1)
+  }
+  const items = (index.json as { items?: Array<{ name?: string }> }).items
+  if (!Array.isArray(items) || items.length === 0) {
+    console.error(`FAIL  ${indexUrl}  registry.json has no items array`)
+    process.exit(1)
+  }
+  const names = [
+    ...new Set(
+      items
+        .map((it) => it.name)
+        .filter((n): n is string => typeof n === 'string' && n.length > 0),
+    ),
+    ...EXTRA_NAMES,
+  ]
+  console.log(
+    `  ${items.length} items in registry.json; probing ${names.length} endpoints`,
+  )
+
+  // 2 + 3. GET every item and check its deps. Collect the field item for step 4.
+  let fieldItem: unknown
+  const failureLists = await mapPool(names, CONCURRENCY, async (name) => {
+    const url = `${origin}/r/${name}`
+    const res = await fetchJson(url)
+    if (res.error || !res.json) {
+      return [{ name, url, reason: res.error ?? 'no body' }]
+    }
+    if (name === 'field') fieldItem = res.json
+    return checkDeps(name, url, res.json)
+  })
+
+  const failures: Failure[] = failureLists.flat()
+
+  // 4. Shape spot-check (only if field was reachable — otherwise step 2 flagged it).
+  if (fieldItem !== undefined) {
+    failures.push(...checkFieldShape(origin, fieldItem))
+  }
+
+  const elapsed = ((Date.now() - started) / 1000).toFixed(1)
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} failure(s):`)
+    for (const f of failures) {
+      console.error(`  FAIL  ${f.name}  ${f.url}\n        ${f.reason}`)
+    }
+    console.error(`\nprobed ${names.length} endpoints in ${elapsed}s — FAILED`)
+    process.exit(1)
+  }
+
+  console.log(
+    `\nOK — probed ${names.length} endpoints in ${elapsed}s, all passed`,
+  )
+}
+
+main().catch((err) => {
+  console.error(`unexpected error: ${(err as Error).stack ?? err}`)
+  process.exit(1)
+})

--- a/www/scripts/registry-probe.ts
+++ b/www/scripts/registry-probe.ts
@@ -34,6 +34,9 @@
 
 const DEFAULT_ORIGIN = 'https://dotui.org'
 const CONCURRENCY = 6
+// Hard per-request ceiling so a slow/blackholing host can't stretch the run
+// past undici's ~300s default headers timeout (× retries).
+const REQUEST_TIMEOUT_MS = 15_000
 // Extra names to probe that don't appear in registry.json's items list.
 const EXTRA_NAMES = ['init']
 
@@ -66,9 +69,17 @@ async function fetchJson(
 ): Promise<{ json?: unknown; error?: string }> {
   let res: Response
   try {
-    res = await fetch(bust(url), { headers: { accept: 'application/json' } })
+    res = await fetch(bust(url), {
+      headers: { accept: 'application/json' },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    })
   } catch (err) {
-    return { error: `network error: ${(err as Error).message}` }
+    const e = err as Error
+    const reason =
+      e.name === 'TimeoutError'
+        ? `timed out after ${REQUEST_TIMEOUT_MS}ms`
+        : `network error: ${e.message}`
+    return { error: reason }
   }
   if (res.status !== 200) {
     return { error: `HTTP ${res.status} ${res.statusText}` }
@@ -105,28 +116,45 @@ async function mapPool<T, R>(
   return results
 }
 
-function isAbsoluteOrNamespaced(dep: string): boolean {
-  return /^https?:\/\//.test(dep) || dep.startsWith('@')
+/**
+ * A served dep must resolve back to us: an absolute URL at the probe origin, or
+ * an "@dotui/…" namespaced id. A bare name means the rewriter didn't recognize
+ * it (the #477 failure); a foreign URL or a non-dotui namespace means it points
+ * somewhere it shouldn't, so shadcn would install from the wrong place.
+ */
+function classifyDep(dep: string, origin: string): string | undefined {
+  if (/^https?:\/\//.test(dep)) {
+    return dep.startsWith(`${origin}/`)
+      ? undefined
+      : `foreign URL dep (not ${origin}): ${dep}`
+  }
+  if (dep.startsWith('@')) {
+    return dep.startsWith('@dotui/')
+      ? undefined
+      : `non-dotui namespaced dep: ${dep}`
+  }
+  return `bare dep (rewriter didn't recognize): ${dep}`
 }
 
-/** Check one served item for bare registryDependencies. */
-function checkDeps(name: string, url: string, item: unknown): Failure[] {
+/** Check one served item's registryDependencies all resolve back to us. */
+function checkDeps(
+  name: string,
+  url: string,
+  item: unknown,
+  origin: string,
+): Failure[] {
   const deps = (item as { registryDependencies?: unknown }).registryDependencies
   if (deps === undefined) return []
   if (!Array.isArray(deps)) {
     return [{ name, url, reason: 'registryDependencies is not an array' }]
   }
-  const bare = deps.filter(
-    (d): d is string => typeof d === 'string' && !isAbsoluteOrNamespaced(d),
-  )
-  if (bare.length === 0) return []
-  return [
-    {
-      name,
-      url,
-      reason: `bare registryDependencies (dep rewriter didn't recognize): ${bare.join(', ')}`,
-    },
-  ]
+  const bad = deps
+    .map((d) =>
+      typeof d === 'string' ? classifyDep(d, origin) : `non-string dep: ${d}`,
+    )
+    .filter((r): r is string => r !== undefined)
+  if (bad.length === 0) return []
+  return [{ name, url, reason: `bad registryDependencies: ${bad.join('; ')}` }]
 }
 
 /**
@@ -215,7 +243,7 @@ async function main(): Promise<void> {
       return [{ name, url, reason: res.error ?? 'no body' }]
     }
     if (name === 'field') fieldItem = res.json
-    return checkDeps(name, url, res.json)
+    return checkDeps(name, url, res.json, origin)
   })
 
   const failures: Failure[] = failureLists.flat()


### PR DESCRIPTION
Closes #496. Completes the reliability arc from #477/#491: CI now guards the build; this probes the **deployed** app — the one gap CI can't cover, since `__generated__/publishables/` is rebuilt per deploy and the edge cache can serve stale registry JSON.

## What it does

`www/scripts/registry-probe.ts` (tsx, zero new deps, ~4s at concurrency 6) against `https://dotui.org`:

1. Derives the expected list from the deployed `/r/registry.json` (no hardcoded names — tracks the deploy).
2. `GET /r/<name>` for all 80 items + `/r/init` — fails on any non-200/non-JSON.
3. Asserts every `registryDependencies` entry is same-origin (`https://dotui.org/…`) or `@dotui/…` — bare names (the #477 signature), foreign URLs, and foreign namespaces all fail.
4. Spot-checks `field`'s emitted code: every destructured slot is declared.
5. Cache-busts every request with a unique param — `/r/$name` carries `s-maxage=3600`, so a probe right after deploy would otherwise read stale JSON (verified: same param → edge HIT, fresh param → MISS; the param doesn't alter `?preset=` semantics).

Runnable locally: `pnpm probe:registry [--origin <url>]` (also `PROBE_ORIGIN`), so preview deployments can be probed too.

## Trigger

`.github/workflows/registry-probe.yml` on `deployment_status` (gated: `state == success && environment == Production` — matches the real vercel[bot] payload; preview and other projects' deploys skip), plus a daily cron safety net and `workflow_dispatch`. 30s wait + 3 retries absorb the promotion race. `timeout-minutes: 10` + 15s per-request `AbortSignal` bound the job; `permissions: contents: read`. A failing run is the alert — no new secrets or services.

## Verification (independent adversarial review)

- Green against production: 81 endpoints, all passed, ~4s.
- Gating checked against real deployment payloads; the classic cron/dispatch-exclusion `if:` bug is explicitly avoided (verified expression short-circuits for non-deployment events).
- Failure modes proven: bogus origin → exit 1; injected 404 name → per-failure report, exit 1; bare dep, foreign-URL dep, foreign-namespace dep, undeclared slot → all flagged.
- `pnpm check` 0 errors, `pnpm typecheck`, `pnpm test` 231/231; zero new dependencies (no lockfile change).

Accepted scope limits (per #496's "spot-check" framing): shape check covers `field` only; `/r/v0` not probed.
