### PR TITLE
fix(www): make composition code pane scrollable past its ceiling

### DIFF
--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -184,11 +184,11 @@ export function CompositionSection() {
               </div>
             </div>
             {/* The pane hugs its snippet between a floor and a ceiling; past the
-                ceiling the code scrolls under the bottom fade. Below lg, where
-                the section stacks, it's pinned instead — the page can't move
-                between steps. */}
+                ceiling the code scrolls, faded at whichever edge still has
+                code beyond it. Below lg, where the section stacks, it's pinned
+                instead — the page can't move between steps. */}
             <div
-              className="no-scrollbar overflow-x-hidden overflow-y-auto overscroll-contain border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out motion-reduce:transition-none max-lg:max-h-62 max-lg:min-h-62 lg:max-h-86 lg:min-h-51"
+              className="no-scrollbar scroll-fade-y overflow-x-hidden overflow-y-auto overscroll-contain border-t transition-[height] ease-in-out scroll-fade-6 motion-reduce:transition-none max-lg:max-h-62 max-lg:min-h-62 lg:max-h-86 lg:min-h-51"
               style={{
                 height: codeHeight ?? 'auto',
                 transitionDuration: '500ms',

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -184,11 +184,11 @@ export function CompositionSection() {
               </div>
             </div>
             {/* The pane hugs its snippet between a floor and a ceiling; past the
-                ceiling the code crops under the bottom fade. Below lg, where the
-                section stacks, it's pinned instead — the page can't move between
-                steps. */}
+                ceiling the code scrolls under the bottom fade. Below lg, where
+                the section stacks, it's pinned instead — the page can't move
+                between steps. */}
             <div
-              className="overflow-hidden border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out motion-reduce:transition-none max-lg:max-h-62 max-lg:min-h-62 lg:max-h-86 lg:min-h-51"
+              className="no-scrollbar overflow-x-hidden overflow-y-auto overscroll-contain border-t [mask-image:linear-gradient(to_bottom,black_calc(100%-1.5rem),transparent)] transition-[height] ease-in-out motion-reduce:transition-none max-lg:max-h-62 max-lg:min-h-62 lg:max-h-86 lg:min-h-51"
               style={{
                 height: codeHeight ?? 'auto',
                 transitionDuration: '500ms',


### PR DESCRIPTION
## Summary

- The code pane in the landing page's Composition section clamps to a height ceiling (`lg:max-h-86`, and a pinned `max-lg:max-h-62`) but was `overflow-hidden`, so any snippet taller than the ceiling was cropped with no way to reach the rest. It now scrolls (`overflow-y-auto`, plus `no-scrollbar` / `overscroll-contain` to match the section's other scroll areas).
- The pane's fade is now `scroll-fade-y` instead of a static bottom-only mask, so it fades whichever edge still has code beyond it — including the top once you've scrolled — and shows no fade at all when the snippet fits.

## Notes for reviewers

- The scroll container is the **outer**, height-animated div — not the inner one. The inner div is measured once on mount to calibrate the per-line height used for the height tween; making it `h-full` would have it report the pane's min-height instead and break that calibration.
- `scroll-fade-y` / `scroll-fade-6` come from shadcn's shared utilities, already used for the docs sidebar, TOC, mobile nav and code modals. `scroll-fade-6` keeps the 1.5rem fade depth the old static mask used.
- Normal steps are unaffected: the pane's height is set to the snippet's exact content height, so scrolling only engages once the ceiling clamps (the Menu / ContextMenu steps today).

Verified on a local dev server against the live DOM: the pane reports `scrollHeight` 438 vs a clamped box on the Menu step and scrolls the full delta, and the scroll-driven fade animations are attached exactly as on the existing `scroll-fade-y` surfaces.
