### PR TITLE
fix(www): align the landing page to one 1440px container

### DIFF
--- a/www/src/components/layout/footer.tsx
+++ b/www/src/components/layout/footer.tsx
@@ -1,6 +1,6 @@
 export function Footer() {
   return (
-    <footer className="mx-auto flex h-24 w-full max-w-[calc(1500px+16rem)] items-center justify-center px-4 sm:px-6 lg:px-32">
+    <footer className="flex h-24 items-center justify-center">
       <p className="text-center text-sm text-fg-muted">
         Built with passion by{' '}
         <a

--- a/www/src/modules/marketing/cards.tsx
+++ b/www/src/modules/marketing/cards.tsx
@@ -18,38 +18,45 @@ export function Cards() {
   }, [])
 
   return (
-    <div className="relative flex flex-col [--grid-max:1500px] [--rail-gap:--spacing(5)] [--rail-peek:2.5rem] sm:[--rail-peek:3.5rem] md:[--rail-peek:5rem] lg:[--rail-peek:7rem]">
+    <div className="relative flex flex-col [--rail-gap:--spacing(5)]">
       {/* Preset wash: the whole section sits on the selected preset's own
           background — the resolved --color-bg from the shared scoped
-          stylesheet, per light/dark mode — spanning the full viewport width.
-          The outer div fades the top edge, the inner div fades the bottom;
-          nested masks instead of mask-composite for browser compatibility.
-          --preset-wash-bg is registered as a <color> in styles.css so it
-          tweens on preset switch. */}
+          stylesheet, per light/dark mode — spanning the full viewport width
+          (broken out of the landing container). The outer div fades the top
+          edge, the inner div fades the bottom; nested masks instead of
+          mask-composite for browser compatibility. --preset-wash-bg is
+          registered as a <color> in styles.css so it tweens on preset switch. */}
       <DesignSystemProvider scoped color={preset.color}>
         <div
           aria-hidden
-          className="pointer-events-none absolute inset-x-0 -top-56 bottom-0 -z-20 [mask-image:linear-gradient(to_bottom,transparent,black_24rem)]"
+          className="pointer-events-none absolute inset-x-[calc(50%-50vw)] -top-56 bottom-0 -z-20 [mask-image:linear-gradient(to_bottom,transparent,black_24rem)]"
         >
           <div className="size-full bg-(--preset-wash-bg) [mask-image:linear-gradient(to_bottom,black_calc(100%-24rem),transparent)] [--preset-wash-bg:var(--color-bg)] motion-safe:transition-[--preset-wash-bg] motion-safe:duration-700" />
         </div>
       </DesignSystemProvider>
       <PresetSwitcher selected={selected} onSelect={handleSelect} />
-      {/* Below lg (no rails) the grid left-aligns to the header logo's padding
-          (--crop-pl mirrors the header's pl-4 md:pl-6) and crops only on the
-          right; lg+ recenters between the rails. */}
-      <div className="relative flex justify-start gap-5 overflow-hidden [mask-image:linear-gradient(to_bottom,black_calc(100%_-_var(--mask-solid)),transparent_calc(100%_-_var(--mask-clear)))] pl-(--crop-pl) [--crop-pl:--spacing(4)] [--mask-clear:45px] [--mask-solid:180px] md:[--crop-pl:--spacing(6)] lg:justify-center lg:pl-0">
+      {/* Below lg (no rails) the grid left-aligns to the container padding
+          (--crop-pl mirrors it for the crop mask math) and crops only on the
+          right; on lg it fills the container and the rails hang off its sides,
+          clipped at the viewport by the page root. */}
+      {/* The bottom fade can't live on this wrapper: a mask clips painting to
+          the element's border box, which would erase the rails hanging outside
+          it — so the grid and each rail carry their own copy (same geometry:
+          the rails span the wrapper's height). */}
+      <div className="relative [--crop-pl:--spacing(4)] [--mask-clear:45px] [--mask-solid:180px] sm:[--crop-pl:--spacing(6)]">
         <SkeletonRail side="left" />
-        <DesignSystemProvider
-          scoped
-          params={preset.componentParams}
-          tokens={preset.tokens}
-          density={preset.density}
-          color={preset.color}
-          icons={preset.icons}
-        >
-          <CardsGrid className="relative z-20 w-[max(52rem,150vw)] max-w-none shrink-0 [zoom:0.8] [mask-image:linear-gradient(to_right,black_calc(125vw_-_1.25*var(--crop-pl)_-_1.25*var(--edge-fade)),transparent_calc(125vw_-_1.25*var(--crop-pl)))] [--edge-fade:2.5rem] lg:w-full lg:max-w-(--grid-max) lg:min-w-0 lg:shrink lg:[zoom:1] lg:[mask-image:none]" />
-        </DesignSystemProvider>
+        <div className="[mask-image:linear-gradient(to_bottom,black_calc(100%_-_var(--mask-solid)),transparent_calc(100%_-_var(--mask-clear)))]">
+          <DesignSystemProvider
+            scoped
+            params={preset.componentParams}
+            tokens={preset.tokens}
+            density={preset.density}
+            color={preset.color}
+            icons={preset.icons}
+          >
+            <CardsGrid className="relative z-20 w-[max(52rem,150vw)] max-w-none [zoom:0.8] [mask-image:linear-gradient(to_right,black_calc(125vw_-_1.25*var(--crop-pl)_-_1.25*var(--edge-fade)),transparent_calc(125vw_-_1.25*var(--crop-pl)))] [--edge-fade:2.5rem] lg:w-full lg:[zoom:1] lg:[mask-image:none]" />
+          </DesignSystemProvider>
+        </div>
         <SkeletonRail side="right" />
       </div>
     </div>

--- a/www/src/modules/marketing/cards.tsx
+++ b/www/src/modules/marketing/cards.tsx
@@ -42,8 +42,11 @@ export function Cards() {
       {/* The bottom fade can't live on this wrapper: a mask clips painting to
           the element's border box, which would erase the rails hanging outside
           it — so the grid and each rail carry their own copy (same geometry:
-          the rails span the wrapper's height). */}
-      <div className="relative [--crop-pl:--spacing(4)] [--mask-clear:45px] [--mask-solid:180px] sm:[--crop-pl:--spacing(6)]">
+          the rails span the wrapper's height). Below lg the wrapper breaks out
+          of the container padding for the same reason: the grid overflows to
+          the viewport edge there, and a container-width mask would crop it
+          short of its own right-edge fade. */}
+      <div className="relative -mx-4 pl-(--crop-pl) [--crop-pl:--spacing(4)] [--mask-clear:45px] [--mask-solid:180px] sm:-mx-6 sm:[--crop-pl:--spacing(6)] lg:mx-0 lg:pl-0">
         <SkeletonRail side="left" />
         <div className="[mask-image:linear-gradient(to_bottom,black_calc(100%_-_var(--mask-solid)),transparent_calc(100%_-_var(--mask-clear)))]">
           <DesignSystemProvider

--- a/www/src/modules/marketing/composition-section.tsx
+++ b/www/src/modules/marketing/composition-section.tsx
@@ -77,8 +77,7 @@ export function CompositionSection() {
   }
 
   return (
-    // Width mirrors the cards strip: 1500px grid + 8rem rail gutters.
-    <section className="mx-auto w-full max-w-[calc(1500px+16rem)] px-4 sm:px-6 lg:px-32">
+    <section>
       <CompositionTransitionStyles />
       <StepTimer player={player} />
       <div

--- a/www/src/modules/marketing/cta-section.tsx
+++ b/www/src/modules/marketing/cta-section.tsx
@@ -40,7 +40,7 @@ export function CtaSection() {
   const ds = preset?.designSystem ?? DEFAULTS
 
   return (
-    <section className="relative overflow-x-clip">
+    <section className="relative">
       {/* Density is pinned rather than taken from the preset: it's the one axis
           that resizes the pill, and a command that changes height mid-switch
           reads as a layout glitch instead of a re-theme. */}
@@ -52,7 +52,7 @@ export function CtaSection() {
         color={ds.color}
         icons={ds.icons}
       >
-        <div className="container flex flex-col items-center text-center">
+        <div className="flex flex-col items-center text-center">
           <h2 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-3xl leading-tight font-normal tracking-[-0.05em] text-balance text-fg antialiased sm:text-5xl">
             <span className="block">Your design system,</span>
             <span className="block text-fg-muted">one command away.</span>

--- a/www/src/modules/marketing/export-section.tsx
+++ b/www/src/modules/marketing/export-section.tsx
@@ -9,7 +9,7 @@ import { V0Icon } from '@/components/icons/v0'
 
 export function ExportSection() {
   return (
-    <section className="mx-auto w-full max-w-[calc(1500px+16rem)] px-4 sm:px-6 lg:px-32">
+    <section>
       <div className="flex flex-col items-start gap-4">
         <h2 className="font-mono text-sm tracking-wide text-fg-muted">
           Export

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -16,78 +16,88 @@ import { ExportSection } from '@/modules/marketing/export-section'
 
 export function HomePage() {
   return (
-    <div>
-      {/* Hero section */}
-      <section className="container flex flex-col pt-14 sm:pt-18 md:pt-26">
-        <div className="flex flex-col items-center text-center">
-          <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.75rem,calc((100vw-2rem)/10.3),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-none">
-            The Design System Studio
-            <br />
-            <span className="text-fg-muted">for the Web</span>
-          </h1>
-          <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
-            Every design decision is yours, previewed live on real components.
-            Install with the shadcn CLI, or export straight to v0.
-          </p>
-          <div className="mt-9 flex items-center gap-3">
-            <LinkButton href="/create" variant="primary" size="lg">
-              Start building
-            </LinkButton>
-            <LinkButton href="/docs/components" variant="secondary" size="lg">
-              View components
-            </LinkButton>
+    // One container for the whole landing; every section aligns to its 1440px
+    // content box. Decorations that bleed past it (cards rails, full-bleed
+    // washes, the CTA backlight) are clipped at the viewport by the root.
+    <div className="overflow-x-clip">
+      <div className="container">
+        {/* Hero section */}
+        <section className="flex flex-col pt-14 sm:pt-18 md:pt-26">
+          <div className="flex flex-col items-center text-center">
+            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.75rem,calc((100vw-2rem)/10.3),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-none">
+              The Design System Studio
+              <br />
+              <span className="text-fg-muted">for the Web</span>
+            </h1>
+            <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
+              Every design decision is yours, previewed live on real components.
+              Install with the shadcn CLI, or export straight to v0.
+            </p>
+            <div className="mt-9 flex items-center gap-3">
+              <LinkButton href="/create" variant="primary" size="lg">
+                Start building
+              </LinkButton>
+              <LinkButton href="/docs/components" variant="secondary" size="lg">
+                View components
+              </LinkButton>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <section className="mt-24">
-        <Cards />
-      </section>
+        <section className="mt-24">
+          <Cards />
+        </section>
 
-      {/* Tools section. Hero, cards and tools read as one opening block, so
-          they keep their own tight spacing instead of the section rhythm. */}
-      <section className="relative z-10 -mt-[20px] pt-12 shadow-xs">
-        <div className="container flex flex-col items-center justify-center gap-5 lg:gap-10">
-          <h2 className="font-mono text-sm tracking-wide text-pretty text-fg-muted xs:text-base lg:text-base">
-            Built on modern tools
-          </h2>
-          <div className="flex flex-wrap items-center justify-center gap-6 sm:gap-8">
-            {tools.map(({ icon, label, href }) => (
-              <Tooltip key={href}>
-                <Link
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label={label}
-                  className="flex items-center justify-center opacity-60 grayscale-100 transition-opacity hover:opacity-100 hover:grayscale-0"
-                  href={href}
-                >
-                  {icon}
-                </Link>
-                <TooltipContent placement="top">{label}</TooltipContent>
-              </Tooltip>
-            ))}
+        {/* Tools section. Hero, cards and tools read as one opening block, so
+            they keep their own tight spacing instead of the section rhythm. */}
+        <section className="relative z-10 -mt-[20px] pt-12">
+          {/* The hairline spans the viewport, like the cards wash it sits over. */}
+          <div
+            aria-hidden
+            className="absolute inset-x-[calc(50%-50vw)] inset-y-0 -z-10 shadow-xs"
+          />
+          <div className="flex flex-col items-center justify-center gap-5 lg:gap-10">
+            <h2 className="font-mono text-sm tracking-wide text-pretty text-fg-muted xs:text-base lg:text-base">
+              Built on modern tools
+            </h2>
+            <div className="flex flex-wrap items-center justify-center gap-6 sm:gap-8">
+              {tools.map(({ icon, label, href }) => (
+                <Tooltip key={href}>
+                  <Link
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={label}
+                    className="flex items-center justify-center opacity-60 grayscale-100 transition-opacity hover:opacity-100 hover:grayscale-0"
+                    href={href}
+                  >
+                    {icon}
+                  </Link>
+                  <TooltipContent placement="top">{label}</TooltipContent>
+                </Tooltip>
+              ))}
+            </div>
           </div>
+        </section>
+
+        {/* Section rhythm lives here, not inside the sections: one gap between
+            peers, one step up before the CTA so the page reads as ending. */}
+        <div className="mt-24 md:mt-32">
+          <CompositionSection />
         </div>
-      </section>
 
-      {/* Section rhythm lives here, not inside the sections: one gap between
-          peers, one step up before the CTA so the page reads as ending. */}
-      <div className="mt-24 md:mt-32">
-        <CompositionSection />
-      </div>
+        {/* Tighter than the section gap: composition ends on a heavy code block
+            and export opens on a small label, so equal space reads as more. */}
+        <div className="mt-16 md:mt-24">
+          <ExportSection />
+        </div>
 
-      {/* Tighter than the section gap: composition ends on a heavy code block
-          and export opens on a small label, so equal space reads as more. */}
-      <div className="mt-16 md:mt-24">
-        <ExportSection />
-      </div>
+        <div className="mt-32 md:mt-44">
+          <CtaSection />
+        </div>
 
-      <div className="mt-32 md:mt-44">
-        <CtaSection />
-      </div>
-
-      <div className="mt-24 md:mt-32">
-        <Footer />
+        <div className="mt-24 md:mt-32">
+          <Footer />
+        </div>
       </div>
     </div>
   )

--- a/www/src/modules/marketing/preset-switcher.tsx
+++ b/www/src/modules/marketing/preset-switcher.tsx
@@ -45,7 +45,9 @@ export function PresetSwitcher({
   } as React.CSSProperties
 
   return (
-    <div className="mb-5 no-scrollbar flex max-w-full scroll-fade-x overflow-x-auto px-4">
+    // Negative margins cancel the landing container's padding so the row still
+    // scrolls edge-to-edge on small screens; lg fits without overflowing.
+    <div className="-mx-4 mb-5 no-scrollbar flex scroll-fade-x overflow-x-auto px-4 sm:-mx-6 sm:px-6 lg:mx-0 lg:px-0">
       <SegmentedControl
         aria-label="Preview design system"
         className="mx-auto bg-transparent p-0 [&_[data-segmented-control-indicator]]:rounded-(--indicator-radius) [&_[data-segmented-control-indicator]]:bg-(--indicator-bg) [&_[data-segmented-control-indicator]]:motion-safe:transition-[translate,width,height,border-radius,background-color]"

--- a/www/src/modules/marketing/skeleton-cards.tsx
+++ b/www/src/modules/marketing/skeleton-cards.tsx
@@ -6,11 +6,12 @@ import { Skeleton } from '@/registry/ui/skeleton'
 
 /*
  * Decorative skeleton-card rails that flank the real showcase grid on large
- * screens — the same idea as shadcn's homepage `CardsSkeletonRails`. They live
- * in the gutters beside the centered real grid and are clipped by the parent's
- * `overflow-hidden`, so they peek in from both edges and reveal more as the
- * viewport widens. Purely decorative: wrapped in a single <Skeleton isLoading>
- * (which adds `inert` + shimmer) and `aria-hidden`.
+ * screens — the same idea as shadcn's homepage `CardsSkeletonRails`. Each rail
+ * hangs absolutely off its side of the grid, overflowing the landing container;
+ * the page root's `overflow-x-clip` crops it at the viewport, so it peeks in
+ * from the edge and reveals more as the viewport widens. Purely decorative:
+ * wrapped in a single <Skeleton isLoading> (which adds `inert` + shimmer) and
+ * `aria-hidden`.
  */
 
 // A single shimmering block. `data-skeleton` is picked up by the parent
@@ -174,21 +175,20 @@ export const SkeletonRail = memo(function SkeletonRail({
       isLoading
       aria-hidden="true"
       className={cn(
-        'relative hidden shrink-0 grow basis-(--rail-peek) overflow-hidden opacity-70 lg:block',
+        'absolute inset-y-0 hidden w-(--rail-w) overflow-hidden opacity-70 lg:block',
         '[--rail-col:18rem] [--rail-w:calc(var(--rail-col)*2+var(--rail-gap))]',
         side === 'left'
-          ? '[mask-image:linear-gradient(to_left,black_92%,transparent)]'
-          : '[mask-image:linear-gradient(to_right,black_92%,transparent)]',
+          ? 'right-full mr-(--rail-gap) [mask-image:linear-gradient(to_left,black_92%,transparent)]'
+          : 'left-full ml-(--rail-gap) [mask-image:linear-gradient(to_right,black_92%,transparent)]',
       )}
     >
-      <div
-        className={cn(
-          'absolute top-0 grid w-(--rail-w) grid-cols-2 gap-(--rail-gap) opacity-45',
-          side === 'left' ? 'right-0' : 'left-0',
-        )}
-      >
-        <RailColumn cards={colA} />
-        <RailColumn cards={colB} />
+      {/* Same bottom fade as the grid, sized by the rail (not the taller,
+          clipped column) so both fade in lockstep. */}
+      <div className="absolute inset-0 [mask-image:linear-gradient(to_bottom,black_calc(100%_-_var(--mask-solid)),transparent_calc(100%_-_var(--mask-clear)))]">
+        <div className="absolute inset-x-0 top-0 grid grid-cols-2 gap-(--rail-gap) opacity-45">
+          <RailColumn cards={colA} />
+          <RailColumn cards={colB} />
+        </div>
       </div>
     </Skeleton>
   )

--- a/www/src/styles.css
+++ b/www/src/styles.css
@@ -44,7 +44,7 @@
 }
 
 @utility container {
-  @apply mx-auto max-w-[1440px] px-4 sm:px-6 lg:px-10 3xl:max-w-screen-2xl;
+  @apply mx-auto max-w-[1440px] px-4 sm:px-6 lg:px-10;
 }
 
 @utility step {


### PR DESCRIPTION
The landing page used three different width systems whose content edges never lined up, so section edges visibly disagreed and the mismatch inverted depending on screen size.

| Section | Was | Content cap | Gutter at lg |
|---|---|---|---|
| Hero, tools, CTA | `container` | 1360px | 40px |
| Composition, Export, Footer | `max-w-[calc(1500px+16rem)]` | 1500px | 128px |
| Cards | own `--grid-max: 1500px` rail system | 1500px | its own `--rail-peek` |

At a 1440px viewport the hero content sat 40px from the screen edge while composition/export/footer sat 128px in — an 88px jump between consecutive sections. Past ~1550px it inverted: the `container` sections froze at 1360px while the others kept growing to 1500px, so the "narrow" sections became the wide ones.

## What changed

Everything now aligns to one 1440px container.

- **`styles.css`** — the `container` utility is a plain `max-w-[1440px]`. Dropped the `3xl:max-w-screen-2xl` bump: past 1920px it widened the container by only 96px, imperceptible on its own and actively confusing next to the 1500px sections.
- **`home-page.tsx`** — a single `container` div wraps every section, inside an `overflow-x-clip` root that clips the decorations meant to bleed past it. Hero, tools, composition, export, CTA and footer all lost their own width wrappers.
- **`cards.tsx`** — the grid fills the container (no more `--grid-max`); the preset wash breaks out to full viewport width via `inset-x-[calc(50%-50vw)]`, as does the tools-section hairline that sits over it.
- **`skeleton-cards.tsx`** — the rails are now positioned absolutely off the grid's sides (`right-full` / `left-full`), clipped at the viewport by the page root. The flex `--rail-peek` / `--grid-max` machinery is gone.

## Two masking bugs found while verifying

A CSS mask clips painting to the element's border box, which bit twice:

1. The strip's bottom-fade mask was erasing the newly absolute rails entirely (black gutters). The fade now lives on a grid-only wrapper, with a matching copy inside each rail so both fade in lockstep.
2. Below `lg` the grid deliberately overflows to the viewport edge and fades there, but the container-width fade wrapper cut it off hard at the container edge. Below `lg` the strip now cancels the container padding (`-mx-4 sm:-mx-6` + `pl-(--crop-pl)`), restoring its original full-width geometry; at `lg` it returns to container width.

## Verification

Measured in-browser at 375 / 900 / 1440 / 1600 / 1800 / 2400px: every section's content edge is identical (40px gutters at lg), wash and hairline are full-bleed, rails peek from both edges and grow with the viewport, the below-`lg` grid fades at the screen edge, and `document.scrollWidth === viewport` everywhere (no stray horizontal scroll). `pnpm check` and `pnpm typecheck` pass; no registry files touched.

## Notes

- The `container` utility is shared with `not-found.tsx` and `default-error.tsx`. Both are centered single-column pages, so losing the 3xl bump is not visible there.
- Side effect worth a look: the cards grid is now wider at laptop sizes (it fills 1360px rather than shrinking to leave ~112px rail peeks), so the rails show less until the screen gets wide. That follows directly from aligning the grid to the container.

## Suggested refactors

- The custom `@utility container` extends Tailwind's built-in rather than replacing it, so the compiled output still carries the built-in's per-breakpoint max-width ladder (40/48/64/80/96rem) as dead, overridden declarations. Harmless today since the custom rule sorts later and wins, but it means the container's width depends on utility sort order. Worth resolving separately.
