### PR TITLE
feat(www): update headline

### DIFF
--- a/www/src/modules/marketing/hero-word-swap.tsx
+++ b/www/src/modules/marketing/hero-word-swap.tsx
@@ -11,7 +11,8 @@ import { useEffect, useRef, useState } from "react"
 import { AnimatePresence, motion, useReducedMotion } from "motion/react"
 
 const WORDS = ["humans", "agents"] as const
-const INTERVAL_MS = 4200
+/** Includes the 460ms swap, so each word holds still for ~2.5s. */
+const INTERVAL_MS = 3000
 
 const ENTER_DURATION = 0.28
 const EXIT_DURATION = 0.18

--- a/www/src/modules/marketing/hero-word-swap.tsx
+++ b/www/src/modules/marketing/hero-word-swap.tsx
@@ -1,109 +1,79 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useId, useMemo, useState } from "react"
+import { AnimatePresence, motion, useReducedMotion } from "motion/react"
 
-// "humans" and "agents" are both 6 letters ending in "s" — the swap can be
-// layout-stable apart from a small width tween between the two words.
 const WORDS = ["humans", "agents"] as const
-
-const EASE = "cubic-bezier(0.77, 0, 0.175, 1)" // ease-in-out-quart
-const DURATION_MS = 600
 const DWELL_MS = 4000
-const STAGGER_MS = 35
 
-function usePrefersReducedMotion() {
-  const [reduced, setReduced] = useState(false)
-  useEffect(() => {
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)")
-    setReduced(mq.matches)
-    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches)
-    mq.addEventListener("change", onChange)
-    return () => mq.removeEventListener("change", onChange)
-  }, [])
-  return reduced
-}
+const TRANSITION = {
+  type: "spring",
+  stiffness: 280,
+  damping: 18,
+  mass: 0.3,
+} as const
+
+const VARIANTS = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+} as const
 
 export function HeroWordSwap() {
-  const reduced = usePrefersReducedMotion()
-  const [swapped, setSwapped] = useState(false)
+  const reduced = useReducedMotion()
+  const [index, setIndex] = useState(0)
+  const word = WORDS[index]!
+  const uid = useId()
 
   useEffect(() => {
     if (reduced) return
-    const id = setInterval(() => setSwapped((s) => !s), DWELL_MS)
+    const id = setInterval(
+      () => setIndex((i) => (i + 1) % WORDS.length),
+      DWELL_MS,
+    )
     return () => clearInterval(id)
   }, [reduced])
 
-  // The words differ in width (~30px at hero size), so the container tracks the
-  // active word's measured width and the centered line gently re-centers.
-  const wordRefs = useRef<(HTMLSpanElement | null)[]>([null, null])
-  const [widths, setWidths] = useState<[number, number] | null>(null)
-  useEffect(() => {
-    if (reduced) return
-    const measure = () => {
-      const [a, b] = wordRefs.current.map(
-        (el) => el?.getBoundingClientRect().width,
-      )
-      if (a && b) setWidths([a, b])
-    }
-    measure()
-    // Re-measures on font swap and on the vw-clamped font-size changing.
-    const ro = new ResizeObserver(measure)
-    for (const el of wordRefs.current) if (el) ro.observe(el)
-    return () => ro.disconnect()
-  }, [reduced])
+  // Per-occurrence character ids: letters both words share (a, n, s) keep their
+  // identity across the swap, so they slide to their new position instead of
+  // fading out and back in. The rest cross-fade.
+  const characters = useMemo(() => {
+    const counts: Record<string, number> = {}
+    return word.split("").map((char) => {
+      counts[char] = (counts[char] ?? 0) + 1
+      return { id: `${uid}-${char}${counts[char]}`, label: char }
+    })
+  }, [word, uid])
 
   if (reduced) {
     return <span>humans</span>
   }
 
-  const transition = `transform ${DURATION_MS}ms ${EASE}, opacity ${DURATION_MS}ms ${EASE}`
-
   return (
     <>
       <span className="sr-only">humans and agents</span>
-      <span
-        aria-hidden
-        className="relative inline-block [clip-path:inset(-0.15em_-0.4em)]"
-        style={{
-          width: widths ? widths[swapped ? 1 : 0] : undefined,
-          transition: `width ${DURATION_MS}ms ${EASE}`,
-        }}
-      >
-        {/* Invisible in-flow anchor: establishes the baseline and the initial
-            (pre-measurement) width, while the visible word rows sit absolutely
-            on top so the wider word can't inflate the animated width. */}
-        <span className="invisible">{WORDS[0]}</span>
-        {WORDS.map((word, wi) => {
-          const active = (wi === 1) === swapped
-          // Each word keeps its natural letter widths; the letters flip
-          // individually with a left-to-right stagger.
-          return (
-            <span
-              key={word}
-              ref={(el) => {
-                wordRefs.current[wi] = el
-              }}
-              className="absolute top-0 left-1/2 inline-flex -translate-x-1/2 whitespace-nowrap"
-            >
-              {word.split("").map((ch, i) => (
-                <span
-                  key={i}
-                  style={{
-                    transition,
-                    transitionDelay: `${i * STAGGER_MS}ms`,
-                    transform: active
-                      ? "translateY(0)"
-                      : `translateY(${wi === 0 ? "-100%" : "100%"})`,
-                    opacity: active ? 1 : 0,
-                    willChange: "transform",
-                  }}
-                >
-                  {ch}
-                </span>
-              ))}
-            </span>
-          )
-        })}
+      {/* Sized to the wider of the two words so the swap never reflows the line:
+          "for" stays put and the morph is the only thing moving. */}
+      <span aria-hidden className="relative inline-block">
+        <span className="invisible">humans</span>
+        <span className="absolute top-0 left-0 whitespace-nowrap">
+          <AnimatePresence mode="popLayout" initial={false}>
+            {characters.map((character) => (
+              <motion.span
+                key={character.id}
+                layoutId={character.id}
+                className="inline-block"
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                variants={VARIANTS}
+                transition={TRANSITION}
+              >
+                {character.label}
+              </motion.span>
+            ))}
+          </AnimatePresence>
+        </span>
       </span>
     </>
   )

--- a/www/src/modules/marketing/hero-word-swap.tsx
+++ b/www/src/modules/marketing/hero-word-swap.tsx
@@ -13,21 +13,27 @@ import { AnimatePresence, motion, useReducedMotion } from "motion/react"
 const WORDS = ["humans", "agents"] as const
 const INTERVAL_MS = 4200
 
-const DURATION = 0.3
-const EXIT_DURATION = 0.22
-const EASE = [0.16, 1, 0.3, 1] as const
+const ENTER_DURATION = 0.28
+const EXIT_DURATION = 0.18
+const EASE_OUT = [0.16, 1, 0.3, 1] as const // easeOutExpo — arrival
+const EASE_IN = [0.55, 0.055, 0.675, 0.19] as const // easeInCubic — departure
 const BLUR = "blur(6px)"
+/** Settles in ~310ms, so the slot has finished resizing before the word sharpens. */
 const WIDTH_SPRING = { type: "spring", stiffness: 260, damping: 30 } as const
 
-// The peak blur lands at opacity 0, so you never see sharp-but-blurred text. Exit
-// carries its own faster transition so the swap doesn't drag.
+// The peak blur lands at opacity 0, so you never see sharp-but-blurred text.
+//
+// The exit eases *in* while the enter eases out. mode="wait" hands over only once
+// the exit's full duration has elapsed, so an ease-out exit would spend its whole
+// tail already invisible — 145ms of empty slot on a 220ms easeOutExpo exit. Easing
+// in holds the word, then releases it exactly as the incoming one mounts (9ms).
 const VARIANTS = {
   initial: { opacity: 0, filter: BLUR },
   animate: { opacity: 1, filter: "blur(0px)" },
   exit: {
     opacity: 0,
     filter: BLUR,
-    transition: { duration: EXIT_DURATION, ease: EASE },
+    transition: { duration: EXIT_DURATION, ease: EASE_IN },
   },
 }
 
@@ -99,7 +105,7 @@ export function HeroWordSwap() {
               initial={variants.initial}
               animate={variants.animate}
               exit={variants.exit}
-              transition={{ duration: DURATION, ease: EASE }}
+              transition={{ duration: ENTER_DURATION, ease: EASE_OUT }}
             >
               {word}
             </motion.span>

--- a/www/src/modules/marketing/hero-word-swap.tsx
+++ b/www/src/modules/marketing/hero-word-swap.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+import { useTweak } from "@/dev/tweaker"
+
+const WORDS = ["humans", "agents"] as const
+
+const EASING = {
+  "letter-flip": "cubic-bezier(0.77, 0, 0.175, 1)", // ease-in-out-quart
+  "slide-blur": "cubic-bezier(0.645, 0.045, 0.355, 1)", // ease-in-out-cubic
+  crossfade: "ease",
+} as const
+
+const STAGGER_MS = 35
+
+function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(false)
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)")
+    setReduced(mq.matches)
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches)
+    mq.addEventListener("change", onChange)
+    return () => mq.removeEventListener("change", onChange)
+  }, [])
+  return reduced
+}
+
+export function HeroWordSwap() {
+  const treatment = useTweak("Treatment", {
+    type: "select",
+    options: ["letter-flip", "slide-blur", "crossfade"],
+    default: "letter-flip",
+    group: "Hero swap",
+  })
+  const cycle = useTweak("Cycle", {
+    type: "select",
+    // loop: alternate forever · settle: humans → agents → humans, stop · once: humans → agents, stop
+    options: ["loop", "settle", "once"],
+    default: "loop",
+    group: "Hero swap",
+  })
+  const dwell = useTweak("Dwell (s)", {
+    type: "number",
+    min: 2,
+    max: 8,
+    step: 0.5,
+    default: 4,
+    group: "Hero swap",
+  })
+  const duration = useTweak("Duration (ms)", {
+    type: "number",
+    min: 300,
+    max: 900,
+    step: 50,
+    default: 600,
+    group: "Hero swap",
+  })
+  const emphasize = useTweak("Emphasize word", {
+    type: "boolean",
+    default: false,
+    group: "Hero swap",
+  })
+
+  const reduced = usePrefersReducedMotion()
+  const [swapped, setSwapped] = useState(false)
+  const toggles = useRef(0)
+
+  useEffect(() => {
+    // Restart the sequence whenever a tweak changes, so each option is seen fresh.
+    toggles.current = 0
+    setSwapped(false)
+    if (reduced) return
+    const max = cycle === "loop" ? Infinity : cycle === "once" ? 1 : 2
+    const id = setInterval(() => {
+      if (toggles.current >= max) {
+        clearInterval(id)
+        return
+      }
+      toggles.current += 1
+      setSwapped((s) => !s)
+    }, dwell * 1000)
+    return () => clearInterval(id)
+  }, [reduced, cycle, dwell, duration, treatment])
+
+  // The words differ in width (~30px at hero size), so the container tracks the
+  // active word's measured width and the centered line gently re-centers.
+  const wordRefs = useRef<(HTMLSpanElement | null)[]>([null, null])
+  const [widths, setWidths] = useState<[number, number] | null>(null)
+  useEffect(() => {
+    if (reduced) return
+    const measure = () => {
+      const [a, b] = wordRefs.current.map(
+        (el) => el?.getBoundingClientRect().width,
+      )
+      if (a && b) setWidths([a, b])
+    }
+    measure()
+    // Re-measures on font swap and on the vw-clamped font-size changing.
+    const ro = new ResizeObserver(measure)
+    for (const el of wordRefs.current) if (el) ro.observe(el)
+    return () => ro.disconnect()
+  }, [reduced, treatment])
+
+  const emphasisClass = emphasize ? "text-fg" : undefined
+
+  if (reduced) {
+    return <span className={emphasisClass}>humans</span>
+  }
+
+  const ease = EASING[treatment]
+  const transition = `transform ${duration}ms ${ease}, opacity ${duration}ms ${ease}, filter ${duration}ms ${ease}`
+  const clip =
+    treatment === "crossfade" ? "" : "[clip-path:inset(-0.15em_-0.4em)]"
+
+  return (
+    <>
+      <span className="sr-only">humans and agents</span>
+      <span
+        aria-hidden
+        className={`relative inline-block ${clip} ${emphasisClass ?? ""}`}
+        style={{
+          width: widths ? widths[swapped ? 1 : 0] : undefined,
+          transition: `width ${duration}ms ${ease}`,
+        }}
+      >
+        {/* Invisible in-flow anchor: establishes the baseline and the initial
+            (pre-measurement) width, while the visible word rows sit absolutely
+            on top so the wider word can't inflate the animated width. */}
+        <span className="invisible">{WORDS[0]}</span>
+        {WORDS.map((word, wi) => {
+          const active = (wi === 1) === swapped
+          if (treatment === "letter-flip") {
+            // Each word keeps its natural letter widths and kerning; the
+            // letters flip individually with a left-to-right stagger.
+            return (
+              <span
+                key={word}
+                ref={(el) => {
+                  wordRefs.current[wi] = el
+                }}
+                className="absolute top-0 left-1/2 inline-flex -translate-x-1/2 whitespace-nowrap"
+              >
+                {word.split("").map((ch, i) => (
+                  <span
+                    key={i}
+                    style={{
+                      transition,
+                      transitionDelay: `${i * STAGGER_MS}ms`,
+                      transform: active
+                        ? "translateY(0)"
+                        : `translateY(${wi === 0 ? "-100%" : "100%"})`,
+                      opacity: active ? 1 : 0,
+                      willChange: "transform",
+                    }}
+                  >
+                    {ch}
+                  </span>
+                ))}
+              </span>
+            )
+          }
+          return (
+            <span
+              key={word}
+              ref={(el) => {
+                wordRefs.current[wi] = el
+              }}
+              className="absolute top-0 left-1/2 whitespace-nowrap"
+              style={{
+                transition,
+                transform: `translateX(-50%) ${
+                  active
+                    ? "translateY(0)"
+                    : treatment === "slide-blur"
+                      ? `translateY(${wi === 0 ? "-0.7em" : "0.7em"})`
+                      : "translateY(0)"
+                }`,
+                opacity: active ? 1 : 0,
+                filter: active
+                  ? "blur(0px)"
+                  : treatment === "slide-blur"
+                    ? "blur(6px)"
+                    : "blur(3px)",
+                willChange: "transform, filter",
+              }}
+            >
+              {word}
+            </span>
+          )
+        })}
+      </span>
+    </>
+  )
+}

--- a/www/src/modules/marketing/hero-word-swap.tsx
+++ b/www/src/modules/marketing/hero-word-swap.tsx
@@ -2,16 +2,13 @@
 
 import { useEffect, useRef, useState } from "react"
 
-import { useTweak } from "@/dev/tweaker"
-
+// "humans" and "agents" are both 6 letters ending in "s" — the swap can be
+// layout-stable apart from a small width tween between the two words.
 const WORDS = ["humans", "agents"] as const
 
-const EASING = {
-  "letter-flip": "cubic-bezier(0.77, 0, 0.175, 1)", // ease-in-out-quart
-  "slide-blur": "cubic-bezier(0.645, 0.045, 0.355, 1)", // ease-in-out-cubic
-  crossfade: "ease",
-} as const
-
+const EASE = "cubic-bezier(0.77, 0, 0.175, 1)" // ease-in-out-quart
+const DURATION_MS = 600
+const DWELL_MS = 4000
 const STAGGER_MS = 35
 
 function usePrefersReducedMotion() {
@@ -27,61 +24,14 @@ function usePrefersReducedMotion() {
 }
 
 export function HeroWordSwap() {
-  const treatment = useTweak("Treatment", {
-    type: "select",
-    options: ["letter-flip", "slide-blur", "crossfade"],
-    default: "letter-flip",
-    group: "Hero swap",
-  })
-  const cycle = useTweak("Cycle", {
-    type: "select",
-    // loop: alternate forever · settle: humans → agents → humans, stop · once: humans → agents, stop
-    options: ["loop", "settle", "once"],
-    default: "loop",
-    group: "Hero swap",
-  })
-  const dwell = useTweak("Dwell (s)", {
-    type: "number",
-    min: 2,
-    max: 8,
-    step: 0.5,
-    default: 4,
-    group: "Hero swap",
-  })
-  const duration = useTweak("Duration (ms)", {
-    type: "number",
-    min: 300,
-    max: 900,
-    step: 50,
-    default: 600,
-    group: "Hero swap",
-  })
-  const emphasize = useTweak("Emphasize word", {
-    type: "boolean",
-    default: false,
-    group: "Hero swap",
-  })
-
   const reduced = usePrefersReducedMotion()
   const [swapped, setSwapped] = useState(false)
-  const toggles = useRef(0)
 
   useEffect(() => {
-    // Restart the sequence whenever a tweak changes, so each option is seen fresh.
-    toggles.current = 0
-    setSwapped(false)
     if (reduced) return
-    const max = cycle === "loop" ? Infinity : cycle === "once" ? 1 : 2
-    const id = setInterval(() => {
-      if (toggles.current >= max) {
-        clearInterval(id)
-        return
-      }
-      toggles.current += 1
-      setSwapped((s) => !s)
-    }, dwell * 1000)
+    const id = setInterval(() => setSwapped((s) => !s), DWELL_MS)
     return () => clearInterval(id)
-  }, [reduced, cycle, dwell, duration, treatment])
+  }, [reduced])
 
   // The words differ in width (~30px at hero size), so the container tracks the
   // active word's measured width and the centered line gently re-centers.
@@ -100,28 +50,23 @@ export function HeroWordSwap() {
     const ro = new ResizeObserver(measure)
     for (const el of wordRefs.current) if (el) ro.observe(el)
     return () => ro.disconnect()
-  }, [reduced, treatment])
-
-  const emphasisClass = emphasize ? "text-fg" : undefined
+  }, [reduced])
 
   if (reduced) {
-    return <span className={emphasisClass}>humans</span>
+    return <span>humans</span>
   }
 
-  const ease = EASING[treatment]
-  const transition = `transform ${duration}ms ${ease}, opacity ${duration}ms ${ease}, filter ${duration}ms ${ease}`
-  const clip =
-    treatment === "crossfade" ? "" : "[clip-path:inset(-0.15em_-0.4em)]"
+  const transition = `transform ${DURATION_MS}ms ${EASE}, opacity ${DURATION_MS}ms ${EASE}`
 
   return (
     <>
       <span className="sr-only">humans and agents</span>
       <span
         aria-hidden
-        className={`relative inline-block ${clip} ${emphasisClass ?? ""}`}
+        className="relative inline-block [clip-path:inset(-0.15em_-0.4em)]"
         style={{
           width: widths ? widths[swapped ? 1 : 0] : undefined,
-          transition: `width ${duration}ms ${ease}`,
+          transition: `width ${DURATION_MS}ms ${EASE}`,
         }}
       >
         {/* Invisible in-flow anchor: establishes the baseline and the initial
@@ -130,62 +75,32 @@ export function HeroWordSwap() {
         <span className="invisible">{WORDS[0]}</span>
         {WORDS.map((word, wi) => {
           const active = (wi === 1) === swapped
-          if (treatment === "letter-flip") {
-            // Each word keeps its natural letter widths and kerning; the
-            // letters flip individually with a left-to-right stagger.
-            return (
-              <span
-                key={word}
-                ref={(el) => {
-                  wordRefs.current[wi] = el
-                }}
-                className="absolute top-0 left-1/2 inline-flex -translate-x-1/2 whitespace-nowrap"
-              >
-                {word.split("").map((ch, i) => (
-                  <span
-                    key={i}
-                    style={{
-                      transition,
-                      transitionDelay: `${i * STAGGER_MS}ms`,
-                      transform: active
-                        ? "translateY(0)"
-                        : `translateY(${wi === 0 ? "-100%" : "100%"})`,
-                      opacity: active ? 1 : 0,
-                      willChange: "transform",
-                    }}
-                  >
-                    {ch}
-                  </span>
-                ))}
-              </span>
-            )
-          }
+          // Each word keeps its natural letter widths; the letters flip
+          // individually with a left-to-right stagger.
           return (
             <span
               key={word}
               ref={(el) => {
                 wordRefs.current[wi] = el
               }}
-              className="absolute top-0 left-1/2 whitespace-nowrap"
-              style={{
-                transition,
-                transform: `translateX(-50%) ${
-                  active
-                    ? "translateY(0)"
-                    : treatment === "slide-blur"
-                      ? `translateY(${wi === 0 ? "-0.7em" : "0.7em"})`
-                      : "translateY(0)"
-                }`,
-                opacity: active ? 1 : 0,
-                filter: active
-                  ? "blur(0px)"
-                  : treatment === "slide-blur"
-                    ? "blur(6px)"
-                    : "blur(3px)",
-                willChange: "transform, filter",
-              }}
+              className="absolute top-0 left-1/2 inline-flex -translate-x-1/2 whitespace-nowrap"
             >
-              {word}
+              {word.split("").map((ch, i) => (
+                <span
+                  key={i}
+                  style={{
+                    transition,
+                    transitionDelay: `${i * STAGGER_MS}ms`,
+                    transform: active
+                      ? "translateY(0)"
+                      : `translateY(${wi === 0 ? "-100%" : "100%"})`,
+                    opacity: active ? 1 : 0,
+                    willChange: "transform",
+                  }}
+                >
+                  {ch}
+                </span>
+              ))}
             </span>
           )
         })}

--- a/www/src/modules/marketing/hero-word-swap.tsx
+++ b/www/src/modules/marketing/hero-word-swap.tsx
@@ -1,80 +1,111 @@
 "use client"
 
-import { useEffect, useId, useMemo, useState } from "react"
+/**
+ * Rotating hero word, modeled on the x.ai hero swap. The word resolves in and out
+ * of focus — `{opacity, blur(6px)}` with no vertical travel — rather than sliding,
+ * and the slot springs to the incoming word's measured width so the "for" before it
+ * never snaps.
+ */
+
+import { useEffect, useRef, useState } from "react"
 import { AnimatePresence, motion, useReducedMotion } from "motion/react"
 
 const WORDS = ["humans", "agents"] as const
-const DWELL_MS = 4000
+const INTERVAL_MS = 4200
 
-const TRANSITION = {
-  type: "spring",
-  stiffness: 280,
-  damping: 18,
-  mass: 0.3,
-} as const
+const DURATION = 0.3
+const EXIT_DURATION = 0.22
+const EASE = [0.16, 1, 0.3, 1] as const
+const BLUR = "blur(6px)"
+const WIDTH_SPRING = { type: "spring", stiffness: 260, damping: 30 } as const
 
+// The peak blur lands at opacity 0, so you never see sharp-but-blurred text. Exit
+// carries its own faster transition so the swap doesn't drag.
 const VARIANTS = {
+  initial: { opacity: 0, filter: BLUR },
+  animate: { opacity: 1, filter: "blur(0px)" },
+  exit: {
+    opacity: 0,
+    filter: BLUR,
+    transition: { duration: EXIT_DURATION, ease: EASE },
+  },
+}
+
+/** Crossfade only — no blur, and the slot width snaps — under prefers-reduced-motion. */
+const REDUCED_VARIANTS = {
   initial: { opacity: 0 },
   animate: { opacity: 1 },
   exit: { opacity: 0 },
-} as const
+}
 
 export function HeroWordSwap() {
-  const reduced = useReducedMotion()
+  const reduce = useReducedMotion() ?? false
   const [index, setIndex] = useState(0)
-  const word = WORDS[index]!
-  const uid = useId()
+  const word = WORDS[index] ?? WORDS[0]
 
   useEffect(() => {
-    if (reduced) return
-    const id = setInterval(
+    const id = window.setInterval(
       () => setIndex((i) => (i + 1) % WORDS.length),
-      DWELL_MS,
+      INTERVAL_MS,
     )
-    return () => clearInterval(id)
-  }, [reduced])
+    return () => window.clearInterval(id)
+  }, [])
 
-  // Per-occurrence character ids: letters both words share (a, n, s) keep their
-  // identity across the swap, so they slide to their new position instead of
-  // fading out and back in. The rest cross-fade.
-  const characters = useMemo(() => {
-    const counts: Record<string, number> = {}
-    return word.split("").map((char) => {
-      counts[char] = (counts[char] ?? 0) + 1
-      return { id: `${uid}-${char}${counts[char]}`, label: char }
-    })
-  }, [word, uid])
+  // Measure the active word from the invisible sizer, then animate the slot to it.
+  // Animating the real `width` (not a transform) is what keeps the line from
+  // snapping. The ResizeObserver catches width changes without a word change: the
+  // webfont swapping in, or the fluid headline font-size crossing a breakpoint.
+  const sizerRef = useRef<HTMLSpanElement | null>(null)
+  const [width, setWidth] = useState<number | undefined>(undefined)
+  useEffect(() => {
+    const el = sizerRef.current
+    if (!el) return
+    const measure = () => {
+      const next = Math.round(el.scrollWidth)
+      setWidth((prev) => (prev === next ? prev : next))
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [word])
 
-  if (reduced) {
-    return <span>humans</span>
-  }
+  const variants = reduce ? REDUCED_VARIANTS : VARIANTS
 
   return (
     <>
       <span className="sr-only">humans and agents</span>
-      {/* Sized to the wider of the two words so the swap never reflows the line:
-          "for" stays put and the morph is the only thing moving. */}
-      <span aria-hidden className="relative inline-block">
-        <span className="invisible">humans</span>
-        <span className="absolute top-0 left-0 whitespace-nowrap">
-          <AnimatePresence mode="popLayout" initial={false}>
-            {characters.map((character) => (
-              <motion.span
-                key={character.id}
-                layoutId={character.id}
-                className="inline-block"
-                initial="initial"
-                animate="animate"
-                exit="exit"
-                variants={VARIANTS}
-                transition={TRANSITION}
-              >
-                {character.label}
-              </motion.span>
-            ))}
+      <motion.span
+        aria-hidden
+        className="inline-grid items-baseline align-baseline"
+        animate={width != null ? { width } : undefined}
+        transition={{ width: reduce ? { duration: 0 } : WIDTH_SPRING }}
+      >
+        {/* Sizer: invisibly holds the current word so the slot keeps a baseline and
+            a measurable width through the swap, and never collapses between words. */}
+        <span
+          ref={sizerRef}
+          className="invisible col-start-1 row-start-1 justify-self-start whitespace-nowrap"
+        >
+          {word}
+        </span>
+        {/* Visible word, swapped sequentially over the sizer (mode="wait").
+            `initial={false}` so the first word shows statically on load. */}
+        <span className="col-start-1 row-start-1 justify-self-start whitespace-nowrap">
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.span
+              key={word}
+              className="inline-block"
+              initial={variants.initial}
+              animate={variants.animate}
+              exit={variants.exit}
+              transition={{ duration: DURATION, ease: EASE }}
+            >
+              {word}
+            </motion.span>
           </AnimatePresence>
         </span>
-      </span>
+      </motion.span>
     </>
   )
 }

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -25,7 +25,7 @@ export function HomePage() {
         {/* Hero section */}
         <section className="flex flex-col pt-14 sm:pt-18 md:pt-26">
           <div className="flex flex-col items-center text-center">
-            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.75rem,calc((100vw-2rem)/10.3),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-none">
+            <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.75rem,calc((100vw-2rem)/10.3),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-[4rem]">
               The Design System Studio
               <br />
               <span className="text-fg-muted">

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -13,8 +13,16 @@ import Cards from "@/modules/marketing/cards"
 import { CompositionSection } from "@/modules/marketing/composition-section"
 import { CtaSection } from "@/modules/marketing/cta-section"
 import { ExportSection } from "@/modules/marketing/export-section"
+import { HeroWordSwap } from "@/modules/marketing/hero-word-swap"
+import { useTweak } from "@/dev/tweaker"
 
 export function HomePage() {
+  const headline = useTweak("Headline", {
+    type: "select",
+    options: ["humans ⇄ agents", "for the Web"],
+    default: "humans ⇄ agents",
+    group: "Hero swap",
+  })
   return (
     // One container for the whole landing; every section aligns to its 1440px
     // content box. Decorations that bleed past it (cards rails, full-bleed
@@ -27,7 +35,15 @@ export function HomePage() {
             <h1 className="[font-feature-settings:'calt'_0,'rlig','ss11'] text-[clamp(1.75rem,calc((100vw-2rem)/10.3),3rem)] leading-[1.17] font-normal tracking-[-0.06em] text-balance antialiased sm:text-[3rem] sm:leading-[3.5rem] xl:text-6xl xl:leading-none">
               The Design System Studio
               <br />
-              <span className="text-fg-muted">for the Web</span>
+              <span className="text-fg-muted">
+                {headline === "for the Web" ? (
+                  "for the Web"
+                ) : (
+                  <>
+                    for <HeroWordSwap />
+                  </>
+                )}
+              </span>
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">
               Every design decision is yours, previewed live on real components.

--- a/www/src/modules/marketing/home-page.tsx
+++ b/www/src/modules/marketing/home-page.tsx
@@ -14,15 +14,8 @@ import { CompositionSection } from "@/modules/marketing/composition-section"
 import { CtaSection } from "@/modules/marketing/cta-section"
 import { ExportSection } from "@/modules/marketing/export-section"
 import { HeroWordSwap } from "@/modules/marketing/hero-word-swap"
-import { useTweak } from "@/dev/tweaker"
 
 export function HomePage() {
-  const headline = useTweak("Headline", {
-    type: "select",
-    options: ["humans ⇄ agents", "for the Web"],
-    default: "humans ⇄ agents",
-    group: "Hero swap",
-  })
   return (
     // One container for the whole landing; every section aligns to its 1440px
     // content box. Decorations that bleed past it (cards rails, full-bleed
@@ -36,13 +29,7 @@ export function HomePage() {
               The Design System Studio
               <br />
               <span className="text-fg-muted">
-                {headline === "for the Web" ? (
-                  "for the Web"
-                ) : (
-                  <>
-                    for <HeroWordSwap />
-                  </>
-                )}
+                for <HeroWordSwap />
               </span>
             </h1>
             <p className="mt-5 max-w-2xl text-lg leading-relaxed text-balance text-fg-muted">


### PR DESCRIPTION
## Summary

- Replace the hero's static `for the Web` with a rotating word: **`for humans` ⇄ `for agents`**. `for the Web` stated the medium; the swap states who the output is for, and matches an export story that already points both ways (shadcn CLI for people, v0 for agents).
- Add `hero-word-swap.tsx` — a blur crossfade with a spring-sized slot.
- Open the headline's leading on `xl` from `leading-none` to `leading-[4rem]`.

No new dependencies — `motion` was already a `www` dependency.

## The animation

This revives the motion design from `www/src/components/rotating-text.tsx` (`AnimatedHeadline`), which rotated export destinations — "Ship it to v0 / bolt.new / Lovable / your code" — and was deleted in 60c14a190 because it advertised destinations we don't support. The copy was the problem, not the motion.

The word swaps as one unit via `{opacity, blur(6px)}` with no vertical travel — it resolves in and out of focus rather than sliding — and the slot springs its width to the incoming word's measured width so the preceding `for` never snaps. Only the motion was kept; the original's segments/connector/brand-logo machinery isn't needed for two plain words, so this is 118 lines against the original's 280.

Two other treatments were built and rejected along the way: a per-letter slot-machine flip, and motion-primitives' per-character `layoutId` morph.

**Why width can be animated here but couldn't with the morph:** a `layoutId` morph measures each letter's target position at swap time, so a container width that keeps changing afterwards drags them off target — that version had to freeze the slot at the wider word and accept an off-centre line. A whole-word crossfade involves no layout projection, so animating the real width is free and the headline stays centred throughout.

## Timing

| | Exit | Enter | Total | Dead air |
|---|---|---|---|---|
| Inherited | 220ms easeOutExpo | 300ms easeOutExpo | 520ms | 145ms (28%) |
| Now | 180ms easeInCubic | 280ms easeOutExpo | 460ms | 9ms (2%) |

**The exit has to ease *in*.** `AnimatePresence mode="wait"` mounts the incoming word only once the exit's full duration elapses, so a front-loaded ease-out exit spends its entire tail already invisible — over a quarter of the swap showed an empty slot. Easing in holds the word, then releases it exactly as the next one mounts.

The width spring (`stiffness 260, damping 30`) settles in ~307ms, inside the 460ms swap, so the slot stops resizing before the word sharpens.

Dwell is 3000ms, which includes the swap — each word holds still ~2.5s, full loop 6s.

## Leading

`leading-none` (60/60) left 7.68px between line 1's descenders (**g**, **y**) and line 2's ascenders. Nothing collided — the nearest descender/ascender pair is 22px apart horizontally — so this was aesthetic, not a correctness fix. At 1.0 the short second line crowded up into "Studio"; `4rem` (ratio 1.0667) reads as a pair with room for the animated line, and smooths the jump from `sm`'s 1.167. The h1 grows 120px → 128px on `xl`, nudging the copy below down 8px. Nothing below `xl` changes.

## Reviewer notes

- **Accessibility:** a static `sr-only` "humans and agents" carries the meaning; the animated part is `aria-hidden`.
- **Reduced motion:** the words still cycle, with a plain opacity crossfade and an instant width change, rather than freezing on one word — inherited from the original component, so that the second half of the message isn't lost. Happy to freeze it instead if you'd rather.
- **Verification caveat:** the preview pane reports itself hidden and pauses `requestAnimationFrame`, so Motion never ticks there. I verified the mechanics structurally (inline `style` values mid-transition, baseline alignment, measured widths) and the timing numerically, but could not watch the animation play. Worth a real look before merge.
- Baselines are pixel-identical between `for`, `humans` and `agents`, and the h1 measures exactly 2 × 64px on `xl`, so the slot isn't inflating the line box.
