### PR TITLE
feat(www): simplify option grid selection and add plain variant

### DIFF
--- a/www/src/modules/control-lab/page.tsx
+++ b/www/src/modules/control-lab/page.tsx
@@ -403,9 +403,11 @@ function StepperDemo({ described }: { described?: boolean }) {
 function OptionGridDemo({
   columns,
   described,
+  plain,
 }: {
   columns: number
   described?: boolean
+  plain?: boolean
 }) {
   const [value, setValue] = useState(columns === 1 ? 'outline' : 'solid')
   return (
@@ -420,6 +422,7 @@ function OptionGridDemo({
       onChange={setValue}
       options={columns === 1 ? INPUT_STYLES : BUTTON_STYLES}
       columns={columns}
+      variant={plain ? 'plain' : undefined}
     />
   )
 }
@@ -675,6 +678,7 @@ const GROUPS: Group[] = [
         variants: [
           { label: '1 column', render: <OptionGridDemo columns={1} /> },
           { label: '2 columns', render: <OptionGridDemo columns={2} /> },
+          { label: 'Plain', render: <OptionGridDemo columns={2} plain /> },
           {
             label: 'With description',
             render: <OptionGridDemo columns={2} described />,

--- a/www/src/modules/control-lab/rows.tsx
+++ b/www/src/modules/control-lab/rows.tsx
@@ -971,12 +971,15 @@ function OptionGrid({
   onChange,
   options,
   columns = 2,
+  variant = 'card',
 }: {
   ariaLabel: string
   value: string
   onChange: (id: string) => void
   options: OptionGridItem[]
   columns?: number
+  /** `plain` drops the card surface: specimens sit right on the panel. */
+  variant?: 'card' | 'plain'
 }) {
   return (
     <RacToggleButtonGroup
@@ -996,10 +999,14 @@ function OptionGrid({
           key={option.id}
           id={option.id}
           aria-label={option.label}
-          className="relative isolate flex min-w-0 cursor-interactive items-center justify-center rounded-lg bg-bg/50 p-4 focus-reset transition-[background-color,transform] hover:bg-bg/75 focus-visible:focus-ring motion-safe:pressed:scale-[0.98]"
+          className={cn(
+            'relative flex min-w-0 cursor-interactive items-center justify-center rounded-lg p-4 focus-reset transition-transform after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:bg-white/5 after:opacity-0 after:transition-opacity hover:after:opacity-100 focus-visible:focus-ring motion-safe:pressed:scale-[0.98]',
+            variant === 'card'
+              ? 'bg-bg selected:inset-ring selected:inset-ring-accent'
+              : 'border border-border transition-[background-color,transform] selected:bg-white/10',
+          )}
         >
-          <SelectionIndicator className="pointer-events-none absolute inset-0 rounded-lg bg-bg inset-ring inset-ring-accent duration-200 ease-out motion-safe:transition-[translate,width,height]" />
-          <span className="relative z-10 flex w-full min-w-0 items-center justify-center">
+          <span className="flex w-full min-w-0 items-center justify-center">
             {option.preview}
           </span>
         </RacToggleButton>
@@ -1019,6 +1026,7 @@ export function OptionGridRow({
   onChange,
   options,
   columns,
+  variant,
 }: {
   label: string
   description?: string
@@ -1026,6 +1034,8 @@ export function OptionGridRow({
   onChange: (id: string) => void
   options: OptionGridItem[]
   columns?: number
+  /** `plain` drops the card surface: specimens sit right on the panel. */
+  variant?: 'card' | 'plain'
 }) {
   const selected = options.find((o) => o.id === value)
   return (
@@ -1045,6 +1055,7 @@ export function OptionGridRow({
         onChange={onChange}
         options={options}
         columns={columns}
+        variant={variant}
       />
     </div>
   )


### PR DESCRIPTION
## What changed

Control Lab's `OptionGrid` (shared by `OptionGridRow` and `ComponentRow`):

- **Dropped the morphing highlight.** The animated `SelectionIndicator` that slid/resized between cards is replaced by static `selected:` classes — selection is instant and simpler. (`SegmentedRow` keeps its morph.)
- **Previews always render on true colors.** Cards went from translucent `bg-bg/50` (blended with the muted panel) to opaque `bg-bg` in every state. Hover no longer shifts the background — a `white/5` overlay fades in on top of the preview instead, lightening it.
- **New `plain` variant** (`variant="plain"` on `OptionGridRow`): no card surface — every option gets a 1px `border-border` hairline, and selection is just a lighter `white/10` background, no accent ring. Added a "Plain" entry to the OptionGridRow showcase.

## Notes for review

- The hover/selection overlays are literal white, so they lighten the specimens themselves; over a white card surface in light themes the hover feedback is minimal. Easy to swap to a `bg-highlight`-based layer if light mode needs more.
- Prototype-only code (`www/src/modules/control-lab/`), no registry impact.