### PR TITLE
feat(www): control-lab OptionGrid on ListBox grid layout

### DIFF
--- a/www/src/modules/control-lab/rows.tsx
+++ b/www/src/modules/control-lab/rows.tsx
@@ -17,6 +17,8 @@ import {
 } from "lucide-react"
 import {
   Button as RacButton,
+  ListBox as RacListBox,
+  ListBoxItem as RacListBoxItem,
   SelectionIndicator,
   ToggleButton as RacToggleButton,
   ToggleButtonGroup as RacToggleButtonGroup,
@@ -1017,12 +1019,16 @@ function OptionGrid({
   variant?: "card" | "plain"
 }) {
   return (
-    <RacToggleButtonGroup
+    // A listbox, not a toggle group: grid layout gives the cards 2-D arrow-key
+    // navigation, which a ToggleButtonGroup (1-D) can't.
+    <RacListBox
       aria-label={ariaLabel}
+      layout="grid"
       selectionMode="single"
       disallowEmptySelection
       selectedKeys={[value]}
       onSelectionChange={(keys) => {
+        if (keys === "all") return
         const next = keys.values().next().value
         if (next) onChange(next as string)
       }}
@@ -1030,10 +1036,11 @@ function OptionGrid({
       style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
     >
       {options.map((option) => (
-        <RacToggleButton
+        <RacListBoxItem
           key={option.id}
           id={option.id}
           aria-label={option.label}
+          textValue={option.label}
           className={cn(
             "relative flex min-w-0 cursor-interactive items-center justify-center rounded-lg p-4 focus-reset transition-transform after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:bg-white/5 after:opacity-0 after:transition-opacity hover:after:opacity-100 focus-visible:focus-ring motion-safe:pressed:scale-[0.98]",
             variant === "card"
@@ -1044,9 +1051,9 @@ function OptionGrid({
           <span className="flex w-full min-w-0 items-center justify-center">
             {option.preview}
           </span>
-        </RacToggleButton>
+        </RacListBoxItem>
       ))}
-    </RacToggleButtonGroup>
+    </RacListBox>
   )
 }
 


### PR DESCRIPTION
## Summary

- Rebuilt Control Lab's `OptionGrid` (the specimen-card grid behind `OptionGridRow` and `ComponentRow`) on React Aria's `ListBox` with `layout="grid"`, replacing the single-select `ToggleButtonGroup`.
- Cards are now `ListBoxItem`s with `aria-label` (accessible name) and `textValue` (typeahead); all styling classes carried over unchanged — `selected:`/`hover:`/`pressed:` map to the same RAC data attributes. The selection handler guards ListBox's `"all"` selection type (the only type-level difference).

## Why

Out of a primitives audit of the control lab against the React Aria docs: every row was on the right primitive, but `ToggleButtonGroup` is one-dimensional — in a 2-column card grid, arrow keys walked the cards linearly with no up/down movement. `ListBox` grid layout is the RAC primitive that provides real 2-D keyboard navigation.

## Verification

Checked live on the worktree dev server at `/internal/panel-lab/controls`:

- Grid renders as `role="listbox"` / `data-layout="grid"` in both `OptionGridRow` demos and `ComponentRow` disclosures; `aria-selected` and labels correct.
- Click selects and the row readout updates; Enter selects the focused card; accent ring renders.
- 2-D nav works: from top-right of the 2×2 Button grid, ArrowDown lands on the card directly below, ArrowLeft moves along the row. (Keyboard verified with synthetic `KeyboardEvent`s — the browser pane couldn't deliver trusted keys — so a quick real-keyboard pass when the lab is next open wouldn't hurt.)
- `pnpm check` and `pnpm typecheck` pass. No registry files touched.

## Notes from the same audit (not in this diff)

Minor items surfaced while reviewing: a factually wrong comment in `NeutralSlider` about slider thumb labeling (the group label does reach the input — verified in react-aria source), an inert `aria-label` on the SectionHeader modified-dot span, and `SegmentedRow`/`MiniSegmented` hand-rolling the registry `SegmentedControl` recipe. All fine for a prototype; worth folding in if the lab graduates into /create.