### PR TITLE
feat(www): panel-lab gap and preview tweaks

### DIFF
--- a/www/src/modules/panel-lab/hero.tsx
+++ b/www/src/modules/panel-lab/hero.tsx
@@ -13,9 +13,13 @@
      real registry icons, real engine colors. Live is the bar, not realistic:
      Shape's arc diagram qualifies because it draws the actual radii. */
 
-import { useState } from "react"
+import { createContext, useContext, useState } from "react"
 
 import { cn } from "@/registry/lib/utils"
+
+/** What a section opens on. `none` drops the hero and starts on controls. */
+export type PreviewMode = "none" | "hero"
+export const PreviewModeContext = createContext<PreviewMode>("hero")
 
 /** The stage. `inset` pads content; full-bleed heroes (a grid with a footer
  *  bar) turn it off and manage their own edges. */
@@ -28,6 +32,7 @@ export function Hero({
   className?: string
   children: React.ReactNode
 }) {
+  if (useContext(PreviewModeContext) === "none") return null
   return (
     <div
       className={cn(
@@ -46,6 +51,7 @@ export function Hero({
 /** Side-by-side mode tiles — the stage for mode-differentiated axes, where
  *  "right in light, wrong in dark" is the failure mode being shopped for. */
 export function HeroModes({ children }: { children: React.ReactNode }) {
+  if (useContext(PreviewModeContext) === "none") return null
   return <div className="flex gap-2">{children}</div>
 }
 

--- a/www/src/modules/panel-lab/sections.tsx
+++ b/www/src/modules/panel-lab/sections.tsx
@@ -460,7 +460,7 @@ export function ShapeSectionBody({ lab }: { lab: Lab }) {
   const { state, set } = lab
   return (
     <>
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-[var(--lab-gap-control,0.375rem)]">
         {/* Self-demo: the row's own corners round with the value. */}
         <SliderRow
           label="Radius"
@@ -625,7 +625,7 @@ export function ShapeSectionBodyV2({ lab }: { lab: Lab }) {
   return (
     <>
       <CornerPreview lab={lab} />
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-[var(--lab-gap-control,0.375rem)]">
         {/* Self-demo: the row's own corners wear the value, 1:1. */}
         <SliderRow
           label="Radius"
@@ -1023,9 +1023,12 @@ export function ComponentsSectionBody({ lab }: { lab: Lab }) {
         onChange={setQuery}
         placeholder="Filter components..."
       />
-      <DisclosureGroup className="flex flex-col gap-1.5">
+      <DisclosureGroup className="flex flex-col gap-[var(--lab-gap-control,0.375rem)]">
         {clusters.map((cluster) => (
-          <div key={cluster.label} className="flex flex-col gap-1.5">
+          <div
+            key={cluster.label}
+            className="flex flex-col gap-[var(--lab-gap-control,0.375rem)]"
+          >
             <ClusterHeader label={cluster.label} />
             {cluster.items.map((item) => (
               <div key={item.name}>{item.render(lab)}</div>

--- a/www/src/modules/panel-lab/variants/chapter.tsx
+++ b/www/src/modules/panel-lab/variants/chapter.tsx
@@ -68,7 +68,7 @@ export function ChapterCard({
         modified={status.modified}
         onReset={status.onReset}
       />
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-[var(--lab-gap-control,0.375rem)]">
         <Body lab={lab} />
       </div>
     </section>

--- a/www/src/modules/panel-lab/variants/panel.tsx
+++ b/www/src/modules/panel-lab/variants/panel.tsx
@@ -6,11 +6,14 @@
    its own chapter list (see versions.tsx), so the chrome is shared and only
    the sections differ between versions. */
 
+import type { CSSProperties } from "react"
 import { ChevronsUpDownIcon, SearchIcon } from "lucide-react"
 
 import { Button } from "@/registry/ui/button"
+import { useTweak } from "@/dev/tweaker"
 
 import type { Lab } from "../data"
+import { PreviewModeContext } from "../hero"
 import { ChapterCard } from "./chapter"
 import type { Chapter } from "./chapter"
 
@@ -21,45 +24,78 @@ export function PanelFrame({
   chapters: Chapter[]
   lab: Lab
 }) {
+  const sectionGap = useTweak("Section gap", {
+    type: "number",
+    min: 0,
+    max: 32,
+    step: 1,
+    default: 12,
+    group: "Spacing",
+  })
+  const controlGap = useTweak("Control gap", {
+    type: "number",
+    min: 0,
+    max: 16,
+    step: 1,
+    default: 6,
+    group: "Spacing",
+  })
+  const preview = useTweak("Section opens on", {
+    type: "select",
+    options: ["hero", "none"],
+    default: "hero",
+    group: "Preview",
+  })
+
   return (
-    <div className="relative flex h-full min-h-0 flex-col">
-      {/* Floating glass header — cards dip under it, never past it. */}
-      <div className="absolute inset-x-0 top-0 z-20 flex items-center justify-between gap-2 rounded-xl border border-border/45 bg-neutral/90 p-1.5 shadow-[0_4px_16px_-4px_rgb(0_0_0/0.2),0_2px_6px_-2px_rgb(0_0_0/0.12)] backdrop-blur-sm">
-        <Button
-          variant="quiet"
-          size="sm"
-          className="min-w-0 justify-start gap-1.5 font-medium"
-        >
-          <span className="truncate">Acme design system</span>
-          <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-muted" />
-        </Button>
-        <Button
-          size="sm"
-          variant="quiet"
-          isIconOnly
-          aria-label="Search controls"
-          className="shrink-0"
-        >
-          <SearchIcon />
-        </Button>
-      </div>
+    <PreviewModeContext.Provider value={preview}>
+      <div
+        className="relative flex h-full min-h-0 flex-col"
+        style={
+          {
+            "--lab-gap-section": `${sectionGap}px`,
+            "--lab-gap-control": `${controlGap}px`,
+          } as CSSProperties
+        }
+      >
+        {/* Floating glass header — cards dip under it, never past it. */}
+        <div className="absolute inset-x-0 top-0 z-20 flex items-center justify-between gap-2 rounded-xl border border-border/45 bg-neutral/90 p-1.5 shadow-[0_4px_16px_-4px_rgb(0_0_0/0.2),0_2px_6px_-2px_rgb(0_0_0/0.12)] backdrop-blur-sm">
+          <Button
+            variant="quiet"
+            size="sm"
+            className="min-w-0 justify-start gap-1.5 font-medium"
+          >
+            <span className="truncate">Acme design system</span>
+            <ChevronsUpDownIcon className="size-3.5 shrink-0 text-fg-muted" />
+          </Button>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            aria-label="Search controls"
+            className="shrink-0"
+          >
+            <SearchIcon />
+          </Button>
+        </div>
 
-      {/* The story scroll: every chapter its own card. */}
-      <div className="no-scrollbar flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain rounded-xl pt-[56px] pb-[62px] *:shrink-0">
-        {chapters.map((chapter) => (
-          <ChapterCard key={chapter.id} chapter={chapter} lab={lab} />
-        ))}
-      </div>
+        {/* The story scroll: every chapter its own card. */}
+        <div className="no-scrollbar flex min-h-0 flex-1 flex-col gap-[var(--lab-gap-section,0.75rem)] overflow-y-auto overscroll-contain rounded-xl pt-[56px] pb-[62px] *:shrink-0">
+          {chapters.map((chapter) => (
+            <ChapterCard key={chapter.id} chapter={chapter} lab={lab} />
+          ))}
+        </div>
 
-      {/* Floating glass footer — same treatment as the header. */}
-      <div className="absolute inset-x-0 bottom-0 z-20 flex items-center gap-2 rounded-xl border border-border/45 bg-neutral/90 p-2 shadow-[0_-4px_16px_-4px_rgb(0_0_0/0.2),0_-2px_6px_-2px_rgb(0_0_0/0.12)] backdrop-blur-sm">
-        <Button size="sm" className="flex-1">
-          Save
-        </Button>
-        <Button variant="primary" size="sm" className="flex-1">
-          Export
-        </Button>
+        {/* Floating glass footer — same treatment as the header. */}
+        <div className="absolute inset-x-0 bottom-0 z-20 flex items-center gap-2 rounded-xl border border-border/45 bg-neutral/90 p-2 shadow-[0_-4px_16px_-4px_rgb(0_0_0/0.2),0_-2px_6px_-2px_rgb(0_0_0/0.12)] backdrop-blur-sm">
+          <Button size="sm" className="flex-1">
+            Save
+          </Button>
+          <Button variant="primary" size="sm" className="flex-1">
+            Export
+          </Button>
+        </div>
       </div>
-    </div>
+    </PreviewModeContext.Provider>
   )
 }


### PR DESCRIPTION
Dev-tweaker controls for exploring panel-lab spacing and section openings live.

## Controls

| Group | Control | Drives | Default |
|---|---|---|---|
| Spacing | Section gap | gap between chapter cards | 12px |
| Spacing | Control gap | gap between controls | 6px |
| Preview | Section opens on | `hero` / `none` | hero |

Both gaps go through CSS variables set on the panel root (`--lab-gap-section`, `--lab-gap-control`), so every gap in the panel reads from one place. The nested control columns in Shape and Components had their own hardcoded `gap-1.5`, which the slider would have skipped — they now read the same variable. Fallbacks are baked into each class, so the #594 draft frame (which doesn't set the vars) keeps today's values.

`Section opens on` flows through a `PreviewModeContext` in `hero.tsx`: `none` makes `Hero`/`HeroModes` render nothing, so every section starts on its first control. A third option later is one more entry in the `options` array.

## Scope note

The controls live on `PanelFrame`, which v1, v2 and the drafts share — so they show on those pages too. Deliberate: it makes v1-vs-v2 spacing directly comparable.

This is `useTweak` scaffolding, dev + preview only — it compiles to a no-op and tree-shakes out of production. It stays until the values are picked, then gets baked in and removed.

## Verified

Live in the browser at section 20 / control 12: section gap 20px, all 10 control columns at 12px, `none` removes all 6 hero stages, draft #594 falls back correctly, no console errors. `pnpm check` and `pnpm typecheck` pass.