### PR TITLE
fix(publisher): detect react-aria-components in emitted deps

### DIFF
--- a/www/src/publisher/publish.test.ts
+++ b/www/src/publisher/publish.test.ts
@@ -14,6 +14,7 @@ import { alertPublishable } from './__fixtures__/alert-publishable'
 import { buttonPublishable } from './__fixtures__/button-publishable'
 import { flatten } from './flatten'
 import {
+  depsFromFileImports,
   publish,
   setDotuiDepResolver,
   setKnownDotuiNames,
@@ -389,5 +390,42 @@ describe('publish', () => {
     expect(base?.content).not.toContain(TV_CONFIG_PLACEHOLDER)
     expect(hook?.content).toBe(hookContent)
     expect(hook?.content).not.toContain('export function Thing()')
+  })
+})
+
+/* ============================================================ */
+/* depsFromFileImports                                           */
+/* ============================================================ */
+
+describe('depsFromFileImports', () => {
+  const deps = (content: string) => depsFromFileImports([{ content }])
+
+  test('deep react-aria-components import maps to react-aria-components', () => {
+    const found = deps(
+      `import { Autocomplete } from "react-aria-components/Autocomplete"`,
+    )
+    expect(found).toContain('react-aria-components')
+    // must NOT be misattributed to the react-aria entry
+    expect(found).not.toContain('react-aria')
+  })
+
+  test('bare react-aria-components import maps to react-aria-components', () => {
+    const found = deps(`import { Button } from "react-aria-components"`)
+    expect(found).toContain('react-aria-components')
+    expect(found).not.toContain('react-aria')
+  })
+
+  test('react-aria deep import still maps to react-aria (not the -components pkg)', () => {
+    const found = deps(`import { useButton } from "react-aria/button"`)
+    expect(found).toContain('react-aria')
+    expect(found).not.toContain('react-aria-components')
+  })
+
+  test('a file importing both lists both packages', () => {
+    const found = deps(
+      `import { useFilter } from "react-aria"\nimport { Autocomplete } from "react-aria-components/Autocomplete"`,
+    )
+    expect(found).toContain('react-aria')
+    expect(found).toContain('react-aria-components')
   })
 })

--- a/www/src/publisher/publish.ts
+++ b/www/src/publisher/publish.ts
@@ -116,6 +116,7 @@ function rewriteDeps(deps: readonly string[] | undefined): string[] {
  */
 const FILE_IMPORT_NPM_DEPS = [
   'lucide-react',
+  'react-aria-components',
   'react-aria',
   'react-stately',
   '@remixicon/react',
@@ -125,7 +126,7 @@ const FILE_IMPORT_NPM_DEPS = [
   '@phosphor-icons/react',
 ]
 
-function depsFromFileImports(
+export function depsFromFileImports(
   files: ReadonlyArray<{ content?: string }>,
 ): string[] {
   const found: string[] = []


### PR DESCRIPTION
Adds `react-aria-components` to `FILE_IMPORT_NPM_DEPS`, so items whose emitted code imports it declare it in `dependencies`. Found during #499 verification: the emitted `react-aria-token-field` lib item imports `react-aria-components/Autocomplete` etc. but didn't list the package — a standalone `shadcn add` on a project without prior dotui init (which installs it via the init item's default dependencies) couldn't resolve it.

## Effect (independently re-derived)

- Exactly **55 of 80** publishables gain exactly `react-aria-components` in `dependencies` — zero removals, zero reorders, zero other changes; 3 items already carried it via meta. `react-aria-token-field` now emits `["react-aria", "react-aria-components", "react-stately"]`.
- **Zero emitted file-content changes** — structurally guaranteed (`depsFromFileImports` feeds only the `dependencies` array) and confirmed by the publish+compile smoke test.
- Matcher verified quote-anchored and collect-all: `react-aria-components/X` never cross-matches `react-aria` (or vice versa); comment/prose mentions of the package don't trigger (9 such lines in token-field, zero false positives across all 80 items).
- 4 new unit tests (`depsFromFileImports` exported for testing); `pnpm test` 235/235, `check` 0 errors, `typecheck` green, `build:registry` zero drift.

Consumer semantics: bare dep name → shadcn installs via the consumer's package manager, respecting an existing installed version; for the normal init-first flow this is a no-op backstop.
