### PR TITLE
feat(buttons): rename default variant to secondary

### DIFF
--- a/www/content/docs/components/date-picker.mdx
+++ b/www/content/docs/components/date-picker.mdx
@@ -37,7 +37,7 @@ import { Popover } from '@/ui/popover'
   <InputGroup>
     <DateInput />
     <InputGroupAddon>
-      <Button variant="default" size="sm" isIconOnly>
+      <Button variant="secondary" size="sm" isIconOnly>
         <CalendarIcon />
       </Button>
     </InputGroupAddon>

--- a/www/content/docs/components/select.mdx
+++ b/www/content/docs/components/select.mdx
@@ -151,7 +151,7 @@ import { Select, SelectValue } from '@/ui/select'
 
 ```tsx
 <Select>
-  <Button variant="outline">
+  <Button variant="secondary">
     <SelectValue placeholder="Select provider" />
     <ChevronDownIcon />
   </Button>

--- a/www/content/docs/components/time-picker.mdx
+++ b/www/content/docs/components/time-picker.mdx
@@ -36,7 +36,7 @@ import { TimePicker, TimePickerColumns } from '@/ui/time-picker'
   <InputGroup>
     <DateInput />
     <InputGroupAddon>
-      <Button variant="default" size="sm" isIconOnly aria-label="Choose time">
+      <Button variant="secondary" size="sm" isIconOnly aria-label="Choose time">
         <ClockIcon />
       </Button>
     </InputGroupAddon>

--- a/www/src/components/showcase/booking.tsx
+++ b/www/src/components/showcase/booking.tsx
@@ -46,7 +46,7 @@ export function Booking({ className, ...props }: React.ComponentProps<'div'>) {
               <InputGroup>
                 <DateInput />
                 <InputGroupAddon>
-                  <Button variant="default" size="sm" isIconOnly>
+                  <Button variant="secondary" size="sm" isIconOnly>
                     <CalendarIcon />
                   </Button>
                 </InputGroupAddon>
@@ -66,7 +66,7 @@ export function Booking({ className, ...props }: React.ComponentProps<'div'>) {
                 <DateInput />
                 <InputGroupAddon>
                   <Button
-                    variant="default"
+                    variant="secondary"
                     size="sm"
                     isIconOnly
                     aria-label="Choose time"
@@ -96,7 +96,7 @@ export function Booking({ className, ...props }: React.ComponentProps<'div'>) {
               <InputGroup>
                 <DateInput />
                 <InputGroupAddon>
-                  <Button variant="default" size="sm" isIconOnly>
+                  <Button variant="secondary" size="sm" isIconOnly>
                     <CalendarIcon />
                   </Button>
                 </InputGroupAddon>
@@ -116,7 +116,7 @@ export function Booking({ className, ...props }: React.ComponentProps<'div'>) {
                 <DateInput />
                 <InputGroupAddon>
                   <Button
-                    variant="default"
+                    variant="secondary"
                     size="sm"
                     isIconOnly
                     aria-label="Choose time"

--- a/www/src/components/showcase/invite-members.tsx
+++ b/www/src/components/showcase/invite-members.tsx
@@ -54,7 +54,7 @@ export function InviteMembers(props: React.ComponentProps<'div'>) {
           Collaborate with members on this project.
         </CardDescription>
         <CardAction>
-          <Button variant="default">
+          <Button variant="secondary">
             <ExternalLinkIcon />
             Invite link
           </Button>

--- a/www/src/components/showcase/upload-avatar.tsx
+++ b/www/src/components/showcase/upload-avatar.tsx
@@ -40,7 +40,7 @@ export function UploadAvatar({
             Drag a file here to upload
           </DropZoneLabel>
           <FileTrigger acceptedFileTypes={['image/png', 'image/jpeg']}>
-            <Button variant="default" size="sm">
+            <Button variant="secondary" size="sm">
               Choose file
             </Button>
           </FileTrigger>

--- a/www/src/modules/charts/charts-page.tsx
+++ b/www/src/modules/charts/charts-page.tsx
@@ -24,7 +24,11 @@ export function ChartsPage() {
           <LinkButton href="/create" variant="primary" size="lg">
             Launch the editor
           </LinkButton>
-          <LinkButton href="/docs/components/chart" variant="default" size="lg">
+          <LinkButton
+            href="/docs/components/chart"
+            variant="secondary"
+            size="lg"
+          >
             View documentation
           </LinkButton>
         </PageHero>

--- a/www/src/modules/colors/cluster.tsx
+++ b/www/src/modules/colors/cluster.tsx
@@ -28,14 +28,14 @@ export function ComponentCluster() {
         <Button variant="primary" size="sm">
           Primary
         </Button>
-        <Button variant="default" size="sm">
+        <Button variant="secondary" size="sm">
           Default
         </Button>
         <Button variant="quiet" size="sm">
           Quiet
         </Button>
         <Menu>
-          <Button variant="default" size="sm">
+          <Button variant="secondary" size="sm">
             Menu
           </Button>
           <Popover>

--- a/www/src/modules/create/panel/macros.tsx
+++ b/www/src/modules/create/panel/macros.tsx
@@ -138,7 +138,7 @@ export function MacroFrontDoor() {
         </span>
         <Button
           size="sm"
-          variant="default"
+          variant="secondary"
           onPress={reroll}
           className="h-7 gap-1.5 px-2 text-xs"
         >

--- a/www/src/modules/docs/components-list/demos/date-picker.tsx
+++ b/www/src/modules/docs/components-list/demos/date-picker.tsx
@@ -35,7 +35,7 @@ export function DatePickerDemo() {
           <InputGroup className="w-full">
             <DateInput />
             <InputGroupAddon>
-              <Button variant="default" size="sm" isIconOnly>
+              <Button variant="secondary" size="sm" isIconOnly>
                 <CalendarIcon />
               </Button>
             </InputGroupAddon>

--- a/www/src/modules/docs/references/generated/button.json
+++ b/www/src/modules/docs/references/generated/button.json
@@ -3,18 +3,14 @@
   "description": "A clickable element that triggers an action. Buttons communicate actions users can take\nand allow users to interact with the page.",
   "props": {
     "variant": {
-      "type": "\"danger\" | \"default\" | \"link\" | \"primary\" | \"quiet\" | \"warning\"",
-      "detailedType": "| 'danger'\n| 'default'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'warning'\n| undefined",
+      "type": "\"danger\" | \"link\" | \"primary\" | \"quiet\" | \"secondary\" | \"warning\"",
+      "detailedType": "| 'danger'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'secondary'\n| 'warning'\n| undefined",
       "typeAst": {
         "type": "union",
         "elements": [
           {
             "type": "stringLiteral",
             "value": "danger"
-          },
-          {
-            "type": "stringLiteral",
-            "value": "default"
           },
           {
             "type": "stringLiteral",
@@ -30,12 +26,16 @@
           },
           {
             "type": "stringLiteral",
+            "value": "secondary"
+          },
+          {
+            "type": "stringLiteral",
             "value": "warning"
           }
         ]
       },
       "description": "The visual style of the button (Vanilla CSS implementation specific).",
-      "default": "'default'"
+      "default": "'secondary'"
     },
     "size": {
       "type": "\"lg\" | \"md\" | \"sm\" | \"xs\"",

--- a/www/src/modules/docs/references/generated/link-button.json
+++ b/www/src/modules/docs/references/generated/link-button.json
@@ -3,18 +3,14 @@
   "description": "A link styled as a button. Link buttons navigate to another page or resource\nwhen pressed, rather than performing an action.",
   "props": {
     "variant": {
-      "type": "\"danger\" | \"default\" | \"link\" | \"primary\" | \"quiet\" | \"warning\"",
-      "detailedType": "| 'danger'\n| 'default'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'warning'\n| undefined",
+      "type": "\"danger\" | \"link\" | \"primary\" | \"quiet\" | \"secondary\" | \"warning\"",
+      "detailedType": "| 'danger'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'secondary'\n| 'warning'\n| undefined",
       "typeAst": {
         "type": "union",
         "elements": [
           {
             "type": "stringLiteral",
             "value": "danger"
-          },
-          {
-            "type": "stringLiteral",
-            "value": "default"
           },
           {
             "type": "stringLiteral",
@@ -30,12 +26,16 @@
           },
           {
             "type": "stringLiteral",
+            "value": "secondary"
+          },
+          {
+            "type": "stringLiteral",
             "value": "warning"
           }
         ]
       },
       "description": "The visual style of the button.",
-      "default": "\"default\""
+      "default": "\"secondary\""
     },
     "size": {
       "type": "\"lg\" | \"md\" | \"sm\" | \"xs\"",

--- a/www/src/modules/docs/references/generated/pagination-link.json
+++ b/www/src/modules/docs/references/generated/pagination-link.json
@@ -11,18 +11,14 @@
       "description": "Whether this link represents the current page. Sets `aria-current=\"page\"`\nand switches to the active visual style."
     },
     "variant": {
-      "type": "\"danger\" | \"default\" | \"link\" | \"primary\" | \"quiet\" | \"warning\"",
-      "detailedType": "| 'danger'\n| 'default'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'warning'\n| undefined",
+      "type": "\"danger\" | \"link\" | \"primary\" | \"quiet\" | \"secondary\" | \"warning\"",
+      "detailedType": "| 'danger'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'secondary'\n| 'warning'\n| undefined",
       "typeAst": {
         "type": "union",
         "elements": [
           {
             "type": "stringLiteral",
             "value": "danger"
-          },
-          {
-            "type": "stringLiteral",
-            "value": "default"
           },
           {
             "type": "stringLiteral",
@@ -38,12 +34,16 @@
           },
           {
             "type": "stringLiteral",
+            "value": "secondary"
+          },
+          {
+            "type": "stringLiteral",
             "value": "warning"
           }
         ]
       },
       "description": "The visual style of the link.",
-      "default": "isActive ? 'default' : 'quiet'"
+      "default": "isActive ? 'secondary' : 'quiet'"
     },
     "size": {
       "type": "\"lg\" | \"md\" | \"sm\" | \"xs\"",

--- a/www/src/modules/docs/references/generated/pagination-next.json
+++ b/www/src/modules/docs/references/generated/pagination-next.json
@@ -742,18 +742,14 @@
       "description": "The target window for the link. See\n[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)."
     },
     "variant": {
-      "type": "\"danger\" | \"default\" | \"link\" | \"primary\" | \"quiet\" | \"warning\"",
-      "detailedType": "| 'danger'\n| 'default'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'warning'\n| undefined",
+      "type": "\"danger\" | \"link\" | \"primary\" | \"quiet\" | \"secondary\" | \"warning\"",
+      "detailedType": "| 'danger'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'secondary'\n| 'warning'\n| undefined",
       "typeAst": {
         "type": "union",
         "elements": [
           {
             "type": "stringLiteral",
             "value": "danger"
-          },
-          {
-            "type": "stringLiteral",
-            "value": "default"
           },
           {
             "type": "stringLiteral",
@@ -769,12 +765,16 @@
           },
           {
             "type": "stringLiteral",
+            "value": "secondary"
+          },
+          {
+            "type": "stringLiteral",
             "value": "warning"
           }
         ]
       },
       "description": "The visual style of the link.",
-      "default": "isActive ? 'default' : 'quiet'"
+      "default": "isActive ? 'secondary' : 'quiet'"
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/pagination-previous.json
+++ b/www/src/modules/docs/references/generated/pagination-previous.json
@@ -742,18 +742,14 @@
       "description": "The target window for the link. See\n[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)."
     },
     "variant": {
-      "type": "\"danger\" | \"default\" | \"link\" | \"primary\" | \"quiet\" | \"warning\"",
-      "detailedType": "| 'danger'\n| 'default'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'warning'\n| undefined",
+      "type": "\"danger\" | \"link\" | \"primary\" | \"quiet\" | \"secondary\" | \"warning\"",
+      "detailedType": "| 'danger'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'secondary'\n| 'warning'\n| undefined",
       "typeAst": {
         "type": "union",
         "elements": [
           {
             "type": "stringLiteral",
             "value": "danger"
-          },
-          {
-            "type": "stringLiteral",
-            "value": "default"
           },
           {
             "type": "stringLiteral",
@@ -769,12 +765,16 @@
           },
           {
             "type": "stringLiteral",
+            "value": "secondary"
+          },
+          {
+            "type": "stringLiteral",
             "value": "warning"
           }
         ]
       },
       "description": "The visual style of the link.",
-      "default": "isActive ? 'default' : 'quiet'"
+      "default": "isActive ? 'secondary' : 'quiet'"
     }
   },
   "typeLinks": {

--- a/www/src/modules/docs/references/generated/toggle-button-group.json
+++ b/www/src/modules/docs/references/generated/toggle-button-group.json
@@ -3,15 +3,11 @@
   "description": "A toggle button group allows a user to toggle multiple options, with single or multiple selection.",
   "props": {
     "variant": {
-      "type": "\"default\" | \"primary\" | \"quiet\"",
-      "detailedType": "'default' | 'primary' | 'quiet' | undefined",
+      "type": "\"primary\" | \"quiet\" | \"secondary\"",
+      "detailedType": "'primary' | 'quiet' | 'secondary' | undefined",
       "typeAst": {
         "type": "union",
         "elements": [
-          {
-            "type": "stringLiteral",
-            "value": "default"
-          },
           {
             "type": "stringLiteral",
             "value": "primary"
@@ -19,11 +15,15 @@
           {
             "type": "stringLiteral",
             "value": "quiet"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "secondary"
           }
         ]
       },
       "description": "The visual style of the toggle buttons.",
-      "default": "'default'"
+      "default": "'secondary'"
     },
     "size": {
       "type": "\"lg\" | \"md\" | \"sm\" | \"xs\"",

--- a/www/src/modules/docs/references/generated/toggle-button.json
+++ b/www/src/modules/docs/references/generated/toggle-button.json
@@ -3,15 +3,11 @@
   "description": "A toggle button allows a user to toggle a selection on or off, for example switching between two states or modes.",
   "props": {
     "variant": {
-      "type": "\"default\" | \"primary\" | \"quiet\"",
-      "detailedType": "'default' | 'primary' | 'quiet' | undefined",
+      "type": "\"primary\" | \"quiet\" | \"secondary\"",
+      "detailedType": "'primary' | 'quiet' | 'secondary' | undefined",
       "typeAst": {
         "type": "union",
         "elements": [
-          {
-            "type": "stringLiteral",
-            "value": "default"
-          },
           {
             "type": "stringLiteral",
             "value": "primary"
@@ -19,11 +15,15 @@
           {
             "type": "stringLiteral",
             "value": "quiet"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "secondary"
           }
         ]
       },
       "description": "The visual style of the toggle button.",
-      "default": "'default'"
+      "default": "'secondary'"
     },
     "size": {
       "type": "\"lg\" | \"md\" | \"sm\" | \"xs\"",

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -33,7 +33,7 @@ export function HomePage() {
             <LinkButton href="/create" variant="primary" size="lg">
               Start building
             </LinkButton>
-            <LinkButton href="/docs/components" variant="default" size="lg">
+            <LinkButton href="/docs/components" variant="secondary" size="lg">
               View components
             </LinkButton>
           </div>

--- a/www/src/modules/preset-lab/renders.tsx
+++ b/www/src/modules/preset-lab/renders.tsx
@@ -42,7 +42,7 @@ export const componentRenders: Record<string, () => ReactNode> = {
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-center gap-2">
         <Button variant="primary">Primary</Button>
-        <Button variant="default">Secondary</Button>
+        <Button variant="secondary">Secondary</Button>
         <Button variant="danger">Destructive</Button>
         <Button variant="quiet">Quiet</Button>
       </div>
@@ -130,7 +130,7 @@ export const componentRenders: Record<string, () => ReactNode> = {
 
   tooltip: () => (
     <Tooltip>
-      <Button variant="default">Hover me</Button>
+      <Button variant="secondary">Hover me</Button>
       <TooltipContent>Add to library</TooltipContent>
     </Tooltip>
   ),

--- a/www/src/publisher/__fixtures__/button-publishable.ts
+++ b/www/src/publisher/__fixtures__/button-publishable.ts
@@ -93,10 +93,10 @@ export const buttonPublishable: Publishable = {
       ],
       variants: {
         variant: {
-          default:
-            'border bg-neutral text-fg-on-neutral hover:border-border-hover hover:bg-neutral-hover pressed:border-border-active pressed:bg-neutral-active',
           primary:
             'bg-primary text-fg-on-primary [--color-disabled:var(--neutral-500)] [--color-fg-disabled:var(--neutral-300)] hover:bg-primary-hover disabled:border-0 pending:border-0 pressed:bg-primary-active',
+          secondary:
+            'border bg-neutral text-fg-on-neutral hover:border-border-hover hover:bg-neutral-hover pressed:border-border-active pressed:bg-neutral-active',
           quiet:
             'bg-transparent text-fg hover:bg-inverse/10 pressed:bg-inverse/20',
           link: 'text-fg underline-offset-4 hover:underline',
@@ -116,7 +116,7 @@ export const buttonPublishable: Publishable = {
         },
       },
       defaultVariants: {
-        variant: 'default',
+        variant: 'secondary',
         size: 'md',
       },
     },

--- a/www/src/publisher/publish.test.ts
+++ b/www/src/publisher/publish.test.ts
@@ -61,7 +61,7 @@ describe('flatten', () => {
     expect(primary).toContain('bg-primary')
 
     // `defaultVariants` flows through.
-    expect(layer.defaultVariants).toEqual({ variant: 'default', size: 'md' })
+    expect(layer.defaultVariants).toEqual({ variant: 'secondary', size: 'md' })
   })
 
   test("button: density 'default' uses the default-density classes", () => {

--- a/www/src/registry/ui/button/demos/playground.tsx
+++ b/www/src/registry/ui/button/demos/playground.tsx
@@ -4,7 +4,7 @@ import { Button, type ButtonProps } from '@/registry/ui/button'
 
 export default function Demo({
   children = 'Button',
-  variant = 'default',
+  variant = 'secondary',
   size = 'md',
   isDisabled = false,
   isPending = false,

--- a/www/src/registry/ui/button/demos/variants.tsx
+++ b/www/src/registry/ui/button/demos/variants.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/registry/ui/button'
 
-const variants = ['default', 'primary', 'quiet', 'warning', 'danger'] as const
+const variants = ['primary', 'secondary', 'quiet', 'warning', 'danger'] as const
 
 export default function Demo() {
   return (

--- a/www/src/registry/ui/button/examples.tsx
+++ b/www/src/registry/ui/button/examples.tsx
@@ -15,7 +15,7 @@ export default function ButtonExamples() {
 }
 
 const sizes = ['xs', 'sm', 'md', 'lg'] as const
-const variants = ['primary', 'default', 'link', 'danger', 'quiet'] as const
+const variants = ['primary', 'secondary', 'link', 'danger', 'quiet'] as const
 
 const ButtonVariantsAndSizes = () => {
   return (

--- a/www/src/registry/ui/button/styles.ts
+++ b/www/src/registry/ui/button/styles.ts
@@ -13,10 +13,10 @@ const { useStyles, styles } = createStyles(buttonMeta, {
     ],
     variants: {
       variant: {
-        default:
-          'border bg-neutral text-fg-on-neutral hover:border-border-hover hover:bg-neutral-hover pressed:border-border-active pressed:bg-neutral-active',
         primary:
           'bg-primary text-fg-on-primary [--color-disabled:var(--neutral-300)] hover:bg-primary-hover disabled:border-0 pending:border-0 pressed:bg-primary-active',
+        secondary:
+          'border bg-neutral text-fg-on-neutral hover:border-border-hover hover:bg-neutral-hover pressed:border-border-active pressed:bg-neutral-active',
         quiet:
           'bg-transparent text-fg hover:bg-inverse/10 pressed:bg-inverse/20',
         link: 'text-fg underline-offset-4 hover:underline',
@@ -36,7 +36,7 @@ const { useStyles, styles } = createStyles(buttonMeta, {
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'secondary',
       size: 'md',
     },
   },

--- a/www/src/registry/ui/button/types.ts
+++ b/www/src/registry/ui/button/types.ts
@@ -10,9 +10,9 @@ export interface ButtonProps extends React.ComponentProps<
 > {
   /**
    * The visual style of the button (Vanilla CSS implementation specific).
-   * @default 'default'
+   * @default 'secondary'
    */
-  variant?: 'default' | 'primary' | 'quiet' | 'link' | 'warning' | 'danger'
+  variant?: 'primary' | 'secondary' | 'quiet' | 'link' | 'warning' | 'danger'
 
   /**
    * The size of the button.
@@ -31,9 +31,9 @@ export interface LinkButtonProps extends React.ComponentProps<
 > {
   /**
    * The visual style of the button.
-   * @default "default"
+   * @default "secondary"
    */
-  variant?: 'default' | 'primary' | 'quiet' | 'link' | 'warning' | 'danger'
+  variant?: 'primary' | 'secondary' | 'quiet' | 'link' | 'warning' | 'danger'
 
   /**
    * The size of the button.

--- a/www/src/registry/ui/calendar/demos/with-dropdowns.tsx
+++ b/www/src/registry/ui/calendar/demos/with-dropdowns.tsx
@@ -16,11 +16,11 @@ export default function Demo() {
       <CardContent>
         <Calendar aria-label="Date" defaultValue={today(getLocalTimeZone())}>
           <CalendarHeader>
-            <Button slot="previous" variant="default" size="sm" isIconOnly>
+            <Button slot="previous" variant="secondary" size="sm" isIconOnly>
               <ChevronLeftIcon />
             </Button>
             <div className="flex flex-1 gap-1.5">dropdowns</div>
-            <Button slot="next" variant="default" size="sm" isIconOnly>
+            <Button slot="next" variant="secondary" size="sm" isIconOnly>
               <ChevronRightIcon />
             </Button>
           </CalendarHeader>

--- a/www/src/registry/ui/calendar/demos/with-presets.tsx
+++ b/www/src/registry/ui/calendar/demos/with-presets.tsx
@@ -40,7 +40,7 @@ export default function Demo() {
         {presets.map((preset) => (
           <Button
             key={preset.label}
-            variant="default"
+            variant="secondary"
             className="flex-1"
             onPress={() => {
               const next = today(getLocalTimeZone()).add({ days: preset.days })

--- a/www/src/registry/ui/card/demos/basic.tsx
+++ b/www/src/registry/ui/card/demos/basic.tsx
@@ -55,7 +55,7 @@ export default function Demo() {
         <Button variant="primary" type="submit" className="w-full">
           Login
         </Button>
-        <Button variant="default" className="w-full">
+        <Button variant="secondary" className="w-full">
           Login with Google
         </Button>
       </CardFooter>

--- a/www/src/registry/ui/card/demos/default.tsx
+++ b/www/src/registry/ui/card/demos/default.tsx
@@ -22,7 +22,7 @@ export default function Demo() {
         </p>
       </CardContent>
       <CardFooter>
-        <Button variant="default" className="w-full">
+        <Button variant="secondary" className="w-full">
           Action
         </Button>
       </CardFooter>

--- a/www/src/registry/ui/card/demos/footer-border-small.tsx
+++ b/www/src/registry/ui/card/demos/footer-border-small.tsx
@@ -11,7 +11,7 @@ export default function Demo() {
         </p>
       </CardContent>
       <CardFooter className="border-t">
-        <Button variant="default" size="sm" className="w-full">
+        <Button variant="secondary" size="sm" className="w-full">
           Footer with Border
         </Button>
       </CardFooter>

--- a/www/src/registry/ui/card/demos/footer-border.tsx
+++ b/www/src/registry/ui/card/demos/footer-border.tsx
@@ -11,7 +11,7 @@ export default function Demo() {
         </p>
       </CardContent>
       <CardFooter className="border-t">
-        <Button variant="default" className="w-full">
+        <Button variant="secondary" className="w-full">
           Footer with Border
         </Button>
       </CardFooter>

--- a/www/src/registry/ui/card/demos/meeting-notes.tsx
+++ b/www/src/registry/ui/card/demos/meeting-notes.tsx
@@ -26,7 +26,7 @@ export default function Demo() {
           Transcript from the meeting with the client.
         </CardDescription>
         <CardAction>
-          <Button variant="default" size="sm">
+          <Button variant="secondary" size="sm">
             <CaptionsIcon />
             Transcribe
           </Button>

--- a/www/src/registry/ui/card/demos/small.tsx
+++ b/www/src/registry/ui/card/demos/small.tsx
@@ -24,7 +24,7 @@ export default function Demo() {
         </p>
       </CardContent>
       <CardFooter>
-        <Button variant="default" size="sm" className="w-full">
+        <Button variant="secondary" size="sm" className="w-full">
           Action
         </Button>
       </CardFooter>

--- a/www/src/registry/ui/color-swatch/demos/in-button.tsx
+++ b/www/src/registry/ui/color-swatch/demos/in-button.tsx
@@ -5,7 +5,7 @@ import { ColorSwatch } from '@/registry/ui/color-swatch'
 
 export default function Demo() {
   return (
-    <Button variant="default" className="w-full max-w-xs justify-between">
+    <Button variant="secondary" className="w-full max-w-xs justify-between">
       <span className="flex items-center gap-2">
         <ColorSwatch color="#8b5cf6" className="size-4" />
         Violet

--- a/www/src/registry/ui/combobox/demos/in-dialog.tsx
+++ b/www/src/registry/ui/combobox/demos/in-dialog.tsx
@@ -22,7 +22,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <Dialog>
-      <Button variant="default">Open Dialog</Button>
+      <Button variant="secondary">Open Dialog</Button>
       <Responsive
         render={(isMobile) => {
           const content = (

--- a/www/src/registry/ui/combobox/demos/with-other-inputs.tsx
+++ b/www/src/registry/ui/combobox/demos/with-other-inputs.tsx
@@ -33,7 +33,7 @@ export default function Demo() {
         </Popover>
       </Combobox>
       <Select aria-label="framework" className="w-52">
-        <SelectTrigger variant="default" />
+        <SelectTrigger variant="secondary" />
         <SelectContent>
           {frameworks.map((framework) => (
             <SelectItem key={framework} id={framework}>
@@ -42,7 +42,7 @@ export default function Demo() {
           ))}
         </SelectContent>
       </Select>
-      <Button variant="default" className="w-52 justify-between">
+      <Button variant="secondary" className="w-52 justify-between">
         <span className="text-fg-muted">Select a framework</span>
         <ChevronDownIcon />
       </Button>

--- a/www/src/registry/ui/date-picker/demos/basic.tsx
+++ b/www/src/registry/ui/date-picker/demos/basic.tsx
@@ -18,7 +18,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/composition.tsx
+++ b/www/src/registry/ui/date-picker/demos/composition.tsx
@@ -16,7 +16,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/controlled.tsx
+++ b/www/src/registry/ui/date-picker/demos/controlled.tsx
@@ -24,7 +24,7 @@ export default function Demo() {
         <InputGroup>
           <DateInput />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/description.tsx
+++ b/www/src/registry/ui/date-picker/demos/description.tsx
@@ -16,7 +16,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/disabled.tsx
+++ b/www/src/registry/ui/date-picker/demos/disabled.tsx
@@ -12,7 +12,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/error-message.tsx
+++ b/www/src/registry/ui/date-picker/demos/error-message.tsx
@@ -14,7 +14,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/granularity.tsx
+++ b/www/src/registry/ui/date-picker/demos/granularity.tsx
@@ -22,7 +22,7 @@ export default function Demo() {
         <InputGroup>
           <DateInput />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>
@@ -42,7 +42,7 @@ export default function Demo() {
         <InputGroup>
           <DateInput />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>
@@ -62,7 +62,7 @@ export default function Demo() {
         <InputGroup>
           <DateInput />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/hide-time-zone.tsx
+++ b/www/src/registry/ui/date-picker/demos/hide-time-zone.tsx
@@ -23,7 +23,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/hour-cycle.tsx
+++ b/www/src/registry/ui/date-picker/demos/hour-cycle.tsx
@@ -21,7 +21,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/label.tsx
+++ b/www/src/registry/ui/date-picker/demos/label.tsx
@@ -15,7 +15,7 @@ export default function Demo() {
         <InputGroup>
           <DateInput />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>
@@ -30,7 +30,7 @@ export default function Demo() {
         <InputGroup>
           <DateInput />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/placeholder.tsx
+++ b/www/src/registry/ui/date-picker/demos/placeholder.tsx
@@ -21,7 +21,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/playground.tsx
+++ b/www/src/registry/ui/date-picker/demos/playground.tsx
@@ -30,7 +30,7 @@ export function DatePickerPlayground({
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/basic.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/basic.tsx
@@ -23,7 +23,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/composition.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/composition.tsx
@@ -18,7 +18,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/controlled.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/controlled.tsx
@@ -31,7 +31,7 @@ export default function Demo() {
           <span>–</span>
           <DateInput slot="end" />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/description.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/description.tsx
@@ -18,7 +18,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/disabled.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/disabled.tsx
@@ -14,7 +14,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/error-message.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/error-message.tsx
@@ -16,7 +16,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/granularity.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/granularity.tsx
@@ -26,7 +26,7 @@ export default function Demo() {
           <span>–</span>
           <DateInput slot="end" />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>
@@ -45,7 +45,7 @@ export default function Demo() {
           <span>–</span>
           <DateInput slot="end" />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>
@@ -64,7 +64,7 @@ export default function Demo() {
           <span>–</span>
           <DateInput slot="end" />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/hide-time-zone.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/hide-time-zone.tsx
@@ -28,7 +28,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/hour-cycle.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/hour-cycle.tsx
@@ -23,7 +23,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/label.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/label.tsx
@@ -17,7 +17,7 @@ export default function Demo() {
           <span>–</span>
           <DateInput slot="end" />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>
@@ -34,7 +34,7 @@ export default function Demo() {
           <span>–</span>
           <DateInput slot="end" />
           <InputGroupAddon>
-            <Button variant="default" size="sm" isIconOnly>
+            <Button variant="secondary" size="sm" isIconOnly>
               <CalendarIcon />
             </Button>
           </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/placeholder.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/placeholder.tsx
@@ -23,7 +23,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/playground.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/playground.tsx
@@ -32,7 +32,7 @@ export function DateRangePickerPlayground({
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/read-only.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/read-only.tsx
@@ -27,7 +27,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/required.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/required.tsx
@@ -16,7 +16,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/time-zones.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/time-zones.tsx
@@ -25,7 +25,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/uncontrolled.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/uncontrolled.tsx
@@ -25,7 +25,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/with-drawer.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/with-drawer.tsx
@@ -14,7 +14,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/range/with-modal.tsx
+++ b/www/src/registry/ui/date-picker/demos/range/with-modal.tsx
@@ -14,7 +14,7 @@ export default function Demo() {
         <span>–</span>
         <DateInput slot="end" />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/read-only.tsx
+++ b/www/src/registry/ui/date-picker/demos/read-only.tsx
@@ -22,7 +22,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/required.tsx
+++ b/www/src/registry/ui/date-picker/demos/required.tsx
@@ -14,7 +14,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/time-zones.tsx
+++ b/www/src/registry/ui/date-picker/demos/time-zones.tsx
@@ -20,7 +20,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/date-picker/demos/uncontrolled.tsx
@@ -20,7 +20,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/with-drawer.tsx
+++ b/www/src/registry/ui/date-picker/demos/with-drawer.tsx
@@ -12,7 +12,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/date-picker/demos/with-modal.tsx
+++ b/www/src/registry/ui/date-picker/demos/with-modal.tsx
@@ -12,7 +12,7 @@ export default function Demo() {
       <InputGroup>
         <DateInput />
         <InputGroupAddon>
-          <Button variant="default" size="sm" isIconOnly>
+          <Button variant="secondary" size="sm" isIconOnly>
             <CalendarIcon />
           </Button>
         </InputGroupAddon>

--- a/www/src/registry/ui/dialog/demos/alert-dialog.tsx
+++ b/www/src/registry/ui/dialog/demos/alert-dialog.tsx
@@ -29,7 +29,7 @@ export default function Demo() {
                 </DialogDescription>
               </DialogHeader>
               <DialogFooter>
-                <Button slot="close" variant="default">
+                <Button slot="close" variant="secondary">
                   Cancel
                 </Button>
                 <Button slot="close" variant="danger">

--- a/www/src/registry/ui/dialog/demos/async-form-submission.tsx
+++ b/www/src/registry/ui/dialog/demos/async-form-submission.tsx
@@ -59,7 +59,7 @@ export default function Demo() {
                     </FormPrimitives.Form>
                   </DialogBody>
                   <DialogFooter>
-                    <Button variant="default" slot="close">
+                    <Button variant="secondary" slot="close">
                       Cancel
                     </Button>
                     <Button

--- a/www/src/registry/ui/dialog/demos/description.tsx
+++ b/www/src/registry/ui/dialog/demos/description.tsx
@@ -16,7 +16,7 @@ import { TextField } from '@/registry/ui/text-field'
 export default function Demo() {
   return (
     <Dialog>
-      <Button variant="default">Edit username</Button>
+      <Button variant="secondary">Edit username</Button>
       <Responsive
         render={(isMobile) => {
           const content = (

--- a/www/src/registry/ui/dialog/demos/drawer.tsx
+++ b/www/src/registry/ui/dialog/demos/drawer.tsx
@@ -25,7 +25,7 @@ export default function Demo() {
     <div className="flex w-full items-center">
       <div className="flex flex-1 items-center justify-center">
         <Dialog>
-          <Button variant="default">Open drawer</Button>
+          <Button variant="secondary">Open drawer</Button>
           <Drawer>
             <DialogContent>
               <DialogHeader>

--- a/www/src/registry/ui/dialog/demos/nested.tsx
+++ b/www/src/registry/ui/dialog/demos/nested.tsx
@@ -32,14 +32,14 @@ export default function Demo() {
   return (
     <div className="flex w-full items-center gap-8">
       <Dialog>
-        <Button variant="default">Dialog</Button>
+        <Button variant="secondary">Dialog</Button>
         <Overlay>
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Dialog</DialogTitle>
             </DialogHeader>
             <Dialog>
-              <Button variant="default">Nested dialog</Button>
+              <Button variant="secondary">Nested dialog</Button>
               <Overlay>
                 <DialogContent>
                   <DialogHeader>

--- a/www/src/registry/ui/dialog/demos/popover.tsx
+++ b/www/src/registry/ui/dialog/demos/popover.tsx
@@ -39,7 +39,7 @@ export default function Demo() {
     <div className="flex w-full items-center">
       <div className="flex flex-1 items-center justify-center">
         <Dialog>
-          <Button variant="default" isIconOnly>
+          <Button variant="secondary" isIconOnly>
             <InfoIcon />
           </Button>
           <Responsive

--- a/www/src/registry/ui/dialog/demos/title.tsx
+++ b/www/src/registry/ui/dialog/demos/title.tsx
@@ -15,7 +15,7 @@ import { TextField } from '@/registry/ui/text-field'
 export default function Demo() {
   return (
     <Dialog>
-      <Button variant="default">Edit username</Button>
+      <Button variant="secondary">Edit username</Button>
       <Responsive
         render={(isMobile) => {
           const content = (

--- a/www/src/registry/ui/empty/demos/basic.tsx
+++ b/www/src/registry/ui/empty/demos/basic.tsx
@@ -23,7 +23,7 @@ export default function Demo() {
           <LinkButton variant="primary" href="#">
             Create project
           </LinkButton>
-          <Button variant="default">Import project</Button>
+          <Button variant="secondary">Import project</Button>
         </div>
         <LinkButton variant="link" href="#" className="text-fg-muted">
           Learn more <ArrowUpRightIcon />

--- a/www/src/registry/ui/empty/demos/in-card.tsx
+++ b/www/src/registry/ui/empty/demos/in-card.tsx
@@ -30,7 +30,7 @@ export default function Demo() {
               <LinkButton variant="primary" href="#">
                 Create project
               </LinkButton>
-              <Button variant="default">Import project</Button>
+              <Button variant="secondary">Import project</Button>
             </div>
             <LinkButton variant="link" href="#" className="text-fg-muted">
               Learn more <ArrowUpRightIcon />

--- a/www/src/registry/ui/empty/demos/with-icon.tsx
+++ b/www/src/registry/ui/empty/demos/with-icon.tsx
@@ -23,7 +23,7 @@ export default function Demo() {
         </EmptyDescription>
       </EmptyHeader>
       <EmptyContent>
-        <Button variant="default">
+        <Button variant="secondary">
           <PlusIcon />
           New Post
         </Button>

--- a/www/src/registry/ui/file-trigger/demos/document-upload.tsx
+++ b/www/src/registry/ui/file-trigger/demos/document-upload.tsx
@@ -28,7 +28,7 @@ export default function Demo() {
           }
         }}
       >
-        <Button variant="default" className="w-full">
+        <Button variant="secondary" className="w-full">
           <UploadIcon /> Upload documents
         </Button>
       </FileTrigger>

--- a/www/src/registry/ui/file-trigger/demos/image-gallery-upload.tsx
+++ b/www/src/registry/ui/file-trigger/demos/image-gallery-upload.tsx
@@ -50,7 +50,7 @@ export default function Demo() {
           }
         }}
       >
-        <Button variant="default" size="sm" className="w-full">
+        <Button variant="secondary" size="sm" className="w-full">
           <UploadIcon /> Upload images
         </Button>
       </FileTrigger>

--- a/www/src/registry/ui/file-trigger/demos/profile-picture.tsx
+++ b/www/src/registry/ui/file-trigger/demos/profile-picture.tsx
@@ -24,7 +24,7 @@ export default function Demo() {
           }
         }}
       >
-        <Button variant="default" size="sm">
+        <Button variant="secondary" size="sm">
           <UploadIcon /> {src ? 'Change photo' : 'Upload photo'}
         </Button>
       </FileTrigger>

--- a/www/src/registry/ui/form/demos/react-aria.tsx
+++ b/www/src/registry/ui/form/demos/react-aria.tsx
@@ -83,7 +83,7 @@ export default function Demo() {
         </Combobox>
         <Select name="referral" isRequired>
           <Label>How did you hear about us?</Label>
-          <SelectTrigger variant="default" className="w-full" />
+          <SelectTrigger variant="secondary" className="w-full" />
           <SelectContent>
             <SelectItem id="linkedin">LinkedIn</SelectItem>
             <SelectItem id="x">X</SelectItem>

--- a/www/src/registry/ui/input-group/demos/buttons.tsx
+++ b/www/src/registry/ui/input-group/demos/buttons.tsx
@@ -5,7 +5,7 @@ import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 import { TextField } from '@/registry/ui/text-field'
 
 const variants = [
-  'default',
+  'secondary',
   'primary',
   'quiet',
   'link',

--- a/www/src/registry/ui/input/examples.tsx
+++ b/www/src/registry/ui/input/examples.tsx
@@ -188,7 +188,7 @@ function InputForm() {
             <Input type="text" placeholder="123 Main St" />
           </TextField>
           <Field orientation="horizontal">
-            <Button type="button" variant="default">
+            <Button type="button" variant="secondary">
               Cancel
             </Button>
             <Button type="submit" variant="primary">

--- a/www/src/registry/ui/menu/demos/account.tsx
+++ b/www/src/registry/ui/menu/demos/account.tsx
@@ -12,7 +12,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Open
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/checkboxes-with-icons.tsx
+++ b/www/src/registry/ui/menu/demos/checkboxes-with-icons.tsx
@@ -24,7 +24,7 @@ export default function Demo() {
   )
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Notifications
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/complex.tsx
+++ b/www/src/registry/ui/menu/demos/complex.tsx
@@ -23,7 +23,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Complex Menu
       </Button>
       <Popover className="w-56">

--- a/www/src/registry/ui/menu/demos/in-dialog.tsx
+++ b/www/src/registry/ui/menu/demos/in-dialog.tsx
@@ -23,7 +23,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Dialog>
-      <Button variant="default">Open Dialog</Button>
+      <Button variant="secondary">Open Dialog</Button>
       <Responsive
         render={(isMobile) => {
           const content = (
@@ -36,7 +36,7 @@ export default function Demo() {
               </DialogHeader>
               <DialogBody>
                 <Menu>
-                  <Button variant="default" className="w-fit">
+                  <Button variant="secondary" className="w-fit">
                     Open Menu
                   </Button>
                   <Popover>

--- a/www/src/registry/ui/menu/demos/link-items.tsx
+++ b/www/src/registry/ui/menu/demos/link-items.tsx
@@ -8,7 +8,7 @@ import { TwitterIcon } from '@/components/icons/twitter'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" size="sm">
+      <Button variant="secondary" size="sm">
         Social
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/long-press.tsx
+++ b/www/src/registry/ui/menu/demos/long-press.tsx
@@ -6,7 +6,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <Menu trigger="longPress">
-      <Button variant="default" isIconOnly>
+      <Button variant="secondary" isIconOnly>
         <MenuIcon />
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/multiple-selection.tsx
+++ b/www/src/registry/ui/menu/demos/multiple-selection.tsx
@@ -17,7 +17,7 @@ export default function Demo() {
   const [selected, setSelected] = React.useState<Set<Key>>(new Set(['status']))
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Checkboxes
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/overlay-type.tsx
+++ b/www/src/registry/ui/menu/demos/overlay-type.tsx
@@ -29,7 +29,7 @@ export default function Demo() {
   return (
     <div className="flex items-center gap-14">
       <Menu>
-        <Button variant="default" isIconOnly>
+        <Button variant="secondary" isIconOnly>
           <MenuIcon />
         </Button>
         <Responsive

--- a/www/src/registry/ui/menu/demos/placement.tsx
+++ b/www/src/registry/ui/menu/demos/placement.tsx
@@ -15,7 +15,7 @@ export default function Demo() {
   return (
     <div className="flex items-center gap-10">
       <Menu>
-        <Button variant="default" size="sm" isIconOnly>
+        <Button variant="secondary" size="sm" isIconOnly>
           <MenuIcon />
         </Button>
         <Popover placement={placement}>

--- a/www/src/registry/ui/menu/demos/prefix-and-suffix.tsx
+++ b/www/src/registry/ui/menu/demos/prefix-and-suffix.tsx
@@ -12,7 +12,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" size="sm" isIconOnly>
+      <Button variant="secondary" size="sm" isIconOnly>
         <MenuIcon />
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/radio-with-icons.tsx
+++ b/www/src/registry/ui/menu/demos/radio-with-icons.tsx
@@ -22,7 +22,7 @@ export default function Demo() {
   const [selected, setSelected] = React.useState<Set<Key>>(new Set(['card']))
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Payment Method
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/section.tsx
+++ b/www/src/registry/ui/menu/demos/section.tsx
@@ -12,7 +12,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" isIconOnly>
+      <Button variant="secondary" isIconOnly>
         <MenuIcon />
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/separator.tsx
+++ b/www/src/registry/ui/menu/demos/separator.tsx
@@ -6,7 +6,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default">File</Button>
+      <Button variant="secondary">File</Button>
       <Popover>
         <MenuContent>
           <MenuItem>New...</MenuItem>

--- a/www/src/registry/ui/menu/demos/shortcut.tsx
+++ b/www/src/registry/ui/menu/demos/shortcut.tsx
@@ -7,7 +7,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" isIconOnly>
+      <Button variant="secondary" isIconOnly>
         <MenuIcon />
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/sides.tsx
+++ b/www/src/registry/ui/menu/demos/sides.tsx
@@ -8,7 +8,7 @@ export default function Demo() {
       {(['bottom', 'top', 'left', 'right', 'start', 'end'] as const).map(
         (placement) => (
           <Menu key={placement}>
-            <Button variant="default" className="w-fit capitalize">
+            <Button variant="secondary" className="w-fit capitalize">
               {placement}
             </Button>
             <Popover placement={placement}>

--- a/www/src/registry/ui/menu/demos/single-selection.tsx
+++ b/www/src/registry/ui/menu/demos/single-selection.tsx
@@ -16,7 +16,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Radio Group
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/submenus.tsx
+++ b/www/src/registry/ui/menu/demos/submenus.tsx
@@ -6,7 +6,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" isIconOnly>
+      <Button variant="secondary" isIconOnly>
         <MenuIcon />
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/with-avatar.tsx
+++ b/www/src/registry/ui/menu/demos/with-avatar.tsx
@@ -40,7 +40,7 @@ export default function Demo() {
     <div className="flex w-full items-center justify-between gap-4">
       <Menu>
         <Button
-          variant="default"
+          variant="secondary"
           className="h-12 justify-start gap-2 px-2 md:max-w-[200px]"
         >
           <Avatar size="sm">

--- a/www/src/registry/ui/menu/demos/with-destructive.tsx
+++ b/www/src/registry/ui/menu/demos/with-destructive.tsx
@@ -12,7 +12,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Actions
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/with-drawer.tsx
+++ b/www/src/registry/ui/menu/demos/with-drawer.tsx
@@ -19,7 +19,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Open drawer menu
       </Button>
       <Drawer placement="bottom">

--- a/www/src/registry/ui/menu/demos/with-icons.tsx
+++ b/www/src/registry/ui/menu/demos/with-icons.tsx
@@ -12,7 +12,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Open
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/with-modal.tsx
+++ b/www/src/registry/ui/menu/demos/with-modal.tsx
@@ -13,7 +13,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Open modal menu
       </Button>
       <Modal>

--- a/www/src/registry/ui/menu/demos/with-shortcuts.tsx
+++ b/www/src/registry/ui/menu/demos/with-shortcuts.tsx
@@ -13,7 +13,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Open
       </Button>
       <Popover>

--- a/www/src/registry/ui/menu/demos/with-submenu.tsx
+++ b/www/src/registry/ui/menu/demos/with-submenu.tsx
@@ -7,7 +7,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Open
       </Button>
       <Popover>

--- a/www/src/registry/ui/pagination/base.tsx
+++ b/www/src/registry/ui/pagination/base.tsx
@@ -67,7 +67,7 @@ const PaginationLink = ({
     <LinkButton
       aria-current={isActive ? 'page' : undefined}
       data-pagination-link=""
-      variant={variant ?? (isActive ? 'default' : 'quiet')}
+      variant={variant ?? (isActive ? 'secondary' : 'quiet')}
       isIconOnly={isIconOnly}
       {...props}
     />

--- a/www/src/registry/ui/pagination/types.ts
+++ b/www/src/registry/ui/pagination/types.ts
@@ -32,9 +32,9 @@ export interface PaginationLinkProps extends React.ComponentProps<
 
   /**
    * The visual style of the link.
-   * @default isActive ? 'default' : 'quiet'
+   * @default isActive ? 'secondary' : 'quiet'
    */
-  variant?: 'default' | 'primary' | 'quiet' | 'link' | 'warning' | 'danger'
+  variant?: 'primary' | 'secondary' | 'quiet' | 'link' | 'warning' | 'danger'
 
   /**
    * The size of the link.

--- a/www/src/registry/ui/popover/demos/in-dialog.tsx
+++ b/www/src/registry/ui/popover/demos/in-dialog.tsx
@@ -14,7 +14,7 @@ import { Popover } from '@/registry/ui/popover'
 export default function Demo() {
   return (
     <Dialog>
-      <Button variant="default">Open Dialog</Button>
+      <Button variant="secondary">Open Dialog</Button>
       <Responsive
         render={(isMobile) => {
           const content = (
@@ -26,7 +26,7 @@ export default function Demo() {
                 </DialogDescription>
               </DialogHeader>
               <Dialog>
-                <Button variant="default" className="w-fit">
+                <Button variant="secondary" className="w-fit">
                   Open Popover
                 </Button>
                 <Popover placement="bottom start">

--- a/www/src/registry/ui/popover/demos/placement.tsx
+++ b/www/src/registry/ui/popover/demos/placement.tsx
@@ -13,7 +13,7 @@ export default function Demo() {
     <div className="flex flex-wrap justify-center gap-6">
       {placements.map((placement) => (
         <Dialog key={placement.label}>
-          <Button variant="default" size="sm">
+          <Button variant="secondary" size="sm">
             {placement.label}
           </Button>
           <Popover placement={placement.placement} className="w-48">

--- a/www/src/registry/ui/popover/demos/with-form.tsx
+++ b/www/src/registry/ui/popover/demos/with-form.tsx
@@ -14,7 +14,7 @@ import { TextField } from '@/registry/ui/text-field'
 export default function Demo() {
   return (
     <Dialog>
-      <Button variant="default">Open Popover</Button>
+      <Button variant="secondary">Open Popover</Button>
       <Popover placement="bottom start" className="w-64">
         <DialogContent>
           <DialogHeader>

--- a/www/src/registry/ui/react-hook-form/demos/register.tsx
+++ b/www/src/registry/ui/react-hook-form/demos/register.tsx
@@ -121,7 +121,7 @@ export default function Demo() {
               <InputGroup>
                 <DateInput />
                 <InputGroupAddon>
-                  <Button variant="default" size="sm" isIconOnly>
+                  <Button variant="secondary" size="sm" isIconOnly>
                     <CalendarIcon />
                   </Button>
                 </InputGroupAddon>
@@ -180,7 +180,7 @@ export default function Demo() {
           render={(props) => (
             <Select className="w-full" {...props}>
               <Label>How did you hear about us?</Label>
-              <SelectTrigger variant="default" className="w-full" />
+              <SelectTrigger variant="secondary" className="w-full" />
               <SelectContent>
                 <SelectItem id="linkedin">LinkedIn</SelectItem>
                 <SelectItem id="x">X</SelectItem>

--- a/www/src/registry/ui/separator/demos/menu-section.tsx
+++ b/www/src/registry/ui/separator/demos/menu-section.tsx
@@ -15,7 +15,7 @@ import { Separator } from '@/registry/ui/separator'
 export default function Demo() {
   return (
     <Menu>
-      <Button variant="default" className="w-fit">
+      <Button variant="secondary" className="w-fit">
         Account
       </Button>
       <Popover>

--- a/www/src/registry/ui/table/demos/tasks.tsx
+++ b/www/src/registry/ui/table/demos/tasks.tsx
@@ -806,7 +806,7 @@ function FacetedFilter({
 }) {
   return (
     <Menu>
-      <Button variant="default" size="sm" className="border-dashed">
+      <Button variant="secondary" size="sm" className="border-dashed">
         <PlusCircleIcon />
         {title}
         {selectedKeys.size > 0 && (
@@ -864,7 +864,7 @@ function ViewOptions({
 
   return (
     <Menu>
-      <Button variant="default" size="sm">
+      <Button variant="secondary" size="sm">
         <Settings2Icon />
         View
       </Button>

--- a/www/src/registry/ui/time-picker/demos/basic.tsx
+++ b/www/src/registry/ui/time-picker/demos/basic.tsx
@@ -18,7 +18,7 @@ export default function Demo() {
         <DateInput />
         <InputGroupAddon>
           <Button
-            variant="default"
+            variant="secondary"
             size="sm"
             isIconOnly
             aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/composition.tsx
+++ b/www/src/registry/ui/time-picker/demos/composition.tsx
@@ -16,7 +16,7 @@ export default function Demo() {
         <DateInput />
         <InputGroupAddon>
           <Button
-            variant="default"
+            variant="secondary"
             size="sm"
             isIconOnly
             aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/controlled.tsx
+++ b/www/src/registry/ui/time-picker/demos/controlled.tsx
@@ -21,7 +21,7 @@ export default function Demo() {
           <DateInput />
           <InputGroupAddon>
             <Button
-              variant="default"
+              variant="secondary"
               size="sm"
               isIconOnly
               aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/description.tsx
+++ b/www/src/registry/ui/time-picker/demos/description.tsx
@@ -16,7 +16,7 @@ export default function Demo() {
         <DateInput />
         <InputGroupAddon>
           <Button
-            variant="default"
+            variant="secondary"
             size="sm"
             isIconOnly
             aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/disabled.tsx
+++ b/www/src/registry/ui/time-picker/demos/disabled.tsx
@@ -16,7 +16,7 @@ export default function Demo() {
         <DateInput />
         <InputGroupAddon>
           <Button
-            variant="default"
+            variant="secondary"
             size="sm"
             isIconOnly
             aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/error-message.tsx
+++ b/www/src/registry/ui/time-picker/demos/error-message.tsx
@@ -14,7 +14,7 @@ export default function Demo() {
         <DateInput />
         <InputGroupAddon>
           <Button
-            variant="default"
+            variant="secondary"
             size="sm"
             isIconOnly
             aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/granularity.tsx
+++ b/www/src/registry/ui/time-picker/demos/granularity.tsx
@@ -26,7 +26,7 @@ export default function Demo() {
             <DateInput />
             <InputGroupAddon>
               <Button
-                variant="default"
+                variant="secondary"
                 size="sm"
                 isIconOnly
                 aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/hour-cycle.tsx
+++ b/www/src/registry/ui/time-picker/demos/hour-cycle.tsx
@@ -19,7 +19,7 @@ export default function Demo() {
           <DateInput />
           <InputGroupAddon>
             <Button
-              variant="default"
+              variant="secondary"
               size="sm"
               isIconOnly
               aria-label="Choose time"
@@ -40,7 +40,7 @@ export default function Demo() {
           <DateInput />
           <InputGroupAddon>
             <Button
-              variant="default"
+              variant="secondary"
               size="sm"
               isIconOnly
               aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/label.tsx
+++ b/www/src/registry/ui/time-picker/demos/label.tsx
@@ -15,7 +15,7 @@ export default function Demo() {
           <DateInput />
           <InputGroupAddon>
             <Button
-              variant="default"
+              variant="secondary"
               size="sm"
               isIconOnly
               aria-label="Choose time"
@@ -35,7 +35,7 @@ export default function Demo() {
           <DateInput />
           <InputGroupAddon>
             <Button
-              variant="default"
+              variant="secondary"
               size="sm"
               isIconOnly
               aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/placeholder.tsx
+++ b/www/src/registry/ui/time-picker/demos/placeholder.tsx
@@ -18,7 +18,7 @@ export default function Demo() {
         <DateInput />
         <InputGroupAddon>
           <Button
-            variant="default"
+            variant="secondary"
             size="sm"
             isIconOnly
             aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/playground.tsx
+++ b/www/src/registry/ui/time-picker/demos/playground.tsx
@@ -30,7 +30,7 @@ export function TimePickerPlayground({
         <DateInput />
         <InputGroupAddon>
           <Button
-            variant="default"
+            variant="secondary"
             size="sm"
             isIconOnly
             aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/read-only.tsx
+++ b/www/src/registry/ui/time-picker/demos/read-only.tsx
@@ -16,7 +16,7 @@ export default function Demo() {
         <DateInput />
         <InputGroupAddon>
           <Button
-            variant="default"
+            variant="secondary"
             size="sm"
             isIconOnly
             aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/required.tsx
+++ b/www/src/registry/ui/time-picker/demos/required.tsx
@@ -14,7 +14,7 @@ export default function Demo() {
         <DateInput />
         <InputGroupAddon>
           <Button
-            variant="default"
+            variant="secondary"
             size="sm"
             isIconOnly
             aria-label="Choose time"

--- a/www/src/registry/ui/time-picker/demos/uncontrolled.tsx
+++ b/www/src/registry/ui/time-picker/demos/uncontrolled.tsx
@@ -18,7 +18,7 @@ export default function Demo() {
         <DateInput />
         <InputGroupAddon>
           <Button
-            variant="default"
+            variant="secondary"
             size="sm"
             isIconOnly
             aria-label="Choose time"

--- a/www/src/registry/ui/toggle-button-group/demos/variants.tsx
+++ b/www/src/registry/ui/toggle-button-group/demos/variants.tsx
@@ -6,7 +6,7 @@ import {
 import { ToggleButton } from '@/registry/ui/toggle-button'
 import { ToggleButtonGroup } from '@/registry/ui/toggle-button-group'
 
-const variants = ['default', 'primary', 'quiet'] as const
+const variants = ['primary', 'secondary', 'quiet'] as const
 
 export default function Demo() {
   return (

--- a/www/src/registry/ui/toggle-button-group/styles.ts
+++ b/www/src/registry/ui/toggle-button-group/styles.ts
@@ -14,10 +14,10 @@ const { useStyles, styles } = createStyles(toggleButtonGroupMeta, {
     variants: {
       orientation: {
         horizontal: {
-          root: 'flex-row has-data-[variant=default]:-space-x-px *:not-first:data-button:rounded-l-none *:not-last:data-button:rounded-r-none',
+          root: 'flex-row has-data-[variant=secondary]:-space-x-px *:not-first:data-button:rounded-l-none *:not-last:data-button:rounded-r-none',
         },
         vertical: {
-          root: 'flex-col has-data-[variant=default]:-space-y-px *:not-first:data-button:rounded-t-none *:not-last:data-button:rounded-b-none',
+          root: 'flex-col has-data-[variant=secondary]:-space-y-px *:not-first:data-button:rounded-t-none *:not-last:data-button:rounded-b-none',
         },
       },
     },

--- a/www/src/registry/ui/toggle-button-group/types.ts
+++ b/www/src/registry/ui/toggle-button-group/types.ts
@@ -8,9 +8,9 @@ export interface ToggleButtonGroupProps extends React.ComponentProps<
 > {
   /**
    * The visual style of the toggle buttons.
-   * @default 'default'
+   * @default 'secondary'
    */
-  variant?: 'default' | 'primary' | 'quiet'
+  variant?: 'primary' | 'secondary' | 'quiet'
 
   /**
    * The size of the toggle buttons.

--- a/www/src/registry/ui/toggle-button/base.tsx
+++ b/www/src/registry/ui/toggle-button/base.tsx
@@ -36,7 +36,7 @@ interface ToggleButtonProps
 const ToggleButton = (localProps: ToggleButtonProps) => {
   const styles = useStyles()
   const {
-    variant = 'default',
+    variant = 'secondary',
     size = 'md',
     isIconOnly,
     className,

--- a/www/src/registry/ui/toggle-button/demos/playground.tsx
+++ b/www/src/registry/ui/toggle-button/demos/playground.tsx
@@ -6,13 +6,13 @@ import { ToggleButton } from '@/registry/ui/toggle-button'
 
 export default function Demo({
   children = 'Pin',
-  variant = 'default',
+  variant = 'secondary',
   size = 'md',
   isIconOnly = false,
   isDisabled = false,
 }: {
   children?: string
-  variant?: 'default' | 'primary' | 'quiet'
+  variant?: 'primary' | 'secondary' | 'quiet'
   size?: 'lg' | 'md' | 'sm' | 'xs'
   isIconOnly?: boolean
   isDisabled?: boolean

--- a/www/src/registry/ui/toggle-button/demos/variants.tsx
+++ b/www/src/registry/ui/toggle-button/demos/variants.tsx
@@ -1,7 +1,7 @@
 import { PinIcon } from '@/registry/__generated__/icons'
 import { ToggleButton } from '@/registry/ui/toggle-button'
 
-const variants = ['default', 'primary', 'quiet'] as const
+const variants = ['primary', 'secondary', 'quiet'] as const
 
 export default function Demo() {
   return (

--- a/www/src/registry/ui/toggle-button/styles.ts
+++ b/www/src/registry/ui/toggle-button/styles.ts
@@ -13,10 +13,10 @@ const { useStyles, styles } = createStyles(toggleButtonMeta, {
     ],
     variants: {
       variant: {
-        default:
-          'border bg-neutral text-fg-on-neutral hover:border-border-hover hover:bg-neutral-hover pressed:border-border-active pressed:bg-neutral-active selected:not-data-disabled:border-border-active',
         primary:
           'bg-primary text-fg-on-primary [--color-disabled:var(--neutral-300)] hover:bg-primary-hover disabled:border-0 pressed:bg-primary-active',
+        secondary:
+          'border bg-neutral text-fg-on-neutral hover:border-border-hover hover:bg-neutral-hover pressed:border-border-active pressed:bg-neutral-active selected:not-data-disabled:border-border-active',
         quiet:
           'bg-transparent text-fg hover:bg-inverse/10 pressed:bg-inverse/20',
       },
@@ -31,7 +31,7 @@ const { useStyles, styles } = createStyles(toggleButtonMeta, {
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'secondary',
       size: 'md',
     },
   },

--- a/www/src/registry/ui/toggle-button/types.ts
+++ b/www/src/registry/ui/toggle-button/types.ts
@@ -8,9 +8,9 @@ export interface ToggleButtonProps extends React.ComponentProps<
 > {
   /**
    * The visual style of the toggle button.
-   * @default 'default'
+   * @default 'secondary'
    */
-  variant?: 'default' | 'primary' | 'quiet'
+  variant?: 'primary' | 'secondary' | 'quiet'
 
   /**
    * The size of the toggle button.

--- a/www/src/registry/ui/tooltip/demos/basic.tsx
+++ b/www/src/registry/ui/tooltip/demos/basic.tsx
@@ -4,7 +4,7 @@ import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
 export default function Demo() {
   return (
     <Tooltip>
-      <Button variant="default">Hover me</Button>
+      <Button variant="secondary">Hover me</Button>
       <TooltipContent>Add to library</TooltipContent>
     </Tooltip>
   )

--- a/www/src/registry/ui/tooltip/demos/formatted.tsx
+++ b/www/src/registry/ui/tooltip/demos/formatted.tsx
@@ -4,7 +4,7 @@ import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
 export default function Demo() {
   return (
     <Tooltip>
-      <Button variant="default">Status</Button>
+      <Button variant="secondary">Status</Button>
       <TooltipContent className="text-left">
         <div className="flex flex-col gap-1">
           <p className="font-semibold">Active</p>

--- a/www/src/registry/ui/tooltip/demos/long-content.tsx
+++ b/www/src/registry/ui/tooltip/demos/long-content.tsx
@@ -4,7 +4,7 @@ import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
 export default function Demo() {
   return (
     <Tooltip>
-      <Button variant="default">Show tooltip</Button>
+      <Button variant="secondary">Show tooltip</Button>
       <TooltipContent>
         To learn more about how this works, check out the docs. If you have any
         questions, please reach out to us.

--- a/www/src/registry/ui/tooltip/demos/with-keyboard.tsx
+++ b/www/src/registry/ui/tooltip/demos/with-keyboard.tsx
@@ -6,7 +6,7 @@ import { Tooltip, TooltipContent } from '@/registry/ui/tooltip'
 export default function Demo() {
   return (
     <Tooltip>
-      <Button variant="default" isIconOnly aria-label="Save">
+      <Button variant="secondary" isIconOnly aria-label="Save">
         <SaveIcon />
       </Button>
       <TooltipContent>


### PR DESCRIPTION
## Summary

Rename Button's `default` variant to `secondary` across the synced group. The ladder becomes `primary / secondary / quiet / link / warning / danger`. The default variant is unchanged in behavior — bare `<Button>` still renders the bordered neutral.

**Why:** across a 38-design-system survey, the second rung is literally named `secondary` in 13 of 26 curated systems, while `default` is ambiguous — it means the *primary* in shadcn/Geist but the *neutral* in Primer/Atlassian, so it misleads half the incoming audience. Renaming now is cheap; after the curated-style catalog (#484 Phase 2) is authored, the rename multiplies across every style.

A `tertiary` variant was considered and deliberately deferred: it's purely additive (non-breaking to add later), none of the flagship presets (Vercel, Linear, Claude) need it, and its look should be dictated by a real preset audit rather than guessed now.

## Synced group

Button ⇄ ToggleButton land together per the group rule; ToggleButtonGroup and Pagination follow:

- ToggleButton: same rename (types, styles, `data-variant` default).
- ToggleButtonGroup: the segmented `-space-x-px` collapse now keys on `data-variant=secondary`.
- PaginationLink active state maps to `secondary`.

## Also in this diff

- All www usages, demos, examples, and MDX samples updated (134 `<Button variant="default">` + SelectTrigger/LinkButton usages).
- Publisher fixture + test synced (fixture header asks for manual sync).
- Fixed a pre-existing docs bug: `select.mdx` used non-existent `variant="outline"`.

## Breaking change

For registry consumers: `variant="default"` no longer exists — use `secondary` (or omit, it's the default).

## Verification

- `pnpm build:registry`, `pnpm build:references` (full run), `pnpm check`, `pnpm typecheck` all green; publisher vitest 26/26.
- Live-verified on a fresh dev server: playground lists the six variants, bare `<Button>` renders the bordered neutral, segmented ToggleButtonGroup borders still collapse.