### PR TITLE
feat(www): add Origin preset as the landing default

### DIFF
--- a/www/src/modules/marketing/cta-section.tsx
+++ b/www/src/modules/marketing/cta-section.tsx
@@ -35,7 +35,7 @@ import type { Preset } from '@/modules/presets/presets-data'
  * the copied `init` URL. The editor is the quiet second path underneath.
  */
 export function CtaSection() {
-  const [presetId, setPresetId] = useState<string | null>('claude')
+  const [presetId, setPresetId] = useState<string | null>('origin')
   const preset = PRESETS.find((p) => p.id === presetId) ?? null
   const ds = preset?.designSystem ?? DEFAULTS
 
@@ -100,9 +100,10 @@ function InstallCommand({
 
   const baseUrl = `${siteConfig.url}/r/init`
   // The encoded preset is a few hundred chars — display it truncated, copy it
-  // whole.
-  const displayUrl = preset
-    ? `${baseUrl}?preset=${(encoded ?? '').slice(0, BLOB_PREVIEW_CHARS)}…`
+  // whole. No param while the codec loads or when the preset is the builder
+  // defaults (`''` — the plain URL already is that preset).
+  const displayUrl = encoded
+    ? `${baseUrl}?preset=${encoded.slice(0, BLOB_PREVIEW_CHARS)}…`
     : baseUrl
   const displayCommand = buildInitCommands(displayUrl)[packageManager]
   // Widest command the slot can show (`yarn dlx` prefix + truncated preset) —

--- a/www/src/modules/presets/presets-data.ts
+++ b/www/src/modules/presets/presets-data.ts
@@ -84,6 +84,14 @@ function makeDesignSystem(opts: {
 
 export const PRESETS: Preset[] = [
   {
+    id: 'origin',
+    name: 'Origin',
+    description: 'dotUI blue, the starting point.',
+    swatch: '#438cd6',
+    // The untouched builder defaults — absent `color` is the default palette.
+    designSystem: DEFAULTS,
+  },
+  {
     id: 'claude',
     name: 'Claude',
     description: 'Warm coral on sand.',


### PR DESCRIPTION
Adds **Origin** — the preset embodying dotUI's own identity — and opens the landing on it.

- `presets-data.ts`: Origin is the first `PRESETS` entry; its design system is the builder `DEFAULTS` themselves (absent `color` = the default generated palette), so it can never drift from the real defaults. Swatch is the default accent `#438cd6`.
- `cta-section.tsx`: the closing CTA starts on Origin instead of Claude, and the displayed install command shows the plain `/r/init` URL when the selected preset encodes to the builder defaults (previously it would render a dangling `?preset=…`).

Verified via SSR: the showcase switcher renders Origin as the first, selected segment; the CTA pill shows Origin; the visible command has no stray param. `pnpm check` and `pnpm typecheck` pass.

Naming context: house presets will use a geometry family (Origin, Arc, Vertex, Grid, …) — Origin is the starting point.