### PR TITLE
feat(www): control-lab disclosure alignment and inset variant

### DIFF
--- a/www/src/modules/control-lab/page.tsx
+++ b/www/src/modules/control-lab/page.tsx
@@ -476,7 +476,15 @@ function ComponentRowDemo({
   )
 }
 
-function DisclosureDemo({ described }: { described?: boolean }) {
+function DisclosureDemo({
+  withValue,
+  described,
+  inset,
+}: {
+  withValue?: boolean
+  described?: boolean
+  inset?: boolean
+}) {
   const [tracking, setTracking] = useState('normal')
   const [size, setSize] = useState(16)
   return (
@@ -485,7 +493,8 @@ function DisclosureDemo({ described }: { described?: boolean }) {
       description={
         described ? 'Every UI string that isn’t a heading.' : undefined
       }
-      value="Inter"
+      value={withValue ? 'Inter' : undefined}
+      inset={inset}
       defaultExpanded
     >
       <SegmentedRow
@@ -746,7 +755,9 @@ const GROUPS: Group[] = [
           'A row that opens in place: label left, current value and chevron right, its own rows inside. Where DrillInRow pushes a sub-panel, this one unfolds — depth without leaving the page.',
         variants: [
           { label: 'Default', render: <DisclosureDemo /> },
+          { label: 'With value', render: <DisclosureDemo withValue /> },
           { label: 'With description', render: <DisclosureDemo described /> },
+          { label: 'Inset', render: <DisclosureDemo withValue inset /> },
         ],
       },
       {

--- a/www/src/modules/control-lab/rows.tsx
+++ b/www/src/modules/control-lab/rows.tsx
@@ -248,6 +248,7 @@ export function DisclosureRow({
   description,
   value,
   defaultExpanded,
+  inset,
   children,
 }: {
   label: string
@@ -255,16 +256,26 @@ export function DisclosureRow({
   /** What the row reads back while collapsed. */
   value?: React.ReactNode
   defaultExpanded?: boolean
+  /** Drops the content onto a recessed, hairlined surface — separates the
+   *  panel from its rows when the flat look reads as one long card. */
+  inset?: boolean
   children?: React.ReactNode
 }) {
   return (
     <Disclosure
       id={label}
       defaultExpanded={defaultExpanded}
-      className="w-full rounded-xl bg-muted"
+      className={cn(
+        'w-full rounded-xl bg-muted',
+        // The root owns the recessed surface; the header keeps its own row
+        // fill and reads as raised on it, content rows clear theirs below.
+        inset &&
+          'bg-[color-mix(in_oklab,var(--color-card),var(--color-muted))]',
+      )}
     >
       <RacButton
         slot="trigger"
+        data-row=""
         className={cn(
           ROW_TRIGGER,
           'cursor-interactive focus-reset focus-visible:focus-ring',
@@ -277,10 +288,21 @@ export function DisclosureRow({
           <ChevronDownIcon className="size-3.5 text-fg-muted transition-transform duration-200 group-expanded/disclosure:rotate-180" />
         </span>
       </RacButton>
-      <DisclosurePanel className="text-inherit">
-        {/* No inset: rows inside sit at the trigger's own padding, so every
-            label in the card shares one left edge. */}
-        <div className="flex flex-col pb-1">{children}</div>
+      {/* `*:pb-0` cancels the panel's built-in bottom pad — spacing is owned
+          here so content bottom matches the row insets. */}
+      <DisclosurePanel className="text-inherit *:pb-0">
+        {/* No inset either way: rows inside carry the trigger's own padding,
+            so content shares the header's text edges on both sides. */}
+        <div
+          className={cn(
+            'flex flex-col pb-2',
+            // Symmetric padding: the raised header needs the same breathing
+            // room above the content as below it.
+            inset && 'pt-2 **:data-row:bg-transparent',
+          )}
+        >
+          {children}
+        </div>
       </DisclosurePanel>
     </Disclosure>
   )
@@ -1078,7 +1100,7 @@ export function SegmentedRow({
       data-row=""
       className={cn(
         ROW,
-        'flex items-center justify-between gap-3 pr-1.5 pl-4',
+        'flex items-center justify-between gap-3 px-4',
         description && ROW_DESCRIBED,
       )}
     >
@@ -1148,7 +1170,7 @@ export function StepperRow({
         data-row=""
         className={cn(
           ROW,
-          'flex items-center justify-between gap-3 pr-1.5 pl-4',
+          'flex items-center justify-between gap-3 px-4',
           description && ROW_DESCRIBED,
         )}
       >


### PR DESCRIPTION
## What changed

**Alignment & padding coherence** (`DisclosureRow` content in the control lab):

- `SegmentedRow` and `StepperRow` were the only rows ending their trailing control at `pr-1.5` (6px) while every other row (switch, select, color, slider) ends at `px-4` (16px). They now use `px-4`, so disclosure content — and these rows anywhere they appear — shares one 16px column with the header text on both sides.
- The registry `DisclosurePanel` hardwires an inner `pb-3` wrapper that was silently stacking with the lab's own bottom padding. `DisclosureRow` cancels it (`*:pb-0`) and owns the spacing locally: control blocks now sit 16px from the right *and* bottom edge, matching the side insets. `ComponentRow`'s style grid gets the same treatment (8px sides and bottom, was 8/16).
- The disclosure trigger now carries `data-row` like every other row surface, so it participates in `ControlGroup`'s row flattening.

**New `inset` variant** on `DisclosureRow`:

- The root owns a recessed surface — `color-mix(in oklab, card, muted)`, opaque and token-driven so it tracks theme changes — with the `bg-muted` header sitting on it as a raised pill and content rows clearing their fills. Collapsed, it's indistinguishable from the default variant. Borderless (a hairline ring was tried and removed); symmetric 8px top/bottom panel padding.
- Demo variants regrouped to isolate one feature each: Default (no value), With value, With description, Inset.

## Notes for review

- Verified live via DOM measurement: labels at 16px, trailing blocks at 16px right/bottom across all four variants.
- `www/src/modules/panel-lab/patterns.tsx:98` copied the old `pr-1.5` pattern and still has the overhang — left out of scope here.