### PR TITLE
fix(www): mount dev tweaker and scoped portal after hydration

### DIFF
--- a/www/src/lib/styles.tsx
+++ b/www/src/lib/styles.tsx
@@ -411,6 +411,11 @@ function DesignSystemProvider({
   // scope *selector* is no longer per-instance — see useScopedTheme.
   const scopeId = React.useId()
 
+  // The portal target must wait for mount: rendering it during hydration inserts
+  // a node into <body> — a React-hydrated element — and the whole tree mismatches.
+  const [mounted, setMounted] = React.useState(false)
+  React.useEffect(() => setMounted(true), [])
+
   // Apply the global token vars to :root so values that reference each other via calc() +
   // var() (e.g. --radius-sm = calc(.25rem * var(--radius-factor))) recompute correctly —
   // setting them on a wrapper <div> would leave the :root-declared tokens frozen. In `scoped`
@@ -539,7 +544,7 @@ function DesignSystemProvider({
       >
         {tree}
       </UNSAFE_PortalProvider>
-      {typeof document === 'undefined'
+      {!mounted
         ? null
         : createPortal(
             <div

--- a/www/src/routes/__root.tsx
+++ b/www/src/routes/__root.tsx
@@ -106,10 +106,14 @@ function RootComponent() {
         <ToastProvider>
           <Outlet />
         </ToastProvider>
+        {/* ClientOnly: the !SSR guard above renders nothing on the server, so
+            without it the client's first render mismatches and hydration fails. */}
         {DevTweaker && (
-          <Suspense fallback={null}>
-            <DevTweaker />
-          </Suspense>
+          <ClientOnly fallback={null}>
+            <Suspense fallback={null}>
+              <DevTweaker />
+            </Suspense>
+          </ClientOnly>
         )}
       </RootDocument>
     </ThemeProvider>


### PR DESCRIPTION
## Problem

The landing page (and every page using scoped `DesignSystemProvider`s) threw a React hydration error on every load — "Hydration failed because the server rendered HTML didn't match the client" — forcing a full client re-render of the tree. Two stacked mismatches, the first masking the second:

1. **DevTweaker** (`www/src/routes/__root.tsx`) is built behind a `!import.meta.env.SSR` guard, so the server renders nothing while the client (dev + Vercel previews) renders a `<Suspense>` in `<body>` on its first render. `RouterDevtools` has the identical guard but was already wrapped in `<ClientOnly>` — DevTweaker wasn't.
2. **Scoped provider portal** (`www/src/lib/styles.tsx`): the overlay portal target was gated on `typeof document === 'undefined'`, so the client's hydration render called `createPortal` into `document.body` — itself a React-hydrated node on this site (the root route renders `<html>`/`<body>`). This one hit production too, on any page with scoped providers (landing cards, presets, docs demos).

## Fix

- Wrap DevTweaker in `<ClientOnly>`, matching RouterDevtools.
- Defer the portal target behind a `mounted` flag flipped in an effect. Overlays can't open before mount, so nothing observable changes.

## Verification

Three consecutive headless-Chrome loads of `/` with `pageerror` + console listeners: zero errors, and both scoped providers' `dotui-portal-*` targets still mount into `<body>` afterward. `pnpm check` and `pnpm typecheck` pass.