### PR TITLE
docs: import from @/ui/ to match shadcn install layout

### DIFF
--- a/www/content/docs/components/accordion.mdx
+++ b/www/content/docs/components/accordion.mdx
@@ -20,12 +20,8 @@ npx shadcn@latest add @dotui/accordion
 ## Anatomy
 
 ```tsx
-import { Accordion } from '@/components/ui/accordion'
-import {
-  Disclosure,
-  DisclosurePanel,
-  DisclosureTrigger,
-} from '@/components/ui/disclosure'
+import { Accordion } from '@/ui/accordion'
+import { Disclosure, DisclosurePanel, DisclosureTrigger } from '@/ui/disclosure'
 ```
 
 ```tsx

--- a/www/content/docs/components/alert.mdx
+++ b/www/content/docs/components/alert.mdx
@@ -35,7 +35,7 @@ npx shadcn@latest add @dotui/alert
 Use alerts to display important messages that require user attention.
 
 ```tsx
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Alert, AlertDescription, AlertTitle } from '@/ui/alert'
 ```
 
 ```tsx
@@ -50,12 +50,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 An alert composes a title, a description, and an optional action. To add an icon, place an icon element as the alert's first child — styles pick it up positionally, there is no icon prop.
 
 ```tsx
-import {
-  Alert,
-  AlertTitle,
-  AlertDescription,
-  AlertAction,
-} from '@/components/ui/alert'
+import { Alert, AlertTitle, AlertDescription, AlertAction } from '@/ui/alert'
 import { CircleAlert } from 'lucide-react'
 ```
 

--- a/www/content/docs/components/avatar.mdx
+++ b/www/content/docs/components/avatar.mdx
@@ -36,7 +36,7 @@ npx shadcn@latest add @dotui/avatar
 Use avatars to represent users or entities with an image or initials.
 
 ```tsx
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { Avatar, AvatarImage, AvatarFallback } from '@/ui/avatar'
 ```
 
 ```tsx
@@ -56,7 +56,7 @@ import {
   AvatarBadge,
   AvatarGroup,
   AvatarGroupCount,
-} from '@/components/ui/avatar'
+} from '@/ui/avatar'
 ```
 
 ```tsx

--- a/www/content/docs/components/badge.mdx
+++ b/www/content/docs/components/badge.mdx
@@ -26,7 +26,7 @@ npx shadcn@latest add @dotui/badge
 Use badges to highlight status, categorize items, or show counts.
 
 ```tsx
-import { Badge } from '@/components/ui/badge'
+import { Badge } from '@/ui/badge'
 ```
 
 ```tsx

--- a/www/content/docs/components/breadcrumbs.mdx
+++ b/www/content/docs/components/breadcrumbs.mdx
@@ -33,7 +33,7 @@ import {
   BreadcrumbLink,
   BreadcrumbSeparator,
   Breadcrumbs,
-} from '@/components/ui/breadcrumbs'
+} from '@/ui/breadcrumbs'
 ```
 
 ```tsx

--- a/www/content/docs/components/calendar.mdx
+++ b/www/content/docs/components/calendar.mdx
@@ -38,7 +38,7 @@ npx shadcn@latest add @dotui/calendar
 Use `Calendar` to allow users to select a single date value.
 
 ```tsx
-import { Calendar } from '@/components/ui/calendar'
+import { Calendar } from '@/ui/calendar'
 ```
 
 ```tsx
@@ -48,7 +48,7 @@ import { Calendar } from '@/components/ui/calendar'
 Use `RangeCalendar` to let users select a contiguous range of dates.
 
 ```tsx
-import { RangeCalendar } from '@/components/ui/calendar'
+import { RangeCalendar } from '@/ui/calendar'
 ```
 
 ```tsx
@@ -69,7 +69,7 @@ import {
   CalendarHeaderCell,
   CalendarGridBody,
   CalendarCell,
-} from '@/components/ui/calendar'
+} from '@/ui/calendar'
 ```
 
 ```tsx

--- a/www/content/docs/components/card.mdx
+++ b/www/content/docs/components/card.mdx
@@ -22,7 +22,7 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card'
+} from '@/ui/card'
 ```
 
 ```tsx

--- a/www/content/docs/components/chart.mdx
+++ b/www/content/docs/components/chart.mdx
@@ -37,7 +37,7 @@ import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
-} from '@/components/ui/chart'
+} from '@/ui/chart'
 ```
 
 A chart is built from three pieces: your **data** (an array of rows), a **config** that describes each series, and the **Recharts chart** wrapped in `ChartContainer`.

--- a/www/content/docs/components/checkbox-group.mdx
+++ b/www/content/docs/components/checkbox-group.mdx
@@ -43,9 +43,9 @@ npx shadcn@latest add @dotui/checkbox-group
 Use `CheckboxGroup` to allow users to select multiple items from a list of options.
 
 ```tsx
-import { CheckboxGroup } from '@/components/ui/checkbox-group'
-import { Checkbox, CheckboxControl } from '@/components/ui/checkbox'
-import { FieldGroup, Label } from '@/components/ui/field'
+import { CheckboxGroup } from '@/ui/checkbox-group'
+import { Checkbox, CheckboxControl } from '@/ui/checkbox'
+import { FieldGroup, Label } from '@/ui/field'
 ```
 
 ```tsx
@@ -85,8 +85,8 @@ const [frameworks, setFrameworks] = useState<string[]>(['nextjs'])
 Set `isRequired` to require a selection, or drive `isInvalid` yourself. Render errors with `FieldError` — with the default `validationBehavior="native"` it surfaces the browser's message on form submit; use `validationBehavior="aria"` to validate live without native form semantics.
 
 ```tsx
-import { CheckboxGroup } from '@/components/ui/checkbox-group'
-import { FieldError, FieldGroup, Label } from '@/components/ui/field'
+import { CheckboxGroup } from '@/ui/checkbox-group'
+import { FieldError, FieldGroup, Label } from '@/ui/field'
 ;<CheckboxGroup isRequired>
   <Label>React frameworks</Label>
   <FieldGroup>{/* ... */}</FieldGroup>

--- a/www/content/docs/components/checkbox.mdx
+++ b/www/content/docs/components/checkbox.mdx
@@ -48,8 +48,8 @@ npx shadcn@latest add @dotui/checkbox
 Use `Checkbox` to allow users to select multiple items from a list of individual items, or to mark one individual item as selected.
 
 ```tsx
-import { Checkbox, CheckboxControl } from '@/components/ui/checkbox'
-import { Label } from '@/components/ui/field'
+import { Checkbox, CheckboxControl } from '@/ui/checkbox'
+import { Label } from '@/ui/field'
 ```
 
 ```tsx
@@ -64,12 +64,8 @@ import { Label } from '@/components/ui/field'
 Pass a plain string and `Checkbox` wraps it in a `CheckboxControl` and `Label` for you. Pass elements instead and you compose the tree yourself — `CheckboxControl` renders the `CheckboxIndicator` (the box) and can hold `FieldContent` with a `Label` and `Description`.
 
 ```tsx
-import {
-  Checkbox,
-  CheckboxControl,
-  CheckboxIndicator,
-} from '@/components/ui/checkbox'
-import { Description, FieldContent, Label } from '@/components/ui/field'
+import { Checkbox, CheckboxControl, CheckboxIndicator } from '@/ui/checkbox'
+import { Description, FieldContent, Label } from '@/ui/field'
 ;<Checkbox>
   <CheckboxControl>
     <CheckboxIndicator />

--- a/www/content/docs/components/color-area.mdx
+++ b/www/content/docs/components/color-area.mdx
@@ -28,8 +28,8 @@ npx shadcn@latest add @dotui/color-area
 Use color areas to allow users to select a color from a two-dimensional gradient.
 
 ```tsx
-import { ColorArea } from '@/components/ui/color-area'
-import { ColorThumb } from '@/components/ui/color-thumb'
+import { ColorArea } from '@/ui/color-area'
+import { ColorThumb } from '@/ui/color-thumb'
 ```
 
 ```tsx
@@ -43,8 +43,8 @@ import { ColorThumb } from '@/components/ui/color-thumb'
 A `ColorArea` renders the gradient and positions a `ColorThumb`. If you omit children, a default `ColorThumb` is rendered for you.
 
 ```tsx
-import { ColorArea } from '@/components/ui/color-area'
-import { ColorThumb } from '@/components/ui/color-thumb'
+import { ColorArea } from '@/ui/color-area'
+import { ColorThumb } from '@/ui/color-thumb'
 ;<ColorArea>
   <ColorThumb />
 </ColorArea>

--- a/www/content/docs/components/color-editor.mdx
+++ b/www/content/docs/components/color-editor.mdx
@@ -34,7 +34,7 @@ npx shadcn@latest add @dotui/color-editor
 Use a color editor to let users adjust a color with a saturation/brightness area, channel sliders, and format-aware fields. Standalone, it manages its own color value; inside a [Color Picker](/docs/components/color-picker), it edits the picker's color instead.
 
 ```tsx
-import { ColorEditor } from '@/components/ui/color-editor'
+import { ColorEditor } from '@/ui/color-editor'
 ```
 
 ```tsx
@@ -50,7 +50,7 @@ import {
   ColorEditor,
   ColorEditorArea,
   ColorEditorFields,
-} from '@/components/ui/color-editor'
+} from '@/ui/color-editor'
 ```
 
 ```tsx

--- a/www/content/docs/components/color-field.mdx
+++ b/www/content/docs/components/color-field.mdx
@@ -39,9 +39,9 @@ npx shadcn@latest add @dotui/color-field
 Use color fields to allow users to edit a color value using a text field.
 
 ```tsx
-import { ColorField } from '@/components/ui/color-field'
-import { Label } from '@/components/ui/field'
-import { Input } from '@/components/ui/input'
+import { ColorField } from '@/ui/color-field'
+import { Label } from '@/ui/field'
+import { Input } from '@/ui/input'
 ```
 
 ```tsx
@@ -56,9 +56,9 @@ import { Input } from '@/components/ui/input'
 A `ColorField` wraps a `Label` and an `Input`. To attach an icon, replace the bare `Input` with an `InputGroup` and place an `InputGroupAddon` on either side.
 
 ```tsx
-import { ColorField } from '@/components/ui/color-field'
-import { Label } from '@/components/ui/field'
-import { Input, InputGroup, InputGroupAddon } from '@/components/ui/input'
+import { ColorField } from '@/ui/color-field'
+import { Label } from '@/ui/field'
+import { Input, InputGroup, InputGroupAddon } from '@/ui/input'
 ;<ColorField>
   <Label />
   <InputGroup>

--- a/www/content/docs/components/color-picker.mdx
+++ b/www/content/docs/components/color-picker.mdx
@@ -20,11 +20,11 @@ npx shadcn@latest add @dotui/color-picker
 Use color pickers to allow users to select a color from a palette or input a custom color value. The editing surface inside the popover is a [Color Editor](/docs/components/color-editor).
 
 ```tsx
-import { Button } from '@/components/ui/button'
-import { ColorEditor } from '@/components/ui/color-editor'
-import { ColorPicker } from '@/components/ui/color-picker'
-import { DialogContent } from '@/components/ui/dialog'
-import { Popover } from '@/components/ui/popover'
+import { Button } from '@/ui/button'
+import { ColorEditor } from '@/ui/color-editor'
+import { ColorPicker } from '@/ui/color-picker'
+import { DialogContent } from '@/ui/dialog'
+import { Popover } from '@/ui/popover'
 ```
 
 ```tsx

--- a/www/content/docs/components/color-slider.mdx
+++ b/www/content/docs/components/color-slider.mdx
@@ -41,8 +41,8 @@ npx shadcn@latest add @dotui/color-slider
 Use color sliders to allow users to adjust an individual channel of a color value.
 
 ```tsx
-import { ColorSlider, ColorSliderControl } from '@/components/ui/color-slider'
-import { Label } from '@/components/ui/field'
+import { ColorSlider, ColorSliderControl } from '@/ui/color-slider'
+import { Label } from '@/ui/field'
 ```
 
 ```tsx
@@ -61,8 +61,8 @@ import {
   ColorSlider,
   ColorSliderControl,
   ColorSliderOutput,
-} from '@/components/ui/color-slider'
-import { Label } from '@/components/ui/field'
+} from '@/ui/color-slider'
+import { Label } from '@/ui/field'
 ```
 
 ```tsx

--- a/www/content/docs/components/color-swatch-picker.mdx
+++ b/www/content/docs/components/color-swatch-picker.mdx
@@ -32,7 +32,7 @@ Use color swatch pickers to allow users to select a color from a list of swatche
 import {
   ColorSwatchPicker,
   ColorSwatchPickerItem,
-} from '@/components/ui/color-swatch-picker'
+} from '@/ui/color-swatch-picker'
 ```
 
 ```tsx
@@ -49,7 +49,7 @@ import {
 import {
   ColorSwatchPicker,
   ColorSwatchPickerItem,
-} from '@/components/ui/color-swatch-picker'
+} from '@/ui/color-swatch-picker'
 ;<ColorSwatchPicker>
   <ColorSwatchPickerItem color="#ff0000" />
 </ColorSwatchPicker>

--- a/www/content/docs/components/color-swatch.mdx
+++ b/www/content/docs/components/color-swatch.mdx
@@ -29,7 +29,7 @@ npx shadcn@latest add @dotui/color-swatch
 Use color swatches to display a color sample.
 
 ```tsx
-import { ColorSwatch } from '@/components/ui/color-swatch'
+import { ColorSwatch } from '@/ui/color-swatch'
 ```
 
 ```tsx

--- a/www/content/docs/components/combobox.mdx
+++ b/www/content/docs/components/combobox.mdx
@@ -44,10 +44,10 @@ npx shadcn@latest add @dotui/combobox
 Use `Combobox` to allow users to filter a list of options to items matching a query and select an item from the list.
 
 ```tsx
-import { Combobox } from '@/components/ui/combobox'
-import { Input, InputGroup, InputGroupAddon } from '@/components/ui/input'
-import { ListBox, ListBoxItem } from '@/components/ui/list-box'
-import { Popover } from '@/components/ui/popover'
+import { Combobox } from '@/ui/combobox'
+import { Input, InputGroup, InputGroupAddon } from '@/ui/input'
+import { ListBox, ListBoxItem } from '@/ui/list-box'
+import { Popover } from '@/ui/popover'
 ```
 
 ```tsx

--- a/www/content/docs/components/command.mdx
+++ b/www/content/docs/components/command.mdx
@@ -31,10 +31,10 @@ npx shadcn@latest add @dotui/command
 ```tsx
 import { SearchIcon } from 'lucide-react'
 
-import { Command } from '@/components/ui/command'
-import { Input, InputGroup, InputGroupAddon } from '@/components/ui/input'
-import { ListBox, ListBoxItem } from '@/components/ui/list-box'
-import { SearchField } from '@/components/ui/search-field'
+import { Command } from '@/ui/command'
+import { Input, InputGroup, InputGroupAddon } from '@/ui/input'
+import { ListBox, ListBoxItem } from '@/ui/list-box'
+import { SearchField } from '@/ui/search-field'
 ```
 
 ```tsx
@@ -71,7 +71,7 @@ import {
   CommandItem,
   CommandSection,
   CommandSectionHeader,
-} from '@/components/ui/command'
+} from '@/ui/command'
 ;<Command>
   <CommandInput />
   <CommandContent>

--- a/www/content/docs/components/context-menu.mdx
+++ b/www/content/docs/components/context-menu.mdx
@@ -20,9 +20,9 @@ npx shadcn@latest add @dotui/context-menu
 Wrap the trigger content and the menu's `Popover` inside `ContextMenu`. The menu opens at the pointer when the trigger is right-clicked, or after a long press on touch devices.
 
 ```tsx
-import { ContextMenu } from '@/components/ui/context-menu'
-import { MenuContent, MenuItem } from '@/components/ui/menu'
-import { Popover } from '@/components/ui/popover'
+import { ContextMenu } from '@/ui/context-menu'
+import { MenuContent, MenuItem } from '@/ui/menu'
+import { Popover } from '@/ui/popover'
 ```
 
 ```tsx
@@ -44,10 +44,10 @@ import { Popover } from '@/components/ui/popover'
 `ContextMenu` is a right-click / long-press trigger wrapping a `Popover` and a `MenuContent`. Items, submenus (`MenuSub`), and every menu concept come from the [Menu](/docs/components/menu) component.
 
 ```tsx
-import { ContextMenu } from '@/components/ui/context-menu'
-import { MenuContent, MenuItem, MenuSub } from '@/components/ui/menu'
-import { Popover } from '@/components/ui/popover'
-import { Separator } from '@/components/ui/separator'
+import { ContextMenu } from '@/ui/context-menu'
+import { MenuContent, MenuItem, MenuSub } from '@/ui/menu'
+import { Popover } from '@/ui/popover'
+import { Separator } from '@/ui/separator'
 ;<ContextMenu>
   {/* trigger content */}
   <Popover>

--- a/www/content/docs/components/date-field.mdx
+++ b/www/content/docs/components/date-field.mdx
@@ -44,9 +44,9 @@ npx shadcn@latest add @dotui/date-field
 Use `DateField` to allow users to enter and edit date values using a keyboard.
 
 ```tsx
-import { DateField } from '@/components/ui/date-field'
-import { DateInput } from '@/components/ui/input'
-import { Label } from '@/components/ui/field'
+import { DateField } from '@/ui/date-field'
+import { DateInput } from '@/ui/input'
+import { Label } from '@/ui/field'
 ```
 
 ```tsx
@@ -61,9 +61,9 @@ import { Label } from '@/components/ui/field'
 `DateField` wraps a `Label`, a `DateInput` that renders the individually editable segments, and optionally a `Description` and `FieldError`.
 
 ```tsx
-import { DateField } from '@/components/ui/date-field'
-import { DateInput } from '@/components/ui/input'
-import { Description, FieldError, Label } from '@/components/ui/field'
+import { DateField } from '@/ui/date-field'
+import { DateInput } from '@/ui/input'
+import { Description, FieldError, Label } from '@/ui/field'
 ;<DateField>
   <Label />
   <DateInput />

--- a/www/content/docs/components/date-picker.mdx
+++ b/www/content/docs/components/date-picker.mdx
@@ -22,13 +22,13 @@ Use date pickers to allow users to select a date using a field and a calendar po
 ```tsx
 import { CalendarIcon } from 'lucide-react'
 
-import { Button } from '@/components/ui/button'
-import { Calendar } from '@/components/ui/calendar'
-import { DatePicker } from '@/components/ui/date-picker'
-import { DialogContent } from '@/components/ui/dialog'
-import { Label } from '@/components/ui/field'
-import { DateInput, InputGroup, InputGroupAddon } from '@/components/ui/input'
-import { Popover } from '@/components/ui/popover'
+import { Button } from '@/ui/button'
+import { Calendar } from '@/ui/calendar'
+import { DatePicker } from '@/ui/date-picker'
+import { DialogContent } from '@/ui/dialog'
+import { Label } from '@/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/ui/input'
+import { Popover } from '@/ui/popover'
 ```
 
 ```tsx
@@ -55,13 +55,13 @@ import { Popover } from '@/components/ui/popover'
 A date picker assembles a date field and a calendar overlay. The `InputGroup` holds the `DateInput` and a trigger `Button`; the `Popover` reveals a `Calendar`. `Label`, `Description`, and `FieldError` are optional field parts.
 
 ```tsx
-import { Button } from '@/components/ui/button'
-import { Calendar } from '@/components/ui/calendar'
-import { DatePicker } from '@/components/ui/date-picker'
-import { DialogContent } from '@/components/ui/dialog'
-import { Description, FieldError, Label } from '@/components/ui/field'
-import { DateInput, InputGroup, InputGroupAddon } from '@/components/ui/input'
-import { Popover } from '@/components/ui/popover'
+import { Button } from '@/ui/button'
+import { Calendar } from '@/ui/calendar'
+import { DatePicker } from '@/ui/date-picker'
+import { DialogContent } from '@/ui/dialog'
+import { Description, FieldError, Label } from '@/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/ui/input'
+import { Popover } from '@/ui/popover'
 ;<DatePicker>
   <Label />
   <InputGroup>
@@ -99,8 +99,8 @@ import { parseDate } from '@internationalized/date'
 ```tsx
 import { parseDate } from '@internationalized/date'
 
-import { RangeCalendar } from '@/components/ui/calendar'
-import { DateRangePicker } from '@/components/ui/date-picker'
+import { RangeCalendar } from '@/ui/calendar'
+import { DateRangePicker } from '@/ui/date-picker'
 ;<DateRangePicker
   defaultValue={{
     start: parseDate('2020-02-03'),

--- a/www/content/docs/components/dialog.mdx
+++ b/www/content/docs/components/dialog.mdx
@@ -39,7 +39,7 @@ npx shadcn@latest add @dotui/dialog
 Use dialog to grab the user's attention for critical tasks, like confirming actions, providing additional details, or capturing input.
 
 ```tsx
-import { Button } from '@/components/ui/button'
+import { Button } from '@/ui/button'
 import {
   Dialog,
   DialogBody,
@@ -48,8 +48,8 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog'
-import { Modal } from '@/components/ui/modal'
+} from '@/ui/dialog'
+import { Modal } from '@/ui/modal'
 ```
 
 ```tsx

--- a/www/content/docs/components/disclosure.mdx
+++ b/www/content/docs/components/disclosure.mdx
@@ -18,11 +18,7 @@ npx shadcn@latest add @dotui/disclosure
 ## Anatomy
 
 ```tsx
-import {
-  Disclosure,
-  DisclosurePanel,
-  DisclosureTrigger,
-} from '@/components/ui/disclosure'
+import { Disclosure, DisclosurePanel, DisclosureTrigger } from '@/ui/disclosure'
 ```
 
 `DisclosureTrigger` renders the heading, button, and chevron; `DisclosurePanel` holds the collapsible content.
@@ -37,9 +33,9 @@ import {
 For full control over the trigger, compose the header from `Heading` and `Button` yourself.
 
 ```tsx
-import { Disclosure, DisclosurePanel } from '@/components/ui/disclosure'
-import { Button } from '@/components/ui/button'
-import { Heading } from '@/components/ui/heading'
+import { Disclosure, DisclosurePanel } from '@/ui/disclosure'
+import { Button } from '@/ui/button'
+import { Heading } from '@/ui/heading'
 import { ChevronDownIcon } from 'your-icon-library'
 ```
 

--- a/www/content/docs/components/drawer.mdx
+++ b/www/content/docs/components/drawer.mdx
@@ -30,9 +30,9 @@ npx shadcn@latest add @dotui/drawer
 Use drawers to display content that slides in from the edge of the screen.
 
 ```tsx
-import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent } from '@/components/ui/dialog'
-import { Drawer } from '@/components/ui/drawer'
+import { Button } from '@/ui/button'
+import { Dialog, DialogContent } from '@/ui/dialog'
+import { Drawer } from '@/ui/drawer'
 ```
 
 ```tsx
@@ -49,8 +49,8 @@ import { Drawer } from '@/components/ui/drawer'
 A `Drawer` has no built-in trigger. Wrap it in a `Dialog` with a `Button` child as the trigger, and put your content inside `DialogContent`.
 
 ```tsx
-import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { Button } from '@/ui/button'
+import { Dialog, DialogContent } from '@/ui/dialog'
 import {
   Drawer,
   DrawerHandle,
@@ -58,7 +58,7 @@ import {
   DrawerProvider,
   DrawerIndent,
   DrawerIndentBackground,
-} from '@/components/ui/drawer'
+} from '@/ui/drawer'
 ;<Dialog>
   <Button />
   <Drawer>

--- a/www/content/docs/components/drop-zone.mdx
+++ b/www/content/docs/components/drop-zone.mdx
@@ -34,7 +34,7 @@ npx shadcn@latest add @dotui/drop-zone
 Use drop zones to allow users to drag and drop files or content into a designated area.
 
 ```tsx
-import { DropZone, DropZoneLabel } from '@/components/ui/drop-zone'
+import { DropZone, DropZoneLabel } from '@/ui/drop-zone'
 ```
 
 ```tsx

--- a/www/content/docs/components/empty.mdx
+++ b/www/content/docs/components/empty.mdx
@@ -15,12 +15,7 @@ npx shadcn@latest add @dotui/empty
 ## Usage
 
 ```tsx
-import {
-  Empty,
-  EmptyDescription,
-  EmptyMedia,
-  EmptyTitle,
-} from '@/components/ui/empty'
+import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/ui/empty'
 ```
 
 ```tsx
@@ -45,7 +40,7 @@ import {
   EmptyTitle,
   EmptyDescription,
   EmptyContent,
-} from '@/components/ui/empty'
+} from '@/ui/empty'
 ;<Empty>
   <EmptyHeader>
     <EmptyMedia variant="icon">{/* icon */}</EmptyMedia>

--- a/www/content/docs/components/field.mdx
+++ b/www/content/docs/components/field.mdx
@@ -13,7 +13,7 @@ npx shadcn@latest add @dotui/field
 ## Usage
 
 ```tsx
-import { Field, Label, Description, FieldError } from '@/components/ui/field'
+import { Field, Label, Description, FieldError } from '@/ui/field'
 ```
 
 ```tsx
@@ -36,7 +36,7 @@ import {
   FieldGroup,
   Fieldset,
   Legend,
-} from '@/components/ui/field'
+} from '@/ui/field'
 ```
 
 ```tsx

--- a/www/content/docs/components/file-trigger.mdx
+++ b/www/content/docs/components/file-trigger.mdx
@@ -29,8 +29,8 @@ npx shadcn@latest add @dotui/file-trigger
 Use file triggers to allow users to upload files using any pressable element.
 
 ```tsx
-import { Button } from '@/components/ui/button'
-import { FileTrigger } from '@/components/ui/file-trigger'
+import { Button } from '@/ui/button'
+import { FileTrigger } from '@/ui/file-trigger'
 ```
 
 ```tsx

--- a/www/content/docs/components/form.mdx
+++ b/www/content/docs/components/form.mdx
@@ -20,11 +20,11 @@ wip: true
 Use forms to wrap groups of form elements and handle form submission with validation.
 
 ```tsx
-import { Form } from '@/components/ui/form'
-import { Button } from '@/components/ui/button'
-import { TextField } from '@/components/ui/text-field'
-import { Label } from '@/components/ui/field'
-import { Input } from '@/components/ui/input'
+import { Form } from '@/ui/form'
+import { Button } from '@/ui/button'
+import { TextField } from '@/ui/text-field'
+import { Label } from '@/ui/field'
+import { Input } from '@/ui/input'
 ```
 
 ```tsx

--- a/www/content/docs/components/group.mdx
+++ b/www/content/docs/components/group.mdx
@@ -15,7 +15,7 @@ npx shadcn@latest add @dotui/group
 ## Usage
 
 ```tsx
-import { Group } from '@/components/ui/group'
+import { Group } from '@/ui/group'
 ```
 
 ```tsx
@@ -30,7 +30,7 @@ import { Group } from '@/components/ui/group'
 `Group` is the container; `GroupText` renders an inline text segment between controls (prefixes, suffixes, labels).
 
 ```tsx
-import { Group, GroupText } from '@/components/ui/group'
+import { Group, GroupText } from '@/ui/group'
 ;<Group>
   <GroupText>Label</GroupText>
   <Button>Action</Button>

--- a/www/content/docs/components/input-group.mdx
+++ b/www/content/docs/components/input-group.mdx
@@ -14,7 +14,7 @@ npx shadcn@latest add @dotui/input
 ## Usage
 
 ```tsx
-import { Input, InputGroup, InputGroupAddon } from '@/components/ui/input'
+import { Input, InputGroup, InputGroupAddon } from '@/ui/input'
 ```
 
 ```tsx
@@ -29,12 +29,7 @@ import { Input, InputGroup, InputGroupAddon } from '@/components/ui/input'
 An `InputGroup` wraps an `Input` or `TextArea` together with one or more `InputGroupAddon` parts. Order the children to place an addon before or after the control.
 
 ```tsx
-import {
-  Input,
-  InputGroup,
-  InputGroupAddon,
-  TextArea,
-} from '@/components/ui/input'
+import { Input, InputGroup, InputGroupAddon, TextArea } from '@/ui/input'
 ;<InputGroup>
   <InputGroupAddon />
   <Input />

--- a/www/content/docs/components/input.mdx
+++ b/www/content/docs/components/input.mdx
@@ -33,7 +33,7 @@ npx shadcn@latest add @dotui/input
 Use `Input` to allow users to enter text. Combine with `InputGroup` and `InputGroupAddon` to add icons, buttons, or labels alongside the input.
 
 ```tsx
-import { Input } from '@/components/ui/input'
+import { Input } from '@/ui/input'
 ```
 
 ```tsx

--- a/www/content/docs/components/kbd.mdx
+++ b/www/content/docs/components/kbd.mdx
@@ -13,7 +13,7 @@ npx shadcn@latest add @dotui/kbd
 ## Usage
 
 ```tsx
-import { Kbd } from '@/components/ui/kbd'
+import { Kbd } from '@/ui/kbd'
 ```
 
 ```tsx
@@ -25,7 +25,7 @@ import { Kbd } from '@/components/ui/kbd'
 Use `Kbd` for a single key. Wrap several in `KbdGroup` to present a key combination as one unit.
 
 ```tsx
-import { Kbd, KbdGroup } from '@/components/ui/kbd'
+import { Kbd, KbdGroup } from '@/ui/kbd'
 ;<KbdGroup>
   <Kbd>⌘</Kbd>
   <Kbd>K</Kbd>

--- a/www/content/docs/components/link.mdx
+++ b/www/content/docs/components/link.mdx
@@ -16,7 +16,7 @@ npx shadcn@latest add @dotui/link
 ## Usage
 
 ```tsx
-import { Link } from '@/components/ui/link'
+import { Link } from '@/ui/link'
 ```
 
 ```tsx

--- a/www/content/docs/components/list-box.mdx
+++ b/www/content/docs/components/list-box.mdx
@@ -36,7 +36,7 @@ npx shadcn@latest add @dotui/list-box
 Use list boxes to display a list of options and allow users to select one or more of them.
 
 ```tsx
-import { ListBox, ListBoxItem } from '@/components/ui/list-box'
+import { ListBox, ListBoxItem } from '@/ui/list-box'
 ```
 
 ```tsx
@@ -57,7 +57,7 @@ import {
   ListBoxItemDescription,
   ListBoxSection,
   ListBoxSectionHeader,
-} from '@/components/ui/list-box'
+} from '@/ui/list-box'
 ```
 
 ```tsx

--- a/www/content/docs/components/loader.mdx
+++ b/www/content/docs/components/loader.mdx
@@ -13,7 +13,7 @@ npx shadcn@latest add @dotui/loader
 ## Usage
 
 ```tsx
-import { Loader } from '@/components/ui/loader'
+import { Loader } from '@/ui/loader'
 ```
 
 ```tsx

--- a/www/content/docs/components/mention.mdx
+++ b/www/content/docs/components/mention.mdx
@@ -34,10 +34,10 @@ npx shadcn@latest add @dotui/mention
 `Mention` wires a mention experience onto the [TokenField](/docs/components/token-field) component: compose a `TokenInput` for the editable area plus a `Popover` + `Menu` for the suggestions, and `Mention` injects the wiring (value, caret-anchored popover, filtering, keyboard navigation, insertion) through context. Typing the trigger character (`@` by default) opens the list at the caret and filters as you type; selecting an item inserts it as an inline token.
 
 ```tsx
-import { Mention } from '@/components/ui/mention'
-import { MenuContent, MenuItem } from '@/components/ui/menu'
-import { Popover } from '@/components/ui/popover'
-import { TokenInput } from '@/components/ui/token-field'
+import { Mention } from '@/ui/mention'
+import { MenuContent, MenuItem } from '@/ui/menu'
+import { Popover } from '@/ui/popover'
+import { TokenInput } from '@/ui/token-field'
 ```
 
 ```tsx
@@ -64,10 +64,10 @@ Add a `Label` before the input when you want a visible label; otherwise give the
 ## Anatomy
 
 ```tsx
-import { Mention } from '@/components/ui/mention'
-import { MenuContent, MenuItem } from '@/components/ui/menu'
-import { Popover } from '@/components/ui/popover'
-import { TokenInput } from '@/components/ui/token-field'
+import { Mention } from '@/ui/mention'
+import { MenuContent, MenuItem } from '@/ui/menu'
+import { Popover } from '@/ui/popover'
+import { TokenInput } from '@/ui/token-field'
 ```
 
 ```tsx

--- a/www/content/docs/components/menu.mdx
+++ b/www/content/docs/components/menu.mdx
@@ -30,9 +30,9 @@ npx shadcn@latest add @dotui/menu
 Use menus to display a list of actions or options that a user can choose from.
 
 ```tsx
-import { Button } from '@/components/ui/button'
-import { Menu, MenuContent, MenuItem } from '@/components/ui/menu'
-import { Popover } from '@/components/ui/popover'
+import { Button } from '@/ui/button'
+import { Menu, MenuContent, MenuItem } from '@/ui/menu'
+import { Popover } from '@/ui/popover'
 ```
 
 ```tsx
@@ -53,7 +53,7 @@ import { Popover } from '@/components/ui/popover'
 A `Menu` links a trigger (`Button`) to an overlay (`Popover`) that wraps the `MenuContent`. Each `MenuItem` auto-wraps string children in a `MenuItemLabel`; add a `MenuItemDescription` for secondary text, group items with `MenuSection` + `MenuSectionHeader`, and nest a submenu with `MenuSub`.
 
 ```tsx
-import { Button } from '@/components/ui/button'
+import { Button } from '@/ui/button'
 import {
   Menu,
   MenuContent,
@@ -63,8 +63,8 @@ import {
   MenuSection,
   MenuSectionHeader,
   MenuSub,
-} from '@/components/ui/menu'
-import { Popover } from '@/components/ui/popover'
+} from '@/ui/menu'
+import { Popover } from '@/ui/popover'
 ;<Menu>
   <Button>Open Menu</Button>
   <Popover>

--- a/www/content/docs/components/modal.mdx
+++ b/www/content/docs/components/modal.mdx
@@ -29,9 +29,9 @@ npx shadcn@latest add @dotui/modal
 Use modals to display content in a layer that overlays the page content.
 
 ```tsx
-import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent } from '@/components/ui/dialog'
-import { Modal } from '@/components/ui/modal'
+import { Button } from '@/ui/button'
+import { Dialog, DialogContent } from '@/ui/dialog'
+import { Modal } from '@/ui/modal'
 ```
 
 ```tsx
@@ -53,7 +53,7 @@ import {
   ModalBackdrop,
   ModalViewport,
   ModalPanel,
-} from '@/components/ui/modal'
+} from '@/ui/modal'
 ;<ModalOverlay>
   <ModalBackdrop />
   <ModalViewport>

--- a/www/content/docs/components/number-field.mdx
+++ b/www/content/docs/components/number-field.mdx
@@ -44,9 +44,9 @@ npx shadcn@latest add @dotui/number-field
 Use `NumberField` to allow users to enter a numeric value with keyboard or increment/decrement buttons.
 
 ```tsx
-import { NumberField } from '@/components/ui/number-field'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/field'
+import { NumberField } from '@/ui/number-field'
+import { Input } from '@/ui/input'
+import { Label } from '@/ui/field'
 ```
 
 ```tsx
@@ -66,9 +66,9 @@ import {
   NumberFieldGroup,
   NumberFieldDecrement,
   NumberFieldIncrement,
-} from '@/components/ui/number-field'
-import { Input } from '@/components/ui/input'
-import { Label, FieldError } from '@/components/ui/field'
+} from '@/ui/number-field'
+import { Input } from '@/ui/input'
+import { Label, FieldError } from '@/ui/field'
 ;<NumberField>
   <Label />
   <NumberFieldGroup>

--- a/www/content/docs/components/otp-field.mdx
+++ b/www/content/docs/components/otp-field.mdx
@@ -20,10 +20,10 @@ npx shadcn@latest add @dotui/otp-field
 Use `OTPField` with `Group` and the existing `Input` component to compose passcode slots.
 
 ```tsx
-import { OTPField } from '@/components/ui/otp-field'
-import { Label } from '@/components/ui/field'
-import { Group } from '@/components/ui/group'
-import { Input } from '@/components/ui/input'
+import { OTPField } from '@/ui/otp-field'
+import { Label } from '@/ui/field'
+import { Group } from '@/ui/group'
+import { Input } from '@/ui/input'
 ```
 
 ```tsx
@@ -45,10 +45,10 @@ import { Input } from '@/components/ui/input'
 `OTPField` wraps a `Label`, one or more `Group`s of single-character `Input` slots, and optional `Description`, `FieldError`, and `OTPFieldSeparator` parts. `length` sets how many slots render. Split the slots across `Group`s with an `OTPFieldSeparator` between them.
 
 ```tsx
-import { OTPField, OTPFieldSeparator } from '@/components/ui/otp-field'
-import { Description, FieldError, Label } from '@/components/ui/field'
-import { Group } from '@/components/ui/group'
-import { Input } from '@/components/ui/input'
+import { OTPField, OTPFieldSeparator } from '@/ui/otp-field'
+import { Description, FieldError, Label } from '@/ui/field'
+import { Group } from '@/ui/group'
+import { Input } from '@/ui/input'
 ```
 
 ```tsx

--- a/www/content/docs/components/pagination.mdx
+++ b/www/content/docs/components/pagination.mdx
@@ -24,7 +24,7 @@ import {
   PaginationList,
   PaginationNext,
   PaginationPrevious,
-} from '@/components/ui/pagination'
+} from '@/ui/pagination'
 ```
 
 ```tsx

--- a/www/content/docs/components/popover.mdx
+++ b/www/content/docs/components/popover.mdx
@@ -30,9 +30,9 @@ npx shadcn@latest add @dotui/popover
 Use popovers to display rich content in a floating container that appears above other content.
 
 ```tsx
-import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { Popover } from '@/components/ui/popover'
+import { Button } from '@/ui/button'
+import { Dialog, DialogContent, DialogTitle } from '@/ui/dialog'
+import { Popover } from '@/ui/popover'
 ```
 
 ```tsx
@@ -52,9 +52,9 @@ import { Popover } from '@/components/ui/popover'
 A `Dialog` wraps the trigger `Button` and the `Popover`; the popover holds a `DialogContent` with its title and body.
 
 ```tsx
-import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { Popover } from '@/components/ui/popover'
+import { Button } from '@/ui/button'
+import { Dialog, DialogContent, DialogTitle } from '@/ui/dialog'
+import { Popover } from '@/ui/popover'
 ;<Dialog>
   <Button />
   <Popover>

--- a/www/content/docs/components/progress-bar.mdx
+++ b/www/content/docs/components/progress-bar.mdx
@@ -41,7 +41,7 @@ npx shadcn@latest add @dotui/progress-bar
 Use progress bars to show the progression of a system operation or task.
 
 ```tsx
-import { ProgressBar, ProgressBarControl } from '@/components/ui/progress-bar'
+import { ProgressBar, ProgressBarControl } from '@/ui/progress-bar'
 ```
 
 ```tsx
@@ -59,7 +59,7 @@ import {
   ProgressBar,
   ProgressBarControl,
   ProgressBarOutput,
-} from '@/components/ui/progress-bar'
+} from '@/ui/progress-bar'
 ;<ProgressBar>
   <ProgressBarOutput />
   <ProgressBarControl />

--- a/www/content/docs/components/qr-code.mdx
+++ b/www/content/docs/components/qr-code.mdx
@@ -29,7 +29,7 @@ npx shadcn@latest add @dotui/qr-code
 ## Usage
 
 ```tsx
-import { QRCode } from '@/components/ui/qr-code'
+import { QRCode } from '@/ui/qr-code'
 ;<QRCode value="https://dotui.org" aria-label="dotUI website" />
 ```
 

--- a/www/content/docs/components/radio-group.mdx
+++ b/www/content/docs/components/radio-group.mdx
@@ -50,8 +50,8 @@ npx shadcn@latest add @dotui/radio-group
 Use radio group to allow users to select a single option from a short list of related options.
 
 ```tsx
-import { Radio, RadioControl, RadioGroup } from '@/components/ui/radio-group'
-import { FieldGroup, Label } from '@/components/ui/field'
+import { Radio, RadioControl, RadioGroup } from '@/ui/radio-group'
+import { FieldGroup, Label } from '@/ui/field'
 ```
 
 ```tsx
@@ -80,13 +80,8 @@ import {
   RadioControl,
   RadioGroup,
   RadioIndicator,
-} from '@/components/ui/radio-group'
-import {
-  Description,
-  FieldError,
-  FieldGroup,
-  Label,
-} from '@/components/ui/field'
+} from '@/ui/radio-group'
+import { Description, FieldError, FieldGroup, Label } from '@/ui/field'
 ;<RadioGroup>
   <Label />
   <FieldGroup>

--- a/www/content/docs/components/search-field.mdx
+++ b/www/content/docs/components/search-field.mdx
@@ -44,9 +44,9 @@ npx shadcn@latest add @dotui/search-field
 Use `SearchField` to allow users to enter and clear a search query.
 
 ```tsx
-import { SearchField } from '@/components/ui/search-field'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/field'
+import { SearchField } from '@/ui/search-field'
+import { Input } from '@/ui/input'
+import { Label } from '@/ui/field'
 ```
 
 ```tsx
@@ -61,9 +61,9 @@ import { Label } from '@/components/ui/field'
 A `SearchField` wraps an optional `Label`, an `Input`, and optional `Description` and `FieldError`. Rendered on its own it supplies a default `InputGroup` with a search icon and a clear button, so `<SearchField><Input /></SearchField>` is enough.
 
 ```tsx
-import { SearchField } from '@/components/ui/search-field'
-import { Label, Description, FieldError } from '@/components/ui/field'
-import { Input } from '@/components/ui/input'
+import { SearchField } from '@/ui/search-field'
+import { Label, Description, FieldError } from '@/ui/field'
+import { Input } from '@/ui/input'
 ;<SearchField>
   <Label />
   <Input />

--- a/www/content/docs/components/segmented-control.mdx
+++ b/www/content/docs/components/segmented-control.mdx
@@ -20,10 +20,7 @@ npx shadcn@latest add @dotui/segmented-control
 Use a segmented control for a small set of mutually exclusive options — view modes, ranges, filters. It's built on `ToggleButtonGroup` with single selection, and the indicator slides between segments (React Aria's `SelectionIndicator`).
 
 ```tsx
-import {
-  SegmentedControl,
-  SegmentedControlItem,
-} from '@/components/ui/segmented-control'
+import { SegmentedControl, SegmentedControlItem } from '@/ui/segmented-control'
 ```
 
 ```tsx
@@ -39,10 +36,7 @@ import {
 A `SegmentedControl` wraps one `SegmentedControlItem` per option. Each item needs a unique `id`, which is the value the control reports as selected.
 
 ```tsx
-import {
-  SegmentedControl,
-  SegmentedControlItem,
-} from '@/components/ui/segmented-control'
+import { SegmentedControl, SegmentedControlItem } from '@/ui/segmented-control'
 ;<SegmentedControl>
   <SegmentedControlItem id="…">…</SegmentedControlItem>
 </SegmentedControl>

--- a/www/content/docs/components/select.mdx
+++ b/www/content/docs/components/select.mdx
@@ -44,12 +44,7 @@ npx shadcn@latest add @dotui/select
 Use `Select` to allow users to choose a single option from a collapsible list of options when space is limited.
 
 ```tsx
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from '@/components/ui/select'
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/ui/select'
 ```
 
 ```tsx
@@ -72,7 +67,7 @@ import {
   SelectItem,
   SelectSection,
   SelectSectionHeader,
-} from '@/components/ui/select'
+} from '@/ui/select'
 ```
 
 ```tsx
@@ -126,7 +121,7 @@ Feed a `useAsyncList` result into `SelectContent` via `items`, and wire `isLoadi
 Add a `Label` and a `FieldError` inside `Select`, and set `isRequired` or `isInvalid` to surface validation.
 
 ```tsx
-import { FieldError, Label } from '@/components/ui/field'
+import { FieldError, Label } from '@/ui/field'
 ;<Select isRequired>
   <Label>Provider</Label>
   <SelectTrigger />
@@ -143,15 +138,15 @@ import { FieldError, Label } from '@/components/ui/field'
 
 ```tsx
 import { ChevronDownIcon } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { Button } from '@/ui/button'
 import {
   ListBox,
   ListBoxItem,
   ListBoxSection,
   ListBoxSectionHeader,
-} from '@/components/ui/list-box'
-import { Popover } from '@/components/ui/popover'
-import { Select, SelectValue } from '@/components/ui/select'
+} from '@/ui/list-box'
+import { Popover } from '@/ui/popover'
+import { Select, SelectValue } from '@/ui/select'
 ```
 
 ```tsx

--- a/www/content/docs/components/separator.mdx
+++ b/www/content/docs/components/separator.mdx
@@ -30,7 +30,7 @@ npx shadcn@latest add @dotui/separator
 Use separators to visually divide content in lists, menus, or other places.
 
 ```tsx
-import { Separator } from '@/components/ui/separator'
+import { Separator } from '@/ui/separator'
 ```
 
 ```tsx

--- a/www/content/docs/components/sidebar.mdx
+++ b/www/content/docs/components/sidebar.mdx
@@ -29,7 +29,7 @@ import {
   SidebarMenuItem,
   SidebarProvider,
   SidebarTrigger,
-} from '@/components/ui/sidebar'
+} from '@/ui/sidebar'
 ```
 
 ```tsx

--- a/www/content/docs/components/skeleton.mdx
+++ b/www/content/docs/components/skeleton.mdx
@@ -29,7 +29,7 @@ npx shadcn@latest add @dotui/skeleton
 Use skeleton components as placeholders while content is loading.
 
 ```tsx
-import { Skeleton } from '@/components/ui/skeleton'
+import { Skeleton } from '@/ui/skeleton'
 ```
 
 ```tsx

--- a/www/content/docs/components/slider.mdx
+++ b/www/content/docs/components/slider.mdx
@@ -40,7 +40,7 @@ npx shadcn@latest add @dotui/slider
 Use slider to allow users to select a value from within a given range.
 
 ```tsx
-import { Slider, SliderControl } from '@/components/ui/slider'
+import { Slider, SliderControl } from '@/ui/slider'
 ```
 
 ```tsx
@@ -61,7 +61,7 @@ import {
   SliderFill,
   SliderThumb,
   SliderOutput,
-} from '@/components/ui/slider'
+} from '@/ui/slider'
 ;<Slider>
   <SliderOutput />
   <SliderControl>

--- a/www/content/docs/components/switch.mdx
+++ b/www/content/docs/components/switch.mdx
@@ -32,8 +32,8 @@ npx shadcn@latest add @dotui/switch
 Use switch for communicating activation (e.g. on/off states), while checkboxes are best used for communicating selection (e.g. multiple table rows).
 
 ```tsx
-import { Label } from '@/components/ui/field'
-import { Switch, SwitchControl } from '@/components/ui/switch'
+import { Label } from '@/ui/field'
+import { Switch, SwitchControl } from '@/ui/switch'
 ```
 
 ```tsx
@@ -48,13 +48,13 @@ import { Switch, SwitchControl } from '@/components/ui/switch'
 A `Switch` wraps a `SwitchControl` (which auto-renders its `SwitchIndicator` and `SwitchThumb`) and a `Label`. Pass a string child for the label shorthand, or omit children for a standalone control with an `aria-label`.
 
 ```tsx
-import { Label } from '@/components/ui/field'
+import { Label } from '@/ui/field'
 import {
   Switch,
   SwitchControl,
   SwitchIndicator,
   SwitchThumb,
-} from '@/components/ui/switch'
+} from '@/ui/switch'
 
 <Switch>
   <SwitchControl>

--- a/www/content/docs/components/table.mdx
+++ b/www/content/docs/components/table.mdx
@@ -40,7 +40,7 @@ import {
   TableHeader,
   TableRow,
   TableVirtualizer,
-} from '@/components/ui/table'
+} from '@/ui/table'
 ```
 
 ```tsx
@@ -118,7 +118,7 @@ import {
   TableFooter,
   TableHeader,
   TableRow,
-} from '@/components/ui/table'
+} from '@/ui/table'
 ;<TableContainer>
   <Table>
     <TableHeader>

--- a/www/content/docs/components/tabs.mdx
+++ b/www/content/docs/components/tabs.mdx
@@ -35,7 +35,7 @@ npx shadcn@latest add @dotui/tabs
 Use tabs to organize content into multiple sections and allow users to navigate between them.
 
 ```tsx
-import { Tab, TabList, TabPanel, Tabs } from '@/components/ui/tabs'
+import { Tab, TabList, TabPanel, Tabs } from '@/ui/tabs'
 ```
 
 ```tsx
@@ -54,7 +54,7 @@ import { Tab, TabList, TabPanel, Tabs } from '@/components/ui/tabs'
 ## Anatomy
 
 ```tsx
-import { Tab, TabList, TabPanel, Tabs } from '@/components/ui/tabs'
+import { Tab, TabList, TabPanel, Tabs } from '@/ui/tabs'
 ```
 
 ```tsx

--- a/www/content/docs/components/tag-group.mdx
+++ b/www/content/docs/components/tag-group.mdx
@@ -18,7 +18,7 @@ npx shadcn@latest add @dotui/tag-group
 ## Usage
 
 ```tsx
-import { TagGroup, TagList, Tag } from '@/components/ui/tag-group'
+import { TagGroup, TagList, Tag } from '@/ui/tag-group'
 ```
 
 ```tsx
@@ -35,8 +35,8 @@ import { TagGroup, TagList, Tag } from '@/components/ui/tag-group'
 A `TagGroup` wraps an optional `Label` and a `TagList` of `Tag` items.
 
 ```tsx
-import { TagGroup, TagList, Tag } from '@/components/ui/tag-group'
-import { Label } from '@/components/ui/field'
+import { TagGroup, TagList, Tag } from '@/ui/tag-group'
+import { Label } from '@/ui/field'
 ;<TagGroup>
   <Label />
   <TagList>

--- a/www/content/docs/components/text-area.mdx
+++ b/www/content/docs/components/text-area.mdx
@@ -61,9 +61,9 @@ npx shadcn@latest add @dotui/text-field
 Use `TextArea` to allow users to enter multi-line text content.
 
 ```tsx
-import { TextField } from '@/components/ui/text-field'
-import { TextArea, InputGroup, InputGroupAddon } from '@/components/ui/input'
-import { Label } from '@/components/ui/field'
+import { TextField } from '@/ui/text-field'
+import { TextArea, InputGroup, InputGroupAddon } from '@/ui/input'
+import { Label } from '@/ui/field'
 ```
 
 ```tsx

--- a/www/content/docs/components/text-field.mdx
+++ b/www/content/docs/components/text-field.mdx
@@ -56,9 +56,9 @@ npx shadcn@latest add @dotui/text-field
 Use a `TextField` to allow users to input custom text entries with a keyboard.
 
 ```tsx
-import { TextField } from '@/components/ui/text-field'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/field'
+import { TextField } from '@/ui/text-field'
+import { Input } from '@/ui/input'
+import { Label } from '@/ui/field'
 ```
 
 ```tsx
@@ -73,9 +73,9 @@ import { Label } from '@/components/ui/field'
 A `TextField` wraps a `Label`, an `Input`, and optional `Description` and `FieldError`. Wrap the `Input` in an `InputGroup` with `InputGroupAddon` to render a prefix or suffix inside the field.
 
 ```tsx
-import { TextField } from '@/components/ui/text-field'
-import { Label, Description, FieldError } from '@/components/ui/field'
-import { Input, InputGroup, InputGroupAddon } from '@/components/ui/input'
+import { TextField } from '@/ui/text-field'
+import { Label, Description, FieldError } from '@/ui/field'
+import { Input, InputGroup, InputGroupAddon } from '@/ui/input'
 ;<TextField>
   <Label />
   <InputGroup>

--- a/www/content/docs/components/time-field.mdx
+++ b/www/content/docs/components/time-field.mdx
@@ -44,9 +44,9 @@ npx shadcn@latest add @dotui/time-field
 Use `TimeField` to allow users to enter and edit time values using a keyboard.
 
 ```tsx
-import { TimeField } from '@/components/ui/time-field'
-import { DateInput } from '@/components/ui/input'
-import { Label } from '@/components/ui/field'
+import { TimeField } from '@/ui/time-field'
+import { DateInput } from '@/ui/input'
+import { Label } from '@/ui/field'
 ```
 
 ```tsx
@@ -61,9 +61,9 @@ import { Label } from '@/components/ui/field'
 `TimeField` wraps a `Label`, the `DateInput` that holds the editable time segments, and an optional `Description` or `FieldError`.
 
 ```tsx
-import { TimeField } from '@/components/ui/time-field'
-import { DateInput } from '@/components/ui/input'
-import { Label, Description, FieldError } from '@/components/ui/field'
+import { TimeField } from '@/ui/time-field'
+import { DateInput } from '@/ui/input'
+import { Label, Description, FieldError } from '@/ui/field'
 ;<TimeField>
   <Label />
   <DateInput />

--- a/www/content/docs/components/time-picker.mdx
+++ b/www/content/docs/components/time-picker.mdx
@@ -22,12 +22,12 @@ Use time pickers to allow users to select a time using a field and a scrollable 
 ```tsx
 import { ClockIcon } from 'lucide-react'
 
-import { Button } from '@/components/ui/button'
-import { DialogContent } from '@/components/ui/dialog'
-import { Label } from '@/components/ui/field'
-import { DateInput, InputGroup, InputGroupAddon } from '@/components/ui/input'
-import { Popover } from '@/components/ui/popover'
-import { TimePicker, TimePickerColumns } from '@/components/ui/time-picker'
+import { Button } from '@/ui/button'
+import { DialogContent } from '@/ui/dialog'
+import { Label } from '@/ui/field'
+import { DateInput, InputGroup, InputGroupAddon } from '@/ui/input'
+import { Popover } from '@/ui/popover'
+import { TimePicker, TimePickerColumns } from '@/ui/time-picker'
 ```
 
 ```tsx

--- a/www/content/docs/components/toast.mdx
+++ b/www/content/docs/components/toast.mdx
@@ -13,7 +13,7 @@ npx shadcn@latest add @dotui/toast
 ## Usage
 
 ```tsx
-import { ToastProvider, toastManager } from '@/components/ui/toast'
+import { ToastProvider, toastManager } from '@/ui/toast'
 ```
 
 ```tsx
@@ -35,7 +35,7 @@ toastManager.add({
 Toasts aren't rendered as JSX. Mount `<ToastProvider />` once at your app root, then push notifications imperatively with `toastManager`. `add` returns an id you can pass to `close`.
 
 ```tsx
-import { ToastProvider, toastManager } from '@/components/ui/toast'
+import { ToastProvider, toastManager } from '@/ui/toast'
 ;<ToastProvider />
 
 const id = toastManager.add({ title: 'Your message has been sent.' })

--- a/www/content/docs/components/toggle-button-group.mdx
+++ b/www/content/docs/components/toggle-button-group.mdx
@@ -20,8 +20,8 @@ npx shadcn@latest add @dotui/toggle-button-group
 Use toggle button groups to let users toggle between multiple options.
 
 ```tsx
-import { ToggleButton } from '@/components/ui/toggle-button'
-import { ToggleButtonGroup } from '@/components/ui/toggle-button-group'
+import { ToggleButton } from '@/ui/toggle-button'
+import { ToggleButtonGroup } from '@/ui/toggle-button-group'
 ```
 
 ```tsx

--- a/www/content/docs/components/toggle-button.mdx
+++ b/www/content/docs/components/toggle-button.mdx
@@ -30,7 +30,7 @@ Use toggle buttons to allow users to toggle a selection on or off, like pinning 
 
 ```tsx
 import { PinIcon } from 'lucide-react'
-import { ToggleButton } from '@/components/ui/toggle-button'
+import { ToggleButton } from '@/ui/toggle-button'
 ```
 
 ```tsx

--- a/www/content/docs/components/token-field.mdx
+++ b/www/content/docs/components/token-field.mdx
@@ -38,8 +38,8 @@ npx shadcn@latest add @dotui/token-field
 Compose a `TokenField` with a `TokenInput` for the editable area, and a `Label` before it when you want a visible label (otherwise give the input an `aria-label`). Without `allowsNewlines` the field stays single-line.
 
 ```tsx
-import { Label } from '@/components/ui/field'
-import { TokenField, TokenInput } from '@/components/ui/token-field'
+import { Label } from '@/ui/field'
+import { TokenField, TokenInput } from '@/ui/token-field'
 ```
 
 ```tsx

--- a/www/content/docs/components/tooltip.mdx
+++ b/www/content/docs/components/tooltip.mdx
@@ -40,8 +40,8 @@ npx shadcn@latest add @dotui/tooltip
 Use tooltips to provide contextual information about an element when it receives focus or the user hovers over it.
 
 ```tsx
-import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent } from '@/components/ui/tooltip'
+import { Button } from '@/ui/button'
+import { Tooltip, TooltipContent } from '@/ui/tooltip'
 ```
 
 ```tsx
@@ -56,7 +56,7 @@ import { Tooltip, TooltipContent } from '@/components/ui/tooltip'
 `Tooltip` wraps a focusable trigger (any element that takes focus, like a `Button` or `Link`) and a `TooltipContent`. The trigger opens the tooltip on hover or focus.
 
 ```tsx
-import { Tooltip, TooltipContent } from '@/components/ui/tooltip'
+import { Tooltip, TooltipContent } from '@/ui/tooltip'
 ;<Tooltip>
   <Button />
   <TooltipContent />

--- a/www/content/docs/components/tree.mdx
+++ b/www/content/docs/components/tree.mdx
@@ -38,7 +38,7 @@ category navigation. Each row is a `TreeItem` whose `TreeItemContent` holds the
 label; nested `TreeItem`s become its children.
 
 ```tsx
-import { Tree, TreeItem, TreeItemContent } from '@/components/ui/tree'
+import { Tree, TreeItem, TreeItemContent } from '@/ui/tree'
 ```
 
 ```tsx

--- a/www/scripts/registry-build.ts
+++ b/www/scripts/registry-build.ts
@@ -732,6 +732,13 @@ const DOCS_REGISTRY_URL_RE =
   /dotui\.org\/r\/([a-z0-9][a-z0-9-]*)(?![/a-z0-9-])/g
 
 /**
+ * Stale consumer import prefix. A `shadcn add` install lands `ui/<name>.tsx`
+ * targets at `@/ui/<name>` — never `@/components/ui/<name>` — so any docs
+ * snippet showing the old prefix would break when copied after install.
+ */
+const DOCS_STALE_UI_IMPORT_RE = /@\/components\/ui\//
+
+/**
  * Guard 3: every install name advertised in the docs must ship. Scans
  * content/docs for `@dotui/<name>` install targets and `dotui.org/r/<name>`
  * URLs; each must be a publishable, a served route (SERVED_ROUTE_NAMES), or an
@@ -750,6 +757,13 @@ async function checkDocsRegistryConsistency(
     const source = await fs.readFile(file, 'utf8')
     const lines = source.split('\n')
     lines.forEach((line, i) => {
+      if (DOCS_STALE_UI_IMPORT_RE.test(line)) {
+        errors.push(
+          `${path.relative(process.cwd(), file)}:${i + 1} imports from "@/components/ui/", ` +
+            `but a shadcn install lands components at "@/ui/". Use "@/ui/<name>" so copied ` +
+            `snippets resolve after install.`,
+        )
+      }
       for (const re of [DOCS_INSTALL_RE, DOCS_REGISTRY_URL_RE]) {
         re.lastIndex = 0
         let match: RegExpExecArray | null

--- a/www/src/modules/charts/data.ts
+++ b/www/src/modules/charts/data.ts
@@ -63,13 +63,13 @@ const rawDemoSources = import.meta.glob(
 
 /**
  * Rewrite a demo's source the way the docs display it: registry imports become
- * the installed `@/components/*` paths, the default export is unwrapped, and
- * tabs become spaces. (Mirrors the docs transformer's full-source output; the
- * ts-morph preview pass it also runs is build-only and unneeded here.)
+ * the installed `@/*` paths, the default export is unwrapped, and tabs become
+ * spaces. (Mirrors the docs transformer's full-source output; the ts-morph
+ * preview pass it also runs is build-only and unneeded here.)
  */
 function toDisplaySource(raw: string): string {
   return raw
-    .replace(/@\/registry\/ui\//g, '@/components/ui/')
+    .replace(/@\/registry\/ui\//g, '@/ui/')
     .replace(/@\/registry\//g, '@/')
     .replace('export default function', 'export function')
     .replace(/\t/g, '  ')

--- a/www/src/modules/docs/codegen/source-overlay.test.ts
+++ b/www/src/modules/docs/codegen/source-overlay.test.ts
@@ -67,7 +67,7 @@ describe('button', () => {
     expect(collapsed).toBe(`<Button variant="primary" size="lg" isDisabled>
   Button
 </Button>`)
-    expect(expanded).toBe(`import { Button } from "@/components/ui/button";
+    expect(expanded).toBe(`import { Button } from "@/ui/button";
 
 export function Demo() {
   return (
@@ -139,8 +139,8 @@ describe('switch', () => {
   <SwitchControl />
   <Label>Airplane mode</Label>
 </Switch>`)
-    expect(expanded).toBe(`import { Label } from "@/components/ui/field";
-import { Switch, SwitchControl } from "@/components/ui/switch";
+    expect(expanded).toBe(`import { Label } from "@/ui/field";
+import { Switch, SwitchControl } from "@/ui/switch";
 
 export function Demo() {
   return (
@@ -289,9 +289,8 @@ describe('accordion', () => {
     </Disclosure>
   ))}
 </Accordion>`)
-    expect(expanded)
-      .toBe(`import { Accordion } from "@/components/ui/accordion";
-import { Disclosure, DisclosurePanel, DisclosureTrigger } from "@/components/ui/disclosure";
+    expect(expanded).toBe(`import { Accordion } from "@/ui/accordion";
+import { Disclosure, DisclosurePanel, DisclosureTrigger } from "@/ui/disclosure";
 
 const items = [
   { id: "a", question: "Q one?", answer: "A one." },

--- a/www/src/modules/docs/codegen/source-overlay.ts
+++ b/www/src/modules/docs/codegen/source-overlay.ts
@@ -167,10 +167,13 @@ function rewriteImports(sf: SourceFile): void {
       imp.remove()
       continue
     }
-    imp.setModuleSpecifier(
+    // `rewriteImportPath` yields the shipped base.tsx paths, where `ui/*` maps to
+    // `@/components/ui/*`. Displayed docs code must match where a real install
+    // lands files — `ui/<name>.tsx` targets resolve to `@/ui/*`.
+    const rewritten =
       rewriteImportPath(imp.getModuleSpecifierValue()) ??
-        imp.getModuleSpecifierValue(),
-    )
+      imp.getModuleSpecifierValue()
+    imp.setModuleSpecifier(rewritten.replace(/^@\/components\/ui\//, '@/ui/'))
   }
 }
 

--- a/www/src/modules/docs/mdx-plugins/transformer.ts
+++ b/www/src/modules/docs/mdx-plugins/transformer.ts
@@ -160,7 +160,7 @@ function findExportFunction(
  */
 function transformPaths(code: string): string {
   return code
-    .replace(/@\/registry\/ui\//g, '@/components/ui/')
+    .replace(/@\/registry\/ui\//g, '@/ui/')
     .replace(/@\/registry\//g, '@/')
 }
 


### PR DESCRIPTION
Every component doc's Usage block imported `@/components/ui/<name>`, but a real install lands files at `src/ui/<name>.tsx` (shadcn places by each file's `target`), so copied snippets didn't resolve. All displayed import paths now read `@/ui/<name>` — matching both where files land and what installed code actually imports.

## Changes

- 68 MDX pages: 229 `@/components/ui/` → `@/ui/` rewrites, all inside code fences (no prose changes, no runtime imports touched).
- 3 display generators fixed at the source: `mdx-plugins/transformer.ts`, `charts/data.ts`, and `codegen/source-overlay.ts` (display-only post-remap; `transform-base.ts` — which builds shipped output — untouched).
- New guard in `checkDocsRegistryConsistency`: any `@/components/ui/` import in docs MDX fails the build with a file:line message pointing to `@/ui/`.

## Verification (independent adversarial review, incl. real install)

- **Real-CLI ground truth**: fresh Next.js project, `shadcn init https://dotui.org/r/init` + `add @dotui/text-field` → files at `src/ui/*`; the CLI rewrites sibling registry imports to the installed locations (`@/components/ui/field` → `@/ui/field`); `tsc --noEmit` exit 0. The docs now show exactly what installed code contains.
- Zero shipped-output drift: full emitted output byte-identical to the merge base.
- Guard proven: injected old-style import → build fails with the actionable message; zero false positives (no legit `@/components/ui/` remains in docs, and installation.mdx's registry JSON isn't matched).
- Sampled pages (accordion, text-area, select, chart, button): pure prefix rewrites + line reflow, symbol lists identical.
- `build:registry` guards green, `pnpm check` 0 errors, `pnpm typecheck`, `pnpm test` 231/231.

## Note

The published `base.tsx` source still carries `@/components/ui/<name>` internally — harmless for the supported `shadcn add` path (the CLI rewrites it), but a manual copy-paste of raw registry source wouldn't resolve. Cosmetic-level; worth folding into the planned publisher rewrite rather than changing now.
