### PR TITLE
fix(www): control-lab control fixes

### DIFF
--- a/www/src/modules/control-lab/rows.tsx
+++ b/www/src/modules/control-lab/rows.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react'
 import {
   Button as RacButton,
+  SelectionIndicator,
   ToggleButton as RacToggleButton,
   ToggleButtonGroup as RacToggleButtonGroup,
 } from 'react-aria-components'
@@ -658,9 +659,12 @@ export function SegmentedRow({
             key={option.value}
             id={option.value}
             aria-label={option.ariaLabel}
-            className="flex h-7 cursor-interactive items-center rounded-md px-3 text-[0.8125rem] text-fg-muted focus-reset transition-colors hover:text-fg focus-visible:focus-ring selected:bg-highlight selected:text-fg **:[svg]:size-3.5"
+            className="relative isolate flex h-7 cursor-interactive items-center rounded-md px-3 text-[0.8125rem] text-fg-muted focus-reset transition-colors hover:text-fg focus-visible:focus-ring selected:text-fg **:[svg]:size-3.5"
           >
-            {option.label}
+            <SelectionIndicator className="pointer-events-none absolute inset-0 rounded-md bg-highlight duration-150 ease-out motion-safe:transition-[translate,width,height]" />
+            <span className="relative z-10 flex items-center">
+              {option.label}
+            </span>
           </RacToggleButton>
         ))}
       </RacToggleButtonGroup>
@@ -774,9 +778,12 @@ export function MiniSegmented({
           key={option.value}
           id={option.value}
           aria-label={option.ariaLabel}
-          className="flex h-6 cursor-interactive items-center rounded-[5px] px-2 text-xs text-fg-muted focus-reset transition-colors hover:text-fg focus-visible:focus-ring selected:bg-highlight selected:text-fg **:[svg]:size-3"
+          className="relative isolate flex h-6 cursor-interactive items-center rounded-[5px] px-2 text-xs text-fg-muted focus-reset transition-colors hover:text-fg focus-visible:focus-ring selected:text-fg **:[svg]:size-3"
         >
-          {option.label}
+          <SelectionIndicator className="pointer-events-none absolute inset-0 rounded-[5px] bg-highlight duration-150 ease-out motion-safe:transition-[translate,width,height]" />
+          <span className="relative z-10 flex items-center">
+            {option.label}
+          </span>
         </RacToggleButton>
       ))}
     </RacToggleButtonGroup>

--- a/www/src/modules/control-lab/rows.tsx
+++ b/www/src/modules/control-lab/rows.tsx
@@ -491,7 +491,7 @@ export function SliderRow({
         >
           <SliderFill className="absolute inset-y-0 left-0 bg-highlight" />
         </SliderTrack>
-        <SliderThumb className="absolute top-1/2 z-10 h-5 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-fg/25" />
+        <SliderThumb className="z-10 h-5 w-0.5 rounded-full bg-fg/25" />
       </SliderControl>
       <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-between px-4">
         <span className={ROW_LABEL}>{label}</span>


### PR DESCRIPTION
Collecting fixes to the Control Lab prototype controls (`www/src/modules/control-lab/`). Internal `/internal/panel-lab/controls` only — nothing here ships or touches the registry.

## Fixes

- **Segmented highlight now slides.** `SegmentedRow` and `MiniSegmented` painted the selection with `selected:bg-highlight` on each toggle button, so the background swapped instantly between segments. They now render React Aria's `SelectionIndicator` inside each item — the same primitive the registry `segmented-control` uses — as an absolutely positioned pill that FLIP-animates its translate/size across the group. Items became `relative isolate` with the label lifted to `z-10` so it sits above the pill.

## Notes

- The registry `segmented-control` is untouched; the lab now matches its motion recipe rather than the reverse.
- Verified on the worktree dev server: clicking a segment applies the FLIP start offset with the 0.15s transition, then releases it a frame later. The in-app browser pane never ticks animation frames, so the glide has to be watched in a real browser.
- `pnpm check` and `pnpm typecheck` pass.
