### PR TITLE
ci: post Claude PR reviews with --comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -38,7 +38,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          # --comment is required: without it the plugin prints the review to the
+          # terminal and posts nothing. See plugins/code-review in anthropics/claude-code.
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment"
           claude_args: "--effort high"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
The Claude review job has run **415 times since 2026-07-06 and posted zero comments**. Every run's log ends with `No buffered inline comments`. The one `claude` comment in the repo's 494 PRs came from `claude.yml` via an `@claude` mention, not from this workflow.

Cause is the plugin's own contract, not a failure. From step 7 of `plugins/code-review/commands/code-review.md` in `anthropics/claude-code`:

> If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.

Our prompt never passed `--comment`, so the plugin spawned its four review agents, validated the findings, printed the review to the terminal, and stopped. `show_full_output` defaults to `false`, so that terminal output never reached the CI log either — the review was computed at full cost and discarded, 415 times.

Behind that sat a second blocker: `permissions` granted `pull-requests: read`, which the run logs confirm (`PullRequests: read`). Both `gh pr comment` and the inline-comment tool need write, so posting would have failed even with the flag.

This PR adds `--comment` to the prompt and raises the permission to `pull-requests: write`.

It cannot verify itself: the action refuses to run when the workflow file on a PR branch differs from the copy on the default branch (`Workflow validation failed. The workflow file must exist and have identical content to the version on the repository`), a guard against PRs editing their own reviewer. The run on this PR skipped for exactly that reason. Verification is the next PR opened after this merges.

## Survey data

| | |
|---|---|
| Runs | 415 (413 success, 2 failure) |
| Runner time | 27.2 h (free — public repo) |
| Runs that posted anything | 0 |
| Claude spend | $711.14 (mean $1.73, median $1.15, max $21.07) |
| Tool permission denials | 4081 across 363 runs (max 93 in one run) |

## Suggested follow-ups

Not in this diff — both need a product call:

- **`synchronize` re-reviews every push.** 415 runs across 159 branches (2.6 per PR, 14 on one). That multiplier is most of the $711. The plugin's step 1 skips PRs Claude has already commented on, so repeat pushes get cheap once comments start landing — but dropping `synchronize` would be more decisive.
- **4081 permission denials.** The agent is being blocked on tools mid-review and we cannot see which, since `show_full_output: false` hides it. Worth one run with it enabled to confirm reviews are not degraded.
