### PR TITLE
ci: run CI on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: ['**']
   merge_group:


### PR DESCRIPTION
Implements fix 1 of #437: `ci.yml` now also runs on `push` to `main`, so a broken `main` (semantic merge conflict, direct push) is caught instead of going unnoticed.

All five jobs verified push-safe by independent review: no job reads PR event payload, and both drift jobs diff the working tree against HEAD (regenerate → `git diff --exit-code` / `git status --porcelain`), not a PR merge base — identical behavior on push and PR. PR-specific workflows (pr-labeler, claude-code-review, claude mention handler) deliberately unchanged. The duplicate run on merge (PR run + push run) is the intended safety net.

**Remaining from #437 — admin settings a commit can't deliver** (for the maintainer; `main` currently has no protection):
- Enable the merge queue on `main` via a branch-protection ruleset (the workflow already declares `merge_group:`).
- Or the fallback: "Require branches to be up to date before merging."
