### PR TITLE
docs: split import/usage fences to drop leading semicolons

### DIFF
--- a/www/content/docs/components/button.mdx
+++ b/www/content/docs/components/button.mdx
@@ -47,7 +47,10 @@ Use `LinkButton` with `href` to render a navigation control styled as a button. 
 
 ```tsx
 import { LinkButton } from '@dotui/registry/ui/button'
-;<LinkButton href="/dashboard">Dashboard</LinkButton>
+```
+
+```tsx
+<LinkButton href="/dashboard">Dashboard</LinkButton>
 ```
 
 ## Examples

--- a/www/content/docs/components/calendar.mdx
+++ b/www/content/docs/components/calendar.mdx
@@ -100,7 +100,10 @@ Calendar values use [`@internationalized/date`](https://react-spectrum.adobe.com
 
 ```tsx
 import { parseDate } from '@internationalized/date'
-;<Calendar defaultValue={parseDate('2020-02-03')} />
+```
+
+```tsx
+<Calendar defaultValue={parseDate('2020-02-03')} />
 ```
 
 ```tsx
@@ -108,9 +111,11 @@ import { useState } from 'react'
 import { parseDate } from '@internationalized/date'
 import type { DateValue } from 'react-aria-components'
 
-const [value, setValue] = useState<DateValue>(parseDate('2020-02-03'))
+function Example() {
+  const [value, setValue] = useState<DateValue>(parseDate('2020-02-03'))
 
-;<Calendar value={value} onChange={setValue} />
+  return <Calendar value={value} onChange={setValue} />
+}
 ```
 
 ## Date availability
@@ -121,8 +126,10 @@ Constrain the selectable range with `minValue` and `maxValue`, or disable indivi
 import { getLocalTimeZone, today } from '@internationalized/date'
 
 const now = today(getLocalTimeZone())
+```
 
-;<Calendar
+```tsx
+<Calendar
   minValue={now}
   maxValue={now.add({ months: 1 })}
   isDateUnavailable={(date) =>

--- a/www/content/docs/components/checkbox-group.mdx
+++ b/www/content/docs/components/checkbox-group.mdx
@@ -73,11 +73,15 @@ Use `defaultValue` for uncontrolled checkbox groups, or `value` and `onChange` f
 ```
 
 ```tsx
-const [frameworks, setFrameworks] = useState<string[]>(['nextjs'])
+function Example() {
+  const [frameworks, setFrameworks] = useState<string[]>(['nextjs'])
 
-;<CheckboxGroup value={frameworks} onChange={setFrameworks}>
-  {/* ... */}
-</CheckboxGroup>
+  return (
+    <CheckboxGroup value={frameworks} onChange={setFrameworks}>
+      {/* ... */}
+    </CheckboxGroup>
+  )
+}
 ```
 
 ## Validation
@@ -87,7 +91,10 @@ Set `isRequired` to require a selection, or drive `isInvalid` yourself. Render e
 ```tsx
 import { CheckboxGroup } from '@/ui/checkbox-group'
 import { FieldError, FieldGroup, Label } from '@/ui/field'
-;<CheckboxGroup isRequired>
+```
+
+```tsx
+<CheckboxGroup isRequired>
   <Label>React frameworks</Label>
   <FieldGroup>{/* ... */}</FieldGroup>
   <FieldError>Please select a framework.</FieldError>

--- a/www/content/docs/components/checkbox.mdx
+++ b/www/content/docs/components/checkbox.mdx
@@ -66,7 +66,10 @@ Pass a plain string and `Checkbox` wraps it in a `CheckboxControl` and `Label` f
 ```tsx
 import { Checkbox, CheckboxControl, CheckboxIndicator } from '@/ui/checkbox'
 import { Description, FieldContent, Label } from '@/ui/field'
-;<Checkbox>
+```
+
+```tsx
+<Checkbox>
   <CheckboxControl>
     <CheckboxIndicator />
     <FieldContent>

--- a/www/content/docs/components/color-area.mdx
+++ b/www/content/docs/components/color-area.mdx
@@ -45,7 +45,10 @@ A `ColorArea` renders the gradient and positions a `ColorThumb`. If you omit chi
 ```tsx
 import { ColorArea } from '@/ui/color-area'
 import { ColorThumb } from '@/ui/color-thumb'
-;<ColorArea>
+```
+
+```tsx
+<ColorArea>
   <ColorThumb />
 </ColorArea>
 ```

--- a/www/content/docs/components/color-field.mdx
+++ b/www/content/docs/components/color-field.mdx
@@ -59,7 +59,10 @@ A `ColorField` wraps a `Label` and an `Input`. To attach an icon, replace the ba
 import { ColorField } from '@/ui/color-field'
 import { Label } from '@/ui/field'
 import { Input, InputGroup, InputGroupAddon } from '@/ui/input'
-;<ColorField>
+```
+
+```tsx
+<ColorField>
   <Label />
   <InputGroup>
     <InputGroupAddon />

--- a/www/content/docs/components/color-swatch-picker.mdx
+++ b/www/content/docs/components/color-swatch-picker.mdx
@@ -50,7 +50,10 @@ import {
   ColorSwatchPicker,
   ColorSwatchPickerItem,
 } from '@/ui/color-swatch-picker'
-;<ColorSwatchPicker>
+```
+
+```tsx
+<ColorSwatchPicker>
   <ColorSwatchPickerItem color="#ff0000" />
 </ColorSwatchPicker>
 ```

--- a/www/content/docs/components/color-swatch.mdx
+++ b/www/content/docs/components/color-swatch.mdx
@@ -42,7 +42,10 @@ The `color` prop accepts a hex or CSS color string, or a `Color` object from `pa
 
 ```tsx
 import { parseColor } from 'react-aria-components'
-;<ColorSwatch color={parseColor('#7f0000aa')} />
+```
+
+```tsx
+<ColorSwatch color={parseColor('#7f0000aa')} />
 ```
 
 ## Examples

--- a/www/content/docs/components/command.mdx
+++ b/www/content/docs/components/command.mdx
@@ -72,7 +72,10 @@ import {
   CommandSection,
   CommandSectionHeader,
 } from '@/ui/command'
-;<Command>
+```
+
+```tsx
+<Command>
   <CommandInput />
   <CommandContent>
     <CommandSection>

--- a/www/content/docs/components/context-menu.mdx
+++ b/www/content/docs/components/context-menu.mdx
@@ -48,7 +48,10 @@ import { ContextMenu } from '@/ui/context-menu'
 import { MenuContent, MenuItem, MenuSub } from '@/ui/menu'
 import { Popover } from '@/ui/popover'
 import { Separator } from '@/ui/separator'
-;<ContextMenu>
+```
+
+```tsx
+<ContextMenu>
   {/* trigger content */}
   <Popover>
     <MenuContent>

--- a/www/content/docs/components/date-field.mdx
+++ b/www/content/docs/components/date-field.mdx
@@ -64,7 +64,10 @@ import { Label } from '@/ui/field'
 import { DateField } from '@/ui/date-field'
 import { DateInput } from '@/ui/input'
 import { Description, FieldError, Label } from '@/ui/field'
-;<DateField>
+```
+
+```tsx
+<DateField>
   <Label />
   <DateInput />
   <Description />
@@ -78,7 +81,10 @@ Values are [`@internationalized/date`](https://react-spectrum.adobe.com/internat
 
 ```tsx
 import { parseDate } from '@internationalized/date'
-;<DateField defaultValue={parseDate('2020-02-03')}>
+```
+
+```tsx
+<DateField defaultValue={parseDate('2020-02-03')}>
   <Label>Date</Label>
   <DateInput />
 </DateField>

--- a/www/content/docs/components/date-picker.mdx
+++ b/www/content/docs/components/date-picker.mdx
@@ -62,7 +62,10 @@ import { DialogContent } from '@/ui/dialog'
 import { Description, FieldError, Label } from '@/ui/field'
 import { DateInput, InputGroup, InputGroupAddon } from '@/ui/input'
 import { Popover } from '@/ui/popover'
-;<DatePicker>
+```
+
+```tsx
+<DatePicker>
   <Label />
   <InputGroup>
     <DateInput />
@@ -86,7 +89,10 @@ The value is an [`@internationalized/date`](https://react-spectrum.adobe.com/int
 
 ```tsx
 import { parseDate } from '@internationalized/date'
-;<DatePicker
+```
+
+```tsx
+<DatePicker
   defaultValue={parseDate('2020-02-03')}
   minValue={parseDate('2020-01-01')}
 />
@@ -101,7 +107,10 @@ import { parseDate } from '@internationalized/date'
 
 import { RangeCalendar } from '@/ui/calendar'
 import { DateRangePicker } from '@/ui/date-picker'
-;<DateRangePicker
+```
+
+```tsx
+<DateRangePicker
   defaultValue={{
     start: parseDate('2020-02-03'),
     end: parseDate('2020-02-12'),

--- a/www/content/docs/components/drawer.mdx
+++ b/www/content/docs/components/drawer.mdx
@@ -59,7 +59,10 @@ import {
   DrawerIndent,
   DrawerIndentBackground,
 } from '@/ui/drawer'
-;<Dialog>
+```
+
+```tsx
+<Dialog>
   <Button />
   <Drawer>
     <DialogContent>

--- a/www/content/docs/components/drop-zone.mdx
+++ b/www/content/docs/components/drop-zone.mdx
@@ -59,7 +59,10 @@ Read dropped data in `onDrop` from `e.items`, filtering by `kind` and `types`, a
 
 ```tsx
 import type { TextDropItem } from 'react-aria-components'
-;<DropZone
+```
+
+```tsx
+<DropZone
   onDrop={async (e) => {
     const items = await Promise.all(
       e.items

--- a/www/content/docs/components/empty.mdx
+++ b/www/content/docs/components/empty.mdx
@@ -41,7 +41,10 @@ import {
   EmptyDescription,
   EmptyContent,
 } from '@/ui/empty'
-;<Empty>
+```
+
+```tsx
+<Empty>
   <EmptyHeader>
     <EmptyMedia variant="icon">{/* icon */}</EmptyMedia>
     <EmptyTitle>{/* heading */}</EmptyTitle>

--- a/www/content/docs/components/group.mdx
+++ b/www/content/docs/components/group.mdx
@@ -31,7 +31,10 @@ import { Group } from '@/ui/group'
 
 ```tsx
 import { Group, GroupText } from '@/ui/group'
-;<Group>
+```
+
+```tsx
+<Group>
   <GroupText>Label</GroupText>
   <Button>Action</Button>
 </Group>

--- a/www/content/docs/components/input-group.mdx
+++ b/www/content/docs/components/input-group.mdx
@@ -30,7 +30,10 @@ An `InputGroup` wraps an `Input` or `TextArea` together with one or more `InputG
 
 ```tsx
 import { Input, InputGroup, InputGroupAddon, TextArea } from '@/ui/input'
-;<InputGroup>
+```
+
+```tsx
+<InputGroup>
   <InputGroupAddon />
   <Input />
   <InputGroupAddon />

--- a/www/content/docs/components/kbd.mdx
+++ b/www/content/docs/components/kbd.mdx
@@ -17,7 +17,7 @@ import { Kbd } from '@/ui/kbd'
 ```
 
 ```tsx
-;<Kbd>⌘</Kbd> + <Kbd>K</Kbd>
+<Kbd>⌘K</Kbd>
 ```
 
 ## Anatomy
@@ -26,7 +26,10 @@ Use `Kbd` for a single key. Wrap several in `KbdGroup` to present a key combinat
 
 ```tsx
 import { Kbd, KbdGroup } from '@/ui/kbd'
-;<KbdGroup>
+```
+
+```tsx
+<KbdGroup>
   <Kbd>⌘</Kbd>
   <Kbd>K</Kbd>
 </KbdGroup>

--- a/www/content/docs/components/menu.mdx
+++ b/www/content/docs/components/menu.mdx
@@ -65,7 +65,10 @@ import {
   MenuSub,
 } from '@/ui/menu'
 import { Popover } from '@/ui/popover'
-;<Menu>
+```
+
+```tsx
+<Menu>
   <Button>Open Menu</Button>
   <Popover>
     <MenuContent>

--- a/www/content/docs/components/modal.mdx
+++ b/www/content/docs/components/modal.mdx
@@ -54,7 +54,10 @@ import {
   ModalViewport,
   ModalPanel,
 } from '@/ui/modal'
-;<ModalOverlay>
+```
+
+```tsx
+<ModalOverlay>
   <ModalBackdrop />
   <ModalViewport>
     <ModalPanel>{children}</ModalPanel>

--- a/www/content/docs/components/number-field.mdx
+++ b/www/content/docs/components/number-field.mdx
@@ -69,7 +69,10 @@ import {
 } from '@/ui/number-field'
 import { Input } from '@/ui/input'
 import { Label, FieldError } from '@/ui/field'
-;<NumberField>
+```
+
+```tsx
+<NumberField>
   <Label />
   <NumberFieldGroup>
     <NumberFieldDecrement />

--- a/www/content/docs/components/popover.mdx
+++ b/www/content/docs/components/popover.mdx
@@ -55,7 +55,10 @@ A `Dialog` wraps the trigger `Button` and the `Popover`; the popover holds a `Di
 import { Button } from '@/ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@/ui/dialog'
 import { Popover } from '@/ui/popover'
-;<Dialog>
+```
+
+```tsx
+<Dialog>
   <Button />
   <Popover>
     <DialogContent>

--- a/www/content/docs/components/progress-bar.mdx
+++ b/www/content/docs/components/progress-bar.mdx
@@ -60,7 +60,10 @@ import {
   ProgressBarControl,
   ProgressBarOutput,
 } from '@/ui/progress-bar'
-;<ProgressBar>
+```
+
+```tsx
+<ProgressBar>
   <ProgressBarOutput />
   <ProgressBarControl />
 </ProgressBar>

--- a/www/content/docs/components/qr-code.mdx
+++ b/www/content/docs/components/qr-code.mdx
@@ -30,7 +30,10 @@ npx shadcn@latest add @dotui/qr-code
 
 ```tsx
 import { QRCode } from '@/ui/qr-code'
-;<QRCode value="https://dotui.org" aria-label="dotUI website" />
+```
+
+```tsx
+<QRCode value="https://dotui.org" aria-label="dotUI website" />
 ```
 
 Pass an `aria-label` describing the destination — to a screen reader, an unlabeled QR code is meaningless.

--- a/www/content/docs/components/radio-group.mdx
+++ b/www/content/docs/components/radio-group.mdx
@@ -82,7 +82,10 @@ import {
   RadioIndicator,
 } from '@/ui/radio-group'
 import { Description, FieldError, FieldGroup, Label } from '@/ui/field'
-;<RadioGroup>
+```
+
+```tsx
+<RadioGroup>
   <Label />
   <FieldGroup>
     <Radio>

--- a/www/content/docs/components/search-field.mdx
+++ b/www/content/docs/components/search-field.mdx
@@ -64,7 +64,10 @@ A `SearchField` wraps an optional `Label`, an `Input`, and optional `Description
 import { SearchField } from '@/ui/search-field'
 import { Label, Description, FieldError } from '@/ui/field'
 import { Input } from '@/ui/input'
-;<SearchField>
+```
+
+```tsx
+<SearchField>
   <Label />
   <Input />
   <Description />

--- a/www/content/docs/components/segmented-control.mdx
+++ b/www/content/docs/components/segmented-control.mdx
@@ -37,7 +37,10 @@ A `SegmentedControl` wraps one `SegmentedControlItem` per option. Each item need
 
 ```tsx
 import { SegmentedControl, SegmentedControlItem } from '@/ui/segmented-control'
-;<SegmentedControl>
+```
+
+```tsx
+<SegmentedControl>
   <SegmentedControlItem id="…">…</SegmentedControlItem>
 </SegmentedControl>
 ```

--- a/www/content/docs/components/select.mdx
+++ b/www/content/docs/components/select.mdx
@@ -122,7 +122,10 @@ Add a `Label` and a `FieldError` inside `Select`, and set `isRequired` or `isInv
 
 ```tsx
 import { FieldError, Label } from '@/ui/field'
-;<Select isRequired>
+```
+
+```tsx
+<Select isRequired>
   <Label>Provider</Label>
   <SelectTrigger />
   <SelectContent>

--- a/www/content/docs/components/slider.mdx
+++ b/www/content/docs/components/slider.mdx
@@ -62,7 +62,10 @@ import {
   SliderThumb,
   SliderOutput,
 } from '@/ui/slider'
-;<Slider>
+```
+
+```tsx
+<Slider>
   <SliderOutput />
   <SliderControl>
     <SliderTrack>

--- a/www/content/docs/components/table.mdx
+++ b/www/content/docs/components/table.mdx
@@ -119,7 +119,10 @@ import {
   TableHeader,
   TableRow,
 } from '@/ui/table'
-;<TableContainer>
+```
+
+```tsx
+<TableContainer>
   <Table>
     <TableHeader>
       <TableColumn isRowHeader>Name</TableColumn>

--- a/www/content/docs/components/tag-group.mdx
+++ b/www/content/docs/components/tag-group.mdx
@@ -37,7 +37,10 @@ A `TagGroup` wraps an optional `Label` and a `TagList` of `Tag` items.
 ```tsx
 import { TagGroup, TagList, Tag } from '@/ui/tag-group'
 import { Label } from '@/ui/field'
-;<TagGroup>
+```
+
+```tsx
+<TagGroup>
   <Label />
   <TagList>
     <Tag />

--- a/www/content/docs/components/text-field.mdx
+++ b/www/content/docs/components/text-field.mdx
@@ -76,7 +76,10 @@ A `TextField` wraps a `Label`, an `Input`, and optional `Description` and `Field
 import { TextField } from '@/ui/text-field'
 import { Label, Description, FieldError } from '@/ui/field'
 import { Input, InputGroup, InputGroupAddon } from '@/ui/input'
-;<TextField>
+```
+
+```tsx
+<TextField>
   <Label />
   <InputGroup>
     <InputGroupAddon />

--- a/www/content/docs/components/time-field.mdx
+++ b/www/content/docs/components/time-field.mdx
@@ -64,7 +64,10 @@ import { Label } from '@/ui/field'
 import { TimeField } from '@/ui/time-field'
 import { DateInput } from '@/ui/input'
 import { Label, Description, FieldError } from '@/ui/field'
-;<TimeField>
+```
+
+```tsx
+<TimeField>
   <Label />
   <DateInput />
   <Description />
@@ -78,7 +81,10 @@ Values are `Time` objects from `@internationalized/date`. Use `defaultValue` for
 
 ```tsx
 import { Time } from '@internationalized/date'
-;<TimeField defaultValue={new Time(11, 45)}>
+```
+
+```tsx
+<TimeField defaultValue={new Time(11, 45)}>
   <Label>Time</Label>
   <DateInput />
 </TimeField>

--- a/www/content/docs/components/toast.mdx
+++ b/www/content/docs/components/toast.mdx
@@ -17,8 +17,10 @@ import { ToastProvider, toastManager } from '@/ui/toast'
 ```
 
 ```tsx
-;<ToastProvider />
+<ToastProvider />
+```
 
+```tsx
 toastManager.add({
   title: 'Your message has been sent.',
 })
@@ -36,8 +38,13 @@ Toasts aren't rendered as JSX. Mount `<ToastProvider />` once at your app root, 
 
 ```tsx
 import { ToastProvider, toastManager } from '@/ui/toast'
-;<ToastProvider />
+```
 
+```tsx
+<ToastProvider />
+```
+
+```tsx
 const id = toastManager.add({ title: 'Your message has been sent.' })
 toastManager.close(id)
 ```

--- a/www/content/docs/components/tooltip.mdx
+++ b/www/content/docs/components/tooltip.mdx
@@ -57,7 +57,10 @@ import { Tooltip, TooltipContent } from '@/ui/tooltip'
 
 ```tsx
 import { Tooltip, TooltipContent } from '@/ui/tooltip'
-;<Tooltip>
+```
+
+```tsx
+<Tooltip>
   <Button />
   <TooltipContent />
 </Tooltip>


### PR DESCRIPTION
## Problem

Many docs code blocks showed a stray leading semicolon:

```tsx
import { LinkButton } from '@dotui/registry/ui/button'
;<LinkButton href="/dashboard">Dashboard</LinkButton>
```

Root cause: oxfmt formats the ```tsx fences inside MDX, and with the repo's `semi: false` it inserts a defensive `;` before any statement-position JSX that follows another statement (ASI protection — Prettier behaves identically, and neither has an option to disable it). A fence whose entire content is a single JSX element is left clean.

## Fix

Restructure the 44 affected snippets across 35 component MDX files so no statement-position JSX follows another statement — keeping embedded formatting fully enabled:

- **import + JSX fences** → split into an import fence and a usage fence (shadcn-docs style).
- **`useState` examples** (calendar, checkbox-group) → wrapped in `function Example() { … }`, which is also more correct since hooks can't be top-level.
- **kbd usage** → `<Kbd>⌘</Kbd> + <Kbd>K</Kbd>` (a `jsx + jsx` expression, which always gets the `;`) became `<Kbd>⌘K</Kbd>`, matching the basic demo; the Anatomy section already documents combos via `KbdGroup`.
- **toast / calendar setup fences** → setup statements and usage JSX split into separate fences.

Verified oxfmt is idempotent over the result (a full re-run adds zero semicolons) and `pnpm check` passes.

Note: deleting a `;` by hand doesn't stick — the next `check:fix` re-adds it; the fence must be restructured instead.

## Suggested refactors

CI's format check can't catch a regression here (a reintroduced `;<` is "correctly formatted"); a one-line grep for `^;<` in `www/content` in CI would guard it. Left out to keep this diff docs-only.