### PR TITLE
docs: move dev-tweaker workflow into a skill

### DIFF
--- a/.claude/skills/dev-tweaker/SKILL.md
+++ b/.claude/skills/dev-tweaker/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: dev-tweaker
+description: Add throwaway useTweak() controls to a www feature component so the user can flip design/layout options live in the dev-only tweaker panel and pick one, then bake the choice in and remove the scaffolding. Use only when they explicitly ask for tweaks or options on a specific feature during PR/feature-branch work.
+---
+
+# Dev tweaker (design exploration)
+
+`www/src/dev/tweaker` is a floating panel for exploring designs/layouts live: you add `useTweak()` calls to a feature component, the user flips the options in the panel and picks one. It runs in dev and on Vercel previews, and is dead-code-eliminated from production builds. Full API + workflow: [`www/src/dev/tweaker/README.md`](../../../www/src/dev/tweaker/README.md).
+
+- **When (strict):** only during active PR/feature-branch work, and only when the user explicitly asks for tweaks/options on a specific feature. Never unprompted, never on `main`, never as a way to add real config.
+- **How:** add `useTweak('Label', { type, default, group? })` in the relevant **www** feature component and branch the JSX/styles on the returned value. Keep each `default` equal to the current look (nothing changes until a control moves); offer a small set (≤~5) of meaningful named variants per axis; `group` related controls. Types: `select`, `boolean`, `number`, `color`, `text`.
+- **Boundaries:** never author `useTweak` in `www/src/registry/` — the product source stays clean (the panel reuses registry UI, but the calls live only in site/feature/module code). It's throwaway scaffolding, **not** a `/create` axis: adding a real axis/variant/token is still a product decision (propose-and-approve — see `CLAUDE.md`).
+- **Cleanup:** once the user picks (their "Copy for AI" output or a verbal choice), bake the values into the code and **remove the `useTweak` scaffolding** before finalizing the PR — unless they want to keep iterating. Don't merge `useTweak` calls into feature code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,12 +79,7 @@ After modifying `www/src/registry/`, run `pnpm build:registry` and commit the re
 
 ## Dev tweaker (design exploration)
 
-`www/src/dev/tweaker` is a **dev-only** floating panel (gated on `import.meta.env.DEV`, dead-code-eliminated from production) for exploring designs/layouts live: you add `useTweak()` calls to a feature component, the user flips the options in the panel and picks one. Full API + workflow: [`www/src/dev/tweaker/README.md`](www/src/dev/tweaker/README.md).
-
-- **When (strict):** only during active PR/feature-branch work, and only when the user explicitly asks for tweaks/options on a specific feature. Never unprompted, never on `main`, never as a way to add real config.
-- **How:** add `useTweak('Label', { type, default, group? })` in the relevant **www** feature component and branch the JSX/styles on the returned value. Keep each `default` equal to the current look (nothing changes until a control moves); offer a small set (≤~5) of meaningful named variants per axis; `group` related controls. Types: `select`, `boolean`, `number`, `color`, `text`.
-- **Boundaries:** never author `useTweak` in `www/src/registry/` — the product source stays clean (the panel reuses registry UI, but the calls live only in site/feature/module code). It's throwaway scaffolding, **not** a `/create` axis: adding a real axis/variant/token is still a product decision (propose-and-approve, below).
-- **Cleanup:** once the user picks (their "Copy for AI" output or a verbal choice), bake the values into the code and **remove the `useTweak` scaffolding** before finalizing the PR — unless they want to keep iterating. Don't merge `useTweak` calls into feature code.
+`www/src/dev/tweaker` is a **dev-only** floating panel for exploring designs/layouts live. Only during active PR/feature-branch work, and only when the user explicitly asks for tweaks/options on a specific feature — never unprompted, never on `main`, never as a way to add real config, and never author `useTweak` in `www/src/registry/`. Workflow and API: the `dev-tweaker` skill, then [`www/src/dev/tweaker/README.md`](www/src/dev/tweaker/README.md).
 
 ## Conventions & gotchas
 


### PR DESCRIPTION
CLAUDE.md carried the full `useTweak` workflow — five bullets covering the API, control types, and cleanup rules — inline. Every session paid for that context whether or not it went anywhere near the tweaker.

This compresses the CLAUDE.md section to the part that must always be in context (the strict *when*, and the `www/src/registry/` boundary) and moves the API and workflow into a `dev-tweaker` skill that loads on demand.

- `CLAUDE.md` — Dev tweaker section: 5 bullets → 1 paragraph, pointing at the skill, then `www/src/dev/tweaker/README.md`.
- `.claude/skills/dev-tweaker/SKILL.md` — new; carries the moved content.

One correction made in passing: the old text said the panel was gated on `import.meta.env.DEV`. It is actually gated on `import.meta.env.DEV || import.meta.env.VERCEL_ENV === 'preview'` (`use-tweak.ts:73`, mirrored at `www/src/routes/__root.tsx:23`), so it runs on Vercel previews too. The skill now says so; `README.md` already did.

No source changes — `www/src/dev/tweaker/` is untouched.

## Verification

- `pnpm check` — 0 errors, formatting clean (68 warnings, all pre-existing).
- `pnpm vitest run www/src/dev/tweaker/store.test.ts` — 10/10 pass.
- Skill content re-checked against the implementation: the five control types match `types.ts`, and the relative link to `README.md` resolves.

## Considered and rejected: replacing the tweaker with Leva

Worth recording since it comes up. [Leva](https://github.com/pmndrs/leva) covers the same ground, but swapping it in would be a downgrade here:

- **It contradicts the repo's own behavior-layer position.** Leva pulls in `@radix-ui/react-portal` and `@radix-ui/react-tooltip`. The docs intro states Radix is effectively unmaintained, as the reason this project is built on React Aria.
- **11 runtime deps for a dev tool**, including `@stitches/react` (runtime CSS-in-JS in a Tailwind v4 repo) and `zustand@^3.6.9` — three majors behind current.
- **No "Copy for AI".** That handoff is the point of the workflow, and it would have to be built on top of Leva anyway.
- **The existing panel already works**, is unit-tested, and tree-shakes out of production.

Leva would win if the panel needed richer control types (vector, bezier, image, monitor). It does not today.

## Suggested refactors

Not in this diff, flagging per CLAUDE.md:

- The tweaker panel is built from `@/registry/ui` components, so a global theme or preset tweak restyles the panel while you are tweaking. Isolating its chrome from the design system under test would make it trustworthy for theme-level exploration.