### PR TITLE
feat(www): color picker overlay and surface/border defaults

### DIFF
--- a/www/src/modules/control-lab/page.tsx
+++ b/www/src/modules/control-lab/page.tsx
@@ -426,7 +426,7 @@ const ENTRIES: Entry[] = [
     id: 'color-picker-row',
     name: 'ColorPickerRow',
     description:
-      'A color seed as a row: hex on the right beside its swatch, opening an area + hue + hex picker anchored to the trigger.',
+      'A color seed as a row: hex on the right beside its swatch, opening a picker anchored to the trigger — preset seeds, area, labelled hue, hex.',
     variants: [{ label: 'Default', render: <ColorDemo /> }],
   },
   {

--- a/www/src/modules/control-lab/rows.tsx
+++ b/www/src/modules/control-lab/rows.tsx
@@ -27,11 +27,20 @@ import { Button } from '@/registry/ui/button'
 import { ColorArea } from '@/registry/ui/color-area'
 import { ColorField } from '@/registry/ui/color-field'
 import { ColorPicker } from '@/registry/ui/color-picker'
-import { ColorSlider } from '@/registry/ui/color-slider'
+import {
+  ColorSlider,
+  ColorSliderControl,
+  ColorSliderOutput,
+} from '@/registry/ui/color-slider'
 import { ColorSwatch } from '@/registry/ui/color-swatch'
+import {
+  ColorSwatchPicker,
+  ColorSwatchPickerItem,
+} from '@/registry/ui/color-swatch-picker'
 import { Command } from '@/registry/ui/command'
 import { DialogContent } from '@/registry/ui/dialog'
 import { Disclosure, DisclosurePanel } from '@/registry/ui/disclosure'
+import { Label } from '@/registry/ui/field'
 import { Input, InputGroup, InputGroupAddon } from '@/registry/ui/input'
 import {
   ListBox,
@@ -261,6 +270,19 @@ export function SelectRow({
 
 /* ------------------------------ Color picker ------------------------------ */
 
+/** Hue-spaced seeds: one tap to a plausible brand before touching the area. */
+const COLOR_PRESETS = [
+  '#EF4444',
+  '#F97316',
+  '#EAB308',
+  '#22C55E',
+  '#14B8A6',
+  '#3B82F6',
+  '#8B5CF6',
+  '#EC4899',
+  '#F43F5E',
+]
+
 /** A color-picker trigger shaped as a settings row: label left, hex + swatch right. */
 export function ColorPickerRow({
   label,
@@ -284,23 +306,38 @@ export function ColorPickerRow({
               <ColorSwatch className="size-5 rounded-full" />
             </span>
           </Button>
-          <Popover placement="right top">
-            <DialogContent className="flex flex-col gap-2">
-              <div className="flex gap-2">
-                <ColorArea
-                  colorSpace="hsb"
-                  xChannel="saturation"
-                  yChannel="brightness"
-                />
-                <ColorSlider
-                  orientation="vertical"
-                  colorSpace="hsb"
-                  channel="hue"
-                  className="h-auto self-stretch"
-                />
-              </div>
+          <Popover placement="right top" className="w-64 min-w-0">
+            <DialogContent className="flex flex-col gap-3 p-3">
+              <ColorSwatchPicker className="justify-between gap-0">
+                {COLOR_PRESETS.map((preset) => (
+                  <ColorSwatchPickerItem
+                    key={preset}
+                    color={preset}
+                    className="size-5 rounded-full ring-offset-2 ring-offset-popover before:hidden selected:ring-2 selected:ring-(--color)"
+                  />
+                ))}
+              </ColorSwatchPicker>
+              <ColorArea
+                aria-label="Saturation and brightness"
+                colorSpace="hsb"
+                xChannel="saturation"
+                yChannel="brightness"
+                className="w-full rounded-xl"
+              />
+              <ColorSlider colorSpace="hsb" channel="hue" className="w-full">
+                <div className="flex items-baseline justify-between">
+                  <Label className={ROW_LABEL}>Hue</Label>
+                  <ColorSliderOutput className={ROW_VALUE} />
+                </div>
+                <ColorSliderControl className="h-5 rounded-full" />
+              </ColorSlider>
               <ColorField aria-label="Hex" className="w-full">
-                <Input size="sm" className="w-full" />
+                <InputGroup size="sm" className="w-full">
+                  <InputGroupAddon>
+                    <ColorSwatch className="size-4 rounded-full" />
+                  </InputGroupAddon>
+                  <Input className="font-mono uppercase" />
+                </InputGroup>
               </ColorField>
             </DialogContent>
           </Popover>

--- a/www/src/publisher/emit-theme.test.ts
+++ b/www/src/publisher/emit-theme.test.ts
@@ -40,7 +40,15 @@ describe('emitInitItem', () => {
     })
 
     expect(item.type).toBe('registry:base')
-    expect(item.css).toEqual(baseRegistryCss.css)
+    // Base CSS passes through, plus the vocabulary's per-mode re-points on `.dark`.
+    expect(item.css).toEqual({
+      ...baseRegistryCss.css,
+      '.dark': {
+        ...baseRegistryCss.css['.dark'],
+        '--color-popover':
+          'color-mix(in oklab, var(--neutral-50) 50%, var(--neutral-100))',
+      },
+    })
     // The semantic block ships resolved from the vocabulary (neutral primary).
     expect(item.cssVars?.theme).toMatchObject({
       '--color-bg': 'var(--neutral-25)',

--- a/www/src/registry/__generated__/base-css.ts
+++ b/www/src/registry/__generated__/base-css.ts
@@ -374,6 +374,7 @@ export const baseRegistryCss = {
 			"--chart-6": "oklch(0.5183 0.1337 253.25)",
 			"--chart-7": "oklch(0.4662 0.1337 254.29)",
 			"--chart-8": "oklch(0.4168 0.1337 255.28)",
+			"--color-popover": "color-mix(in oklab, var(--neutral-50) 50%, var(--neutral-100))",
 		},
 	},
 	cssVars: {
@@ -463,6 +464,7 @@ export const baseRegistryCss = {
 			"--color-fg-disabled": "var(--neutral-600)",
 			"--color-fg-on-neutral": "var(--neutral-950)",
 			"--color-border": "var(--neutral-400)",
+			"--color-border-muted": "var(--neutral-200)",
 			"--color-border-hover": "var(--neutral-500)",
 			"--color-border-active": "var(--neutral-600)",
 			"--color-border-field": "var(--neutral-500)",

--- a/www/src/registry/base/theme.css
+++ b/www/src/registry/base/theme.css
@@ -86,6 +86,7 @@
 	--color-fg-disabled: var(--neutral-600);
 	--color-fg-on-neutral: var(--neutral-950);
 	--color-border: var(--neutral-400);
+	--color-border-muted: var(--neutral-200);
 	--color-border-hover: var(--neutral-500);
 	--color-border-active: var(--neutral-600);
 	--color-border-field: var(--neutral-500);
@@ -101,5 +102,9 @@
 	--color-border-sidebar: var(--neutral-400);
 	--color-overlay: oklch(0 0 0);
 	--color-thumb: oklch(1 0 0);
+}
+
+.dark {
+	--color-popover: color-mix(in oklab, var(--neutral-50) 50%, var(--neutral-100));
 }
 /* END AUTO-GENERATED */

--- a/www/src/registry/theme/semantics.ts
+++ b/www/src/registry/theme/semantics.ts
@@ -182,6 +182,9 @@ export function semanticVocabulary(
     'color-fg-on-neutral': fg(ref('neutral', '950')),
     // ---- borders ----
     'color-border': bd(ref('neutral', '400'), NEUTRAL),
+    // Quiet edges on non-interactive containers (cards, separators) — the
+    // Radix step-6 role; `color-border` keeps the interactive-adjacent weight.
+    'color-border-muted': bd(ref('neutral', '200'), NEUTRAL),
     'color-border-hover': bd(ref('neutral', '500'), NEUTRAL),
     'color-border-active': bd(ref('neutral', '600'), NEUTRAL),
     'color-border-field': bd(ref('neutral', '500'), NEUTRAL),
@@ -199,7 +202,17 @@ export function semanticVocabulary(
     'color-tooltip': bg(ref('neutral', '950'), NEUTRAL),
     'color-fg-on-tooltip': fg(ref('neutral', '25')),
     'color-card': bg(ref('neutral', '50'), NEUTRAL),
-    'color-popover': bg(ref('neutral', '50'), NEUTRAL),
+    // Dark overlays get their own rung between card (50) and muted (100), so a
+    // popover lifts off the card it floats over while field/muted content
+    // inside it still reads. Light keeps the card value — there the shadow
+    // separates, as in Atlassian/shadcn.
+    'color-popover': bg(
+      {
+        light: ref('neutral', '50'),
+        dark: mix(ref('neutral', '50'), 50, ref('neutral', '100')),
+      },
+      NEUTRAL,
+    ),
     'color-sidebar': bg(ref('neutral', '50'), NEUTRAL),
     'color-border-sidebar': bd(ref('neutral', '400'), NEUTRAL),
     // ---- overlay / chrome (previously hardcoded in components) ----

--- a/www/src/registry/ui/card/styles.ts
+++ b/www/src/registry/ui/card/styles.ts
@@ -5,7 +5,7 @@ import cardMeta from './meta'
 const { useStyles, styles } = createStyles(cardMeta, {
   base: {
     slots: {
-      root: 'group/card flex flex-col rounded-(--card-radius) border bg-card shadow-[var(--shadow-card,none)] has-[>img:first-child]:pt-0 *:[img]:first:rounded-t-(--card-radius) *:[img]:last:rounded-b-(--card-radius)',
+      root: 'group/card flex flex-col rounded-(--card-radius) border border-border-muted bg-card shadow-[var(--shadow-card,none)] has-[>img:first-child]:pt-0 *:[img]:first:rounded-t-(--card-radius) *:[img]:last:rounded-b-(--card-radius)',
       header:
         'group/card-header @container/card-header grid auto-rows-min items-start rounded-t-(--card-radius) has-data-card-action:grid-cols-[1fr_auto] has-data-card-description:grid-rows-[auto_auto]',
       title: 'font-heading',

--- a/www/src/registry/ui/modal/meta.ts
+++ b/www/src/registry/ui/modal/meta.ts
@@ -35,7 +35,7 @@ const modalMeta = {
       kind: 'scalar',
       type: 'color',
       cssVar: '--modal-background',
-      default: '--color-bg',
+      default: '--color-popover',
       description: 'Background color of the modal surface.',
     },
     radius: {

--- a/www/src/registry/ui/modal/styles.css
+++ b/www/src/registry/ui/modal/styles.css
@@ -1,6 +1,6 @@
 :root {
   --modal-backdrop-blur: var(--blur-sm);
   --modal-backdrop-opacity: 40%;
-  --modal-background: var(--color-bg);
+  --modal-background: var(--color-popover);
   --modal-radius: var(--radius-lg);
 }

--- a/www/src/registry/ui/separator/styles.ts
+++ b/www/src/registry/ui/separator/styles.ts
@@ -4,7 +4,7 @@ import separatorMeta from './meta'
 
 const { useStyles, styles } = createStyles(separatorMeta, {
   base: {
-    base: 'separator shrink-0 border-0 bg-border',
+    base: 'separator shrink-0 border-0 bg-border-muted',
     variants: {
       orientation: {
         horizontal: 'h-px w-full',


### PR DESCRIPTION
## What

Two related changes to the Control Lab picker and the surface/border defaults it exposed.

### 1. Control Lab color picker overlay redesign

`ColorPickerRow`'s popover now matches the reference: preset swatch row (9 hue-spaced seeds via `ColorSwatchPicker`, selection ring in the seed's own color), full-width saturation/brightness area, labelled hue slider with live degree output, hex field with leading swatch. Popover pinned to `w-64 min-w-0`.

### 2. Surface & border defaults (dark elevation)

The picker work exposed that dark overlays had no elevation story: card = popover = sidebar all resolved to `neutral-50`, the modal defaulted *below* them (`--color-bg`), and the only border rung near containers was `neutral-400` — a border/surface ratio of 4.3 where Linear/Geist/shadcn cluster near 1.

- `--color-popover` is now per-mode: light keeps `neutral-50` (shadow separates, as in Atlassian/shadcn light); dark gets `mix(neutral-50, 50%, neutral-100)` — a rung ΔL .027 above card, matching Atlassian's (.025) and Linear's (.03) elevation steps while keeping `field`/`muted` content readable inside overlays. First per-mode default; emitted as the generated `.dark` block.
- New `--color-border-muted` (`neutral-200`) — the Radix step-6 role: quiet edges on non-interactive containers. Consumed by Card (outer border) and Separator. Interactive components keep the `border` → `border-hover` → `border-active` ladder untouched.
- `--modal-background` default: `--color-bg` → `--color-popover` (meta default + styles.css kept in sync).

Dark ladder before → after:

| step | before | after |
|---|---|---|
| card → popover | .000 | .027 |
| popover → its border (ratio) | 4.3 | 2.3 |
| card border vs surface step (ratio) | 4.3 | 2.1 |

Verified live in both modes: picker/menu popovers lift off cards, modal reads above the scrim, themed preview scopes re-emit the per-mode default correctly. `pnpm check`, `tsc`, overrides tests (9/9), registry regenerated.

## Suggested follow-ups (separate issues)

- **Shadow defaults**: `--shadow-overlay/card/control` ship unset and the popover fallback (`shadow-md`, 10% black) is invisible in dark. Real fix needs per-mode shadow values (`color-scheme` + `light-dark()`, or per-mode token slots) — deliberately not bolted on here.
- **Divider inversion**: card footer (`card/styles.ts:78`) and dialog footer (`modal/styles.ts:39`) draw internal dividers at n400, now stronger than their containers' n200/floating edges. Same question for command's search divider inside popovers.
- **Card-family drift**: `alert`, `color-editor`, `group` addons, and the labeled wrappers of checkbox/radio/switch render card-like statics but keep the n400 border — decide whether they follow card → `border-muted`.
- **Darker-than-surface hairlines**: the engine's `solveBorderTarget` only searches away from the background, so Linear-style grooves (divider darker than its dark surface) are unreachable; the labs hand-roll them as `divide-bg/50`.
