### PR TITLE
feat(www): replace hero CTA with "Start building"

### DIFF
--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -33,7 +33,7 @@ export function HomePage() {
           </p>
           <div className="mt-9 flex items-center gap-3">
             <LinkButton href="/create" variant="primary" size="lg">
-              Launch the editor
+              Start building
             </LinkButton>
             <LinkButton href="/docs/components" variant="default" size="lg">
               View components


### PR DESCRIPTION
Replaces the homepage hero CTA "Launch the editor" with "Start building".

The H1 right above it promises an outcome — *Build your design system, not someone else's* — and the button then offered a generic tool. A CTA should complete the sentence "I want to ___": nobody wants to launch an editor, everyone on that page wants to build theirs.

"Start building" was picked over "Build yours" to avoid echoing shadcn's own `Build Your Own` CTA, and because it stays true if the hero copy changes.

### Context

This came out of a naming discussion about what to call the /create experience. For reference, shadcn deliberately uses **no noun** for their equivalent tool — nav says `Create`, homepage CTA says `Build Your Own`, page title is `New Project`. No "editor", "builder", "studio" or "generator" anywhere in their chrome.

The wider question — whether /create should get a proper name (candidate: **Foundry**) for the nav, page title and docs deep-links — is deliberately **not** in this PR. That's an experience-spec decision and belongs with the queued /create rewrite; what a place feels like should dictate what it's called. This PR is only the CTA fix, which is worth landing regardless of how the naming lands.

### Not included (follow-ups)

- Naming the /create destination, and the resulting nav / `<title>` / docs "Customize in …" copy.
- `Resume building` for returning users with a saved system — "Start building" is wrong for someone mid-project, but there's no returning-user CTA state today.

### Test plan

- [x] `pnpm check` — 0 errors, formatting clean (68 pre-existing warnings, none in touched file)
- [ ] Visual check of the hero on the preview deploy
