### PR TITLE
feat(www): give Origin a blue accent and selection ramp

### DIFF
--- a/www/src/modules/presets/presets-data.ts
+++ b/www/src/modules/presets/presets-data.ts
@@ -4,7 +4,7 @@ import {
   FONT_SANS_VAR,
   fontStack,
 } from '@/lib/fonts'
-import type { ColorConfig } from '@/registry/theme'
+import { DEFAULT_COLOR_CONFIG, type ColorConfig } from '@/registry/theme'
 import { DEFAULTS, type DesignSystem } from '@/modules/create/preset'
 
 /**
@@ -82,14 +82,29 @@ function makeDesignSystem(opts: {
   }
 }
 
+/** Geist's measured blue: Vercel's selection ramp, Origin's accent + selection. */
+const SELECTION_BLUE = '#0072f5'
+
 export const PRESETS: Preset[] = [
   {
     id: 'origin',
     name: 'Origin',
     description: 'dotUI blue, the starting point.',
-    swatch: '#438cd6',
-    // The untouched builder defaults — absent `color` is the default palette.
-    designSystem: DEFAULTS,
+    swatch: SELECTION_BLUE,
+    // Tracks the builder defaults on every axis but the brand blue, which drives
+    // both the accent ramp and — since `primary` stays absent (neutral
+    // black/white actions) — the split selection + focus ramp.
+    designSystem: {
+      ...DEFAULTS,
+      color: {
+        ...DEFAULT_COLOR_CONFIG,
+        seeds: {
+          ...DEFAULT_COLOR_CONFIG.seeds,
+          accent: SELECTION_BLUE,
+          selection: SELECTION_BLUE,
+        },
+      },
+    },
   },
   {
     id: 'claude',
@@ -182,7 +197,7 @@ export const PRESETS: Preset[] = [
       // controls. The #171717 accent + #737373 neutral seeds are already
       // achromatic, so the monochrome chrome needs no vividness clamp — and
       // clamping it would flatten this chromatic selection ramp back to gray.
-      selection: '#0072f5',
+      selection: SELECTION_BLUE,
       // Vercel dark runs a true-black page with #0a0a0a panels; dark:0 lands
       // n50 (the card step) on 0x0a0a0a exactly.
       background: { dark: 0 },


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## Summary

- Origin was `designSystem: DEFAULTS` verbatim — a passthrough of the builder defaults, so the gallery's "starting point" had no identity of its own and its picker dot showed a blue (`#438cd6`) the preset never actually rendered as a brand color.
- It now spreads `...DEFAULTS` and overrides one thing: Geist's `#0072f5` drives **both** the accent ramp and the split selection + focus ramp. `primary` stays absent, so primary actions remain the default neutral black/white.
- The blue is a single `SELECTION_BLUE` constant that Vercel's `selection:` seed now references too, so the two can't drift apart by typo. The Origin swatch reuses it.

Spreading `...DEFAULTS` is deliberate: Origin keeps tracking the builder defaults on every other axis (density, radius, typography, component params), so future default changes flow into it for free. Only the color seeds are Origin-only.

## Reviewer notes

- **Origin no longer matches the docs site's own look.** The site renders with no `DesignSystemProvider` at the root, so it falls back to the registry defaults (accent `#438cd6`, no split selection ramp) — the Origin card in the gallery is now bluer than the page around it. If we'd rather the site move too, that's a one-line change to `DEFAULT_COLOR_CONFIG.seeds.accent` in `www/src/registry/theme/color-config.ts`, which would also change what CLI users install; happy to fold it in.
- No registry source touched, so no `__generated__` drift and no change to CLI output.

## Verification

- Landing-page SSR emits an Origin scope whose `--accent-*` and `--selection-*` ramps are identical, solid step at `oklch(0.5787 0.2113 258.04)` ≈ `#0072f5`.
- `pnpm check` (0 errors), `pnpm typecheck`, `pnpm test` (235 passed, incl. the preset codec and publish-smoke tests).
