### PR TITLE
feat(www): panel-lab hover preview rail draft

### DIFF
--- a/www/src/modules/control-lab/rows.tsx
+++ b/www/src/modules/control-lab/rows.tsx
@@ -6,7 +6,7 @@
    the grouped-list container that fuses rows into cards.
    Prototype only: local state in, callback out, no design-system wiring. */
 
-import { useState } from "react"
+import { createContext, useContext, useState } from 'react'
 import {
   ChevronDownIcon,
   ChevronRightIcon,
@@ -77,6 +77,12 @@ export const ROW_LABEL = "truncate text-[0.8125rem] font-medium text-fg"
 export const ROW_VALUE = "truncate text-[0.8125rem] text-fg-muted"
 /** What a fixed-height row becomes once it carries a description. */
 export const ROW_DESCRIBED = "h-auto py-2.5"
+
+/* Where row-attached overlays (pickers, selects, menus) open. Panel-lab's
+   preview-rail draft overrides it to explore preview/popover combos. */
+export type RowOverlayPlacement = 'right top' | 'left top' | 'bottom start'
+export const RowOverlayPlacementContext =
+  createContext<RowOverlayPlacement>('right top')
 
 /** The left column of a row: the label, and the line under it that says what
  *  the axis actually changes. Rows stay one line until a description arrives.
@@ -355,7 +361,10 @@ export function SelectRow({
           <ChevronsUpDownIcon className="size-3.5 text-fg-muted" />
         </span>
       </Button>
-      <Popover className="w-(--trigger-width)" placement="right top">
+      <Popover
+        className="w-(--trigger-width)"
+        placement={useContext(RowOverlayPlacementContext)}
+      >
         <ListBox>
           {options.map((opt) => (
             <ListBoxItem key={opt.value} id={opt.value} textValue={opt.label}>
@@ -402,7 +411,8 @@ export function ColorPickerRow({
   value: string
   onChange: (hex: string) => void
 }) {
-  const tile = layout === "tile"
+  const tile = layout === 'tile'
+  const rowPlacement = useContext(RowOverlayPlacementContext)
   return (
     <ColorPicker value={value} onChange={(c) => onChange(c.toString("hex"))}>
       {({ color }) => (
@@ -443,7 +453,7 @@ export function ColorPickerRow({
           <Popover
             // A tile is as wide as the picker, so opening below it keeps the
             // two edges aligned; a row has no width to align to.
-            placement={tile ? "bottom start" : "right top"}
+            placement={tile ? 'bottom start' : rowPlacement}
             className="w-64 min-w-0"
           >
             <DialogContent className="flex flex-col gap-3 p-3">
@@ -667,7 +677,10 @@ export function NeutralPickerRow({
           </span>
         </span>
       </Button>
-      <Popover placement="right top" className="w-64 min-w-0">
+      <Popover
+        placement={useContext(RowOverlayPlacementContext)}
+        className="w-64 min-w-0"
+      >
         <DialogContent className="flex flex-col gap-3 p-3">
           {/* Seeds, same as the brand picker: one tap to a known gray family,
               then the sliders for anything between them. Tapping while flat
@@ -772,7 +785,7 @@ export function FontListPopover({
   return (
     <Popover
       className="w-(--trigger-width) outline-hidden"
-      placement="right top"
+      placement={useContext(RowOverlayPlacementContext)}
     >
       <Command>
         <SearchField autoFocus aria-label="Search fonts">

--- a/www/src/modules/control-lab/rows.tsx
+++ b/www/src/modules/control-lab/rows.tsx
@@ -6,7 +6,7 @@
    the grouped-list container that fuses rows into cards.
    Prototype only: local state in, callback out, no design-system wiring. */
 
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useState } from "react"
 import {
   ChevronDownIcon,
   ChevronRightIcon,
@@ -80,9 +80,9 @@ export const ROW_DESCRIBED = "h-auto py-2.5"
 
 /* Where row-attached overlays (pickers, selects, menus) open. Panel-lab's
    preview-rail draft overrides it to explore preview/popover combos. */
-export type RowOverlayPlacement = 'right top' | 'left top' | 'bottom start'
+export type RowOverlayPlacement = "right top" | "left top" | "bottom start"
 export const RowOverlayPlacementContext =
-  createContext<RowOverlayPlacement>('right top')
+  createContext<RowOverlayPlacement>("right top")
 
 /** The left column of a row: the label, and the line under it that says what
  *  the axis actually changes. Rows stay one line until a description arrives.
@@ -411,7 +411,7 @@ export function ColorPickerRow({
   value: string
   onChange: (hex: string) => void
 }) {
-  const tile = layout === 'tile'
+  const tile = layout === "tile"
   const rowPlacement = useContext(RowOverlayPlacementContext)
   return (
     <ColorPicker value={value} onChange={(c) => onChange(c.toString("hex"))}>
@@ -453,7 +453,7 @@ export function ColorPickerRow({
           <Popover
             // A tile is as wide as the picker, so opening below it keeps the
             // two edges aligned; a row has no width to align to.
-            placement={tile ? 'bottom start' : rowPlacement}
+            placement={tile ? "bottom start" : rowPlacement}
             className="w-64 min-w-0"
           >
             <DialogContent className="flex flex-col gap-3 p-3">

--- a/www/src/modules/panel-lab/color-working.tsx
+++ b/www/src/modules/panel-lab/color-working.tsx
@@ -11,7 +11,7 @@
    active mode; the Modes row manages the set. Still engine-real: each mode
    resolves through @dotui/colors with its own background/guarantee settings. */
 
-import { useContext, useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from "react"
 import {
   CheckIcon,
   MoonIcon,
@@ -55,7 +55,7 @@ import {
   ROW_LABEL,
   ROW_VALUE,
   RowOverlayPlacementContext,
-} from '@/modules/control-lab/rows'
+} from "@/modules/control-lab/rows"
 
 import { DEFAULTS, PRIMARY_OPTIONS } from "./data"
 import type { Lab, LabMode, LabState } from "./data"

--- a/www/src/modules/panel-lab/color-working.tsx
+++ b/www/src/modules/panel-lab/color-working.tsx
@@ -11,7 +11,7 @@
    active mode; the Modes row manages the set. Still engine-real: each mode
    resolves through @dotui/colors with its own background/guarantee settings. */
 
-import { useMemo, useState } from "react"
+import { useContext, useMemo, useState } from 'react'
 import {
   CheckIcon,
   MoonIcon,
@@ -54,7 +54,8 @@ import {
   ROW,
   ROW_LABEL,
   ROW_VALUE,
-} from "@/modules/control-lab/rows"
+  RowOverlayPlacementContext,
+} from '@/modules/control-lab/rows'
 
 import { DEFAULTS, PRIMARY_OPTIONS } from "./data"
 import type { Lab, LabMode, LabState } from "./data"
@@ -467,7 +468,7 @@ function AddModeRow({
           <PlusIcon className="size-3.5" />
           {disabled ? `Up to ${MAX_MODES} modes` : "Add mode"}
         </Button>
-        <Popover placement="right top">
+        <Popover placement={useContext(RowOverlayPlacementContext)}>
           <MenuContent>
             {MODE_ARCHETYPES.map(({ key, note, mode }) => (
               <MenuItem

--- a/www/src/modules/panel-lab/drafts.tsx
+++ b/www/src/modules/panel-lab/drafts.tsx
@@ -13,7 +13,13 @@
 
 import { LayersIcon, PaletteIcon, SmileIcon, TypeIcon } from "lucide-react"
 
-import { ICON_KEYS, TYPE_KEYS, WORKING_COLOR_KEYS, type LabState } from "./data"
+import {
+  ICON_KEYS,
+  TYPE_KEYS,
+  WORKING_COLOR_KEYS,
+  type Lab,
+  type LabState,
+} from './data'
 import {
   ColorSectionV2Body as Color560,
   SurfacesSectionBody as Surfaces560,
@@ -21,13 +27,14 @@ import {
 import {
   ColorSectionV2Body as Color561,
   SurfacesSectionBody as Surfaces561,
-} from "./drafts/color-561"
-import { ColorSectionV2Body as Color562 } from "./drafts/color-562"
-import { IdealIconsSectionBody as Icons564 } from "./drafts/icons-564"
-import { SurfacesSectionBody as Surfaces562 } from "./drafts/surfaces-562"
-import { IdealTypeSectionBody as Type563 } from "./drafts/type-563"
-import { IdealTypeSectionBody as Type565 } from "./drafts/type-565"
-import type { Chapter } from "./variants/chapter"
+} from './drafts/color-561'
+import { ColorSectionV2Body as Color562 } from './drafts/color-562'
+import { IdealIconsSectionBody as Icons564 } from './drafts/icons-564'
+import { HoverPreviewFrame } from './drafts/preview-594'
+import { SurfacesSectionBody as Surfaces562 } from './drafts/surfaces-562'
+import { IdealTypeSectionBody as Type563 } from './drafts/type-563'
+import { IdealTypeSectionBody as Type565 } from './drafts/type-565'
+import type { Chapter } from './variants/chapter'
 
 const SURFACE_KEYS: (keyof LabState)[] = [
   "shadows",
@@ -82,6 +89,8 @@ export interface Draft {
   section: string
   /** Chapters replacing (by id) or extending the base version's list. */
   overrides: Chapter[]
+  /** Replaces the shared panel chrome — for drafts exploring the frame. */
+  Frame?: React.ComponentType<{ chapters: Chapter[]; lab: Lab }>
 }
 
 export const DRAFTS: Draft[] = [
@@ -147,7 +156,17 @@ export const DRAFTS: Draft[] = [
     ],
   },
   {
-    id: "pr-564",
+    id: 'pr-594',
+    pr: 594,
+    section: 'Frame',
+    title: 'Hover preview rail',
+    summary:
+      'A frame take, sections untouched: hovering a section floats a live preview beside the panel — one shared container that glides between cards and morphs its content.',
+    overrides: [],
+    Frame: HoverPreviewFrame,
+  },
+  {
+    id: 'pr-564',
     pr: 564,
     section: "Icons",
     title: "Ideal Icons section",

--- a/www/src/modules/panel-lab/drafts.tsx
+++ b/www/src/modules/panel-lab/drafts.tsx
@@ -161,7 +161,7 @@ export const DRAFTS: Draft[] = [
     section: 'Frame',
     title: 'Hover preview rail',
     summary:
-      'A frame take, sections untouched: hovering a section floats a live preview beside the panel — one shared container that glides between cards and morphs its content.',
+      'A frame take, sections untouched: hovering, focusing or opening a control floats its live preview beside the panel — one shared container that glides between rows and morphs its content.',
     overrides: [],
     Frame: HoverPreviewFrame,
   },

--- a/www/src/modules/panel-lab/drafts.tsx
+++ b/www/src/modules/panel-lab/drafts.tsx
@@ -19,7 +19,7 @@ import {
   WORKING_COLOR_KEYS,
   type Lab,
   type LabState,
-} from './data'
+} from "./data"
 import {
   ColorSectionV2Body as Color560,
   SurfacesSectionBody as Surfaces560,
@@ -27,14 +27,14 @@ import {
 import {
   ColorSectionV2Body as Color561,
   SurfacesSectionBody as Surfaces561,
-} from './drafts/color-561'
-import { ColorSectionV2Body as Color562 } from './drafts/color-562'
-import { IdealIconsSectionBody as Icons564 } from './drafts/icons-564'
-import { HoverPreviewFrame } from './drafts/preview-594'
-import { SurfacesSectionBody as Surfaces562 } from './drafts/surfaces-562'
-import { IdealTypeSectionBody as Type563 } from './drafts/type-563'
-import { IdealTypeSectionBody as Type565 } from './drafts/type-565'
-import type { Chapter } from './variants/chapter'
+} from "./drafts/color-561"
+import { ColorSectionV2Body as Color562 } from "./drafts/color-562"
+import { IdealIconsSectionBody as Icons564 } from "./drafts/icons-564"
+import { HoverPreviewFrame } from "./drafts/preview-594"
+import { SurfacesSectionBody as Surfaces562 } from "./drafts/surfaces-562"
+import { IdealTypeSectionBody as Type563 } from "./drafts/type-563"
+import { IdealTypeSectionBody as Type565 } from "./drafts/type-565"
+import type { Chapter } from "./variants/chapter"
 
 const SURFACE_KEYS: (keyof LabState)[] = [
   "shadows",
@@ -156,17 +156,17 @@ export const DRAFTS: Draft[] = [
     ],
   },
   {
-    id: 'pr-594',
+    id: "pr-594",
     pr: 594,
-    section: 'Frame',
-    title: 'Hover preview rail',
+    section: "Frame",
+    title: "Hover preview rail",
     summary:
-      'A frame take, sections untouched: hovering, focusing or opening a control floats its live preview beside the panel — one shared container that glides between rows and morphs its content.',
+      "A frame take, sections untouched: hovering, focusing or opening a control floats its live preview beside the panel — one shared container that glides between rows and morphs its content.",
     overrides: [],
     Frame: HoverPreviewFrame,
   },
   {
-    id: 'pr-564',
+    id: "pr-564",
     pr: 564,
     section: "Icons",
     title: "Ideal Icons section",

--- a/www/src/modules/panel-lab/drafts/preview-594.tsx
+++ b/www/src/modules/panel-lab/drafts/preview-594.tsx
@@ -1,0 +1,502 @@
+'use client'
+
+/* Draft #594 — the hover preview rail. A FRAME experiment, not a section one:
+   the panel chrome is the v2 frame verbatim, but hovering a section floats a
+   live preview card beside the panel, aligned with the hovered card. One
+   shared container stays mounted across sections — it glides to the new card
+   and morphs its height while the content crossfades, so moving down the
+   panel reads as one surface retargeting, never popping tooltips.
+
+   Motion model: glide + height share one no-bounce spring (they must move as
+   a unit); content swaps with a short direction-aware ease-out fade; the
+   container itself enters/exits with a scale fade. Reduced motion drops the
+   glide and offsets, keeping only fades. */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  BellIcon,
+  CalendarIcon,
+  ChevronsUpDownIcon,
+  HeartIcon,
+  HouseIcon,
+  MailIcon,
+  MousePointerClickIcon,
+  SearchIcon,
+  SendIcon,
+  SettingsIcon,
+  StarIcon,
+  TrashIcon,
+} from 'lucide-react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+
+import { Button } from '@/registry/ui/button'
+
+import type { Lab } from '../data'
+import { ChapterCard } from '../variants/chapter'
+import type { Chapter } from '../variants/chapter'
+
+const PREVIEW_W = 300
+/* The page mounts the panel at this fixed height (version-page.tsx). */
+const FRAME_H = 720
+const EASE_OUT = [0.215, 0.61, 0.355, 1] as const
+const GLIDE = {
+  type: 'spring',
+  stiffness: 500,
+  damping: 46,
+  mass: 0.8,
+} as const
+
+interface Hovered {
+  id: string
+  /** Card top relative to the frame, unclamped. */
+  top: number
+  /** +1 when the hover moved down the panel, -1 up — steers the crossfade. */
+  dir: 1 | -1
+}
+
+export function HoverPreviewFrame({
+  chapters,
+  lab,
+}: {
+  chapters: Chapter[]
+  lab: Lab
+}) {
+  const reduce = useReducedMotion()
+  const frameRef = useRef<HTMLDivElement>(null)
+  const cardRefs = useRef(new Map<string, HTMLDivElement>())
+  const leaveTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const contentObserver = useRef<ResizeObserver>(undefined)
+  const [hovered, setHovered] = useState<Hovered | null>(null)
+  const [contentH, setContentH] = useState(0)
+
+  useEffect(() => () => clearTimeout(leaveTimer.current), [])
+
+  const topOf = (id: string) => {
+    const frame = frameRef.current
+    const card = cardRefs.current.get(id)
+    if (!frame || !card) return 0
+    return card.getBoundingClientRect().top - frame.getBoundingClientRect().top
+  }
+
+  const hoverCard = (id: string) => {
+    clearTimeout(leaveTimer.current)
+    setHovered((prev) => ({
+      id,
+      top: topOf(id),
+      dir:
+        prev &&
+        chapters.findIndex((c) => c.id === id) <
+          chapters.findIndex((c) => c.id === prev.id)
+          ? -1
+          : 1,
+    }))
+  }
+
+  /* Grace delay so brushing past the panel edge doesn't flicker the card. */
+  const scheduleLeave = () => {
+    clearTimeout(leaveTimer.current)
+    leaveTimer.current = setTimeout(() => setHovered(null), 120)
+  }
+
+  /* Keep the preview glued to its card while the panel scrolls under it. */
+  const onScroll = () => {
+    setHovered((prev) => prev && { ...prev, top: topOf(prev.id) })
+  }
+
+  const measureRef = useCallback((node: HTMLDivElement | null) => {
+    contentObserver.current?.disconnect()
+    if (!node) return
+    const observer = new ResizeObserver(() => setContentH(node.offsetHeight))
+    observer.observe(node)
+    contentObserver.current = observer
+  }, [])
+
+  const active = hovered && chapters.find((c) => c.id === hovered.id)
+  /* Align with the card, but never let the preview leave the frame. */
+  const previewTop = hovered
+    ? Math.max(4, Math.min(hovered.top, FRAME_H - contentH - 4))
+    : 0
+  const dir = reduce ? 0 : (hovered?.dir ?? 1)
+
+  return (
+    <div ref={frameRef} className="relative flex h-full min-h-0 flex-col">
+      {/* Floating glass header — cards dip under it, never past it. */}
+      <div className="absolute inset-x-0 top-0 z-20 flex items-center justify-between gap-2 rounded-xl border border-border/45 bg-neutral/90 p-1.5 shadow-[0_4px_16px_-4px_rgb(0_0_0/0.2),0_2px_6px_-2px_rgb(0_0_0/0.12)] backdrop-blur-sm">
+        <Button
+          variant="quiet"
+          size="sm"
+          className="min-w-0 justify-start gap-1.5 font-medium"
+        >
+          <span className="truncate">Acme design system</span>
+          <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-muted" />
+        </Button>
+        <Button
+          size="sm"
+          variant="quiet"
+          isIconOnly
+          aria-label="Search controls"
+          className="shrink-0"
+        >
+          <SearchIcon />
+        </Button>
+      </div>
+
+      {/* The story scroll: every chapter its own card, wrapped for hover. */}
+      <div
+        className="no-scrollbar flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain rounded-xl pt-[56px] pb-[62px] *:shrink-0"
+        onPointerLeave={scheduleLeave}
+        onScroll={onScroll}
+      >
+        {chapters.map((chapter) => (
+          <div
+            key={chapter.id}
+            ref={(node) => {
+              if (node) cardRefs.current.set(chapter.id, node)
+              else cardRefs.current.delete(chapter.id)
+            }}
+            onPointerEnter={() => hoverCard(chapter.id)}
+          >
+            <ChapterCard chapter={chapter} lab={lab} />
+          </div>
+        ))}
+      </div>
+
+      {/* Floating glass footer — same treatment as the header. */}
+      <div className="absolute inset-x-0 bottom-0 z-20 flex items-center gap-2 rounded-xl border border-border/45 bg-neutral/90 p-2 shadow-[0_-4px_16px_-4px_rgb(0_0_0/0.2),0_-2px_6px_-2px_rgb(0_0_0/0.12)] backdrop-blur-sm">
+        <Button size="sm" className="flex-1">
+          Save
+        </Button>
+        <Button variant="primary" size="sm" className="flex-1">
+          Export
+        </Button>
+      </div>
+
+      {/* The preview rail: one container, retargeted — never re-mounted —
+          as the hover moves between sections. Inert by design. */}
+      <AnimatePresence>
+        {active && hovered && (
+          <motion.div
+            key="preview"
+            aria-hidden
+            className="pointer-events-none absolute top-0 left-full z-30 ml-4 origin-left overflow-hidden rounded-2xl border border-border/45 bg-card shadow-[0_12px_32px_-8px_rgb(0_0_0/0.24),0_4px_12px_-4px_rgb(0_0_0/0.12)] select-none"
+            style={{ width: PREVIEW_W }}
+            initial={{
+              opacity: 0,
+              scale: reduce ? 1 : 0.96,
+              y: previewTop,
+            }}
+            animate={{
+              opacity: 1,
+              scale: 1,
+              y: previewTop,
+              height: contentH || 'auto',
+            }}
+            exit={{
+              opacity: 0,
+              scale: reduce ? 1 : 0.98,
+              transition: { duration: 0.15, ease: EASE_OUT },
+            }}
+            transition={{
+              opacity: { duration: 0.2, ease: EASE_OUT },
+              scale: { duration: 0.2, ease: EASE_OUT },
+              y: reduce ? { duration: 0 } : GLIDE,
+              height: reduce ? { duration: 0 } : GLIDE,
+            }}
+          >
+            <div ref={measureRef}>
+              <AnimatePresence mode="popLayout" initial={false} custom={dir}>
+                <motion.div
+                  key={active.id}
+                  custom={dir}
+                  variants={contentVariants}
+                  initial="enter"
+                  animate="center"
+                  exit="exit"
+                  transition={{ duration: 0.18, ease: EASE_OUT }}
+                  className="flex flex-col gap-3 p-4"
+                >
+                  <div className="flex items-center gap-2">
+                    <active.icon className="size-3.5 text-fg-muted" />
+                    <span className="text-[0.8125rem] font-medium text-fg">
+                      {active.label}
+                    </span>
+                    <span className="ml-auto text-[11px] text-fg-muted">
+                      Live preview
+                    </span>
+                  </div>
+                  <PreviewBody id={active.id} lab={lab} />
+                </motion.div>
+              </AnimatePresence>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
+
+const contentVariants = {
+  enter: (dir: number) => ({
+    opacity: 0,
+    y: 14 * dir,
+    filter: 'blur(4px)',
+  }),
+  center: { opacity: 1, y: 0, filter: 'blur(0px)' },
+  exit: (dir: number) => ({
+    opacity: 0,
+    y: -10 * dir,
+    filter: 'blur(4px)',
+  }),
+}
+
+/* ------------------------------- Previews -------------------------------- */
+/* One demo per chapter — enough real UI to read the section's decisions at a
+   glance, reacting to the lab state where a single value carries the idea. */
+
+function PreviewBody({ id, lab }: { id: string; lab: Lab }) {
+  switch (id) {
+    case 'color':
+      return <ColorPreview lab={lab} />
+    case 'typography':
+      return <TypePreview />
+    case 'icons':
+      return <IconsPreview lab={lab} />
+    case 'shape':
+      return <ShapePreview lab={lab} />
+    case 'space':
+      return <SpacePreview lab={lab} />
+    case 'details':
+      return <DetailsPreview lab={lab} />
+    case 'components':
+      return <ComponentsPreview lab={lab} />
+    default:
+      return (
+        <p className="text-xs/relaxed text-fg-muted">
+          No preview for this section yet.
+        </p>
+      )
+  }
+}
+
+function Caption({ children }: { children: React.ReactNode }) {
+  return <span className="text-[11px] text-fg-muted">{children}</span>
+}
+
+function ColorPreview({ lab }: { lab: Lab }) {
+  const semantics = [
+    { label: 'Accent', className: 'bg-accent' },
+    { label: 'Success', className: 'bg-success' },
+    { label: 'Warning', className: 'bg-warning' },
+    { label: 'Danger', className: 'bg-danger' },
+    { label: 'Info', className: 'bg-info' },
+  ]
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2.5 rounded-lg border border-border/45 bg-bg p-2.5">
+        <span
+          className="size-8 shrink-0 rounded-md"
+          style={{ backgroundColor: lab.state.brand }}
+        />
+        <div className="flex min-w-0 flex-col">
+          <span className="text-xs font-medium text-fg">Brand</span>
+          <span className="truncate font-mono text-[11px] text-fg-muted uppercase">
+            {lab.state.brand}
+          </span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Caption>Semantic scales</Caption>
+        <div className="flex gap-1.5">
+          {semantics.map((semantic) => (
+            <div key={semantic.label} className="flex flex-1 flex-col gap-1">
+              <span className={`h-7 rounded-md ${semantic.className}`} />
+              <span className="text-center text-[10px] text-fg-muted">
+                {semantic.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Caption>Modes</Caption>
+        <div className="flex gap-1.5">
+          {lab.state.modes.map((mode) => (
+            <span
+              key={mode.id}
+              className="flex-1 rounded-md border border-border/45 px-2 py-1 text-center text-[11px]"
+              style={{
+                backgroundColor: `oklch(${mode.bg}% 0 0)`,
+                color: mode.polarity === 'light' ? 'black' : 'white',
+              }}
+            >
+              {mode.name}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TypePreview() {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex items-end gap-3 rounded-lg border border-border/45 bg-bg p-3">
+        <span className="text-4xl/none font-semibold text-fg">Ag</span>
+        <div className="flex flex-col gap-0.5">
+          <span className="text-sm font-semibold text-fg">
+            Ship your design system
+          </span>
+          <span className="text-xs text-fg-muted">
+            Every decision, one panel — previewed live on real components.
+          </span>
+        </div>
+      </div>
+      <span className="rounded-lg border border-border/45 bg-bg px-3 py-2 font-mono text-[11px] text-fg-muted">
+        npx shadcn add button
+      </span>
+    </div>
+  )
+}
+
+const ICON_SAMPLE = [
+  HouseIcon,
+  SearchIcon,
+  BellIcon,
+  HeartIcon,
+  StarIcon,
+  SettingsIcon,
+  CalendarIcon,
+  MailIcon,
+]
+
+function IconsPreview({ lab }: { lab: Lab }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="grid grid-cols-4 gap-1.5">
+        {ICON_SAMPLE.map((Icon, index) => (
+          <span
+            key={index}
+            className="flex h-11 items-center justify-center rounded-lg border border-border/45 bg-bg"
+          >
+            <Icon
+              className="size-4.5 text-fg"
+              strokeWidth={lab.state.iconStroke}
+            />
+          </span>
+        ))}
+      </div>
+      <Caption>
+        {lab.state.iconLibrary} · stroke {lab.state.iconStroke}
+      </Caption>
+    </div>
+  )
+}
+
+/* Role ratios from the #575 rung ladder (md/lg/xl over the base radius). */
+const SHAPE_ROLE_DEMOS = [
+  { label: 'Control', ratio: 0.75 },
+  { label: 'Surface', ratio: 1 },
+  { label: 'Panel', ratio: 1.5 },
+]
+
+function ShapePreview({ lab }: { lab: Lab }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex gap-1.5">
+        {SHAPE_ROLE_DEMOS.map((role) => (
+          <div key={role.label} className="flex flex-1 flex-col gap-1">
+            <span
+              className="flex h-14 items-center justify-center border border-border bg-bg font-mono text-[10px] text-fg-muted"
+              style={{ borderRadius: lab.state.radiusPx * role.ratio }}
+            >
+              {Math.round(lab.state.radiusPx * role.ratio)}px
+            </span>
+            <span className="text-center text-[10px] text-fg-muted">
+              {role.label}
+            </span>
+          </div>
+        ))}
+      </div>
+      <Caption>Base radius {lab.state.radiusPx}px</Caption>
+    </div>
+  )
+}
+
+const DENSITY_PADDING: Record<string, string> = {
+  compact: 'py-1',
+  default: 'py-1.5',
+  comfortable: 'py-2.5',
+}
+
+function SpacePreview({ lab }: { lab: Lab }) {
+  const padding = DENSITY_PADDING[lab.state.density] ?? DENSITY_PADDING.default
+  const rows = [
+    { icon: MousePointerClickIcon, label: 'Select all' },
+    { icon: SendIcon, label: 'Share…' },
+    { icon: SettingsIcon, label: 'Preferences' },
+    { icon: TrashIcon, label: 'Delete' },
+  ]
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col rounded-lg border border-border/45 bg-bg p-1">
+        {rows.map((row) => (
+          <span
+            key={row.label}
+            className={`flex items-center gap-2 rounded-md px-2 text-xs text-fg first:bg-muted ${padding}`}
+          >
+            <row.icon className="size-3.5 text-fg-muted" />
+            {row.label}
+          </span>
+        ))}
+      </div>
+      <Caption>Density: {lab.state.density}</Caption>
+    </div>
+  )
+}
+
+const SHADOW_DEMOS = [
+  { label: 'Card', className: 'shadow-sm' },
+  { label: 'Popover', className: 'shadow-md' },
+  { label: 'Modal', className: 'shadow-xl' },
+]
+
+function DetailsPreview({ lab }: { lab: Lab }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex gap-2 rounded-lg bg-bg p-3">
+        {SHADOW_DEMOS.map((demo) => (
+          <span
+            key={demo.label}
+            className={`flex h-12 flex-1 items-center justify-center rounded-lg border border-border/45 bg-card text-[10px] text-fg-muted ${lab.state.shadows === 'none' ? '' : demo.className}`}
+          >
+            {demo.label}
+          </span>
+        ))}
+      </div>
+      <Caption>Shadows: {lab.state.shadows}</Caption>
+    </div>
+  )
+}
+
+function ComponentsPreview({ lab }: { lab: Lab }) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex items-center gap-2">
+        <Button variant="primary" size="sm">
+          Confirm
+        </Button>
+        <Button size="sm">Cancel</Button>
+        <Button variant="quiet" size="sm">
+          Skip
+        </Button>
+      </div>
+      <span className="flex h-8 items-center rounded-lg border border-border bg-bg px-2.5 text-xs text-fg-muted">
+        Email address
+      </span>
+      <Caption>
+        Button: {lab.state.buttonStyle} · Input: {lab.state.inputStyle}
+      </Caption>
+    </div>
+  )
+}

--- a/www/src/modules/panel-lab/drafts/preview-594.tsx
+++ b/www/src/modules/panel-lab/drafts/preview-594.tsx
@@ -6,10 +6,11 @@
    it glides to the active spot and morphs its height while the content
    crossfades, so moving through the panel reads as one surface retargeting.
 
-   Two levels of preview. Every section has a global preview; controls with
-   something meaningful to show override it with their own (Brand shows the
-   color in real demos, the Input row shows real inputs). A control's preview
-   anchors to its ROW, not the section card.
+   Control previews only. Rows with something meaningful to show have their
+   own preview (Brand shows the color in real demos, the Input row shows real
+   inputs), anchored to the ROW. Rows without one show nothing — a section
+   fallback proved noisy between controls, so it's gone. The 120ms grace also
+   covers the gaps between rows, so control-to-control never flickers.
 
    Three signals drive the target, strongest first: an OPEN overlay (a picker,
    select or menu whose trigger reads aria-expanded inside the panel) pins its
@@ -77,9 +78,9 @@ interface Target {
   /** Content identity — drives the crossfade. */
   key: string
   sectionId: string
-  /** Row label when a control preview matched; null = section preview. */
-  control: string | null
-  /** Element the preview aligns to (row, disclosure root, or section card). */
+  /** The matched row's label. */
+  control: string
+  /** Element the preview aligns to (the row or its disclosure root). */
   anchor: Element
   /** Anchor top relative to the frame, unclamped. */
   top: number
@@ -94,12 +95,12 @@ function labelOf(el: Element): string | null {
   )
 }
 
-/** Climb from a DOM node to the innermost thing with a registered preview:
+/** Climb from a DOM node to the innermost row with a registered preview:
  *  a labeled row first, then the enclosing disclosure (so "Success" inside
- *  Semantic colors attributes to Semantic colors), else the section. */
+ *  Semantic colors attributes to Semantic colors). No match → no preview. */
 function resolveTarget(
   start: Element,
-): { sectionId: string; control: string | null; anchor: Element } | null {
+): { sectionId: string; control: string; anchor: Element } | null {
   const section = start.closest('[data-chapter]')
   if (!section) return null
   const sectionId = section.getAttribute('data-chapter') ?? ''
@@ -117,7 +118,7 @@ function resolveTarget(
     }
     node = candidate.parentElement
   }
-  return { sectionId, control: null, anchor: section }
+  return null
 }
 
 export function HoverPreviewFrame({
@@ -184,9 +185,7 @@ export function HoverPreviewFrame({
       if (!resolved || !frame) return null
       const { sectionId, control, anchor } = resolved
       return {
-        key: control
-          ? `control:${sectionId}:${control}`
-          : `section:${sectionId}`,
+        key: `${sectionId}:${control}`,
         sectionId,
         control,
         anchor,
@@ -219,9 +218,17 @@ export function HoverPreviewFrame({
     return () => observer.disconnect()
   }, [toTarget])
 
+  /* A non-control spot doesn't clear immediately — the grace delay carries
+     the preview across the gaps between rows, so only genuinely leaving the
+     controls (heroes, captions, out of the panel) hides it. */
   const onPointerOver = (e: React.PointerEvent) => {
-    clearTimeout(leaveTimer.current)
-    setHoverT(toTarget(resolveTarget(e.target as Element)))
+    const target = toTarget(resolveTarget(e.target as Element))
+    if (target) {
+      clearTimeout(leaveTimer.current)
+      setHoverT(target)
+    } else {
+      scheduleLeave()
+    }
   }
 
   /* Grace delay so brushing past the panel edge doesn't flicker the card. */
@@ -407,12 +414,10 @@ export function HoverPreviewFrame({
                     <chapter.icon className="size-3.5 text-fg-muted" />
                     <span className="text-[0.8125rem] font-medium text-fg">
                       {chapter.label}
-                      {display.control && (
-                        <span className="text-fg-muted">
-                          {' · '}
-                          {display.control}
-                        </span>
-                      )}
+                      <span className="text-fg-muted">
+                        {' · '}
+                        {display.control}
+                      </span>
                     </span>
                     <span className="ml-auto text-[11px] text-fg-muted">
                       Live preview
@@ -448,9 +453,8 @@ const contentVariants = {
 }
 
 /* ------------------------------- Previews --------------------------------- */
-/* Section previews are the fallback; control previews override them when a
-   row has something specific to show. Each reads the lab state where a
-   single value carries the idea. */
+/* One demo per registered control, reading the lab state where a single
+   value carries the idea. Rows without an entry show no preview. */
 
 function PreviewBody({
   sectionId,
@@ -458,20 +462,11 @@ function PreviewBody({
   lab,
 }: {
   sectionId: string
-  control: string | null
+  control: string
   lab: Lab
 }) {
-  const Control = control ? CONTROL_PREVIEWS[sectionId]?.[control] : undefined
-  const Section = SECTION_PREVIEWS[sectionId]
-  const Body = Control ?? Section
-  if (!Body) {
-    return (
-      <p className="text-xs/relaxed text-fg-muted">
-        No preview for this section yet.
-      </p>
-    )
-  }
-  return <Body lab={lab} />
+  const Body = CONTROL_PREVIEWS[sectionId]?.[control]
+  return Body ? <Body lab={lab} /> : null
 }
 
 type Preview = React.ComponentType<{ lab: Lab }>
@@ -497,69 +492,6 @@ function Panel({
 }
 
 /* --------------------------------- Color ---------------------------------- */
-
-function ColorSectionPreview({ lab }: { lab: Lab }) {
-  const semantics = [
-    { label: 'Accent', className: 'bg-accent' },
-    { label: 'Success', className: 'bg-success' },
-    { label: 'Warning', className: 'bg-warning' },
-    { label: 'Danger', className: 'bg-danger' },
-    { label: 'Info', className: 'bg-info' },
-  ]
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-2.5 rounded-lg border border-border/45 bg-bg p-2.5">
-        <span
-          className="size-8 shrink-0 rounded-md"
-          style={{ backgroundColor: lab.state.brand }}
-        />
-        <div className="flex min-w-0 flex-col">
-          <span className="text-xs font-medium text-fg">Brand</span>
-          <span className="truncate font-mono text-[11px] text-fg-muted uppercase">
-            {lab.state.brand}
-          </span>
-        </div>
-      </div>
-      <div className="flex flex-col gap-1.5">
-        <Caption>Semantic scales</Caption>
-        <div className="flex gap-1.5">
-          {semantics.map((semantic) => (
-            <div key={semantic.label} className="flex flex-1 flex-col gap-1">
-              <span className={`h-7 rounded-md ${semantic.className}`} />
-              <span className="text-center text-[10px] text-fg-muted">
-                {semantic.label}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-      <ModeChips lab={lab} />
-    </div>
-  )
-}
-
-function ModeChips({ lab }: { lab: Lab }) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <Caption>Modes</Caption>
-      <div className="flex gap-1.5">
-        {lab.state.modes.map((mode) => (
-          <span
-            key={mode.id}
-            className="flex-1 rounded-md border border-border/45 px-2 py-1 text-center text-[11px]"
-            style={{
-              backgroundColor: `oklch(${mode.bg}% 0 0)`,
-              color: mode.polarity === 'light' ? 'black' : 'white',
-            }}
-          >
-            {mode.name}
-            {mode.id === lab.state.defaultMode ? ' ✦' : ''}
-          </span>
-        ))}
-      </div>
-    </div>
-  )
-}
 
 /** The brand color doing its real jobs: CTA, link, controls, badge. */
 function BrandPreview({ lab }: { lab: Lab }) {
@@ -733,25 +665,6 @@ function SemanticPreview({ lab }: { lab: Lab }) {
 
 /* ------------------------------- Typography ------------------------------- */
 
-function TypeSectionPreview() {
-  return (
-    <div className="flex flex-col gap-2.5">
-      <Panel className="gap-1">
-        <span className="text-4xl/none font-semibold text-fg">Ag</span>
-        <span className="mt-1 text-sm font-semibold text-fg">
-          Ship your design system
-        </span>
-        <span className="text-xs text-fg-muted">
-          Every decision, one panel — previewed live on real components.
-        </span>
-      </Panel>
-      <span className="rounded-lg border border-border/45 bg-bg px-3 py-2 font-mono text-[11px] text-fg-muted">
-        npx shadcn add button
-      </span>
-    </div>
-  )
-}
-
 function FontPreview({
   family,
   role,
@@ -816,7 +729,7 @@ const ICON_SAMPLE = [
   MailIcon,
 ]
 
-function IconsSectionPreview({ lab }: { lab: Lab }) {
+function IconGridPreview({ lab }: { lab: Lab }) {
   return (
     <div className="flex flex-col gap-1.5">
       <div className="grid grid-cols-4 gap-1.5">
@@ -873,7 +786,7 @@ const SHAPE_ROLE_DEMOS = [
 const cornerShapeStyle = (shape: string): React.CSSProperties =>
   shape === 'round' ? {} : ({ cornerShape: shape } as React.CSSProperties)
 
-function ShapeSectionPreview({ lab }: { lab: Lab }) {
+function RadiusPreview({ lab }: { lab: Lab }) {
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex gap-1.5">
@@ -981,7 +894,7 @@ const DENSITY_PADDING: Record<string, string> = {
   comfortable: 'py-2.5',
 }
 
-function SpaceSectionPreview({ lab }: { lab: Lab }) {
+function DensityPreview({ lab }: { lab: Lab }) {
   const padding = DENSITY_PADDING[lab.state.density] ?? DENSITY_PADDING.default
   const rows = [
     { icon: MousePointerClickIcon, label: 'Select all' },
@@ -1015,7 +928,7 @@ const SHADOW_DEMOS = [
   { label: 'Modal', className: 'shadow-xl' },
 ]
 
-function DetailsSectionPreview({ lab }: { lab: Lab }) {
+function ShadowsPreview({ lab }: { lab: Lab }) {
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex gap-2 rounded-lg bg-bg p-3">
@@ -1353,42 +1266,10 @@ function LoaderPreview({ lab }: { lab: Lab }) {
   )
 }
 
-function ComponentsSectionPreview({ lab }: { lab: Lab }) {
-  return (
-    <div className="flex flex-col gap-2.5">
-      <div className="flex items-center gap-2">
-        <Button variant="primary" size="sm">
-          Confirm
-        </Button>
-        <Button size="sm">Cancel</Button>
-        <Button variant="quiet" size="sm">
-          Skip
-        </Button>
-      </div>
-      <span className="flex h-8 items-center rounded-lg border border-border bg-bg px-2.5 text-xs text-fg-muted">
-        Email address
-      </span>
-      <Caption>
-        Button: {lab.state.buttonStyle} · Input: {lab.state.inputStyle}
-      </Caption>
-    </div>
-  )
-}
-
-/* ------------------------------- Registries ------------------------------- */
-
-const SECTION_PREVIEWS: Record<string, Preview> = {
-  color: ColorSectionPreview,
-  typography: TypeSectionPreview,
-  icons: IconsSectionPreview,
-  shape: ShapeSectionPreview,
-  space: SpaceSectionPreview,
-  details: DetailsSectionPreview,
-  components: ComponentsSectionPreview,
-}
+/* ------------------------------- Registry --------------------------------- */
 
 /* Keyed by the row's visible label (or aria-label) — what resolveTarget
-   reads from the DOM. Rows not listed fall back to the section preview. */
+   reads from the DOM. Rows not listed show no preview. */
 const CONTROL_PREVIEWS: Record<string, Record<string, Preview>> = {
   color: {
     Brand: BrandPreview,
@@ -1405,21 +1286,21 @@ const CONTROL_PREVIEWS: Record<string, Record<string, Preview>> = {
     Mono: ({ lab }) => <FontPreview family={lab.state.monoFont} role="mono" />,
   },
   icons: {
-    Library: IconsSectionPreview,
+    Library: IconGridPreview,
     Stroke: StrokePreview,
-    Weight: IconsSectionPreview,
+    Weight: IconGridPreview,
   },
   shape: {
-    Radius: ShapeSectionPreview,
+    Radius: RadiusPreview,
     Character: RolesPreview,
     Roles: RolesPreview,
     Corners: CornersPreview,
   },
   space: {
-    Density: SpaceSectionPreview,
+    Density: DensityPreview,
   },
   details: {
-    Shadows: DetailsSectionPreview,
+    Shadows: ShadowsPreview,
     Cursor: CursorPreview,
     'Disabled cursor': CursorPreview,
   },

--- a/www/src/modules/panel-lab/drafts/preview-594.tsx
+++ b/www/src/modules/panel-lab/drafts/preview-594.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client"
 
 /* Draft #594 — the hover preview rail. A FRAME experiment, not a section one:
    the panel chrome is the v2 frame verbatim, but interacting with the panel
@@ -27,7 +27,7 @@
    while an overlay is open, where row overlays open (threaded to the shared
    rows via RowOverlayPlacementContext), and the disable affordance. */
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from "react"
 import {
   BellIcon,
   CalendarIcon,
@@ -46,27 +46,27 @@ import {
   SettingsIcon,
   StarIcon,
   TrashIcon,
-} from 'lucide-react'
-import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+} from "lucide-react"
+import { AnimatePresence, motion, useReducedMotion } from "motion/react"
 
-import { fontStack } from '@/lib/fonts'
-import { Button } from '@/registry/ui/button'
-import { RowOverlayPlacementContext } from '@/modules/control-lab/rows'
-import type { RowOverlayPlacement } from '@/modules/control-lab/rows'
-import { useLoadedFamilies } from '@/modules/create/typography'
-import { useTweak } from '@/dev/tweaker'
+import { fontStack } from "@/lib/fonts"
+import { Button } from "@/registry/ui/button"
+import { RowOverlayPlacementContext } from "@/modules/control-lab/rows"
+import type { RowOverlayPlacement } from "@/modules/control-lab/rows"
+import { useLoadedFamilies } from "@/modules/create/typography"
+import { useTweak } from "@/dev/tweaker"
 
-import { SHAPE_RUNGS } from '../data'
-import type { Lab } from '../data'
-import { ChapterCard } from '../variants/chapter'
-import type { Chapter } from '../variants/chapter'
+import { SHAPE_RUNGS } from "../data"
+import type { Lab } from "../data"
+import { ChapterCard } from "../variants/chapter"
+import type { Chapter } from "../variants/chapter"
 
 const PREVIEW_W = 300
 /* The page mounts the panel at this fixed height (version-page.tsx). */
 const FRAME_H = 720
 const EASE_OUT = [0.215, 0.61, 0.355, 1] as const
 const GLIDE = {
-  type: 'spring',
+  type: "spring",
   stiffness: 500,
   damping: 46,
   mass: 0.8,
@@ -89,8 +89,8 @@ interface Target {
 /** Row label: the ROW_LABEL span, else the element's own aria-label. */
 function labelOf(el: Element): string | null {
   return (
-    el.querySelector('.font-medium.truncate')?.textContent?.trim() ??
-    el.getAttribute('aria-label')?.trim() ??
+    el.querySelector(".font-medium.truncate")?.textContent?.trim() ??
+    el.getAttribute("aria-label")?.trim() ??
     null
   )
 }
@@ -101,9 +101,9 @@ function labelOf(el: Element): string | null {
 function resolveTarget(
   start: Element,
 ): { sectionId: string; control: string; anchor: Element } | null {
-  const section = start.closest('[data-chapter]')
+  const section = start.closest("[data-chapter]")
   if (!section) return null
-  const sectionId = section.getAttribute('data-chapter') ?? ''
+  const sectionId = section.getAttribute("data-chapter") ?? ""
   const registry = CONTROL_PREVIEWS[sectionId]
 
   let node: Element | null = start
@@ -138,45 +138,45 @@ export function HoverPreviewFrame({
   const [contentH, setContentH] = useState(0)
   const [enabled, setEnabled] = useState(true)
 
-  const side = useTweak('Preview side', {
-    type: 'select',
-    options: ['right', 'right far', 'left'],
-    default: 'right',
-    group: 'Preview rail',
+  const side = useTweak("Preview side", {
+    type: "select",
+    options: ["right", "right far", "left"],
+    default: "right",
+    group: "Preview rail",
   })
-  const whileOpen = useTweak('While overlay open', {
-    type: 'select',
-    options: ['show', 'hide'],
-    default: 'show',
-    group: 'Preview rail',
+  const whileOpen = useTweak("While overlay open", {
+    type: "select",
+    options: ["show", "hide"],
+    default: "show",
+    group: "Preview rail",
   })
-  const overlayPlacement = useTweak('Overlay placement', {
-    type: 'select',
-    options: ['right top', 'left top', 'bottom start'],
-    default: 'right top',
-    group: 'Preview rail',
+  const overlayPlacement = useTweak("Overlay placement", {
+    type: "select",
+    options: ["right top", "left top", "bottom start"],
+    default: "right top",
+    group: "Preview rail",
   })
-  const affordance = useTweak('Disable affordance', {
-    type: 'select',
-    options: ['none', 'header eye', 'press P'],
-    default: 'none',
-    group: 'Preview rail',
+  const affordance = useTweak("Disable affordance", {
+    type: "select",
+    options: ["none", "header eye", "press P"],
+    default: "none",
+    group: "Preview rail",
   })
 
   useEffect(() => () => clearTimeout(leaveTimer.current), [])
   useEffect(() => {
-    if (affordance === 'none') setEnabled(true)
+    if (affordance === "none") setEnabled(true)
   }, [affordance])
   useEffect(() => {
-    if (affordance !== 'press P') return
+    if (affordance !== "press P") return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== 'p' && e.key !== 'P') return
+      if (e.key !== "p" && e.key !== "P") return
       const el = e.target as HTMLElement | null
-      if (el?.closest('input, textarea, [contenteditable]')) return
+      if (el?.closest("input, textarea, [contenteditable]")) return
       setEnabled((v) => !v)
     }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
   }, [affordance])
 
   const toTarget = useCallback(
@@ -213,7 +213,7 @@ export function HoverPreviewFrame({
     observer.observe(frame, {
       subtree: true,
       attributes: true,
-      attributeFilter: ['aria-expanded'],
+      attributeFilter: ["aria-expanded"],
     })
     return () => observer.disconnect()
   }, [toTarget])
@@ -268,7 +268,7 @@ export function HoverPreviewFrame({
 
   const display = !enabled
     ? null
-    : openT && whileOpen === 'hide'
+    : openT && whileOpen === "hide"
       ? null
       : (openT ?? hoverT ?? focusT)
   const chapter = display && chapters.find((c) => c.id === display.sectionId)
@@ -295,7 +295,7 @@ export function HoverPreviewFrame({
       // "left" keeps the page usable: the panel slides over so the preview
       // lands where the panel was, and row overlays open into free space.
       style={
-        side === 'left'
+        side === "left"
           ? { transform: `translateX(${PREVIEW_W + 16}px)` }
           : undefined
       }
@@ -311,14 +311,14 @@ export function HoverPreviewFrame({
           <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-muted" />
         </Button>
         <div className="flex shrink-0 items-center">
-          {affordance === 'header eye' && (
+          {affordance === "header eye" && (
             <Button
               size="sm"
               variant="quiet"
               isIconOnly
-              aria-label={enabled ? 'Hide previews' : 'Show previews'}
+              aria-label={enabled ? "Hide previews" : "Show previews"}
               onPress={() => setEnabled((v) => !v)}
-              className={enabled ? undefined : 'text-fg-muted'}
+              className={enabled ? undefined : "text-fg-muted"}
             >
               {enabled ? <EyeIcon /> : <EyeOffIcon />}
             </Button>
@@ -372,11 +372,11 @@ export function HoverPreviewFrame({
             key="preview"
             aria-hidden
             className={`pointer-events-none absolute top-0 z-30 overflow-hidden rounded-2xl border border-border/45 bg-card shadow-[0_12px_32px_-8px_rgb(0_0_0/0.24),0_4px_12px_-4px_rgb(0_0_0/0.12)] select-none ${
-              side === 'left'
-                ? 'right-full mr-4 origin-right'
-                : side === 'right far'
-                  ? 'left-full ml-[352px] origin-left'
-                  : 'left-full ml-4 origin-left'
+              side === "left"
+                ? "right-full mr-4 origin-right"
+                : side === "right far"
+                  ? "left-full ml-[352px] origin-left"
+                  : "left-full ml-4 origin-left"
             }`}
             style={{ width: PREVIEW_W }}
             initial={{ opacity: 0, scale: reduce ? 1 : 0.96, y: previewTop }}
@@ -384,7 +384,7 @@ export function HoverPreviewFrame({
               opacity: 1,
               scale: 1,
               y: previewTop,
-              height: contentH || 'auto',
+              height: contentH || "auto",
             }}
             exit={{
               opacity: 0,
@@ -415,7 +415,7 @@ export function HoverPreviewFrame({
                     <span className="text-[0.8125rem] font-medium text-fg">
                       {chapter.label}
                       <span className="text-fg-muted">
-                        {' · '}
+                        {" · "}
                         {display.control}
                       </span>
                     </span>
@@ -442,13 +442,13 @@ const contentVariants = {
   enter: (dir: number) => ({
     opacity: 0,
     y: 14 * dir,
-    filter: 'blur(4px)',
+    filter: "blur(4px)",
   }),
-  center: { opacity: 1, y: 0, filter: 'blur(0px)' },
+  center: { opacity: 1, y: 0, filter: "blur(0px)" },
   exit: (dir: number) => ({
     opacity: 0,
     y: -10 * dir,
-    filter: 'blur(4px)',
+    filter: "blur(4px)",
   }),
 }
 
@@ -477,7 +477,7 @@ function Caption({ children }: { children: React.ReactNode }) {
 
 function Panel({
   children,
-  className = 'gap-2.5',
+  className = "gap-2.5",
 }: {
   children: React.ReactNode
   className?: string
@@ -555,9 +555,9 @@ function GrayPreview({ lab }: { lab: Lab }) {
         </span>
       </Panel>
       <Caption>
-        Seed:{' '}
-        {lab.state.graySeed === ''
-          ? 'Auto (derived from brand)'
+        Seed:{" "}
+        {lab.state.graySeed === ""
+          ? "Auto (derived from brand)"
           : lab.state.graySeed}
       </Caption>
     </div>
@@ -572,9 +572,9 @@ function PrimaryPreview({ lab }: { lab: Lab }) {
       <div className="flex items-center gap-2">
         <span
           className={`flex h-8 items-center rounded-lg px-3 text-xs font-medium ${
-            primary === 'neutral'
-              ? 'bg-neutral text-fg-on-neutral'
-              : 'bg-accent text-white'
+            primary === "neutral"
+              ? "bg-neutral text-fg-on-neutral"
+              : "bg-accent text-white"
           }`}
         >
           Primary action
@@ -584,7 +584,7 @@ function PrimaryPreview({ lab }: { lab: Lab }) {
         </span>
       </div>
       <Caption>
-        Primary buttons use the {primary === 'neutral' ? 'neutral' : 'accent'}{' '}
+        Primary buttons use the {primary === "neutral" ? "neutral" : "accent"}{" "}
         scale
       </Caption>
     </div>
@@ -601,12 +601,12 @@ function ModesPreview({ lab }: { lab: Lab }) {
             className="flex items-center justify-between rounded-lg border border-border/45 px-3 py-2 text-xs"
             style={{
               backgroundColor: `oklch(${mode.bg}% 0 0)`,
-              color: mode.polarity === 'light' ? 'black' : 'white',
+              color: mode.polarity === "light" ? "black" : "white",
             }}
           >
             <span className="font-medium">{mode.name}</span>
             <span className="flex items-center gap-1.5 text-[10px] opacity-70">
-              {mode.contrast === 'high' && <span>HC</span>}
+              {mode.contrast === "high" && <span>HC</span>}
               <span>L* {mode.bg}</span>
               {mode.id === lab.state.defaultMode && <span>· default</span>}
             </span>
@@ -614,10 +614,10 @@ function ModesPreview({ lab }: { lab: Lab }) {
         ))}
       </div>
       <Caption>
-        {lab.state.modes.length}{' '}
-        {lab.state.modes.length === 1 ? 'mode' : 'modes'} · users land on{' '}
+        {lab.state.modes.length}{" "}
+        {lab.state.modes.length === 1 ? "mode" : "modes"} · users land on{" "}
         {lab.state.modes.find((m) => m.id === lab.state.defaultMode)?.name ??
-          'the default'}
+          "the default"}
       </Caption>
     </div>
   )
@@ -627,17 +627,17 @@ function ModesPreview({ lab }: { lab: Lab }) {
 function SemanticPreview({ lab }: { lab: Lab }) {
   const rows = [
     {
-      label: 'Payment received',
-      dot: 'bg-success',
+      label: "Payment received",
+      dot: "bg-success",
       seed: lab.state.successSeed,
     },
     {
-      label: 'Storage almost full',
-      dot: 'bg-warning',
+      label: "Storage almost full",
+      dot: "bg-warning",
       seed: lab.state.warningSeed,
     },
-    { label: 'Build failed', dot: 'bg-danger', seed: lab.state.dangerSeed },
-    { label: 'Update available', dot: 'bg-info', seed: lab.state.infoSeed },
+    { label: "Build failed", dot: "bg-danger", seed: lab.state.dangerSeed },
+    { label: "Update available", dot: "bg-info", seed: lab.state.infoSeed },
   ]
   return (
     <div className="flex flex-col gap-2.5">
@@ -648,12 +648,12 @@ function SemanticPreview({ lab }: { lab: Lab }) {
             className="flex items-center gap-2 rounded-lg border border-border/45 bg-bg px-2.5 py-1.5 text-xs text-fg"
           >
             <span
-              className={`size-2 rounded-full ${row.seed ? '' : row.dot}`}
+              className={`size-2 rounded-full ${row.seed ? "" : row.dot}`}
               style={row.seed ? { backgroundColor: row.seed } : undefined}
             />
             {row.label}
             <span className="ml-auto font-mono text-[10px] text-fg-muted uppercase">
-              {row.seed || 'Auto'}
+              {row.seed || "Auto"}
             </span>
           </span>
         ))}
@@ -670,14 +670,14 @@ function FontPreview({
   role,
 }: {
   family: string
-  role: 'heading' | 'body' | 'mono'
+  role: "heading" | "body" | "mono"
 }) {
   useLoadedFamilies([family])
   const stack = fontStack(family)
   return (
     <div className="flex flex-col gap-2.5">
       <Panel className="gap-1.5">
-        {role === 'heading' && (
+        {role === "heading" && (
           <>
             <span
               className="text-xl/tight font-semibold text-fg"
@@ -693,7 +693,7 @@ function FontPreview({
             </span>
           </>
         )}
-        {role === 'body' && (
+        {role === "body" && (
           <span
             className="text-xs/relaxed text-fg"
             style={{ fontFamily: stack }}
@@ -702,12 +702,12 @@ function FontPreview({
             small sizes, through long paragraphs, in both modes.
           </span>
         )}
-        {role === 'mono' && (
+        {role === "mono" && (
           <span
             className="text-[11px]/relaxed whitespace-pre text-fg"
             style={{ fontFamily: stack }}
           >
-            {'const theme = createTheme({\n  radius: 10,\n})'}
+            {"const theme = createTheme({\n  radius: 10,\n})"}
           </span>
         )}
       </Panel>
@@ -777,14 +777,14 @@ function StrokePreview({ lab }: { lab: Lab }) {
 /* --------------------------------- Shape ---------------------------------- */
 
 const SHAPE_ROLE_DEMOS = [
-  { label: 'Control', ratio: 0.75 },
-  { label: 'Surface', ratio: 1 },
-  { label: 'Panel', ratio: 1.5 },
+  { label: "Control", ratio: 0.75 },
+  { label: "Surface", ratio: 1 },
+  { label: "Panel", ratio: 1.5 },
 ]
 
 /* corner-shape is progressive enhancement — unsupported browsers render round. */
 const cornerShapeStyle = (shape: string): React.CSSProperties =>
-  shape === 'round' ? {} : ({ cornerShape: shape } as React.CSSProperties)
+  shape === "round" ? {} : ({ cornerShape: shape } as React.CSSProperties)
 
 function RadiusPreview({ lab }: { lab: Lab }) {
   return (
@@ -823,7 +823,7 @@ function RolesPreview({ lab }: { lab: Lab }) {
     return ratio === Infinity ? 999 : radiusPx * ratio
   }
   const label = (name: string, role: string) =>
-    `${name} · ${rungRatio(role) === Infinity ? 'pill' : `${Math.round(px(role))}px`}`
+    `${name} · ${rungRatio(role) === Infinity ? "pill" : `${Math.round(px(role))}px`}`
   return (
     <div className="flex flex-col gap-1.5">
       <div
@@ -831,27 +831,27 @@ function RolesPreview({ lab }: { lab: Lab }) {
         style={{ borderRadius: px(rolePanel) }}
       >
         <span className="text-[10px] text-fg-muted">
-          {label('Panel', rolePanel)}
+          {label("Panel", rolePanel)}
         </span>
         <div
           className="flex flex-col gap-2 border border-border/60 bg-card p-2.5"
           style={{ borderRadius: px(roleSurface) }}
         >
           <span className="text-[10px] text-fg-muted">
-            {label('Surface', roleSurface)}
+            {label("Surface", roleSurface)}
           </span>
           <span
             className="flex h-7 items-center justify-center bg-primary text-[11px] font-medium text-fg-on-primary"
             style={{ borderRadius: px(roleControl) }}
           >
-            {label('Control', roleControl)}
+            {label("Control", roleControl)}
           </span>
         </div>
       </div>
       <Caption>
-        Items:{' '}
-        {lab.state.roleItem === 'auto'
-          ? 'auto (one rung below surfaces)'
+        Items:{" "}
+        {lab.state.roleItem === "auto"
+          ? "auto (one rung below surfaces)"
           : lab.state.roleItem}
       </Caption>
     </div>
@@ -862,13 +862,13 @@ function CornersPreview({ lab }: { lab: Lab }) {
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex gap-1.5">
-        {['round', 'squircle', 'bevel'].map((shape) => (
+        {["round", "squircle", "bevel"].map((shape) => (
           <div key={shape} className="flex flex-1 flex-col gap-1">
             <span
               className={`h-14 border bg-bg ${
                 shape === lab.state.cornerShape
-                  ? 'border-accent'
-                  : 'border-border'
+                  ? "border-accent"
+                  : "border-border"
               }`}
               style={{
                 borderRadius: Math.max(lab.state.radiusPx * 1.5, 8),
@@ -889,18 +889,18 @@ function CornersPreview({ lab }: { lab: Lab }) {
 /* --------------------------------- Space ---------------------------------- */
 
 const DENSITY_PADDING: Record<string, string> = {
-  compact: 'py-1',
-  default: 'py-1.5',
-  comfortable: 'py-2.5',
+  compact: "py-1",
+  default: "py-1.5",
+  comfortable: "py-2.5",
 }
 
 function DensityPreview({ lab }: { lab: Lab }) {
   const padding = DENSITY_PADDING[lab.state.density] ?? DENSITY_PADDING.default
   const rows = [
-    { icon: MousePointerClickIcon, label: 'Select all' },
-    { icon: SendIcon, label: 'Share…' },
-    { icon: SettingsIcon, label: 'Preferences' },
-    { icon: TrashIcon, label: 'Delete' },
+    { icon: MousePointerClickIcon, label: "Select all" },
+    { icon: SendIcon, label: "Share…" },
+    { icon: SettingsIcon, label: "Preferences" },
+    { icon: TrashIcon, label: "Delete" },
   ]
   return (
     <div className="flex flex-col gap-1.5">
@@ -923,9 +923,9 @@ function DensityPreview({ lab }: { lab: Lab }) {
 /* -------------------------------- Details --------------------------------- */
 
 const SHADOW_DEMOS = [
-  { label: 'Card', className: 'shadow-sm' },
-  { label: 'Popover', className: 'shadow-md' },
-  { label: 'Modal', className: 'shadow-xl' },
+  { label: "Card", className: "shadow-sm" },
+  { label: "Popover", className: "shadow-md" },
+  { label: "Modal", className: "shadow-xl" },
 ]
 
 function ShadowsPreview({ lab }: { lab: Lab }) {
@@ -935,7 +935,7 @@ function ShadowsPreview({ lab }: { lab: Lab }) {
         {SHADOW_DEMOS.map((demo) => (
           <span
             key={demo.label}
-            className={`flex h-12 flex-1 items-center justify-center rounded-lg border border-border/45 bg-card text-[10px] text-fg-muted ${lab.state.shadows === 'none' ? '' : demo.className}`}
+            className={`flex h-12 flex-1 items-center justify-center rounded-lg border border-border/45 bg-card text-[10px] text-fg-muted ${lab.state.shadows === "none" ? "" : demo.className}`}
           >
             {demo.label}
           </span>
@@ -971,17 +971,17 @@ function CursorPreview({ lab }: { lab: Lab }) {
 /* ------------------------------- Components ------------------------------- */
 
 const BUTTON_STYLE_CLASSES: Record<string, string> = {
-  solid: 'bg-primary text-fg-on-primary',
-  soft: 'bg-neutral text-fg-on-neutral',
-  outline: 'border border-border-field text-fg',
-  quiet: 'text-fg',
+  solid: "bg-primary text-fg-on-primary",
+  soft: "bg-neutral text-fg-on-neutral",
+  outline: "border border-border-field text-fg",
+  quiet: "text-fg",
 }
 
 function buttonRadius(lab: Lab): number {
   const { buttonRadius: r, radiusPx } = lab.state
-  if (r === 'sharp') return 0
-  if (r === 'pill') return 999
-  if (r === 'round') return Math.max(radiusPx, 8)
+  if (r === "sharp") return 0
+  if (r === "pill") return 999
+  if (r === "round") return Math.max(radiusPx, 8)
   return radiusPx * 0.75
 }
 
@@ -1012,7 +1012,7 @@ function ButtonPreview({ lab }: { lab: Lab }) {
         </span>
       </div>
       <Caption>
-        {lab.state.buttonStyle} · radius {lab.state.buttonRadius} · hover{' '}
+        {lab.state.buttonStyle} · radius {lab.state.buttonRadius} · hover{" "}
         {lab.state.buttonHover}
       </Caption>
     </div>
@@ -1020,10 +1020,10 @@ function ButtonPreview({ lab }: { lab: Lab }) {
 }
 
 const INPUT_STYLE_CLASSES: Record<string, string> = {
-  outline: 'rounded-lg border border-border-field bg-bg',
-  line: 'border-b border-border-field',
-  'filled-line-bottom': 'rounded-t-lg border-b border-border-field bg-neutral',
-  filled: 'rounded-lg bg-neutral',
+  outline: "rounded-lg border border-border-field bg-bg",
+  line: "border-b border-border-field",
+  "filled-line-bottom": "rounded-t-lg border-b border-border-field bg-neutral",
+  filled: "rounded-lg bg-neutral",
 }
 
 function InputPreview({ lab }: { lab: Lab }) {
@@ -1069,8 +1069,8 @@ function CheckboxPreview({ lab }: { lab: Lab }) {
     <div className="flex flex-col gap-2.5">
       <div className="flex flex-col gap-1.5">
         {[
-          { label: 'Email me product updates', checked: true },
-          { label: 'Share usage analytics', checked: false },
+          { label: "Email me product updates", checked: true },
+          { label: "Share usage analytics", checked: false },
         ].map((row) => (
           <span
             key={row.label}
@@ -1079,8 +1079,8 @@ function CheckboxPreview({ lab }: { lab: Lab }) {
             <span
               className={`flex size-4 items-center justify-center ${
                 row.checked
-                  ? 'bg-primary text-fg-on-primary'
-                  : 'border border-border-field'
+                  ? "bg-primary text-fg-on-primary"
+                  : "border border-border-field"
               }`}
               style={{ borderRadius: radius }}
             >
@@ -1096,14 +1096,14 @@ function CheckboxPreview({ lab }: { lab: Lab }) {
 }
 
 function CardPreview({ lab }: { lab: Lab }) {
-  const tasnim = lab.state.cardStyle === 'tasnim'
+  const tasnim = lab.state.cardStyle === "tasnim"
   return (
     <div className="flex flex-col gap-2.5">
       <div
         className={`flex flex-col gap-1 p-3 ${
           tasnim
-            ? 'bg-muted shadow-[0_6px_16px_rgb(0_0_0/0.45)]'
-            : 'border border-border bg-card'
+            ? "bg-muted shadow-[0_6px_16px_rgb(0_0_0/0.45)]"
+            : "border border-border bg-card"
         }`}
         style={{ borderRadius: lab.state.radiusPx }}
       >
@@ -1146,9 +1146,9 @@ function BadgePreview({ lab }: { lab: Lab }) {
 }
 
 const MODAL_BLUR: Record<string, string> = {
-  none: '',
-  sm: 'backdrop-blur-[2px]',
-  md: 'backdrop-blur-[6px]',
+  none: "",
+  sm: "backdrop-blur-[2px]",
+  md: "backdrop-blur-[6px]",
 }
 
 function ModalPreview({ lab }: { lab: Lab }) {
@@ -1163,7 +1163,7 @@ function ModalPreview({ lab }: { lab: Lab }) {
           <span className="h-2 w-2/3 rounded-sm bg-muted" />
         </div>
         <div
-          className={`absolute inset-0 flex items-center justify-center bg-black ${MODAL_BLUR[modalBlur] ?? ''}`}
+          className={`absolute inset-0 flex items-center justify-center bg-black ${MODAL_BLUR[modalBlur] ?? ""}`}
           style={{
             backgroundColor: `rgb(0 0 0 / ${Number(modalBackdrop) / 100})`,
           }}
@@ -1178,7 +1178,7 @@ function ModalPreview({ lab }: { lab: Lab }) {
             </span>
             <div
               className={`-m-3 mt-0 flex justify-end gap-1.5 p-2 ${
-                modalStyle === 'muted' ? 'bg-muted' : ''
+                modalStyle === "muted" ? "bg-muted" : ""
               }`}
             >
               <span className="rounded-md px-2 py-1 text-[10px] text-fg">
@@ -1199,13 +1199,13 @@ function ModalPreview({ lab }: { lab: Lab }) {
 }
 
 function TooltipPreview({ lab }: { lab: Lab }) {
-  const translucid = lab.state.tooltipSurface === 'translucid'
+  const translucid = lab.state.tooltipSurface === "translucid"
   return (
     <div className="flex flex-col gap-2.5">
       <div className="flex h-24 flex-col items-center justify-center gap-1.5 rounded-lg border border-border/45 bg-bg">
         <span
           className={`px-2 py-1 text-[10px] font-medium ${
-            translucid ? 'bg-fg/75 text-bg backdrop-blur-sm' : 'bg-fg text-bg'
+            translucid ? "bg-fg/75 text-bg backdrop-blur-sm" : "bg-fg text-bg"
           }`}
           style={{
             borderRadius: Math.min(
@@ -1228,8 +1228,8 @@ function TooltipPreview({ lab }: { lab: Lab }) {
 }
 
 function MenuPreview({ lab }: { lab: Lab }) {
-  const accent = lab.state.menuHighlight === 'accent'
-  const rows = ['Rename', 'Duplicate', 'Move to…', 'Delete']
+  const accent = lab.state.menuHighlight === "accent"
+  const rows = ["Rename", "Duplicate", "Move to…", "Delete"]
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex flex-col rounded-lg border border-border/45 bg-bg p-1">
@@ -1239,9 +1239,9 @@ function MenuPreview({ lab }: { lab: Lab }) {
             className={`rounded-md px-2 py-1.5 text-xs ${
               index === 1
                 ? accent
-                  ? 'bg-primary text-fg-on-primary'
-                  : 'bg-muted text-fg'
-                : 'text-fg'
+                  ? "bg-primary text-fg-on-primary"
+                  : "bg-muted text-fg"
+                : "text-fg"
             }`}
           >
             {row}
@@ -1254,7 +1254,7 @@ function MenuPreview({ lab }: { lab: Lab }) {
 }
 
 function LoaderPreview({ lab }: { lab: Lab }) {
-  const Icon = lab.state.loaderStyle === 'ring' ? LoaderCircleIcon : LoaderIcon
+  const Icon = lab.state.loaderStyle === "ring" ? LoaderCircleIcon : LoaderIcon
   return (
     <div className="flex flex-col gap-2.5">
       <div className="flex h-16 items-center justify-center gap-3 rounded-lg border border-border/45 bg-bg">
@@ -1276,7 +1276,7 @@ const CONTROL_PREVIEWS: Record<string, Record<string, Preview>> = {
     Gray: GrayPreview,
     Primary: PrimaryPreview,
     Modes: ModesPreview,
-    'Semantic colors': SemanticPreview,
+    "Semantic colors": SemanticPreview,
   },
   typography: {
     Heading: ({ lab }) => (
@@ -1302,7 +1302,7 @@ const CONTROL_PREVIEWS: Record<string, Record<string, Preview>> = {
   details: {
     Shadows: ShadowsPreview,
     Cursor: CursorPreview,
-    'Disabled cursor': CursorPreview,
+    "Disabled cursor": CursorPreview,
   },
   components: {
     Button: ButtonPreview,

--- a/www/src/modules/panel-lab/drafts/preview-594.tsx
+++ b/www/src/modules/panel-lab/drafts/preview-594.tsx
@@ -1,24 +1,43 @@
 'use client'
 
 /* Draft #594 — the hover preview rail. A FRAME experiment, not a section one:
-   the panel chrome is the v2 frame verbatim, but hovering a section floats a
-   live preview card beside the panel, aligned with the hovered card. One
-   shared container stays mounted across sections — it glides to the new card
-   and morphs its height while the content crossfades, so moving down the
-   panel reads as one surface retargeting, never popping tooltips.
+   the panel chrome is the v2 frame verbatim, but interacting with the panel
+   floats a live preview card beside it. One shared container stays mounted —
+   it glides to the active spot and morphs its height while the content
+   crossfades, so moving through the panel reads as one surface retargeting.
 
-   Motion model: glide + height share one no-bounce spring (they must move as
-   a unit); content swaps with a short direction-aware ease-out fade; the
-   container itself enters/exits with a scale fade. Reduced motion drops the
-   glide and offsets, keeping only fades. */
+   Two levels of preview. Every section has a global preview; controls with
+   something meaningful to show override it with their own (Brand shows the
+   color in real demos, the Input row shows real inputs). A control's preview
+   anchors to its ROW, not the section card.
+
+   Three signals drive the target, strongest first: an OPEN overlay (a picker,
+   select or menu whose trigger reads aria-expanded inside the panel) pins its
+   row; then the HOVERED row/section; then the FOCUSED row, so keyboard use
+   and open disclosures keep their preview when the pointer leaves. Rows are
+   resolved from the DOM (data-row / slot=trigger / aria-label / the
+   data-disclosure root), so section bodies stay untouched.
+
+   Motion model: glide + height share one no-bounce spring; content swaps
+   with a short direction-aware ease-out fade; the container enters/exits
+   with a scale fade. Reduced motion keeps only the fades.
+
+   Dev tweaks (group "Preview rail"): preview side vs the panel, what happens
+   while an overlay is open, where row overlays open (threaded to the shared
+   rows via RowOverlayPlacementContext), and the disable affordance. */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   BellIcon,
   CalendarIcon,
+  CheckIcon,
   ChevronsUpDownIcon,
+  EyeIcon,
+  EyeOffIcon,
   HeartIcon,
   HouseIcon,
+  LoaderCircleIcon,
+  LoaderIcon,
   MailIcon,
   MousePointerClickIcon,
   SearchIcon,
@@ -29,8 +48,14 @@ import {
 } from 'lucide-react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 
+import { fontStack } from '@/lib/fonts'
 import { Button } from '@/registry/ui/button'
+import { RowOverlayPlacementContext } from '@/modules/control-lab/rows'
+import type { RowOverlayPlacement } from '@/modules/control-lab/rows'
+import { useLoadedFamilies } from '@/modules/create/typography'
+import { useTweak } from '@/dev/tweaker'
 
+import { SHAPE_RUNGS } from '../data'
 import type { Lab } from '../data'
 import { ChapterCard } from '../variants/chapter'
 import type { Chapter } from '../variants/chapter'
@@ -46,12 +71,53 @@ const GLIDE = {
   mass: 0.8,
 } as const
 
-interface Hovered {
-  id: string
-  /** Card top relative to the frame, unclamped. */
+/* ------------------------------ Target model ------------------------------ */
+
+interface Target {
+  /** Content identity — drives the crossfade. */
+  key: string
+  sectionId: string
+  /** Row label when a control preview matched; null = section preview. */
+  control: string | null
+  /** Element the preview aligns to (row, disclosure root, or section card). */
+  anchor: Element
+  /** Anchor top relative to the frame, unclamped. */
   top: number
-  /** +1 when the hover moved down the panel, -1 up — steers the crossfade. */
-  dir: 1 | -1
+}
+
+/** Row label: the ROW_LABEL span, else the element's own aria-label. */
+function labelOf(el: Element): string | null {
+  return (
+    el.querySelector('.font-medium.truncate')?.textContent?.trim() ??
+    el.getAttribute('aria-label')?.trim() ??
+    null
+  )
+}
+
+/** Climb from a DOM node to the innermost thing with a registered preview:
+ *  a labeled row first, then the enclosing disclosure (so "Success" inside
+ *  Semantic colors attributes to Semantic colors), else the section. */
+function resolveTarget(
+  start: Element,
+): { sectionId: string; control: string | null; anchor: Element } | null {
+  const section = start.closest('[data-chapter]')
+  if (!section) return null
+  const sectionId = section.getAttribute('data-chapter') ?? ''
+  const registry = CONTROL_PREVIEWS[sectionId]
+
+  let node: Element | null = start
+  while (registry && node && node !== section) {
+    const candidate: Element | null = node.closest(
+      '[data-row], button[slot="trigger"], [aria-label], [data-disclosure]',
+    )
+    if (!candidate || !section.contains(candidate)) break
+    const label = labelOf(candidate)
+    if (label && registry[label]) {
+      return { sectionId, control: label, anchor: candidate }
+    }
+    node = candidate.parentElement
+  }
+  return { sectionId, control: null, anchor: section }
 }
 
 export function HoverPreviewFrame({
@@ -63,44 +129,126 @@ export function HoverPreviewFrame({
 }) {
   const reduce = useReducedMotion()
   const frameRef = useRef<HTMLDivElement>(null)
-  const cardRefs = useRef(new Map<string, HTMLDivElement>())
   const leaveTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
   const contentObserver = useRef<ResizeObserver>(undefined)
-  const [hovered, setHovered] = useState<Hovered | null>(null)
+  const [openT, setOpenT] = useState<Target | null>(null)
+  const [hoverT, setHoverT] = useState<Target | null>(null)
+  const [focusT, setFocusT] = useState<Target | null>(null)
   const [contentH, setContentH] = useState(0)
+  const [enabled, setEnabled] = useState(true)
+
+  const side = useTweak('Preview side', {
+    type: 'select',
+    options: ['right', 'right far', 'left'],
+    default: 'right',
+    group: 'Preview rail',
+  })
+  const whileOpen = useTweak('While overlay open', {
+    type: 'select',
+    options: ['show', 'hide'],
+    default: 'show',
+    group: 'Preview rail',
+  })
+  const overlayPlacement = useTweak('Overlay placement', {
+    type: 'select',
+    options: ['right top', 'left top', 'bottom start'],
+    default: 'right top',
+    group: 'Preview rail',
+  })
+  const affordance = useTweak('Disable affordance', {
+    type: 'select',
+    options: ['none', 'header eye', 'press P'],
+    default: 'none',
+    group: 'Preview rail',
+  })
 
   useEffect(() => () => clearTimeout(leaveTimer.current), [])
+  useEffect(() => {
+    if (affordance === 'none') setEnabled(true)
+  }, [affordance])
+  useEffect(() => {
+    if (affordance !== 'press P') return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'p' && e.key !== 'P') return
+      const el = e.target as HTMLElement | null
+      if (el?.closest('input, textarea, [contenteditable]')) return
+      setEnabled((v) => !v)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [affordance])
 
-  const topOf = (id: string) => {
+  const toTarget = useCallback(
+    (resolved: ReturnType<typeof resolveTarget>): Target | null => {
+      const frame = frameRef.current
+      if (!resolved || !frame) return null
+      const { sectionId, control, anchor } = resolved
+      return {
+        key: control
+          ? `control:${sectionId}:${control}`
+          : `section:${sectionId}`,
+        sectionId,
+        control,
+        anchor,
+        top:
+          anchor.getBoundingClientRect().top -
+          frame.getBoundingClientRect().top,
+      }
+    },
+    [],
+  )
+
+  /* Pin the row whose overlay (picker/select/menu) is open — its trigger
+     keeps aria-expanded while focus lives in the portal. Disclosures also
+     read aria-expanded but lack aria-haspopup, so they don't pin. */
+  useEffect(() => {
     const frame = frameRef.current
-    const card = cardRefs.current.get(id)
-    if (!frame || !card) return 0
-    return card.getBoundingClientRect().top - frame.getBoundingClientRect().top
-  }
+    if (!frame) return
+    const update = () => {
+      const trigger = frame.querySelector(
+        '[aria-haspopup][aria-expanded="true"]',
+      )
+      setOpenT(trigger ? toTarget(resolveTarget(trigger)) : null)
+    }
+    const observer = new MutationObserver(update)
+    observer.observe(frame, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['aria-expanded'],
+    })
+    return () => observer.disconnect()
+  }, [toTarget])
 
-  const hoverCard = (id: string) => {
+  const onPointerOver = (e: React.PointerEvent) => {
     clearTimeout(leaveTimer.current)
-    setHovered((prev) => ({
-      id,
-      top: topOf(id),
-      dir:
-        prev &&
-        chapters.findIndex((c) => c.id === id) <
-          chapters.findIndex((c) => c.id === prev.id)
-          ? -1
-          : 1,
-    }))
+    setHoverT(toTarget(resolveTarget(e.target as Element)))
   }
 
   /* Grace delay so brushing past the panel edge doesn't flicker the card. */
   const scheduleLeave = () => {
     clearTimeout(leaveTimer.current)
-    leaveTimer.current = setTimeout(() => setHovered(null), 120)
+    leaveTimer.current = setTimeout(() => setHoverT(null), 120)
   }
 
-  /* Keep the preview glued to its card while the panel scrolls under it. */
+  const onFocus = (e: React.FocusEvent) => {
+    setFocusT(toTarget(resolveTarget(e.target as Element)))
+  }
+  const onBlur = (e: React.FocusEvent) => {
+    if (!frameRef.current?.contains(e.relatedTarget as Node | null)) {
+      setFocusT(null)
+    }
+  }
+
+  /* Keep the preview glued to its anchor while the panel scrolls under it. */
   const onScroll = () => {
-    setHovered((prev) => prev && { ...prev, top: topOf(prev.id) })
+    const frame = frameRef.current
+    if (!frame) return
+    const frameTop = frame.getBoundingClientRect().top
+    const refresh = (t: Target | null) =>
+      t && { ...t, top: t.anchor.getBoundingClientRect().top - frameTop }
+    setOpenT(refresh)
+    setHoverT(refresh)
+    setFocusT(refresh)
   }
 
   const measureRef = useCallback((node: HTMLDivElement | null) => {
@@ -111,15 +259,40 @@ export function HoverPreviewFrame({
     contentObserver.current = observer
   }, [])
 
-  const active = hovered && chapters.find((c) => c.id === hovered.id)
-  /* Align with the card, but never let the preview leave the frame. */
-  const previewTop = hovered
-    ? Math.max(4, Math.min(hovered.top, FRAME_H - contentH - 4))
+  const display = !enabled
+    ? null
+    : openT && whileOpen === 'hide'
+      ? null
+      : (openT ?? hoverT ?? focusT)
+  const chapter = display && chapters.find((c) => c.id === display.sectionId)
+
+  /* Crossfade direction: toward the new anchor. Render-time ref bookkeeping
+     so the exiting content still animates away from where it sat. */
+  const lastRef = useRef<{ key: string; top: number } | null>(null)
+  const dirRef = useRef<1 | -1>(1)
+  if (display && lastRef.current && display.key !== lastRef.current.key) {
+    dirRef.current = display.top >= lastRef.current.top ? 1 : -1
+  }
+  if (display) lastRef.current = { key: display.key, top: display.top }
+  const dir = reduce ? 0 : dirRef.current
+
+  /* Align with the anchor, but never let the preview leave the frame. */
+  const previewTop = display
+    ? Math.max(4, Math.min(display.top, FRAME_H - contentH - 4))
     : 0
-  const dir = reduce ? 0 : (hovered?.dir ?? 1)
 
   return (
-    <div ref={frameRef} className="relative flex h-full min-h-0 flex-col">
+    <div
+      ref={frameRef}
+      className="relative flex h-full min-h-0 flex-col"
+      // "left" keeps the page usable: the panel slides over so the preview
+      // lands where the panel was, and row overlays open into free space.
+      style={
+        side === 'left'
+          ? { transform: `translateX(${PREVIEW_W + 16}px)` }
+          : undefined
+      }
+    >
       {/* Floating glass header — cards dip under it, never past it. */}
       <div className="absolute inset-x-0 top-0 z-20 flex items-center justify-between gap-2 rounded-xl border border-border/45 bg-neutral/90 p-1.5 shadow-[0_4px_16px_-4px_rgb(0_0_0/0.2),0_2px_6px_-2px_rgb(0_0_0/0.12)] backdrop-blur-sm">
         <Button
@@ -130,36 +303,49 @@ export function HoverPreviewFrame({
           <span className="truncate">Acme design system</span>
           <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-muted" />
         </Button>
-        <Button
-          size="sm"
-          variant="quiet"
-          isIconOnly
-          aria-label="Search controls"
-          className="shrink-0"
-        >
-          <SearchIcon />
-        </Button>
+        <div className="flex shrink-0 items-center">
+          {affordance === 'header eye' && (
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              aria-label={enabled ? 'Hide previews' : 'Show previews'}
+              onPress={() => setEnabled((v) => !v)}
+              className={enabled ? undefined : 'text-fg-muted'}
+            >
+              {enabled ? <EyeIcon /> : <EyeOffIcon />}
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            aria-label="Search controls"
+          >
+            <SearchIcon />
+          </Button>
+        </div>
       </div>
 
-      {/* The story scroll: every chapter its own card, wrapped for hover. */}
-      <div
-        className="no-scrollbar flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain rounded-xl pt-[56px] pb-[62px] *:shrink-0"
-        onPointerLeave={scheduleLeave}
-        onScroll={onScroll}
+      {/* The story scroll: every chapter its own card, tagged for resolution. */}
+      <RowOverlayPlacementContext.Provider
+        value={overlayPlacement as RowOverlayPlacement}
       >
-        {chapters.map((chapter) => (
-          <div
-            key={chapter.id}
-            ref={(node) => {
-              if (node) cardRefs.current.set(chapter.id, node)
-              else cardRefs.current.delete(chapter.id)
-            }}
-            onPointerEnter={() => hoverCard(chapter.id)}
-          >
-            <ChapterCard chapter={chapter} lab={lab} />
-          </div>
-        ))}
-      </div>
+        <div
+          className="no-scrollbar flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain rounded-xl pt-[56px] pb-[62px] *:shrink-0"
+          onPointerOver={onPointerOver}
+          onPointerLeave={scheduleLeave}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onScroll={onScroll}
+        >
+          {chapters.map((c) => (
+            <div key={c.id} data-chapter={c.id}>
+              <ChapterCard chapter={c} lab={lab} />
+            </div>
+          ))}
+        </div>
+      </RowOverlayPlacementContext.Provider>
 
       {/* Floating glass footer — same treatment as the header. */}
       <div className="absolute inset-x-0 bottom-0 z-20 flex items-center gap-2 rounded-xl border border-border/45 bg-neutral/90 p-2 shadow-[0_-4px_16px_-4px_rgb(0_0_0/0.2),0_-2px_6px_-2px_rgb(0_0_0/0.12)] backdrop-blur-sm">
@@ -172,19 +358,21 @@ export function HoverPreviewFrame({
       </div>
 
       {/* The preview rail: one container, retargeted — never re-mounted —
-          as the hover moves between sections. Inert by design. */}
+          as the target moves between rows and sections. Inert by design. */}
       <AnimatePresence>
-        {active && hovered && (
+        {display && chapter && (
           <motion.div
             key="preview"
             aria-hidden
-            className="pointer-events-none absolute top-0 left-full z-30 ml-4 origin-left overflow-hidden rounded-2xl border border-border/45 bg-card shadow-[0_12px_32px_-8px_rgb(0_0_0/0.24),0_4px_12px_-4px_rgb(0_0_0/0.12)] select-none"
+            className={`pointer-events-none absolute top-0 z-30 overflow-hidden rounded-2xl border border-border/45 bg-card shadow-[0_12px_32px_-8px_rgb(0_0_0/0.24),0_4px_12px_-4px_rgb(0_0_0/0.12)] select-none ${
+              side === 'left'
+                ? 'right-full mr-4 origin-right'
+                : side === 'right far'
+                  ? 'left-full ml-[352px] origin-left'
+                  : 'left-full ml-4 origin-left'
+            }`}
             style={{ width: PREVIEW_W }}
-            initial={{
-              opacity: 0,
-              scale: reduce ? 1 : 0.96,
-              y: previewTop,
-            }}
+            initial={{ opacity: 0, scale: reduce ? 1 : 0.96, y: previewTop }}
             animate={{
               opacity: 1,
               scale: 1,
@@ -206,7 +394,7 @@ export function HoverPreviewFrame({
             <div ref={measureRef}>
               <AnimatePresence mode="popLayout" initial={false} custom={dir}>
                 <motion.div
-                  key={active.id}
+                  key={display.key}
                   custom={dir}
                   variants={contentVariants}
                   initial="enter"
@@ -216,15 +404,25 @@ export function HoverPreviewFrame({
                   className="flex flex-col gap-3 p-4"
                 >
                   <div className="flex items-center gap-2">
-                    <active.icon className="size-3.5 text-fg-muted" />
+                    <chapter.icon className="size-3.5 text-fg-muted" />
                     <span className="text-[0.8125rem] font-medium text-fg">
-                      {active.label}
+                      {chapter.label}
+                      {display.control && (
+                        <span className="text-fg-muted">
+                          {' · '}
+                          {display.control}
+                        </span>
+                      )}
                     </span>
                     <span className="ml-auto text-[11px] text-fg-muted">
                       Live preview
                     </span>
                   </div>
-                  <PreviewBody id={active.id} lab={lab} />
+                  <PreviewBody
+                    sectionId={display.sectionId}
+                    control={display.control}
+                    lab={lab}
+                  />
                 </motion.div>
               </AnimatePresence>
             </div>
@@ -249,40 +447,58 @@ const contentVariants = {
   }),
 }
 
-/* ------------------------------- Previews -------------------------------- */
-/* One demo per chapter — enough real UI to read the section's decisions at a
-   glance, reacting to the lab state where a single value carries the idea. */
+/* ------------------------------- Previews --------------------------------- */
+/* Section previews are the fallback; control previews override them when a
+   row has something specific to show. Each reads the lab state where a
+   single value carries the idea. */
 
-function PreviewBody({ id, lab }: { id: string; lab: Lab }) {
-  switch (id) {
-    case 'color':
-      return <ColorPreview lab={lab} />
-    case 'typography':
-      return <TypePreview />
-    case 'icons':
-      return <IconsPreview lab={lab} />
-    case 'shape':
-      return <ShapePreview lab={lab} />
-    case 'space':
-      return <SpacePreview lab={lab} />
-    case 'details':
-      return <DetailsPreview lab={lab} />
-    case 'components':
-      return <ComponentsPreview lab={lab} />
-    default:
-      return (
-        <p className="text-xs/relaxed text-fg-muted">
-          No preview for this section yet.
-        </p>
-      )
+function PreviewBody({
+  sectionId,
+  control,
+  lab,
+}: {
+  sectionId: string
+  control: string | null
+  lab: Lab
+}) {
+  const Control = control ? CONTROL_PREVIEWS[sectionId]?.[control] : undefined
+  const Section = SECTION_PREVIEWS[sectionId]
+  const Body = Control ?? Section
+  if (!Body) {
+    return (
+      <p className="text-xs/relaxed text-fg-muted">
+        No preview for this section yet.
+      </p>
+    )
   }
+  return <Body lab={lab} />
 }
+
+type Preview = React.ComponentType<{ lab: Lab }>
 
 function Caption({ children }: { children: React.ReactNode }) {
   return <span className="text-[11px] text-fg-muted">{children}</span>
 }
 
-function ColorPreview({ lab }: { lab: Lab }) {
+function Panel({
+  children,
+  className = 'gap-2.5',
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div
+      className={`flex flex-col rounded-lg border border-border/45 bg-bg p-3 ${className}`}
+    >
+      {children}
+    </div>
+  )
+}
+
+/* --------------------------------- Color ---------------------------------- */
+
+function ColorSectionPreview({ lab }: { lab: Lab }) {
   const semantics = [
     { label: 'Accent', className: 'bg-accent' },
     { label: 'Success', className: 'bg-success' },
@@ -317,47 +533,277 @@ function ColorPreview({ lab }: { lab: Lab }) {
           ))}
         </div>
       </div>
-      <div className="flex flex-col gap-1.5">
-        <Caption>Modes</Caption>
-        <div className="flex gap-1.5">
-          {lab.state.modes.map((mode) => (
-            <span
-              key={mode.id}
-              className="flex-1 rounded-md border border-border/45 px-2 py-1 text-center text-[11px]"
-              style={{
-                backgroundColor: `oklch(${mode.bg}% 0 0)`,
-                color: mode.polarity === 'light' ? 'black' : 'white',
-              }}
-            >
-              {mode.name}
-            </span>
-          ))}
-        </div>
+      <ModeChips lab={lab} />
+    </div>
+  )
+}
+
+function ModeChips({ lab }: { lab: Lab }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Caption>Modes</Caption>
+      <div className="flex gap-1.5">
+        {lab.state.modes.map((mode) => (
+          <span
+            key={mode.id}
+            className="flex-1 rounded-md border border-border/45 px-2 py-1 text-center text-[11px]"
+            style={{
+              backgroundColor: `oklch(${mode.bg}% 0 0)`,
+              color: mode.polarity === 'light' ? 'black' : 'white',
+            }}
+          >
+            {mode.name}
+            {mode.id === lab.state.defaultMode ? ' ✦' : ''}
+          </span>
+        ))}
       </div>
     </div>
   )
 }
 
-function TypePreview() {
+/** The brand color doing its real jobs: CTA, link, controls, badge. */
+function BrandPreview({ lab }: { lab: Lab }) {
+  const brand = lab.state.brand
   return (
     <div className="flex flex-col gap-2.5">
-      <div className="flex items-end gap-3 rounded-lg border border-border/45 bg-bg p-3">
-        <span className="text-4xl/none font-semibold text-fg">Ag</span>
-        <div className="flex flex-col gap-0.5">
-          <span className="text-sm font-semibold text-fg">
-            Ship your design system
-          </span>
-          <span className="text-xs text-fg-muted">
-            Every decision, one panel — previewed live on real components.
-          </span>
-        </div>
+      <Panel>
+        <span className="text-xs font-semibold text-fg">Create account</span>
+        <span className="flex h-8 items-center rounded-lg border border-border bg-bg px-2.5 text-xs text-fg-muted">
+          you@acme.com
+        </span>
+        <span
+          className="flex h-8 items-center justify-center rounded-lg text-xs font-medium text-white"
+          style={{ backgroundColor: brand }}
+        >
+          Continue
+        </span>
+        <span className="text-center text-[11px]" style={{ color: brand }}>
+          Already have an account?
+        </span>
+      </Panel>
+      <div className="flex items-center gap-2.5">
+        <span
+          className="flex h-5 w-9 items-center rounded-full p-0.5"
+          style={{ backgroundColor: brand }}
+        >
+          <span className="ml-auto size-4 rounded-full bg-white" />
+        </span>
+        <span
+          className="flex size-4 items-center justify-center rounded-sm"
+          style={{ backgroundColor: brand }}
+        >
+          <CheckIcon className="size-3 text-white" />
+        </span>
+        <span
+          className="rounded-full px-2 py-0.5 text-[10px] font-medium text-white"
+          style={{ backgroundColor: brand }}
+        >
+          New
+        </span>
+        <span className="ml-auto font-mono text-[11px] text-fg-muted uppercase">
+          {brand}
+        </span>
       </div>
+    </div>
+  )
+}
+
+/** Gray carries the quiet 90% — surfaces, borders, secondary text. */
+function GrayPreview({ lab }: { lab: Lab }) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <Panel>
+        <span className="text-xs font-medium text-fg">Primary text</span>
+        <span className="text-xs text-fg-muted">
+          Secondary text sits a step back.
+        </span>
+        <span className="flex items-center justify-between rounded-md bg-muted px-2.5 py-1.5 text-[11px] text-fg-muted">
+          Muted surface
+          <span className="h-3 w-10 rounded-sm border border-border" />
+        </span>
+      </Panel>
+      <Caption>
+        Seed:{' '}
+        {lab.state.graySeed === ''
+          ? 'Auto (derived from brand)'
+          : lab.state.graySeed}
+      </Caption>
+    </div>
+  )
+}
+
+/** What "primary" points at — the neutral or the accent. */
+function PrimaryPreview({ lab }: { lab: Lab }) {
+  const primary = lab.state.primary
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex items-center gap-2">
+        <span
+          className={`flex h-8 items-center rounded-lg px-3 text-xs font-medium ${
+            primary === 'neutral'
+              ? 'bg-neutral text-fg-on-neutral'
+              : 'bg-accent text-white'
+          }`}
+        >
+          Primary action
+        </span>
+        <span className="flex h-8 items-center rounded-lg border border-border-field px-3 text-xs text-fg">
+          Secondary
+        </span>
+      </div>
+      <Caption>
+        Primary buttons use the {primary === 'neutral' ? 'neutral' : 'accent'}{' '}
+        scale
+      </Caption>
+    </div>
+  )
+}
+
+function ModesPreview({ lab }: { lab: Lab }) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex flex-col gap-1.5">
+        {lab.state.modes.map((mode) => (
+          <span
+            key={mode.id}
+            className="flex items-center justify-between rounded-lg border border-border/45 px-3 py-2 text-xs"
+            style={{
+              backgroundColor: `oklch(${mode.bg}% 0 0)`,
+              color: mode.polarity === 'light' ? 'black' : 'white',
+            }}
+          >
+            <span className="font-medium">{mode.name}</span>
+            <span className="flex items-center gap-1.5 text-[10px] opacity-70">
+              {mode.contrast === 'high' && <span>HC</span>}
+              <span>L* {mode.bg}</span>
+              {mode.id === lab.state.defaultMode && <span>· default</span>}
+            </span>
+          </span>
+        ))}
+      </div>
+      <Caption>
+        {lab.state.modes.length}{' '}
+        {lab.state.modes.length === 1 ? 'mode' : 'modes'} · users land on{' '}
+        {lab.state.modes.find((m) => m.id === lab.state.defaultMode)?.name ??
+          'the default'}
+      </Caption>
+    </div>
+  )
+}
+
+/** The four status colors in their natural habitat. */
+function SemanticPreview({ lab }: { lab: Lab }) {
+  const rows = [
+    {
+      label: 'Payment received',
+      dot: 'bg-success',
+      seed: lab.state.successSeed,
+    },
+    {
+      label: 'Storage almost full',
+      dot: 'bg-warning',
+      seed: lab.state.warningSeed,
+    },
+    { label: 'Build failed', dot: 'bg-danger', seed: lab.state.dangerSeed },
+    { label: 'Update available', dot: 'bg-info', seed: lab.state.infoSeed },
+  ]
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex flex-col gap-1.5">
+        {rows.map((row) => (
+          <span
+            key={row.label}
+            className="flex items-center gap-2 rounded-lg border border-border/45 bg-bg px-2.5 py-1.5 text-xs text-fg"
+          >
+            <span
+              className={`size-2 rounded-full ${row.seed ? '' : row.dot}`}
+              style={row.seed ? { backgroundColor: row.seed } : undefined}
+            />
+            {row.label}
+            <span className="ml-auto font-mono text-[10px] text-fg-muted uppercase">
+              {row.seed || 'Auto'}
+            </span>
+          </span>
+        ))}
+      </div>
+      <Caption>Auto seeds derive from the brand hue</Caption>
+    </div>
+  )
+}
+
+/* ------------------------------- Typography ------------------------------- */
+
+function TypeSectionPreview() {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <Panel className="gap-1">
+        <span className="text-4xl/none font-semibold text-fg">Ag</span>
+        <span className="mt-1 text-sm font-semibold text-fg">
+          Ship your design system
+        </span>
+        <span className="text-xs text-fg-muted">
+          Every decision, one panel — previewed live on real components.
+        </span>
+      </Panel>
       <span className="rounded-lg border border-border/45 bg-bg px-3 py-2 font-mono text-[11px] text-fg-muted">
         npx shadcn add button
       </span>
     </div>
   )
 }
+
+function FontPreview({
+  family,
+  role,
+}: {
+  family: string
+  role: 'heading' | 'body' | 'mono'
+}) {
+  useLoadedFamilies([family])
+  const stack = fontStack(family)
+  return (
+    <div className="flex flex-col gap-2.5">
+      <Panel className="gap-1.5">
+        {role === 'heading' && (
+          <>
+            <span
+              className="text-xl/tight font-semibold text-fg"
+              style={{ fontFamily: stack }}
+            >
+              Almost before we knew it
+            </span>
+            <span
+              className="text-sm font-medium text-fg-muted"
+              style={{ fontFamily: stack }}
+            >
+              we had left the ground.
+            </span>
+          </>
+        )}
+        {role === 'body' && (
+          <span
+            className="text-xs/relaxed text-fg"
+            style={{ fontFamily: stack }}
+          >
+            Body text carries the reading load: it has to stay comfortable at
+            small sizes, through long paragraphs, in both modes.
+          </span>
+        )}
+        {role === 'mono' && (
+          <span
+            className="text-[11px]/relaxed whitespace-pre text-fg"
+            style={{ fontFamily: stack }}
+          >
+            {'const theme = createTheme({\n  radius: 10,\n})'}
+          </span>
+        )}
+      </Panel>
+      <Caption>{family}</Caption>
+    </div>
+  )
+}
+
+/* --------------------------------- Icons ---------------------------------- */
 
 const ICON_SAMPLE = [
   HouseIcon,
@@ -370,7 +816,7 @@ const ICON_SAMPLE = [
   MailIcon,
 ]
 
-function IconsPreview({ lab }: { lab: Lab }) {
+function IconsSectionPreview({ lab }: { lab: Lab }) {
   return (
     <div className="flex flex-col gap-1.5">
       <div className="grid grid-cols-4 gap-1.5">
@@ -393,14 +839,41 @@ function IconsPreview({ lab }: { lab: Lab }) {
   )
 }
 
-/* Role ratios from the #575 rung ladder (md/lg/xl over the base radius). */
+/** Stroke reads best big — three icons at display size. */
+function StrokePreview({ lab }: { lab: Lab }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex gap-1.5">
+        {[HeartIcon, BellIcon, SettingsIcon].map((Icon, index) => (
+          <span
+            key={index}
+            className="flex h-16 flex-1 items-center justify-center rounded-lg border border-border/45 bg-bg"
+          >
+            <Icon
+              className="size-8 text-fg"
+              strokeWidth={lab.state.iconStroke}
+            />
+          </span>
+        ))}
+      </div>
+      <Caption>Stroke {lab.state.iconStroke}px</Caption>
+    </div>
+  )
+}
+
+/* --------------------------------- Shape ---------------------------------- */
+
 const SHAPE_ROLE_DEMOS = [
   { label: 'Control', ratio: 0.75 },
   { label: 'Surface', ratio: 1 },
   { label: 'Panel', ratio: 1.5 },
 ]
 
-function ShapePreview({ lab }: { lab: Lab }) {
+/* corner-shape is progressive enhancement — unsupported browsers render round. */
+const cornerShapeStyle = (shape: string): React.CSSProperties =>
+  shape === 'round' ? {} : ({ cornerShape: shape } as React.CSSProperties)
+
+function ShapeSectionPreview({ lab }: { lab: Lab }) {
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex gap-1.5">
@@ -408,7 +881,10 @@ function ShapePreview({ lab }: { lab: Lab }) {
           <div key={role.label} className="flex flex-1 flex-col gap-1">
             <span
               className="flex h-14 items-center justify-center border border-border bg-bg font-mono text-[10px] text-fg-muted"
-              style={{ borderRadius: lab.state.radiusPx * role.ratio }}
+              style={{
+                borderRadius: lab.state.radiusPx * role.ratio,
+                ...cornerShapeStyle(lab.state.cornerShape),
+              }}
             >
               {Math.round(lab.state.radiusPx * role.ratio)}px
             </span>
@@ -423,13 +899,89 @@ function ShapePreview({ lab }: { lab: Lab }) {
   )
 }
 
+const rungRatio = (id: string) =>
+  SHAPE_RUNGS.find((rung) => rung.id === id)?.ratio ?? 1
+
+/** The role vector nested the way it ships: panel > surface > control. */
+function RolesPreview({ lab }: { lab: Lab }) {
+  const { radiusPx, rolePanel, roleSurface, roleControl } = lab.state
+  const px = (role: string) => {
+    const ratio = rungRatio(role)
+    return ratio === Infinity ? 999 : radiusPx * ratio
+  }
+  const label = (name: string, role: string) =>
+    `${name} · ${rungRatio(role) === Infinity ? 'pill' : `${Math.round(px(role))}px`}`
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div
+        className="flex flex-col gap-2 border border-border bg-bg p-3"
+        style={{ borderRadius: px(rolePanel) }}
+      >
+        <span className="text-[10px] text-fg-muted">
+          {label('Panel', rolePanel)}
+        </span>
+        <div
+          className="flex flex-col gap-2 border border-border/60 bg-card p-2.5"
+          style={{ borderRadius: px(roleSurface) }}
+        >
+          <span className="text-[10px] text-fg-muted">
+            {label('Surface', roleSurface)}
+          </span>
+          <span
+            className="flex h-7 items-center justify-center bg-primary text-[11px] font-medium text-fg-on-primary"
+            style={{ borderRadius: px(roleControl) }}
+          >
+            {label('Control', roleControl)}
+          </span>
+        </div>
+      </div>
+      <Caption>
+        Items:{' '}
+        {lab.state.roleItem === 'auto'
+          ? 'auto (one rung below surfaces)'
+          : lab.state.roleItem}
+      </Caption>
+    </div>
+  )
+}
+
+function CornersPreview({ lab }: { lab: Lab }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex gap-1.5">
+        {['round', 'squircle', 'bevel'].map((shape) => (
+          <div key={shape} className="flex flex-1 flex-col gap-1">
+            <span
+              className={`h-14 border bg-bg ${
+                shape === lab.state.cornerShape
+                  ? 'border-accent'
+                  : 'border-border'
+              }`}
+              style={{
+                borderRadius: Math.max(lab.state.radiusPx * 1.5, 8),
+                ...cornerShapeStyle(shape),
+              }}
+            />
+            <span className="text-center text-[10px] text-fg-muted">
+              {shape}
+            </span>
+          </div>
+        ))}
+      </div>
+      <Caption>corner-shape: {lab.state.cornerShape}</Caption>
+    </div>
+  )
+}
+
+/* --------------------------------- Space ---------------------------------- */
+
 const DENSITY_PADDING: Record<string, string> = {
   compact: 'py-1',
   default: 'py-1.5',
   comfortable: 'py-2.5',
 }
 
-function SpacePreview({ lab }: { lab: Lab }) {
+function SpaceSectionPreview({ lab }: { lab: Lab }) {
   const padding = DENSITY_PADDING[lab.state.density] ?? DENSITY_PADDING.default
   const rows = [
     { icon: MousePointerClickIcon, label: 'Select all' },
@@ -455,13 +1007,15 @@ function SpacePreview({ lab }: { lab: Lab }) {
   )
 }
 
+/* -------------------------------- Details --------------------------------- */
+
 const SHADOW_DEMOS = [
   { label: 'Card', className: 'shadow-sm' },
   { label: 'Popover', className: 'shadow-md' },
   { label: 'Modal', className: 'shadow-xl' },
 ]
 
-function DetailsPreview({ lab }: { lab: Lab }) {
+function DetailsSectionPreview({ lab }: { lab: Lab }) {
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex gap-2 rounded-lg bg-bg p-3">
@@ -479,7 +1033,327 @@ function DetailsPreview({ lab }: { lab: Lab }) {
   )
 }
 
-function ComponentsPreview({ lab }: { lab: Lab }) {
+function CursorPreview({ lab }: { lab: Lab }) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      <Panel className="gap-1.5">
+        <span className="flex items-center justify-between text-xs text-fg">
+          Buttons, links, menu items
+          <span className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-[10px] text-fg-muted">
+            cursor: {lab.state.cursorInteractive}
+          </span>
+        </span>
+        <span className="flex items-center justify-between text-xs text-fg-muted">
+          Disabled controls
+          <span className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-[10px] text-fg-muted">
+            cursor: {lab.state.cursorDisabled}
+          </span>
+        </span>
+      </Panel>
+      <Caption>Hover the real panel controls to feel it</Caption>
+    </div>
+  )
+}
+
+/* ------------------------------- Components ------------------------------- */
+
+const BUTTON_STYLE_CLASSES: Record<string, string> = {
+  solid: 'bg-primary text-fg-on-primary',
+  soft: 'bg-neutral text-fg-on-neutral',
+  outline: 'border border-border-field text-fg',
+  quiet: 'text-fg',
+}
+
+function buttonRadius(lab: Lab): number {
+  const { buttonRadius: r, radiusPx } = lab.state
+  if (r === 'sharp') return 0
+  if (r === 'pill') return 999
+  if (r === 'round') return Math.max(radiusPx, 8)
+  return radiusPx * 0.75
+}
+
+function ButtonPreview({ lab }: { lab: Lab }) {
+  const cls =
+    BUTTON_STYLE_CLASSES[lab.state.buttonStyle] ?? BUTTON_STYLE_CLASSES.solid
+  const radius = buttonRadius(lab)
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex items-center gap-2">
+        <span
+          className={`flex h-8 items-center px-3 text-xs font-medium ${cls}`}
+          style={{ borderRadius: radius }}
+        >
+          Confirm
+        </span>
+        <span
+          className="flex h-8 items-center border border-border-field px-3 text-xs text-fg"
+          style={{ borderRadius: radius }}
+        >
+          Cancel
+        </span>
+        <span
+          className="flex h-8 items-center px-3 text-xs text-fg-muted"
+          style={{ borderRadius: radius }}
+        >
+          Skip
+        </span>
+      </div>
+      <Caption>
+        {lab.state.buttonStyle} · radius {lab.state.buttonRadius} · hover{' '}
+        {lab.state.buttonHover}
+      </Caption>
+    </div>
+  )
+}
+
+const INPUT_STYLE_CLASSES: Record<string, string> = {
+  outline: 'rounded-lg border border-border-field bg-bg',
+  line: 'border-b border-border-field',
+  'filled-line-bottom': 'rounded-t-lg border-b border-border-field bg-neutral',
+  filled: 'rounded-lg bg-neutral',
+}
+
+function InputPreview({ lab }: { lab: Lab }) {
+  const cls =
+    INPUT_STYLE_CLASSES[lab.state.inputStyle] ?? INPUT_STYLE_CLASSES.outline
+  return (
+    <div className="flex flex-col gap-2.5">
+      <label className="flex flex-col gap-1">
+        <span className="text-[11px] font-medium text-fg">Email</span>
+        <span
+          className={`flex h-8 items-center px-2.5 text-xs text-fg-muted ${cls}`}
+        >
+          you@acme.com
+        </span>
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="text-[11px] font-medium text-fg">Focused</span>
+        <span
+          className={`flex h-8 items-center px-2.5 text-xs text-fg ring-2 ring-accent ${cls}`}
+        >
+          Acme Inc.
+        </span>
+      </label>
+      <Caption>Style: {lab.state.inputStyle}</Caption>
+    </div>
+  )
+}
+
+const TOKEN_RADIUS_RATIO: Record<string, number> = {
+  sharp: 0,
+  sm: 0.5,
+  md: 0.75,
+  lg: 1,
+}
+
+function tokenRadius(lab: Lab, key: string): number {
+  return lab.state.radiusPx * (TOKEN_RADIUS_RATIO[key] ?? 0.75)
+}
+
+function CheckboxPreview({ lab }: { lab: Lab }) {
+  const radius = Math.min(tokenRadius(lab, lab.state.checkboxRadius), 8)
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex flex-col gap-1.5">
+        {[
+          { label: 'Email me product updates', checked: true },
+          { label: 'Share usage analytics', checked: false },
+        ].map((row) => (
+          <span
+            key={row.label}
+            className="flex items-center gap-2 text-xs text-fg"
+          >
+            <span
+              className={`flex size-4 items-center justify-center ${
+                row.checked
+                  ? 'bg-primary text-fg-on-primary'
+                  : 'border border-border-field'
+              }`}
+              style={{ borderRadius: radius }}
+            >
+              {row.checked && <CheckIcon className="size-3" />}
+            </span>
+            {row.label}
+          </span>
+        ))}
+      </div>
+      <Caption>Radius: {lab.state.checkboxRadius}</Caption>
+    </div>
+  )
+}
+
+function CardPreview({ lab }: { lab: Lab }) {
+  const tasnim = lab.state.cardStyle === 'tasnim'
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div
+        className={`flex flex-col gap-1 p-3 ${
+          tasnim
+            ? 'bg-muted shadow-[0_6px_16px_rgb(0_0_0/0.45)]'
+            : 'border border-border bg-card'
+        }`}
+        style={{ borderRadius: lab.state.radiusPx }}
+      >
+        <span className="text-xs font-medium text-fg">Usage this month</span>
+        <span className="text-lg/none font-semibold text-fg">12,403</span>
+        <span className="text-[11px] text-fg-muted">+18% vs last month</span>
+      </div>
+      <Caption>Style: {lab.state.cardStyle}</Caption>
+    </div>
+  )
+}
+
+function BadgePreview({ lab }: { lab: Lab }) {
+  const radius = Math.min(tokenRadius(lab, lab.state.badgeRadius), 10)
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex items-center gap-1.5">
+        <span
+          className="bg-neutral px-2 py-0.5 text-[10px] font-medium text-fg-on-neutral"
+          style={{ borderRadius: radius }}
+        >
+          Draft
+        </span>
+        <span
+          className="bg-success px-2 py-0.5 text-[10px] font-medium text-white"
+          style={{ borderRadius: radius }}
+        >
+          Live
+        </span>
+        <span
+          className="bg-danger px-2 py-0.5 text-[10px] font-medium text-white"
+          style={{ borderRadius: radius }}
+        >
+          Failed
+        </span>
+      </div>
+      <Caption>Radius: {lab.state.badgeRadius}</Caption>
+    </div>
+  )
+}
+
+const MODAL_BLUR: Record<string, string> = {
+  none: '',
+  sm: 'backdrop-blur-[2px]',
+  md: 'backdrop-blur-[6px]',
+}
+
+function ModalPreview({ lab }: { lab: Lab }) {
+  const { modalBackdrop, modalBlur, modalRadius, modalStyle } = lab.state
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="relative h-44 overflow-hidden rounded-lg border border-border/45 bg-bg">
+        {/* A fake page for the backdrop to obscure. */}
+        <div className="flex flex-col gap-1.5 p-3">
+          <span className="h-2 w-1/2 rounded-sm bg-muted" />
+          <span className="h-2 w-3/4 rounded-sm bg-muted" />
+          <span className="h-2 w-2/3 rounded-sm bg-muted" />
+        </div>
+        <div
+          className={`absolute inset-0 flex items-center justify-center bg-black ${MODAL_BLUR[modalBlur] ?? ''}`}
+          style={{
+            backgroundColor: `rgb(0 0 0 / ${Number(modalBackdrop) / 100})`,
+          }}
+        >
+          <div
+            className="flex w-4/5 flex-col gap-2 border border-border/45 bg-card p-3 shadow-xl"
+            style={{ borderRadius: tokenRadius(lab, modalRadius) * 1.5 }}
+          >
+            <span className="text-xs font-medium text-fg">Delete project?</span>
+            <span className="text-[11px] text-fg-muted">
+              This can't be undone.
+            </span>
+            <div
+              className={`-m-3 mt-0 flex justify-end gap-1.5 p-2 ${
+                modalStyle === 'muted' ? 'bg-muted' : ''
+              }`}
+            >
+              <span className="rounded-md px-2 py-1 text-[10px] text-fg">
+                Cancel
+              </span>
+              <span className="rounded-md bg-danger px-2 py-1 text-[10px] font-medium text-white">
+                Delete
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Caption>
+        backdrop {modalBackdrop}% · blur {modalBlur} · footer {modalStyle}
+      </Caption>
+    </div>
+  )
+}
+
+function TooltipPreview({ lab }: { lab: Lab }) {
+  const translucid = lab.state.tooltipSurface === 'translucid'
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex h-24 flex-col items-center justify-center gap-1.5 rounded-lg border border-border/45 bg-bg">
+        <span
+          className={`px-2 py-1 text-[10px] font-medium ${
+            translucid ? 'bg-fg/75 text-bg backdrop-blur-sm' : 'bg-fg text-bg'
+          }`}
+          style={{
+            borderRadius: Math.min(
+              tokenRadius(lab, lab.state.tooltipRadius),
+              8,
+            ),
+          }}
+        >
+          Copy to clipboard
+        </span>
+        <span className="flex h-7 items-center rounded-lg border border-border-field px-2.5 text-[11px] text-fg">
+          Copy
+        </span>
+      </div>
+      <Caption>
+        {lab.state.tooltipSurface} · radius {lab.state.tooltipRadius}
+      </Caption>
+    </div>
+  )
+}
+
+function MenuPreview({ lab }: { lab: Lab }) {
+  const accent = lab.state.menuHighlight === 'accent'
+  const rows = ['Rename', 'Duplicate', 'Move to…', 'Delete']
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col rounded-lg border border-border/45 bg-bg p-1">
+        {rows.map((row, index) => (
+          <span
+            key={row}
+            className={`rounded-md px-2 py-1.5 text-xs ${
+              index === 1
+                ? accent
+                  ? 'bg-primary text-fg-on-primary'
+                  : 'bg-muted text-fg'
+                : 'text-fg'
+            }`}
+          >
+            {row}
+          </span>
+        ))}
+      </div>
+      <Caption>Highlight: {lab.state.menuHighlight}</Caption>
+    </div>
+  )
+}
+
+function LoaderPreview({ lab }: { lab: Lab }) {
+  const Icon = lab.state.loaderStyle === 'ring' ? LoaderCircleIcon : LoaderIcon
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex h-16 items-center justify-center gap-3 rounded-lg border border-border/45 bg-bg">
+        <Icon className="size-5 animate-spin text-fg-muted" />
+        <span className="text-xs text-fg-muted">Loading workspace…</span>
+      </div>
+      <Caption>Style: {lab.state.loaderStyle}</Caption>
+    </div>
+  )
+}
+
+function ComponentsSectionPreview({ lab }: { lab: Lab }) {
   return (
     <div className="flex flex-col gap-2.5">
       <div className="flex items-center gap-2">
@@ -499,4 +1373,65 @@ function ComponentsPreview({ lab }: { lab: Lab }) {
       </Caption>
     </div>
   )
+}
+
+/* ------------------------------- Registries ------------------------------- */
+
+const SECTION_PREVIEWS: Record<string, Preview> = {
+  color: ColorSectionPreview,
+  typography: TypeSectionPreview,
+  icons: IconsSectionPreview,
+  shape: ShapeSectionPreview,
+  space: SpaceSectionPreview,
+  details: DetailsSectionPreview,
+  components: ComponentsSectionPreview,
+}
+
+/* Keyed by the row's visible label (or aria-label) — what resolveTarget
+   reads from the DOM. Rows not listed fall back to the section preview. */
+const CONTROL_PREVIEWS: Record<string, Record<string, Preview>> = {
+  color: {
+    Brand: BrandPreview,
+    Gray: GrayPreview,
+    Primary: PrimaryPreview,
+    Modes: ModesPreview,
+    'Semantic colors': SemanticPreview,
+  },
+  typography: {
+    Heading: ({ lab }) => (
+      <FontPreview family={lab.state.headingFont} role="heading" />
+    ),
+    Body: ({ lab }) => <FontPreview family={lab.state.bodyFont} role="body" />,
+    Mono: ({ lab }) => <FontPreview family={lab.state.monoFont} role="mono" />,
+  },
+  icons: {
+    Library: IconsSectionPreview,
+    Stroke: StrokePreview,
+    Weight: IconsSectionPreview,
+  },
+  shape: {
+    Radius: ShapeSectionPreview,
+    Character: RolesPreview,
+    Roles: RolesPreview,
+    Corners: CornersPreview,
+  },
+  space: {
+    Density: SpaceSectionPreview,
+  },
+  details: {
+    Shadows: DetailsSectionPreview,
+    Cursor: CursorPreview,
+    'Disabled cursor': CursorPreview,
+  },
+  components: {
+    Button: ButtonPreview,
+    Input: InputPreview,
+    Checkbox: CheckboxPreview,
+    Card: CardPreview,
+    Badge: BadgePreview,
+    Modal: ModalPreview,
+    Tooltip: TooltipPreview,
+    Menu: MenuPreview,
+    Loader: LoaderPreview,
+  },
 }

--- a/www/src/modules/panel-lab/gallery.tsx
+++ b/www/src/modules/panel-lab/gallery.tsx
@@ -23,7 +23,13 @@ const PANEL_W = 360
 const PANEL_H = 720
 
 /** The scaled, inert panel shared by version and draft cards. */
-function PanelPreview({ chapters }: { chapters: PanelVersion["chapters"] }) {
+function PanelPreview({
+  chapters,
+  Frame = PanelFrame,
+}: {
+  chapters: PanelVersion['chapters']
+  Frame?: NonNullable<Draft['Frame']>
+}) {
   const lab = useStaticLab()
   return (
     <div
@@ -41,7 +47,7 @@ function PanelPreview({ chapters }: { chapters: PanelVersion["chapters"] }) {
           transformOrigin: "top center",
         }}
       >
-        <PanelFrame chapters={chapters} lab={lab} />
+        <Frame chapters={chapters} lab={lab} />
       </div>
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-card to-transparent" />
     </div>
@@ -57,7 +63,10 @@ function DraftCard({ draft }: { draft: Draft }) {
       params={{ draft: draft.id }}
       className="group/draft flex cursor-interactive flex-col gap-3 rounded-2xl border border-border/45 bg-card p-3 focus-reset transition-colors hover:border-border focus-visible:focus-ring"
     >
-      <PanelPreview chapters={draftChapters(base.chapters, draft)} />
+      <PanelPreview
+        chapters={draftChapters(base.chapters, draft)}
+        Frame={draft.Frame}
+      />
       <div className="flex flex-col gap-1 px-1 pb-1">
         <span className="flex items-center gap-1.5">
           <span className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-[11px] text-fg-muted">

--- a/www/src/modules/panel-lab/gallery.tsx
+++ b/www/src/modules/panel-lab/gallery.tsx
@@ -27,8 +27,8 @@ function PanelPreview({
   chapters,
   Frame = PanelFrame,
 }: {
-  chapters: PanelVersion['chapters']
-  Frame?: NonNullable<Draft['Frame']>
+  chapters: PanelVersion["chapters"]
+  Frame?: NonNullable<Draft["Frame"]>
 }) {
   const lab = useStaticLab()
   return (

--- a/www/src/modules/panel-lab/patterns.tsx
+++ b/www/src/modules/panel-lab/patterns.tsx
@@ -4,9 +4,9 @@
    on the control-lab row language. If one earns its keep it graduates into
    control-lab/rows.tsx. Prototype only: local state in, callback out. */
 
-import { useContext } from 'react'
-import { ChevronDownIcon, SearchIcon } from 'lucide-react'
-import { Button as RacButton } from 'react-aria-components'
+import { useContext } from "react"
+import { ChevronDownIcon, SearchIcon } from "lucide-react"
+import { Button as RacButton } from "react-aria-components"
 
 import { fontStack } from "@/lib/fonts"
 import { cn } from "@/registry/lib/utils"
@@ -21,14 +21,14 @@ import { SearchField } from "@/registry/ui/search-field"
 import {
   SegmentedControl,
   SegmentedControlItem,
-} from '@/registry/ui/segmented-control'
+} from "@/registry/ui/segmented-control"
 import {
   ROW,
   ROW_LABEL,
   ROW_VALUE,
   RowOverlayPlacementContext,
-} from '@/modules/control-lab/rows'
-import { useLoadedFamilies } from '@/modules/create/typography'
+} from "@/modules/control-lab/rows"
+import { useLoadedFamilies } from "@/modules/create/typography"
 
 /* -------------------------------- Detail row ------------------------------- */
 

--- a/www/src/modules/panel-lab/patterns.tsx
+++ b/www/src/modules/panel-lab/patterns.tsx
@@ -4,8 +4,9 @@
    on the control-lab row language. If one earns its keep it graduates into
    control-lab/rows.tsx. Prototype only: local state in, callback out. */
 
-import { ChevronDownIcon, SearchIcon } from "lucide-react"
-import { Button as RacButton } from "react-aria-components"
+import { useContext } from 'react'
+import { ChevronDownIcon, SearchIcon } from 'lucide-react'
+import { Button as RacButton } from 'react-aria-components'
 
 import { fontStack } from "@/lib/fonts"
 import { cn } from "@/registry/lib/utils"
@@ -20,9 +21,14 @@ import { SearchField } from "@/registry/ui/search-field"
 import {
   SegmentedControl,
   SegmentedControlItem,
-} from "@/registry/ui/segmented-control"
-import { ROW, ROW_LABEL, ROW_VALUE } from "@/modules/control-lab/rows"
-import { useLoadedFamilies } from "@/modules/create/typography"
+} from '@/registry/ui/segmented-control'
+import {
+  ROW,
+  ROW_LABEL,
+  ROW_VALUE,
+  RowOverlayPlacementContext,
+} from '@/modules/control-lab/rows'
+import { useLoadedFamilies } from '@/modules/create/typography'
 
 /* -------------------------------- Detail row ------------------------------- */
 
@@ -143,7 +149,7 @@ export function SwatchDots({ colors }: { colors: string[] }) {
 /** Shared picker popover body (area + hue + hex). */
 export function PickerPopoverContent() {
   return (
-    <Popover placement="right top">
+    <Popover placement={useContext(RowOverlayPlacementContext)}>
       <DialogContent className="flex flex-col gap-2">
         <div className="flex gap-2">
           <ColorArea

--- a/www/src/modules/panel-lab/version-page.tsx
+++ b/www/src/modules/panel-lab/version-page.tsx
@@ -79,11 +79,11 @@ export function PanelDraftPage({ draft }: { draft: Draft }) {
     >
       <div className="flex flex-col gap-3">
         <p className="max-w-lg text-xs/relaxed text-pretty text-fg-muted">
-          An open draft, shown on top of{' '}
-          <span className="text-fg">{base.label}</span> —{' '}
+          An open draft, shown on top of{" "}
+          <span className="text-fg">{base.label}</span> —{" "}
           {draft.Frame
-            ? 'only the frame differs; hover a control.'
-            : `only the ${draft.section} section differs.`}{' '}
+            ? "only the frame differs; hover a control."
+            : `only the ${draft.section} section differs.`}{" "}
           Not merged; one of several takes.
         </p>
         <div className="flex h-[720px] w-[360px] shrink-0 flex-col">

--- a/www/src/modules/panel-lab/version-page.tsx
+++ b/www/src/modules/panel-lab/version-page.tsx
@@ -55,6 +55,7 @@ export function PanelDraftPage({ draft }: { draft: Draft }) {
   const base = PANEL_VERSIONS[PANEL_VERSIONS.length - 1]
   if (!base) return null
   const chapters = draftChapters(base.chapters, draft)
+  const Frame = draft.Frame ?? PanelFrame
 
   return (
     <InternalShell
@@ -78,12 +79,15 @@ export function PanelDraftPage({ draft }: { draft: Draft }) {
     >
       <div className="flex flex-col gap-3">
         <p className="max-w-lg text-xs/relaxed text-pretty text-fg-muted">
-          An open draft, shown on top of{" "}
-          <span className="text-fg">{base.label}</span> — only the{" "}
-          {draft.section} section differs. Not merged; one of several takes.
+          An open draft, shown on top of{' '}
+          <span className="text-fg">{base.label}</span> —{' '}
+          {draft.Frame
+            ? 'only the frame differs; hover a section.'
+            : `only the ${draft.section} section differs.`}{' '}
+          Not merged; one of several takes.
         </p>
         <div className="flex h-[720px] w-[360px] shrink-0 flex-col">
-          <PanelFrame chapters={chapters} lab={lab} />
+          <Frame chapters={chapters} lab={lab} />
         </div>
       </div>
     </InternalShell>

--- a/www/src/modules/panel-lab/version-page.tsx
+++ b/www/src/modules/panel-lab/version-page.tsx
@@ -82,7 +82,7 @@ export function PanelDraftPage({ draft }: { draft: Draft }) {
           An open draft, shown on top of{' '}
           <span className="text-fg">{base.label}</span> —{' '}
           {draft.Frame
-            ? 'only the frame differs; hover a section.'
+            ? 'only the frame differs; hover a control.'
             : `only the ${draft.section} section differs.`}{' '}
           Not merged; one of several takes.
         </p>


### PR DESCRIPTION
A new panel-lab draft exploring the frame, not a section: interacting with a control in the builder panel floats its live preview beside the panel.

## The interaction

- **One shared container** — mounted once, retargeted. It **glides** to align with the active row (no-bounce spring, y and height as one unit) while content **crossfades** direction-aware (slide from direction of travel + subtle blur).
- **Control previews only.** Rows with something meaningful to show have their own preview, anchored to the row: Brand shows the color doing its real jobs (CTA, link, switch, badge), Gray shows text/surface hierarchy, Modes and Semantic colors show themselves in use; Heading/Body/Mono show live specimens of the chosen face; per-component rows (Button, Input, Checkbox, Card, Badge, Modal, Tooltip, Menu, Loader) render mini demos reacting to their params. Rows without an entry show nothing — a per-section fallback proved noisy between controls and was removed; the 120ms grace carries the container across row gaps so control-to-control never flickers.
- **Three signals, strongest first:** an open overlay (picker/select/menu — `aria-haspopup` + `aria-expanded` inside the frame) pins its row; then hover; then focus — so keyboard use and open disclosures keep their preview when the pointer leaves. Rows are resolved from the DOM (`data-row` / `slot=trigger` / `aria-label` / `data-disclosure` climb), so the shared section bodies stay untouched.
- Clamped inside the frame, glued to its anchor on scroll, scale-fade exit, `prefers-reduced-motion` keeps only fades.

## Dev tweaks (group "Preview rail")

The known tension: row overlays open `right top` — exactly where the preview sits. Four tweaks to find the right combo:

- **Preview side**: right / right far (clears the popover channel) / left (panel slides over, preview lands in the freed space, popovers open right unobstructed)
- **While overlay open**: show (pin) / hide
- **Overlay placement**: right top / left top / bottom start — threaded to the shared row primitives via a new `RowOverlayPlacementContext` (defaults to today's `right top`; zero change outside this draft)
- **Disable affordance**: none / header eye toggle / press P

## Mechanics

- `HoverPreviewFrame` in `drafts/preview-594.tsx`; `Draft` gains an optional `Frame` (first frame-level draft, `overrides: []`).
- `control-lab/rows.tsx`, `panel-lab/patterns.tsx`, `color-working.tsx`: overlay placements now read `RowOverlayPlacementContext` instead of hardcoding `right top` — behavior unchanged everywhere else.

Try it at `/internal/panel-lab/draft/pr-594`.

Draft — one of several takes, not meant to land as-is.

