### PR TITLE
fix(www): unify landing spacing, center footer, tune CTA

### DIFF
--- a/www/src/components/layout/footer.tsx
+++ b/www/src/components/layout/footer.tsx
@@ -1,7 +1,7 @@
 export function Footer() {
   return (
-    <footer className="mx-auto flex h-24 w-full max-w-[calc(1500px+16rem)] items-center justify-start px-4 sm:px-6 lg:px-32">
-      <p className="text-sm text-fg-muted">
+    <footer className="mx-auto flex h-24 w-full max-w-[calc(1500px+16rem)] items-center justify-center px-4 sm:px-6 lg:px-32">
+      <p className="text-center text-sm text-fg-muted">
         Built with passion by{' '}
         <a
           href="https://x.com/mehdibha"

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -78,7 +78,7 @@ export function CompositionSection() {
 
   return (
     // Width mirrors the cards strip: 1500px grid + 8rem rail gutters.
-    <section className="mx-auto mt-24 w-full max-w-[calc(1500px+16rem)] px-4 sm:px-6 md:mt-32 lg:px-32">
+    <section className="mx-auto w-full max-w-[calc(1500px+16rem)] px-4 sm:px-6 lg:px-32">
       <CompositionTransitionStyles />
       <StepTimer player={player} />
       <div

--- a/www/src/modules/marketing/cta-section.tsx
+++ b/www/src/modules/marketing/cta-section.tsx
@@ -41,11 +41,14 @@ export function CtaSection() {
 
   return (
     <section className="relative overflow-x-clip">
+      {/* Density is pinned rather than taken from the preset: it's the one axis
+          that resizes the pill, and a command that changes height mid-switch
+          reads as a layout glitch instead of a re-theme. */}
       <DesignSystemProvider
         scoped
         params={ds.componentParams}
         tokens={ds.tokens}
-        density={ds.density}
+        density="default"
         color={ds.color}
         icons={ds.icons}
       >

--- a/www/src/modules/marketing/cta-section.tsx
+++ b/www/src/modules/marketing/cta-section.tsx
@@ -131,7 +131,7 @@ function InstallCommand({
       <PillBacklight
         pillRef={pillRef}
         color={preset?.swatch ?? null}
-        className="-inset-x-64 -inset-y-40 -z-10"
+        className="-inset-x-64 -inset-y-40 -z-10 opacity-50"
       />
       <PillGlow />
       <Menu>

--- a/www/src/modules/marketing/cta-section.tsx
+++ b/www/src/modules/marketing/cta-section.tsx
@@ -40,7 +40,7 @@ export function CtaSection() {
   const ds = preset?.designSystem ?? DEFAULTS
 
   return (
-    <section className="relative mt-32 overflow-x-clip md:mt-44">
+    <section className="relative overflow-x-clip">
       <DesignSystemProvider
         scoped
         params={ds.componentParams}
@@ -49,7 +49,7 @@ export function CtaSection() {
         color={ds.color}
         icons={ds.icons}
       >
-        <div className="container flex flex-col items-center py-16 text-center md:py-24">
+        <div className="container flex flex-col items-center text-center">
           <h2 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-3xl leading-tight font-normal tracking-[-0.05em] text-balance text-fg antialiased sm:text-5xl">
             <span className="block">Your design system,</span>
             <span className="block text-fg-muted">one command away.</span>

--- a/www/src/modules/marketing/export-section.tsx
+++ b/www/src/modules/marketing/export-section.tsx
@@ -9,7 +9,7 @@ import { V0Icon } from '@/components/icons/v0'
 
 export function ExportSection() {
   return (
-    <section className="mx-auto mt-24 w-full max-w-[calc(1500px+16rem)] px-4 sm:px-6 md:mt-32 lg:px-32">
+    <section className="mx-auto w-full max-w-[calc(1500px+16rem)] px-4 sm:px-6 lg:px-32">
       <div className="flex flex-col items-start gap-4">
         <h2 className="font-mono text-sm tracking-wide text-fg-muted">
           Export

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -40,12 +40,13 @@ export function HomePage() {
         </div>
       </section>
 
-      <section className="mt-23">
+      <section className="mt-24">
         <Cards />
       </section>
 
-      {/* Tools section. */}
-      <section className="relative z-10 -mt-[20px] py-12 shadow-xs">
+      {/* Tools section. Hero, cards and tools read as one opening block, so
+          they keep their own tight spacing instead of the section rhythm. */}
+      <section className="relative z-10 -mt-[20px] pt-12 shadow-xs">
         <div className="container flex flex-col items-center justify-center gap-5 lg:gap-10">
           <h2 className="font-mono text-sm tracking-wide text-pretty text-fg-muted xs:text-base lg:text-base">
             Built on modern tools
@@ -69,13 +70,21 @@ export function HomePage() {
         </div>
       </section>
 
-      <CompositionSection />
+      {/* Section rhythm lives here, not inside the sections: one gap between
+          peers, one step up before the CTA so the page reads as ending. */}
+      <div className="mt-24 md:mt-32">
+        <CompositionSection />
+      </div>
 
-      <ExportSection />
+      <div className="mt-24 md:mt-32">
+        <ExportSection />
+      </div>
 
-      <CtaSection />
+      <div className="mt-32 md:mt-44">
+        <CtaSection />
+      </div>
 
-      <div className="mt-10 md:mt-14">
+      <div className="mt-24 md:mt-32">
         <Footer />
       </div>
     </div>

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -76,7 +76,9 @@ export function HomePage() {
         <CompositionSection />
       </div>
 
-      <div className="mt-24 md:mt-32">
+      {/* Tighter than the section gap: composition ends on a heavy code block
+          and export opens on a small label, so equal space reads as more. */}
+      <div className="mt-16 md:mt-24">
         <ExportSection />
       </div>
 


### PR DESCRIPTION
## Problem

The vertical gaps between landing sections read as incoherent. The cause wasn't badly chosen numbers — **the gap was set in two places at once**. Each section owned its own outer `mt-*`, and two of them (tools, CTA) *also* carried internal vertical padding. The rendered gap was the sum, so nobody wrote `272px`; it accumulated.

## Changes

**1. Section rhythm.** Sections no longer own their outer margins — the gaps moved up to `home-page.tsx`, so the page rhythm reads as one scannable column instead of being scattered across four files. Dropped the padding that was doubling as spacing (the tools band's `pb`, the CTA's `py-16 md:py-24`). The tools band keeps `pt-12` — genuine internal breathing under the cards overlap, not a gap in disguise.

Three values, each with a stateable reason:

| | |
|---|---|
| `mt-16 md:mt-24` | paired sections — composition + export are one argument |
| `mt-24 md:mt-32` | peers |
| `mt-32 md:mt-44` | the closing beat before the CTA |

Effective gaps (last visible pixel → next visible pixel):

| Boundary | Before (base / md) | After |
|---|---|---|
| Hero → Cards | 92 | **96** |
| Cards → Tools | −20 | −20 (unchanged) |
| Tools → Composition | 144 / 176 | **96 / 128** |
| Composition → Export | 96 / 128 | **64 / 96** |
| Export → CTA | 192 / 272 | **128 / 176** |
| CTA → Footer | 104 / 152 | **96 / 128** |

Composition → export is deliberately tighter: composition ends on a heavy code block and export opens on a small label, so equal measured space read as more.

**2. Centered footer.** `justify-center` plus `text-center`. Note this is a shared component — it centers `/charts` too.

**3. CTA shader at 50%.** `opacity-50` on the `PillBacklight` canvas wrapper. The `PillGlow` ring and halo are siblings and keep their own opacity (0.8 / 0.5).

**4. Pinned CTA density.** The pill's buttons are `size="sm"`, which density resizes (`h-7` default, `h-8` comfortable), so selecting Airbnb — the one `comfortable` preset — grew the command bar from 46px to 50px mid-switch and read as a layout glitch. Density is now pinned; color, fonts and params still carry the re-theme.

## Verification

Measured computed styles and element rects on the deployed preview at 1280px and base width. Gaps `96 · −20 · 128 · 96 · 176 · 128`; pill 46px with 28px buttons; shader `opacity: 0.5`; footer centered at both widths. `pnpm check` and `pnpm typecheck` pass. No registry files touched.

Two things verified indirectly rather than by eye: screenshots return black frames on this site, so all confirmation here is structural; and the Airbnb preset switch was verified by reading the density style table, because the RAC menu doesn't open under synthetic pointer events.

## Suggested refactors

- The section gaps are literal Tailwind classes repeated 4×. A real `--section-gap` token would be better, but that's a spacing-axis product decision and belongs in its own proposal.
- `-mt-[20px]` on the tools section is the last arbitrary value on the page — load-bearing for the preset wash overlap.
- The footer still carries `max-w-[calc(1500px+16rem)]` and `lg:px-32`, which no longer do anything now that its content is centered.