### PR TITLE
feat(www): SelectRow grid layout with illustrated cards

### DIFF
--- a/www/src/modules/control-lab/page.tsx
+++ b/www/src/modules/control-lab/page.tsx
@@ -14,9 +14,13 @@ import {
   AlignCenterIcon,
   AlignLeftIcon,
   AlignRightIcon,
+  GrabIcon,
   MonitorIcon,
   MoonIcon,
+  MousePointer2Icon,
+  PointerIcon,
   SunIcon,
+  TextCursorIcon,
 } from "lucide-react"
 import { useTheme } from "starter-themes"
 
@@ -53,7 +57,12 @@ import {
   OptionGridRow,
   SwitchRow,
 } from "./rows"
-import type { NeutralValue, SegmentedRowOption, OptionGridItem } from "./rows"
+import type {
+  NeutralValue,
+  SegmentedRowOption,
+  OptionGridItem,
+  SelectRowOption,
+} from "./rows"
 
 /* ------------------------------ Mini specimens ----------------------------- */
 
@@ -155,6 +164,15 @@ const CURSOR_OPTIONS = ["default", "pointer", "grab", "text"].map((c) => ({
   label: c,
 }))
 
+/* The grid layout earns its keep when the option is a look, not a name: each
+   card draws the cursor it stands for. */
+const CURSOR_GRID_OPTIONS: SelectRowOption[] = [
+  { value: "default", label: "Default", icon: <MousePointer2Icon /> },
+  { value: "pointer", label: "Pointer", icon: <PointerIcon /> },
+  { value: "grab", label: "Grab", icon: <GrabIcon /> },
+  { value: "text", label: "Text", icon: <TextCursorIcon /> },
+]
+
 /* --------------------------------- Catalog --------------------------------- */
 
 interface Entry {
@@ -223,6 +241,19 @@ function SelectDemo({
       value={value}
       onChange={setValue}
       options={withIcons ? THEME_OPTIONS : CURSOR_OPTIONS}
+    />
+  )
+}
+
+function SelectGridDemo() {
+  const [value, setValue] = useState("default")
+  return (
+    <SelectRow
+      label="Cursor"
+      value={value}
+      onChange={setValue}
+      options={CURSOR_GRID_OPTIONS}
+      layout="grid"
     />
   )
 }
@@ -628,11 +659,12 @@ const GROUPS: Group[] = [
         id: "select-row",
         name: "SelectRow",
         description:
-          "A listbox trigger shaped as a settings row: label left, value and chevrons right. Options may carry a glyph, shown in both trigger and list.",
+          "A listbox trigger shaped as a settings row: label left, value and chevrons right. Options may carry a glyph, shown in both trigger and list. The grid layout swaps the list for illustrated cards — artwork on top, label below — for options that are looks rather than names.",
         variants: [
           { label: "Default", render: <SelectDemo /> },
           { label: "With icons", render: <SelectDemo withIcons /> },
           { label: "With description", render: <SelectDemo described /> },
+          { label: "Grid, illustrated", render: <SelectGridDemo /> },
         ],
       },
       {

--- a/www/src/modules/control-lab/rows.tsx
+++ b/www/src/modules/control-lab/rows.tsx
@@ -17,6 +17,8 @@ import {
 } from "lucide-react"
 import {
   Button as RacButton,
+  ListBox as RacListBox,
+  ListBoxItem as RacListBoxItem,
   SelectionIndicator,
   ToggleButton as RacToggleButton,
   ToggleButtonGroup as RacToggleButtonGroup,
@@ -321,6 +323,8 @@ export interface SelectRowOption {
   label: string
   /** Optional glyph shown before the label in the list and in the trigger. */
   icon?: React.ReactNode
+  /** Grid layout only: the artwork drawn on the card. Falls back to `icon`. */
+  illustration?: React.ReactNode
 }
 
 /** A listbox trigger shaped as a settings row: label left, value + chevrons right. */
@@ -330,12 +334,16 @@ export function SelectRow({
   value,
   onChange,
   options,
+  layout = "list",
 }: {
   label: string
   description?: string
   value: string
   onChange: (value: string) => void
   options: SelectRowOption[]
+  /** `grid` swaps the dropdown list for illustrated cards — artwork on top,
+   *  label below — with 2D arrow-key navigation. Pick by look, in a popover. */
+  layout?: "list" | "grid"
 }) {
   const selected = options.find((o) => o.value === value)
   return (
@@ -365,16 +373,39 @@ export function SelectRow({
         className="w-(--trigger-width)"
         placement={useContext(RowOverlayPlacementContext)}
       >
-        <ListBox>
-          {options.map((opt) => (
-            <ListBoxItem key={opt.value} id={opt.value} textValue={opt.label}>
-              <span className="flex items-center gap-2 **:[svg]:size-4">
-                {opt.icon}
-                {opt.label}
-              </span>
-            </ListBoxItem>
-          ))}
-        </ListBox>
+        {layout === "grid" ? (
+          /* Raw RAC listbox: Select wires it up through context, and
+             layout="grid" gives the cards real 2D arrow-key navigation. */
+          <RacListBox
+            layout="grid"
+            className="grid max-h-[inherit] grid-cols-2 gap-2 overflow-auto p-2 outline-hidden"
+          >
+            {options.map((opt) => (
+              <RacListBoxItem
+                key={opt.value}
+                id={opt.value}
+                textValue={opt.label}
+                className="flex min-w-0 cursor-interactive flex-col items-center gap-2 rounded-lg bg-muted p-4 text-fg-muted outline-hidden transition-transform select-none focus:bg-highlight focus:text-fg-on-highlight motion-safe:pressed:scale-[0.98] selected:text-fg selected:inset-ring selected:inset-ring-accent"
+              >
+                <span className="flex h-9 items-center justify-center text-fg **:[svg]:size-6">
+                  {opt.illustration ?? opt.icon}
+                </span>
+                <span className="truncate text-xs">{opt.label}</span>
+              </RacListBoxItem>
+            ))}
+          </RacListBox>
+        ) : (
+          <ListBox>
+            {options.map((opt) => (
+              <ListBoxItem key={opt.value} id={opt.value} textValue={opt.label}>
+                <span className="flex items-center gap-2 **:[svg]:size-4">
+                  {opt.icon}
+                  {opt.label}
+                </span>
+              </ListBoxItem>
+            ))}
+          </ListBox>
+        )}
       </Popover>
     </Select>
   )


### PR DESCRIPTION
## Summary

Adds a `layout="grid"` variant to the control lab's `SelectRow`: the popover swaps the dropdown list for a 2-column grid of illustrated cards — artwork on top, label below — for options that are looks rather than names.

- `SelectRow` gains `layout?: "list" | "grid"`; `SelectRowOption` gains an optional `illustration` (falls back to `icon`).
- Grid mode renders a raw RAC `ListBox` with `layout="grid"` (RAC `Select` only wires its state to a `ListBox`, so this is the sanctioned way to get GridList-style 2D arrow-key navigation inside a select).
- Cards: `bg-muted` surface, focus highlight, accent inset ring on the selected card, pressed scale.
- New catalog variant "Grid, illustrated": a Cursor select whose four cards draw the cursor they stand for (lucide glyphs), reused small in the trigger.

## Verification

Verified live in the lab (`/internal/panel-lab/controls`): 2×2 card grid, ArrowDown moves focus down a column (true 2D nav), real click commits selection, trigger updates label + glyph, select closes. `pnpm check` and `pnpm typecheck` pass.