### PR TITLE
feat(www): swap CTA backlight cursor follow for hover rim glow

### DIFF
--- a/www/src/modules/marketing/pill-backlight/fragment.ts
+++ b/www/src/modules/marketing/pill-backlight/fragment.ts
@@ -1,4 +1,4 @@
-import { LED_COUNT } from './strip'
+import { LED_COUNT, WAVE_AMP, WAVE_BASE, WAVE_COUNT } from './strip'
 
 /**
  * Backlit pill — an LED strip runs behind the perimeter of the CTA pill, and a
@@ -32,6 +32,9 @@ uniform vec3  uTint;
 uniform vec4  uPanel;
 // Cluster position along the perimeter, normalised [0, 1).
 uniform float uCluster;
+// Hover blend [0, 1] toward the whole-rim wave, and the wave phase in laps.
+uniform float uHover;
+uniform float uPhase;
 uniform vec4  uLed[${LED_COUNT}];
 
 // The rim is analytic (distance to the stadium border), so it stays perfectly
@@ -42,7 +45,7 @@ uniform vec4  uLed[${LED_COUNT}];
 const float TIGHT_R = 0.06;
 const float TIGHT_G = 0.2;
 const float TIGHT_SCALE = 0.006;
-const float WIDE_R  = 0.8;
+const float WIDE_R  = 1.2;
 const float WIDE_G  = 0.005;
 
 // Emitter weights are normalised to sum to 1, so the accumulation is a
@@ -51,9 +54,9 @@ const float EXPOSURE = 150.0;
 const float GAMMA    = 1.15;
 const float GRAIN    = 0.035;
 
-// 2σ² of the travelling-cluster envelope, σ = 0.14 of the perimeter — keep in
+// 2σ² of the travelling-cluster envelope, σ = 0.18 of the perimeter — keep in
 // sync with ENVELOPE_SIGMA in strip.ts.
-const float ENV_2SIGMA2 = 0.0392;
+const float ENV_2SIGMA2 = 0.0648;
 
 // Stadium (capsule) signed distance, negative inside the pill.
 float panel(vec2 p) {
@@ -113,7 +116,10 @@ void main() {
   }
   float dsc = abs(s / per - uCluster);
   dsc = min(dsc, 1.0 - dsc);
-  float env = 0.1 + exp(-dsc * dsc / ENV_2SIGMA2);
+  float bump = exp(-dsc * dsc / ENV_2SIGMA2);
+  float wave = ${WAVE_BASE} +
+    ${WAVE_AMP} * cos(${2 * Math.PI} * (s / per * float(${WAVE_COUNT}) - uPhase));
+  float env = 0.1 + mix(bump, wave, uHover);
   float tight = env / (1.0 + sd * sd / (TIGHT_R * TIGHT_R));
 
   float v = TIGHT_G * TIGHT_SCALE * tight + WIDE_G * wide;

--- a/www/src/modules/marketing/pill-backlight/index.tsx
+++ b/www/src/modules/marketing/pill-backlight/index.tsx
@@ -8,20 +8,20 @@ import {
   buildStrip,
   LED_COUNT,
   packStrip,
-  stadiumParamPx,
   stadiumPointPx,
+  WAVE_SPEED,
 } from './strip'
 import type { Led } from './strip'
 
 // Laps of the pill perimeter per second — a full circuit takes about 11s.
 const DRIFT_RATE = 0.09
 
-// Cursor capture, measured from the pill border in canvas-height units: full
-// capture inside NEAR, pure drift beyond FAR.
-const FOLLOW_NEAR = 0.1
-const FOLLOW_FAR = 0.42
-// The beam point chases its target in 2D (see draw), not along the perimeter.
-const CHASE_STIFFNESS = 12
+// Hovering the pill trades the travelling cluster for the whole-rim wave
+// (see strip.ts): full within the border, gone this far outside it (in
+// canvas-height units), eased in time at the given rate. The same blend
+// brightens the CSS ring glow.
+const HOVER_FADE = 0.06
+const HOVER_EASE = 6
 
 // Tint tween toward the preset accent — roughly the ring glow's 700ms ease.
 const TINT_STIFFNESS = 5
@@ -91,10 +91,11 @@ function createProgram(gl: WebGL2RenderingContext) {
 
 /**
  * The CTA pill's light field: an LED strip rides the pill's stadium perimeter
- * behind the DOM, one bright cluster drifts around it and is captured by the
- * cursor when it comes close. The same loop drives the CSS ring glow — it
- * writes `--cta-glow-x/y/boost` on the pill, so the border highlight and the
- * spill always sit on the same point of the perimeter.
+ * behind the DOM, one bright cluster drifts around it, and hovering the pill
+ * crossfades the cluster into an animated whole-rim glow. The same loop
+ * drives the CSS ring glow — it writes `--cta-glow-x/y/boost` on the pill,
+ * so the border highlight and the spill always sit on the same point of the
+ * perimeter.
  *
  * Purely decorative: the canvas is inert to pointer events and `-z`-stacked
  * behind the pill. Without WebGL2 the ring glow simply stays parked at its
@@ -144,6 +145,8 @@ export function PillBacklight({
     const uTint = gl.getUniformLocation(program, 'uTint')
     const uPanel = gl.getUniformLocation(program, 'uPanel')
     const uCluster = gl.getUniformLocation(program, 'uCluster')
+    const uHover = gl.getUniformLocation(program, 'uHover')
+    const uPhase = gl.getUniformLocation(program, 'uPhase')
     const uLed = gl.getUniformLocation(program, 'uLed')
 
     const reduced = window.matchMedia('(prefers-reduced-motion: reduce)')
@@ -152,12 +155,9 @@ export function PillBacklight({
     let strip: Led[] = []
     let geomKey = ''
     let stillS = 0 // top-centre of the perimeter, the reduced-motion park spot
-    let cluster = -1 // parked at stillS once the geometry is first measured
-    let sOrbit = -1 // free-drift phase along the perimeter, normalised
-    let posX = 0 // rendered beam point (pill border-box px)
-    let posY = 0
-    let hasPos = false
-    let boost = 0 // smoothed cursor pull, also drives the ring brightness
+    let cluster = -1 // drift phase along the perimeter, parked at stillS
+    let hover = 0 // eased whole-rim blend, 1 with the cursor on the pill
+    let phase = 0 // hover wave position, in laps
     let width = 0
     let height = 0
     let frame = 0
@@ -210,64 +210,25 @@ export function PillBacklight({
         gl.uniform4f(uPanel, cx, cy, halfFlat, radius)
       }
       if (cluster < 0) cluster = stillS
-      if (sOrbit < 0) sOrbit = stillS
 
       const pxR = pRect.height / 2
       const pxFlat = Math.max(pRect.width - pRect.height, 0)
       const perimeter = 2 * pxFlat + 2 * Math.PI * pxR
 
       if (dt > 0) {
-        // Cursor pull (1 at the border, 0 at FOLLOW_FAR away) and the border
-        // point nearest the cursor, in pill border-box px.
-        let pull = 0
-        let projX = 0
-        let projY = 0
-        let hasProj = false
+        // Hover: 1 with the cursor on the pill, fading over HOVER_FADE
+        // outside the border.
+        let onPill = 0
         if (cursor.active) {
           const px = cursor.x - pRect.left
           const py = cursor.y - pRect.top
           const cxq = Math.min(Math.max(px, pxR), pxR + pxFlat)
-          const dx = px - cxq
-          const dy = py - pxR
-          const dist = Math.hypot(dx, dy)
-          pull =
-            1 -
-            smoothstep(FOLLOW_NEAR, FOLLOW_FAR, Math.max(dist - pxR, 0) / unit)
-          if (dist > 0) {
-            projX = cxq + (dx / dist) * pxR
-            projY = pxR + (dy / dist) * pxR
-            hasProj = true
-          }
+          const dist = Math.hypot(px - cxq, py - pxR)
+          onPill = 1 - smoothstep(0, HOVER_FADE, Math.max(dist - pxR, 0) / unit)
         }
-        boost += (pull - boost) * (1 - Math.exp(-10 * dt))
-        // Positional pull uses the instantaneous distance so a cursor darting
-        // away releases the beam immediately; boost keeps the brightness
-        // fading smoothly on its own.
-        const capture = hasProj ? boost * pull : 0
-
-        // Orbit slows as the cursor takes over; the target blends between the
-        // orbit point and the cursor's border point. The beam chases it in
-        // 2D, so when the nearest side flips (cursor crossing the pill's
-        // centerline) it cuts straight across the interior instead of lapping
-        // around a cap.
-        sOrbit = wrap(sOrbit + DRIFT_RATE * dt * (1 - capture))
-        const [ox, oy] = stadiumPointPx(sOrbit * perimeter, pxR, pxFlat)
-        const tx = ox + (projX - ox) * capture
-        const ty = oy + (projY - oy) * capture
-        if (!hasPos) {
-          posX = tx
-          posY = ty
-          hasPos = true
-        } else {
-          const k = 1 - Math.exp(-CHASE_STIFFNESS * dt)
-          posX += (tx - posX) * k
-          posY += (ty - posY) * k
-        }
-        // The cluster lives on the perimeter: project the beam back onto it.
-        // Re-anchoring the orbit there means leaving the cursor resumes the
-        // tour from wherever the beam is now.
-        cluster = wrap(stadiumParamPx(posX, posY, pxR, pxFlat) / perimeter)
-        if (capture > 0.05) sOrbit = cluster
+        hover += (onPill - hover) * (1 - Math.exp(-HOVER_EASE * dt))
+        phase = wrap(phase + WAVE_SPEED * dt)
+        cluster = wrap(cluster + DRIFT_RATE * dt)
 
         const kt = 1 - Math.exp(-TINT_STIFFNESS * dt)
         tint = [
@@ -275,25 +236,24 @@ export function PillBacklight({
           tint[1] + (tintTarget[1] - tint[1]) * kt,
           tint[2] + (tintTarget[2] - tint[2]) * kt,
         ]
-      } else if (!hasPos) {
-        ;[posX, posY] = stadiumPointPx(cluster * perimeter, pxR, pxFlat)
-        hasPos = true
       }
+      const [posX, posY] = stadiumPointPx(cluster * perimeter, pxR, pxFlat)
 
       syncTint()
-      packStrip(strip, cluster, packed)
+      packStrip(strip, cluster, packed, hover, phase)
       gl.uniform2f(uResolution, width, height)
       gl.uniform1f(uSeed, reduced.matches ? 0 : Math.random() * 1000)
       gl.uniform1f(uCluster, cluster)
+      gl.uniform1f(uHover, hover)
+      gl.uniform1f(uPhase, phase)
       gl.uniform3f(uTint, tint[0], tint[1], tint[2])
       gl.uniform4fv(uLed, packed)
       gl.drawArrays(gl.TRIANGLES, 0, 3)
 
-      // The CSS ring glow follows the 2D beam point itself — masked to the
-      // border, it dims naturally while the beam crosses the interior.
+      // The CSS ring glow rides the drifting cluster and brightens on hover.
       pill.style.setProperty('--cta-glow-x', `${posX}px`)
       pill.style.setProperty('--cta-glow-y', `${posY}px`)
-      pill.style.setProperty('--cta-glow-boost', boost.toFixed(3))
+      pill.style.setProperty('--cta-glow-boost', hover.toFixed(3))
     }
 
     const loop = (now: number) => {

--- a/www/src/modules/marketing/pill-backlight/strip.ts
+++ b/www/src/modules/marketing/pill-backlight/strip.ts
@@ -25,7 +25,16 @@ const MIN_PER_SEGMENT = 4
 // in sync with ENV_2SIGMA2 in fragment.ts.
 const ENVELOPE_FLOOR = 0.1
 const ENVELOPE_PEAK = 1
-const ENVELOPE_SIGMA = 0.14
+const ENVELOPE_SIGMA = 0.18
+
+// Whole-rim hover glow: while the pill is hovered the cluster gives way to a
+// band of light around the entire perimeter, kept alive by waves circling it.
+// The count must be an integer so the pattern tiles around the loop; speed is
+// in laps per second. Mirrored in fragment.ts via template constants.
+export const WAVE_BASE = 0.55
+export const WAVE_AMP = 0.3
+export const WAVE_COUNT = 2
+export const WAVE_SPEED = 0.25
 
 export type Led = {
   x: number
@@ -127,15 +136,26 @@ export function buildStrip({ cx, cy, halfFlat, radius }: Stadium): Led[] {
  * normal times quadrature weight times brightness. Folding all three into one
  * vector lets the shader recover cosine, weight and brightness from a single
  * dot product — the weight cancels against the `1/r` in the cosine.
+ *
+ * `hover` crossfades the travelling bump toward the circling whole-rim wave
+ * (the floor stays), with `phase` its position in laps.
  */
-export function packStrip(leds: Led[], target: number, out: Float32Array) {
+export function packStrip(
+  leds: Led[],
+  target: number,
+  out: Float32Array,
+  hover = 0,
+  phase = 0,
+) {
   let o = 0
   for (const led of leds) {
     let ds = Math.abs(led.s - target)
     if (ds > 0.5) ds = 1 - ds
-    const b =
-      ENVELOPE_FLOOR +
-      ENVELOPE_PEAK * Math.exp(-(ds * ds) / (2 * ENVELOPE_SIGMA ** 2))
+    const bump = Math.exp(-(ds * ds) / (2 * ENVELOPE_SIGMA ** 2))
+    const wave =
+      WAVE_BASE +
+      WAVE_AMP * Math.cos(2 * Math.PI * (led.s * WAVE_COUNT - phase))
+    const b = ENVELOPE_FLOOR + ENVELOPE_PEAK * (bump + (wave - bump) * hover)
     out[o] = led.x
     out[o + 1] = led.y
     out[o + 2] = led.nx * b
@@ -166,23 +186,4 @@ export function stadiumPointPx(
   if (s < flat) return [r + flat - s, 2 * r]
   const beta = Math.PI + (s - flat) / r
   return [r + Math.sin(beta) * r, r - Math.cos(beta) * r]
-}
-
-/** Perimeter distance of the stadium point nearest to (px, py) — the inverse
- *  of stadiumPointPx, used to project the beam back onto the border. */
-export function stadiumParamPx(
-  px: number,
-  py: number,
-  r: number,
-  flat: number,
-) {
-  const cx = Math.min(Math.max(px, r), r + flat)
-  if (cx > r && cx < r + flat) {
-    return py < r ? cx - r : flat + Math.PI * r + (r + flat - cx)
-  }
-  // Caps: angle from the cap's top, clockwise.
-  let beta = Math.atan2(px - cx, r - py)
-  if (cx === r + flat) return flat + Math.max(beta, 0) * r
-  if (beta < Math.PI) beta += 2 * Math.PI
-  return 2 * flat + Math.PI * r + (beta - Math.PI) * r
 }


### PR DESCRIPTION
## What

Reworks the CTA pill backlight's cursor interaction. The cursor-follow behavior (the bright cluster being captured and dragged along the border by the pointer) is removed entirely — it could not change sides gracefully: the nearest-border projection is discontinuous at the pill's centerline, so bottom↔top moves either teleported, toured the whole perimeter, or flashed, and none of the smoothing approaches tried (perimeter sweep, dip crossfade, eased re-appearance) read well.

New behavior:

- **Idle:** the cluster simply drifts around the perimeter, as before — the cursor no longer steers it.
- **Pill hovered:** the cluster crossfades (~170 ms ease, fading over ~20 px outside the border) into a whole-rim glow kept alive by two soft lobes circling the perimeter at 0.25 laps/s. The CSS ring glow brightens with the same blend.

Also included, from design review on the branch: a wider soft spill (`WIDE_R` 0.8 → 1.2) and a wider travelling streak (`ENVELOPE_SIGMA` 0.14 → 0.18, shader constant synced).

Net −33 lines: the capture/chase/projection machinery is gone; the wave constants live once in `strip.ts` and are injected into the GLSL template.

## Verification

- Driven via synthetic pointer events on the dev server: cluster drifts with no cursor input; hover blend eases 0 → 1 on the pill and back to 0 on leave; ring glow variables track the drifting cluster.
- Shader compiles clean (no `pill-backlight:` console errors), `pnpm check` and `pnpm typecheck` pass.

## Tuning knobs

`strip.ts`: `WAVE_BASE`/`WAVE_AMP` (hover glow level vs. shimmer depth), `WAVE_COUNT` (lobes, keep integer), `WAVE_SPEED` (laps/s). `index.tsx`: `HOVER_FADE`/`HOVER_EASE` (hover reach and easing), `DRIFT_RATE` (idle lap speed).