### PR TITLE
fix(www): scope logo brand-assets menu to the landing page

### DIFF
--- a/www/src/components/layout/logo.tsx
+++ b/www/src/components/layout/logo.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router'
+import { Link, useLocation } from '@tanstack/react-router'
 import { TypeIcon } from 'lucide-react'
 import { useTheme } from 'starter-themes'
 
@@ -37,14 +37,10 @@ function BrandAssetPreview({
   )
 }
 
-export function Logo({
-  className,
-  type = 'link',
-}: {
-  className?: string
-  type?: 'link' | 'span'
-}) {
+export function Logo({ className }: { className?: string }) {
   const { resolvedTheme } = useTheme()
+  const pathname = useLocation({ select: (location) => location.pathname })
+  const isLanding = pathname === '/'
 
   const copyBrandAsset = (file: string) => {
     fetch(`/brand/${file}`)
@@ -80,22 +76,26 @@ export function Logo({
     </svg>
   )
 
+  // On the landing page the logo is already "home": no self-link, and
+  // right-click offers the brand assets. Everywhere else it's a plain link.
+  if (!isLanding) {
+    return (
+      <Link
+        to="/"
+        aria-label={`${siteConfig.name} home`}
+        className={cn(
+          'flex items-center opacity-100 transition-opacity duration-150 ease-out hover:opacity-80',
+          className,
+        )}
+      >
+        {mark}
+      </Link>
+    )
+  }
+
   return (
     <ContextMenu aria-label="Brand assets">
-      {type === 'link' ? (
-        <Link
-          to="/"
-          aria-label={`${siteConfig.name} home`}
-          className={cn(
-            'flex items-center opacity-100 transition-opacity duration-150 ease-out hover:opacity-80',
-            className,
-          )}
-        >
-          {mark}
-        </Link>
-      ) : (
-        <span className={cn('flex items-center', className)}>{mark}</span>
-      )}
+      <span className={cn('flex items-center', className)}>{mark}</span>
       <Popover className="w-56">
         <MenuContent>
           <MenuItem


### PR DESCRIPTION
## Summary

- The header logo now shows the right-click brand-assets menu (copy logo / wordmark as SVG) only on the landing page, where it renders as a non-link mark — it would only link to itself there.
- On every other page the logo is a plain link back to home, with no context menu.
- Removed the unused `type: 'link' | 'span'` prop from `Logo` — the header is its only consumer and the link/span decision is now derived from the route.

## SSR

The branch is chosen with TanStack Router's `useLocation`, which resolves on the server too — server and client render the same branch, no `window` checks, no hydration mismatch. Verified by curling the server-rendered HTML: `/` contains the `data-context-menu` wrapper and no home self-link; `/docs` contains the `aria-label="dotUI home"` link and no context-menu wrapper.

## Note for review

The brand-assets menu is now only reachable from the landing page — anyone on a docs page loses that affordance. If we'd rather keep it everywhere, link + context menu can be combined on all pages.