### PR TITLE
style(www): rewrite the landing hero description

### DIFF
--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -28,8 +28,8 @@ export function HomePage() {
             not someone else&rsquo;s.
           </h1>
           <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
-            Beautiful components, accessibility out of the box, composition, and
-            more.
+            Set the colors, the type, the whole personality. Every component
+            follows. Export it as code you own, or straight to v0.
           </p>
           <div className="mt-9 flex items-center gap-3">
             <LinkButton href="/create" variant="primary" size="lg">


### PR DESCRIPTION
Replaces the landing hero description, which read as generic component-library boilerplate that could sit on any shadcn clone's site.

**Before**
> Beautiful components, accessibility out of the box, composition, and more.

**After**
> Set the colors, the type, the whole personality. Every component follows. Export it as code you own, or straight to v0.

## Why this line

- **It makes the headline literal.** "Build your design system" is the claim; "set the colors, the type, the whole personality" is what building actually consists of. Headline claims, subtitle shows the mechanism.
- **"the whole personality"** says the third thing you can change isn't another token — it's the taste/identity of the system, not a variables skin over someone else's components.
- **"Every component follows"** carries the live-preview-on-real-components differentiator in three words, without the words "live" or "realtime" that every tool claims.
- **"code you own, or straight to v0"** lands the ownership wedge and the export breadth. Component libraries give you a starting point to hand-edit; theme editors patch CSS variables. Neither ships you the source.

Copy was explored by running four independent drafting passes (product truth, competitive positioning, pure craft, minimalist voice) and the variants were compared live in the browser via the dev tweaker — content wording, muted vs full-strength color, and font size. The tweaker scaffolding is not part of this diff.

## Suggested follow-ups (not in this PR)

- The site meta description in `www/src/config/site.ts` still reads "Compose beautiful, accessible React components and export them as code you own." — the framing this PR moves away from. Worth aligning.
- A more visual hero variant was prototyped and dropped: the sentence becomes "Set the ⟨word⟩." with the word cycling through colors / type / personality / density / radius, each with a tiny inline visual. Parked as an idea rather than deleted silently.

## Test plan

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] Verified rendered copy on the local dev server
- [ ] Visual check on the Vercel preview

Note: touches `www` marketing copy only — no registry or references regeneration needed.