### PR TITLE
fix(presets): drop doubled hairline ring from Vercel shadows

### DIFF
--- a/www/src/modules/presets/presets-data.ts
+++ b/www/src/modules/presets/presets-data.ts
@@ -115,13 +115,14 @@ export const PRESETS: Preset[] = [
         badge: { radius: '--radius-full' },
       },
       tokens: {
-        // Geist elevation: two soft layered shadows + a 1px hairline ring that
-        // rides the neutral ramp so it adapts per mode. Overlays and cards share
-        // the value — both float over the page.
+        // Geist elevation: two soft layered shadows. The hairline comes from the
+        // components' own border (color-border above) — a shadow ring on top
+        // would double it and smear the corners. Overlays and cards share the
+        // value — both float over the page.
         '--shadow-overlay':
-          '0 8px 16px -4px rgb(0 0 0 / 0.04), 0 24px 32px -8px rgb(0 0 0 / 0.06), 0 0 0 1px var(--neutral-400)',
+          '0 8px 16px -4px rgb(0 0 0 / 0.04), 0 24px 32px -8px rgb(0 0 0 / 0.06)',
         '--shadow-card':
-          '0 8px 16px -4px rgb(0 0 0 / 0.04), 0 24px 32px -8px rgb(0 0 0 / 0.06), 0 0 0 1px var(--neutral-400)',
+          '0 8px 16px -4px rgb(0 0 0 / 0.04), 0 24px 32px -8px rgb(0 0 0 / 0.06)',
       },
     }),
   },


### PR DESCRIPTION
## Summary

- Removed the `0 0 0 1px var(--neutral-400)` ring from the Vercel preset's `--shadow-card` and `--shadow-overlay` tokens.
- Card, popover, and modal all draw their own 1px `border`, and the preset already remaps `color-border` to the measured Geist hairline step — the shadow ring added a second 1px line in a different gray outside the border box, so edges rendered as two offset hairlines and corners doubled (8px inner curve vs ~9px outer).
- With the ring gone, the border carries the single hairline. Verified live: computed `box-shadow` on Vercel-preset cards is now just the two soft Geist shadows. Tooltips (borderless) are solid dark in Geist and need no ring.