### PR TITLE
feat(www): panel-lab v2 surfaces section with delineation recipes

### DIFF
--- a/www/src/modules/panel-lab/color-working.tsx
+++ b/www/src/modules/panel-lab/color-working.tsx
@@ -155,6 +155,26 @@ function buildModeConfig(state: SharedColorState, mode: LabMode): ColorConfig {
   }
 }
 
+/** Shared slice + one mode, resolved to that mode's engine half — how other
+ *  sections (Surfaces) read the mode set without owning color state. */
+export function useModeTheme(state: LabState, mode?: LabMode) {
+  const sharedKey = JSON.stringify(SHARED_KEYS.map((key) => state[key]))
+  const shared = useMemo(
+    (): SharedColorState =>
+      Object.fromEntries(
+        SHARED_KEYS.map((key) => [key, state[key]]),
+      ) as SharedColorState,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sharedKey],
+  )
+  const config = useMemo(
+    () => (mode ? buildModeConfig(shared, mode) : null),
+    [shared, mode],
+  )
+  if (!config || !mode) return null
+  return resolveColorConfigCached(config)[mode.polarity]
+}
+
 /** WCAG of the untouched borders vs the app background — the border sliders'
  *  stable zero point, measured with any border targets stripped. */
 function useBorderSeeds(config: ColorConfig) {

--- a/www/src/modules/panel-lab/data.tsx
+++ b/www/src/modules/panel-lab/data.tsx
@@ -26,11 +26,39 @@ export const PRIMARY_OPTIONS = [
   { value: "accent", label: "Accent" },
 ]
 
-/** Draft-only (drafts/surfaces-562): overlay material for menus/popovers. */
+/** Overlay material for menus/popovers (Surfaces v2 + drafts/surfaces-562). */
 export const OVERLAY_OPTIONS: SegmentedRowOption[] = [
   { value: "solid", label: "Solid" },
   { value: "glass", label: "Glass" },
 ]
+
+/* Surface delineation recipes — the Surfaces axis (issue #590, the 7-system
+   border survey). Hairline, shadow role and dark elevation are traded against
+   each other in every surveyed system, so they move as one recipe, never as
+   independent knobs. References: Hairline ≈ shadcn/coss, Adaptive ≈ Spectrum
+   S2/Geist (shadow-only light, hairline dark), Shadow ≈ HeroUI/Astryx,
+   Outline ≈ Linear (solid near-bg step + heavy shadow). */
+export const SURFACE_RECIPES = [
+  { id: "hairline", label: "Hairline" },
+  { id: "adaptive", label: "Adaptive" },
+  { id: "shadow", label: "Shadow" },
+  { id: "outline", label: "Outline" },
+] as const
+
+export type SurfaceRecipeId = (typeof SURFACE_RECIPES)[number]["id"]
+
+/** Hairline ink strength — fg alpha, the survey's observed 5–12% band. */
+export const HAIRLINE_OPTIONS: SegmentedRowOption[] = [
+  { value: "subtle", label: "Subtle" },
+  { value: "default", label: "Default" },
+  { value: "strong", label: "Strong" },
+]
+
+export const HAIRLINE_ALPHA: Record<string, number> = {
+  subtle: 6,
+  default: 9,
+  strong: 13,
+}
 
 export const ICON_LIBRARY_OPTIONS = [
   { value: "lucide", label: "Lucide" },
@@ -405,7 +433,6 @@ export const DEFAULTS = {
   // Draft-only state (see drafts/) — keys the open section PRs introduced.
   // Drafts on the same section are alternatives, so where two chose the same
   // name for different things the numeric one is suffixed (headingTrackingEm).
-  overlayMaterial: "solid",
   headingWeight: "600",
   headingTracking: "normal",
   headingTrackingEm: 0,
@@ -435,6 +462,12 @@ export const DEFAULTS = {
   roleSurface: "lg",
   rolePanel: "xl",
   density: "default",
+  // Surfaces (v2) — the delineation axis (issue #590). Defaults are the
+  // study's recommended direction, not today's solid neutral-400.
+  surfaceDelineation: "hairline",
+  surfaceHairline: "default",
+  surfaceDarkElevate: true,
+  overlayMaterial: "solid",
   // Effects
   shadows: "soft",
   cursorInteractive: "default",
@@ -534,6 +567,19 @@ export const SHAPE_KEYS_V2: (keyof LabState)[] = [
 export const SPACE_KEYS_V2: (keyof LabState)[] = ["density"]
 export const EFFECT_KEYS: (keyof LabState)[] = [
   "shadows",
+  "cursorInteractive",
+  "cursorDisabled",
+]
+/** v2: Surfaces absorbs shadows (the recipe and the shadow family are one
+ *  decision) and the overlay material; Details keeps the cursors. */
+export const SURFACE_KEYS_V2: (keyof LabState)[] = [
+  "surfaceDelineation",
+  "surfaceHairline",
+  "surfaceDarkElevate",
+  "shadows",
+  "overlayMaterial",
+]
+export const EFFECT_KEYS_V2: (keyof LabState)[] = [
   "cursorInteractive",
   "cursorDisabled",
 ]

--- a/www/src/modules/panel-lab/sections.tsx
+++ b/www/src/modules/panel-lab/sections.tsx
@@ -416,6 +416,28 @@ export function EffectsSectionBody({ lab }: { lab: Lab }) {
   )
 }
 
+/* v2: shadows moved into Surfaces — the recipe and the shadow family are one
+   decision there. Details keeps only the cursors. */
+export function EffectsSectionBodyV2({ lab }: { lab: Lab }) {
+  const { state, set } = lab
+  return (
+    <ControlGroup>
+      <SelectRow
+        label="Cursor"
+        value={state.cursorInteractive}
+        onChange={set("cursorInteractive")}
+        options={CURSOR_OPTIONS}
+      />
+      <SelectRow
+        label="Disabled cursor"
+        value={state.cursorDisabled}
+        onChange={set("cursorDisabled")}
+        options={CURSOR_OPTIONS}
+      />
+    </ControlGroup>
+  )
+}
+
 export function ComponentsSectionBody({ lab }: { lab: Lab }) {
   const [query, setQuery] = useState("")
   const q = query.trim().toLowerCase()

--- a/www/src/modules/panel-lab/surfaces.tsx
+++ b/www/src/modules/panel-lab/surfaces.tsx
@@ -1,0 +1,345 @@
+"use client"
+
+/* Surfaces — the delineation axis (issue #590): how elevated surfaces separate
+   from the page. The 7-system border survey showed hairline, shadow and dark
+   bg-elevation are traded against each other, never independent — so the
+   section's primary control is a recipe, with strength/elevation/material as
+   the only loose levers. The hero renders both modes at once, engine-true:
+   a recipe that looks right in light and wrong in dark is the axis's whole
+   failure mode, so the two tiles are read together, never toggled. */
+
+import { useMemo } from "react"
+import { MoonIcon, SunIcon } from "lucide-react"
+
+import {
+  ControlGroup,
+  GroupCaption,
+  OptionGridRow,
+  SwitchRow,
+} from "@/modules/control-lab/rows"
+import type { OptionGridItem } from "@/modules/control-lab/rows"
+
+import { useModeTheme } from "./color-working"
+import {
+  HAIRLINE_ALPHA,
+  HAIRLINE_OPTIONS,
+  OVERLAY_OPTIONS,
+  SHADOW_OPTIONS,
+  SURFACE_RECIPES,
+} from "./data"
+import type { Lab, LabState, SurfaceRecipeId } from "./data"
+import { SegmentedControlRow } from "./patterns"
+
+/* ------------------------------- Recipe model ------------------------------ */
+
+/** One resolved surface treatment: what the tile actually paints. */
+interface SurfaceLook {
+  bg: string
+  borderColor?: string
+  boxShadow?: string
+  backdropFilter?: string
+}
+
+/** Shadow family → css per surface class, scaled up for dark (a shadow that
+ *  reads on white disappears on near-black). */
+function shadowCss(
+  family: string,
+  kind: "card" | "floating",
+  dark: boolean,
+): string | undefined {
+  const a = (light: number) => (dark ? Math.min(light * 2.2, 0.7) : light)
+  if (family === "none") return undefined
+  if (family === "crisp")
+    return kind === "card"
+      ? `0 1px 2px rgb(0 0 0 / ${a(0.08)})`
+      : `0 1px 2px rgb(0 0 0 / ${a(0.16)})`
+  if (family === "floating")
+    return kind === "card"
+      ? `0 2px 6px rgb(0 0 0 / ${a(0.08)})`
+      : `0 14px 32px -6px rgb(0 0 0 / ${a(0.3)})`
+  // soft (default)
+  return kind === "card"
+    ? `0 1px 3px rgb(0 0 0 / ${a(0.06)})`
+    : `0 8px 24px -6px rgb(0 0 0 / ${a(0.24)})`
+}
+
+/**
+ * The recipe resolver — the axis's semantics in one place. `ink` is the mode's
+ * strongest neutral (the fg side), `step` the 200 rung; a hairline is ink at
+ * the strength alpha, composited over the surface (the survey's consensus).
+ */
+function surfaceLook(
+  state: LabState,
+  kind: "card" | "floating",
+  dark: boolean,
+  scales: Record<string, Record<string, string> | undefined>,
+  background: string,
+): SurfaceLook {
+  const recipe = state.surfaceDelineation as SurfaceRecipeId
+  const neutral = scales.neutral ?? {}
+  const surface = neutral["50"] ?? background
+  const ink = neutral["950"] ?? background
+  const step = neutral["200"] ?? background
+  const alpha = HAIRLINE_ALPHA[state.surfaceHairline] ?? 9
+  const hairline = `color-mix(in srgb, ${ink} ${alpha}%, transparent)`
+
+  const elevated =
+    dark && state.surfaceDarkElevate && kind === "floating"
+      ? `color-mix(in oklab, ${surface} 50%, ${neutral["100"] ?? surface})`
+      : surface
+  const glass = kind === "floating" && state.overlayMaterial === "glass"
+
+  const look: SurfaceLook = {
+    bg: glass ? `color-mix(in srgb, ${elevated} 72%, transparent)` : elevated,
+    backdropFilter: glass ? "blur(6px)" : undefined,
+    boxShadow: shadowCss(state.shadows, kind, dark),
+  }
+
+  if (recipe === "hairline") look.borderColor = hairline
+  else if (recipe === "adaptive") {
+    if (dark) look.borderColor = hairline
+  } else if (recipe === "outline") {
+    look.borderColor =
+      kind === "floating"
+        ? step
+        : `color-mix(in srgb, ${ink} ${HAIRLINE_ALPHA.subtle}%, transparent)`
+  }
+  // 'shadow': no border on any surface — separation is shadow + elevation.
+  return look
+}
+
+/* ---------------------------------- Hero ----------------------------------- */
+
+/** One mode's stack: the page carrying a card, and a floating menu straddling
+ *  the card's edge so the treatment is read against both surfaces at once. */
+function SurfaceTile({
+  label,
+  icon: Icon,
+  dark,
+  state,
+  scales,
+  background,
+}: {
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  dark: boolean
+  state: LabState
+  scales: Record<string, Record<string, string> | undefined>
+  background: string
+}) {
+  const fg = scales.neutral?.["900"] ?? background
+  const accent = scales.accent?.["700"] ?? background
+  const card = surfaceLook(state, "card", dark, scales, background)
+  const menu = surfaceLook(state, "floating", dark, scales, background)
+  const border = (look: SurfaceLook) =>
+    look.borderColor
+      ? { border: `1px solid ${look.borderColor}` }
+      : { border: "1px solid transparent" }
+
+  return (
+    <div
+      className="flex-1 overflow-hidden rounded-xl border border-border/45"
+      style={{ backgroundColor: background, color: fg }}
+    >
+      <div className="flex items-center justify-between px-3 pt-2.5">
+        <span className="flex items-center gap-1.5 opacity-60">
+          <Icon className="size-3" />
+          <span className="text-[10px] font-medium">{label}</span>
+        </span>
+      </div>
+      <div className="relative mx-3 mt-2 mb-3 h-24">
+        <div
+          className="absolute inset-x-0 top-0 h-14 rounded-lg p-2"
+          style={{
+            backgroundColor: card.bg,
+            boxShadow: card.boxShadow,
+            ...border(card),
+          }}
+        >
+          <span className="block h-1.5 w-1/2 rounded-full bg-current opacity-70" />
+          <span className="mt-1.5 block h-1.5 w-2/3 rounded-full bg-current opacity-25" />
+          <span
+            aria-hidden
+            className="absolute top-2 right-2 size-4 rounded-full"
+            style={{ backgroundColor: accent }}
+          />
+        </div>
+        <div
+          className="absolute top-8 right-4 flex w-20 flex-col gap-1 rounded-md p-1.5"
+          style={{
+            backgroundColor: menu.bg,
+            boxShadow: menu.boxShadow,
+            backdropFilter: menu.backdropFilter,
+            ...border(menu),
+          }}
+        >
+          <span className="flex h-3.5 items-center rounded-sm bg-current/10 px-1">
+            <span className="block h-1 w-3/4 rounded-full bg-current opacity-60" />
+          </span>
+          <span className="block h-1 w-1/2 rounded-full bg-current opacity-25" />
+          <span className="block h-1 w-2/3 rounded-full bg-current opacity-25" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------ Recipe glyphs ------------------------------ */
+
+/** A recipe's mini specimen: a dark page tile with one floating surface —
+ *  dark is where the recipes actually diverge. Adaptive shows both halves. */
+function Glyph({
+  border,
+  bg,
+  shadow,
+}: {
+  border?: string
+  bg: string
+  shadow?: string
+}) {
+  return (
+    <span
+      className="size-9 rounded-md p-1.5"
+      style={{ backgroundColor: "#141517" }}
+    >
+      <span
+        className="block size-full rounded-[5px]"
+        style={{
+          backgroundColor: bg,
+          border: border ? `1px solid ${border}` : undefined,
+          boxShadow: shadow,
+        }}
+      />
+    </span>
+  )
+}
+
+const RECIPE_PREVIEWS: Record<SurfaceRecipeId, React.ReactNode> = {
+  hairline: <Glyph bg="#1e1f22" border="rgba(255,255,255,0.16)" />,
+  adaptive: (
+    <span className="relative size-9 overflow-hidden rounded-md">
+      <span
+        className="absolute inset-y-0 left-0 w-1/2 p-1.5 pr-0"
+        style={{ backgroundColor: "#fafafa" }}
+      >
+        <span
+          className="block size-full rounded-l-[5px]"
+          style={{
+            backgroundColor: "#ffffff",
+            boxShadow: "0 2px 5px rgb(0 0 0 / 0.18)",
+          }}
+        />
+      </span>
+      <span
+        className="absolute inset-y-0 right-0 w-1/2 p-1.5 pl-0"
+        style={{ backgroundColor: "#141517" }}
+      >
+        <span
+          className="block size-full rounded-r-[5px]"
+          style={{
+            backgroundColor: "#1e1f22",
+            borderBlock: "1px solid rgba(255,255,255,0.16)",
+            borderRight: "1px solid rgba(255,255,255,0.16)",
+          }}
+        />
+      </span>
+    </span>
+  ),
+  shadow: <Glyph bg="#26272b" shadow="0 4px 10px rgb(0 0 0 / 0.55)" />,
+  outline: (
+    <Glyph bg="#191a1d" border="#3c3e44" shadow="0 4px 10px rgb(0 0 0 / 0.4)" />
+  ),
+}
+
+const RECIPE_OPTIONS: OptionGridItem[] = SURFACE_RECIPES.map((recipe) => ({
+  id: recipe.id,
+  label: recipe.label,
+  preview: RECIPE_PREVIEWS[recipe.id],
+}))
+
+/* --------------------------------- Section --------------------------------- */
+
+export function SurfacesSectionBody({ lab }: { lab: Lab }) {
+  const { state, set } = lab
+  const modes = state.modes
+  const lightMode = useMemo(
+    () => modes.find((mode) => mode.polarity === "light"),
+    [modes],
+  )
+  const darkMode = useMemo(
+    () => modes.find((mode) => mode.polarity === "dark"),
+    [modes],
+  )
+  const light = useModeTheme(state, lightMode)
+  const darkTheme = useModeTheme(state, darkMode)
+
+  return (
+    <>
+      <div className="flex gap-2">
+        {light && lightMode && (
+          <SurfaceTile
+            label={lightMode.name}
+            icon={SunIcon}
+            dark={false}
+            state={state}
+            scales={light.scales}
+            background={light.background}
+          />
+        )}
+        {darkTheme && darkMode && (
+          <SurfaceTile
+            label={darkMode.name}
+            icon={MoonIcon}
+            dark
+            state={state}
+            scales={darkTheme.scales}
+            background={darkTheme.background}
+          />
+        )}
+      </div>
+      <OptionGridRow
+        label="Delineation"
+        value={state.surfaceDelineation}
+        onChange={set("surfaceDelineation")}
+        options={RECIPE_OPTIONS}
+        columns={4}
+      />
+      <GroupCaption>
+        One recipe for every elevated edge — card, popover, menu, modal.
+        Adaptive is shadow-only in light and grows the hairline in dark.
+      </GroupCaption>
+      <ControlGroup>
+        {state.surfaceDelineation !== "shadow" && (
+          <SegmentedControlRow
+            label="Hairline"
+            value={state.surfaceHairline}
+            onChange={set("surfaceHairline")}
+            options={HAIRLINE_OPTIONS}
+          />
+        )}
+        <SwitchRow
+          label="Dark elevation"
+          description="Lift popovers and menus to a lighter surface than the card in dark mode."
+          value={state.surfaceDarkElevate}
+          onChange={set("surfaceDarkElevate")}
+        />
+      </ControlGroup>
+      <OptionGridRow
+        label="Shadows"
+        value={state.shadows}
+        onChange={set("shadows")}
+        options={SHADOW_OPTIONS}
+        columns={4}
+      />
+      <SegmentedControlRow
+        label="Overlays"
+        value={state.overlayMaterial}
+        onChange={set("overlayMaterial")}
+        options={OVERLAY_OPTIONS}
+      />
+      <GroupCaption>
+        One material for menus, popovers and tooltips together.
+      </GroupCaption>
+    </>
+  )
+}

--- a/www/src/modules/panel-lab/versions.tsx
+++ b/www/src/modules/panel-lab/versions.tsx
@@ -11,6 +11,7 @@
 
 import {
   BoxSelectIcon,
+  LayersIcon,
   PaletteIcon,
   ShapesIcon,
   SlidersHorizontalIcon,
@@ -25,22 +26,26 @@ import {
   COLOR_KEYS,
   COMPONENT_KEYS,
   EFFECT_KEYS,
+  EFFECT_KEYS_V2,
   ICON_KEYS,
   SHAPE_KEYS,
   SHAPE_KEYS_V2,
   SPACE_KEYS_V2,
+  SURFACE_KEYS_V2,
   TYPE_KEYS,
   WORKING_COLOR_KEYS,
 } from "./data"
 import {
   ComponentsSectionBody,
   EffectsSectionBody,
+  EffectsSectionBodyV2,
   IconsSectionBody,
   ShapeSectionBody,
   ShapeSectionBodyV2,
   SpaceSectionBody,
   TypographySectionBody,
 } from "./sections"
+import { SurfacesSectionBody } from "./surfaces"
 import type { Chapter } from "./variants/chapter"
 
 /* The chapters every version shares so far — only Color has diverged. */
@@ -111,7 +116,7 @@ export const PANEL_VERSIONS: PanelVersion[] = [
     id: "v2",
     label: "v2 (wip)",
     summary:
-      "Color modes become a user-defined set — one to many, with archetypes and per-mode contrast. Shape and Space split; radius speaks px (#575) with a nested-corner preview and a corner-shape axis.",
+      "Color modes become a user-defined set — one to many, with archetypes and per-mode contrast. Shape and Space split; radius speaks px (#575) with a nested-corner preview and a corner-shape axis. Surfaces lands as its own chapter (#590): a delineation recipe (hairline · adaptive · shadow · outline) that absorbs shadows and the overlay material.",
     chapters: [
       {
         id: "color",
@@ -120,26 +125,43 @@ export const PANEL_VERSIONS: PanelVersion[] = [
         keys: WORKING_COLOR_KEYS,
         Body: WorkingColorSectionBody,
       },
-      ...SHARED_CHAPTERS.flatMap((chapter) =>
-        chapter.id === "shape"
-          ? [
-              {
-                id: "shape",
-                label: "Shape",
-                icon: ShapesIcon,
-                keys: SHAPE_KEYS_V2,
-                Body: ShapeSectionBodyV2,
-              },
-              {
-                id: "space",
-                label: "Space",
-                icon: StretchVerticalIcon,
-                keys: SPACE_KEYS_V2,
-                Body: SpaceSectionBody,
-              },
-            ]
-          : [chapter],
-      ),
+      ...SHARED_CHAPTERS.flatMap((chapter) => {
+        if (chapter.id === "shape")
+          return [
+            {
+              id: "shape",
+              label: "Shape",
+              icon: ShapesIcon,
+              keys: SHAPE_KEYS_V2,
+              Body: ShapeSectionBodyV2,
+            },
+            {
+              id: "space",
+              label: "Space",
+              icon: StretchVerticalIcon,
+              keys: SPACE_KEYS_V2,
+              Body: SpaceSectionBody,
+            },
+          ]
+        if (chapter.id === "details")
+          return [
+            {
+              id: "surfaces",
+              label: "Surfaces",
+              icon: LayersIcon,
+              keys: SURFACE_KEYS_V2,
+              Body: SurfacesSectionBody,
+            },
+            {
+              id: "details",
+              label: "Details",
+              icon: SlidersHorizontalIcon,
+              keys: EFFECT_KEYS_V2,
+              Body: EffectsSectionBodyV2,
+            },
+          ]
+        return [chapter]
+      }),
     ],
   },
 ]


### PR DESCRIPTION
## Summary

Adds the **Surfaces** chapter to panel-lab v2 (`/internal/panel-lab/v2`) — the delineation axis from the border study in #590: how elevated surfaces (card, popover, menu, modal) separate from the page.

The 7-system survey (Spectrum S2, Linear, Geist, Astryx, shadcn, HeroUI, coss ui) showed hairline, shadow role and dark bg-elevation are traded against each other in every real system, never independent — so the section's primary control is a **recipe**, with strength/elevation/material as the only loose levers:

- **Hairline** (shadcn · coss) — ink-alpha hairline on every elevated edge, both modes
- **Adaptive** (S2 · Geist) — shadow-only in light, hairline grows in for dark
- **Shadow** (HeroUI · Astryx) — no borders; shadow + dark elevation carry separation
- **Outline** (Linear) — solid near-bg step on floating surfaces + heavy shadow, ink on cards

Plus: **Hairline strength** (6/9/13% ink, hidden for the Shadow recipe), **Dark elevation** switch (the n50/n100 popover mix production currently hardcodes, now a controlled variable), and **Overlay material** (Solid/Glass) promoted from the surfaces-562 draft.

## Details

- Engine-true two-mode hero: light and dark resolved from the user's mode set via a new `useModeTheme` export from color-working — the two tiles are read together, never toggled, since a recipe that works in one mode and fails in the other is this axis's whole failure mode. The floating menu straddles the card edge so treatments read against both surfaces at once.
- **Shadows moves from Details into Surfaces** in v2 (the recipe and the shadow family are one decision); v2 Details keeps only the cursors. v1 bodies untouched per the versions rule.
- Defaults are #590's recommended direction (hairline @ 9%, elevation on), not today's solid neutral-400.

## Verification

- All four recipes DOM-verified in the browser: computed borders/shadows/bg match the spec per mode (Adaptive: transparent light border + dark hairline; Outline: solid n200 menu; elevation resolves to the 50/50 oklab mix).
- Section modified-dot + reset restore defaults.
- `pnpm typecheck` and `pnpm check` clean.

Closes nothing — #590 stays open for the production token/substrate work; this is the builder-spec half of the axis.