### PR TITLE
docs: add Shadows category with shadow.floriankiem.com

### DIFF
--- a/docs/design-system-references.md
+++ b/docs/design-system-references.md
@@ -69,3 +69,7 @@ The systems worth studying when researching presets, missing axes, or component 
 
 ### Command Dialog
 
+### Shadows
+
+- [Shadow (Florian Kiem)](https://shadow.floriankiem.com/) — Tailwind CSS plugin for smoother, layered shadow effects
+


### PR DESCRIPTION
## Summary
- Add a new "Shadows" subsection to the Inspiration section of the design system references doc
- Link https://shadow.floriankiem.com/ — a Tailwind CSS plugin for smoother, layered shadow effects

## Test plan
- N/A (docs-only change)