### PR TITLE
chore: ignore quote reformat in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Mechanical reformats to skip in git blame.
+# GitHub honors this file automatically; locally run once:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# style: switch to double quotes (#592)
+3b13610effbdcb41143fcc5e7918cd4339401e0f


### PR DESCRIPTION
Adds `.git-blame-ignore-revs` with the squash SHA of #592 (the 1766-file double-quote reformat). GitHub honors this file automatically, so blame views skip the reformat and show real authorship.

For local blame, run once:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

Future mechanical sweeps can append their SHAs here.