### PR TITLE
feat(www): chromeless preview panel with floating pill toolbar

### DIFF
--- a/www/src/components/showcase/cards-grid.tsx
+++ b/www/src/components/showcase/cards-grid.tsx
@@ -147,7 +147,7 @@ export const CardsGrid = memo(function CardsGrid({
 
 // The /create preview canvas — the shadcn-create shape: a fixed-pixel,
 // horizontally scrollable life-size surface rather than a fluid grid, so card
-// size comes from the ~385px column track, never from the pane width. Columns
+// size comes from the ~360px column track, never from the pane width. Columns
 // are hand-curated stacks; the wide slot holds the AI banner over a 2-col
 // sub-grid. `content-visibility` keeps off-screen columns free to lay out.
 const CANVAS_1: CardKey[] = ["controls", "twoFactor", "filters", "accountMenu"]
@@ -178,7 +178,7 @@ function CanvasColumn({
   return (
     <div
       className={cn(
-        "flex flex-col gap-(--gap) p-px [contain-intrinsic-size:385px_1200px] [content-visibility:auto]",
+        "flex flex-col gap-(--gap) p-px [contain-intrinsic-size:360px_1200px] [content-visibility:auto]",
         className,
       )}
     >
@@ -195,9 +195,9 @@ export function CardsCanvas() {
       {/* Centers the canvas when the viewport is wider than it; otherwise the
           canvas starts flush-left and scrolls. */}
       <div className="flex w-full min-w-max justify-center">
-        {/* Width tracks the gap: 6 × ~385px columns + 5 gaps + 2 edge paddings,
+        {/* Width tracks the gap: 6 × ~360px columns + 5 gaps + 2 edge paddings,
             so tightening --gap keeps cards life-size instead of growing them. */}
-        <div className="grid w-[2000px] grid-cols-6 items-start gap-(--gap) p-(--gap) md:w-[2480px]">
+        <div className="grid w-[2000px] grid-cols-6 items-start gap-(--gap) p-(--gap) md:w-[2328px]">
           <CanvasColumn cards={CANVAS_1} />
           <CanvasColumn cards={CANVAS_2} />
           <div className="col-span-2 flex flex-col gap-(--gap) p-px [contain-intrinsic-size:790px_1200px] [content-visibility:auto]">

--- a/www/src/components/showcase/cards-grid.tsx
+++ b/www/src/components/showcase/cards-grid.tsx
@@ -147,7 +147,7 @@ export const CardsGrid = memo(function CardsGrid({
 
 // The /create preview canvas — the shadcn-create shape: a fixed-pixel,
 // horizontally scrollable life-size surface rather than a fluid grid, so card
-// size comes from the ~360px column track, never from the pane width. Columns
+// size comes from the ~340px column track, never from the pane width. Columns
 // are hand-curated stacks; the wide slot holds the AI banner over a 2-col
 // sub-grid. `content-visibility` keeps off-screen columns free to lay out.
 const CANVAS_1: CardKey[] = ["controls", "twoFactor", "filters", "accountMenu"]
@@ -178,7 +178,7 @@ function CanvasColumn({
   return (
     <div
       className={cn(
-        "flex flex-col gap-(--gap) p-px [contain-intrinsic-size:360px_1200px] [content-visibility:auto]",
+        "flex flex-col gap-(--gap) p-px [contain-intrinsic-size:340px_1200px] [content-visibility:auto]",
         className,
       )}
     >
@@ -195,9 +195,9 @@ export function CardsCanvas() {
       {/* Centers the canvas when the viewport is wider than it; otherwise the
           canvas starts flush-left and scrolls. */}
       <div className="flex w-full min-w-max justify-center">
-        {/* Width tracks the gap: 6 × ~360px columns + 5 gaps + 2 edge paddings,
+        {/* Width tracks the gap: 6 × ~340px columns + 5 gaps + 2 edge paddings,
             so tightening --gap keeps cards life-size instead of growing them. */}
-        <div className="grid w-[2000px] grid-cols-6 items-start gap-(--gap) p-(--gap) md:w-[2328px]">
+        <div className="grid w-[2000px] grid-cols-6 items-start gap-(--gap) p-(--gap) md:w-[2208px]">
           <CanvasColumn cards={CANVAS_1} />
           <CanvasColumn cards={CANVAS_2} />
           <div className="col-span-2 flex flex-col gap-(--gap) p-px [contain-intrinsic-size:790px_1200px] [content-visibility:auto]">

--- a/www/src/components/showcase/cards-grid.tsx
+++ b/www/src/components/showcase/cards-grid.tsx
@@ -145,22 +145,77 @@ export const CardsGrid = memo(function CardsGrid({
   )
 })
 
-// The /create preview and preset thumbnails: the banner over a CSS-columns
-// masonry of every card. It never animates, so the column balancer's per-frame
-// re-flow cost doesn't apply here.
-export function CardsMasonry({ className }: { className?: string }) {
+// The /create preview canvas — the shadcn-create shape: a fixed-pixel,
+// horizontally scrollable life-size surface rather than a fluid grid, so card
+// size comes from the ~385px column track, never from the pane width. Columns
+// are hand-curated stacks; the wide slot holds the AI banner over a 2-col
+// sub-grid. `content-visibility` keeps off-screen columns free to lay out.
+const CANVAS_1: CardKey[] = ["controls", "twoFactor", "filters", "accountMenu"]
+const CANVAS_2: CardKey[] = ["commandMenu", "payment", "storage", "loginForm"]
+const CANVAS_WIDE_LEFT: CardKey[] = ["metrics", "booking"]
+const CANVAS_WIDE_RIGHT: CardKey[] = ["uploadAvatar", "pricingPlans"]
+const CANVAS_5: CardKey[] = [
+  "computerUse",
+  "notifications",
+  "faq",
+  "displaySettings",
+]
+const CANVAS_6: CardKey[] = [
+  "inviteMembers",
+  "appearance",
+  "colorEditor",
+  "cookiePreferences",
+  "teamName",
+]
+
+function CanvasColumn({
+  cards,
+  className,
+}: {
+  cards: CardKey[]
+  className?: string
+}) {
   return (
-    <div className={cn("flex flex-col gap-4", className)}>
-      <AiPrompt />
-      <div className="columns-1 gap-4 sm:columns-2 lg:columns-3">
-        {[...RAIL, ...MAIN_LEFT, ...MAIN_RIGHT, ...SIDE].map((key) => (
-          // The vertical gap is the cell's *padding*, not a margin: Safari leaks
-          // a child's margin-bottom across column breaks, pushing the next
-          // column's first card down.
-          <div key={key} className="break-inside-avoid pb-4">
-            {CARDS[key]}
+    <div
+      className={cn(
+        "flex flex-col gap-(--gap) p-px [contain-intrinsic-size:385px_1200px] [content-visibility:auto]",
+        className,
+      )}
+    >
+      {cards.map((key) => (
+        <div key={key}>{CARDS[key]}</div>
+      ))}
+    </div>
+  )
+}
+
+export function CardsCanvas() {
+  return (
+    <div className="min-h-svh overflow-x-auto overflow-y-hidden bg-neutral [--gap:--spacing(4)] md:[--gap:--spacing(10)] dark:bg-bg">
+      {/* Centers the canvas when the viewport is wider than it; otherwise the
+          canvas starts flush-left and scrolls. */}
+      <div className="flex w-full min-w-max justify-center">
+        <div className="grid w-[2000px] grid-cols-6 items-start gap-(--gap) p-(--gap) md:w-[2600px]">
+          <CanvasColumn cards={CANVAS_1} />
+          <CanvasColumn cards={CANVAS_2} />
+          <div className="col-span-2 flex flex-col gap-(--gap) p-px [contain-intrinsic-size:790px_1200px] [content-visibility:auto]">
+            <AiPrompt />
+            <div className="grid grid-cols-2 items-start gap-(--gap)">
+              <div className="flex flex-col gap-(--gap)">
+                {CANVAS_WIDE_LEFT.map((key) => (
+                  <div key={key}>{CARDS[key]}</div>
+                ))}
+              </div>
+              <div className="flex flex-col gap-(--gap)">
+                {CANVAS_WIDE_RIGHT.map((key) => (
+                  <div key={key}>{CARDS[key]}</div>
+                ))}
+              </div>
+            </div>
           </div>
-        ))}
+          <CanvasColumn cards={CANVAS_5} />
+          <CanvasColumn cards={CANVAS_6} />
+        </div>
       </div>
     </div>
   )

--- a/www/src/components/showcase/cards-grid.tsx
+++ b/www/src/components/showcase/cards-grid.tsx
@@ -191,11 +191,13 @@ function CanvasColumn({
 
 export function CardsCanvas() {
   return (
-    <div className="min-h-svh overflow-x-auto overflow-y-hidden bg-neutral [--gap:--spacing(4)] md:[--gap:--spacing(10)] dark:bg-bg">
+    <div className="min-h-svh overflow-x-auto overflow-y-hidden bg-neutral [--gap:--spacing(4)] md:[--gap:--spacing(6)] dark:bg-bg">
       {/* Centers the canvas when the viewport is wider than it; otherwise the
           canvas starts flush-left and scrolls. */}
       <div className="flex w-full min-w-max justify-center">
-        <div className="grid w-[2000px] grid-cols-6 items-start gap-(--gap) p-(--gap) md:w-[2600px]">
+        {/* Width tracks the gap: 6 × ~385px columns + 5 gaps + 2 edge paddings,
+            so tightening --gap keeps cards life-size instead of growing them. */}
+        <div className="grid w-[2000px] grid-cols-6 items-start gap-(--gap) p-(--gap) md:w-[2480px]">
           <CanvasColumn cards={CANVAS_1} />
           <CanvasColumn cards={CANVAS_2} />
           <div className="col-span-2 flex flex-col gap-(--gap) p-px [contain-intrinsic-size:790px_1200px] [content-visibility:auto]">

--- a/www/src/modules/create/panel/components-section.tsx
+++ b/www/src/modules/create/panel/components-section.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { ChevronRightIcon } from "lucide-react"
 import * as ButtonPrimitives from "react-aria-components/Button"
 
 import { cn } from "@/registry/lib/utils"
+import { componentDemos } from "@/modules/docs/components-list/demos"
 
 import {
   ComponentDetailView,
@@ -32,28 +32,39 @@ export function ComponentsSection({
       {paramComponents.map((comp) => {
         const isExpanded = comp.name === expanded
         const count = comp.params ? Object.keys(comp.params).length : 0
+        const Demo = componentDemos[comp.name]
         return (
           <div key={comp.name} className="border-b last:border-b-0">
-            <ButtonPrimitives.Button
-              onPress={() => onToggle(isExpanded ? undefined : comp.name)}
-              className={cn(
-                "flex w-full items-center justify-between gap-2 rounded-md px-1 py-2.5 text-sm focus-reset transition-colors hover:bg-neutral focus-visible:focus-ring",
-                isExpanded && "font-medium",
+            {/* `content-visibility` keeps the 60 mounted demos from costing
+                layout while scrolled out of view. */}
+            <div className="relative overflow-hidden rounded-md [contain-intrinsic-size:auto_48px] [content-visibility:auto]">
+              <ButtonPrimitives.Button
+                onPress={() => onToggle(isExpanded ? undefined : comp.name)}
+                className={cn(
+                  "flex h-12 w-full items-center gap-1.5 rounded-md px-1 text-sm focus-reset transition-colors hover:bg-neutral focus-visible:focus-ring",
+                  isExpanded && "font-medium",
+                )}
+              >
+                <span className="max-w-[55%] truncate">
+                  {getComponentDisplayName(comp.name)}
+                </span>
+                <span className="shrink-0 text-xs text-fg-muted/60">
+                  {count}
+                </span>
+              </ButtonPrimitives.Button>
+              {/* Mini-preview peek — a live render anchored past mid-row and
+                  cropped by the wrapper's overflow at the right edge. Inert and
+                  non-hit-testable: the whole row stays one click target. */}
+              {Demo && (
+                <div
+                  aria-hidden
+                  inert
+                  className="pointer-events-none absolute top-1/2 left-[55%] -translate-y-1/2 [zoom:0.4] select-none"
+                >
+                  <Demo />
+                </div>
               )}
-            >
-              <span className="truncate">
-                {getComponentDisplayName(comp.name)}
-              </span>
-              <span className="flex shrink-0 items-center gap-1.5 text-xs text-fg-muted/60">
-                {count}
-                <ChevronRightIcon
-                  className={cn(
-                    "size-4 text-fg-muted transition-transform",
-                    isExpanded && "rotate-90",
-                  )}
-                />
-              </span>
-            </ButtonPrimitives.Button>
+            </div>
             {isExpanded && (
               <div className="pb-4" data-control={`component-${comp.name}`}>
                 <ComponentDetailView

--- a/www/src/modules/create/panel/components-section.tsx
+++ b/www/src/modules/create/panel/components-section.tsx
@@ -1,9 +1,9 @@
 "use client"
 
+import { ChevronRightIcon } from "lucide-react"
 import * as ButtonPrimitives from "react-aria-components/Button"
 
 import { cn } from "@/registry/lib/utils"
-import { componentDemos } from "@/modules/docs/components-list/demos"
 
 import {
   ComponentDetailView,
@@ -32,39 +32,28 @@ export function ComponentsSection({
       {paramComponents.map((comp) => {
         const isExpanded = comp.name === expanded
         const count = comp.params ? Object.keys(comp.params).length : 0
-        const Demo = componentDemos[comp.name]
         return (
           <div key={comp.name} className="border-b last:border-b-0">
-            {/* `content-visibility` keeps the 60 mounted demos from costing
-                layout while scrolled out of view. */}
-            <div className="relative overflow-hidden rounded-md [contain-intrinsic-size:auto_48px] [content-visibility:auto]">
-              <ButtonPrimitives.Button
-                onPress={() => onToggle(isExpanded ? undefined : comp.name)}
-                className={cn(
-                  "flex h-12 w-full items-center gap-1.5 rounded-md px-1 text-sm focus-reset transition-colors hover:bg-neutral focus-visible:focus-ring",
-                  isExpanded && "font-medium",
-                )}
-              >
-                <span className="max-w-[55%] truncate">
-                  {getComponentDisplayName(comp.name)}
-                </span>
-                <span className="shrink-0 text-xs text-fg-muted/60">
-                  {count}
-                </span>
-              </ButtonPrimitives.Button>
-              {/* Mini-preview peek — a live render anchored past mid-row and
-                  cropped by the wrapper's overflow at the right edge. Inert and
-                  non-hit-testable: the whole row stays one click target. */}
-              {Demo && (
-                <div
-                  aria-hidden
-                  inert
-                  className="pointer-events-none absolute top-1/2 left-[55%] -translate-y-1/2 [zoom:0.4] select-none"
-                >
-                  <Demo />
-                </div>
+            <ButtonPrimitives.Button
+              onPress={() => onToggle(isExpanded ? undefined : comp.name)}
+              className={cn(
+                "flex w-full items-center justify-between gap-2 rounded-md px-1 py-2.5 text-sm focus-reset transition-colors hover:bg-neutral focus-visible:focus-ring",
+                isExpanded && "font-medium",
               )}
-            </div>
+            >
+              <span className="truncate">
+                {getComponentDisplayName(comp.name)}
+              </span>
+              <span className="flex shrink-0 items-center gap-1.5 text-xs text-fg-muted/60">
+                {count}
+                <ChevronRightIcon
+                  className={cn(
+                    "size-4 text-fg-muted transition-transform",
+                    isExpanded && "rotate-90",
+                  )}
+                />
+              </span>
+            </ButtonPrimitives.Button>
             {isExpanded && (
               <div className="pb-4" data-control={`component-${comp.name}`}>
                 <ComponentDetailView

--- a/www/src/modules/create/panel/control-panel.tsx
+++ b/www/src/modules/create/panel/control-panel.tsx
@@ -348,7 +348,7 @@ export function CreatePanel({ className }: { className?: string }) {
           bars and clipped, so cards show below the header but never exceed it. */}
       <div
         ref={bodyRef}
-        className="no-scrollbar flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain rounded-xl"
+        className="no-scrollbar flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain rounded-xl [--control-label:4.5rem]"
         style={{
           paddingTop: barHeights.header + PANELS_GAP,
           paddingBottom: barHeights.footer + PANELS_GAP,

--- a/www/src/modules/create/panel/primitives.tsx
+++ b/www/src/modules/create/panel/primitives.tsx
@@ -81,7 +81,9 @@ export function ChapterHeading({
 
 /* ------------------------------ Inline row ------------------------------- */
 
-/** A one-line control: quiet label on the left, the input filling the right. */
+/** A one-line control: quiet label on the left, the input filling the right.
+ *  The label column is `--control-label` (set on the panel scroller) so every
+ *  left-labeled row shares one width and their controls align. */
 export function InlineRow({
   label,
   children,
@@ -90,7 +92,7 @@ export function InlineRow({
   children: ReactNode
 }) {
   return (
-    <div className="grid grid-cols-[4.5rem_1fr] items-center gap-2">
+    <div className="grid grid-cols-[var(--control-label,4.5rem)_1fr] items-center gap-2">
       <span className="truncate text-xs text-fg-muted">{label}</span>
       {children}
     </div>

--- a/www/src/modules/create/panel/schema.tsx
+++ b/www/src/modules/create/panel/schema.tsx
@@ -547,7 +547,7 @@ function ShadowField({ varName, label }: { varName: string; label: string }) {
     >
       <InputGroup>
         <InputGroupAddon>
-          <span className="w-14 shrink-0 text-left text-xs text-fg-muted">
+          <span className="w-(--control-label,4.5rem) shrink-0 text-left text-xs text-fg-muted">
             {label}
           </span>
         </InputGroupAddon>
@@ -604,7 +604,7 @@ function CursorWidget({
         className="w-full justify-start gap-2 pl-2.5"
         style={{ cursor: value }}
       >
-        <span className="w-14 shrink-0 text-left text-xs font-normal text-fg-muted">
+        <span className="w-(--control-label,4.5rem) shrink-0 text-left text-xs font-normal text-fg-muted">
           {label}
         </span>
         <SelectValue className="min-w-0 flex-1 truncate text-left" />

--- a/www/src/modules/create/preset/iframe-sync.ts
+++ b/www/src/modules/create/preset/iframe-sync.ts
@@ -96,7 +96,14 @@ export function useIframeMessageListener(
  * out-of-band where the provider would revert it on the next OS-pref / storage event.
  */
 export function usePreviewForcedTheme(): PreviewMode | undefined {
-  const [mode, setMode] = React.useState<PreviewMode | undefined>(undefined)
+  // Seeded from the iframe URL so the first paint already uses the previewed
+  // mode — waiting for the parent's post-load `preview-mode` message would
+  // flash the iframe's own stored theme first whenever the two differ.
+  const [mode, setMode] = React.useState<PreviewMode | undefined>(() => {
+    if (typeof window === "undefined" || !isInIframe()) return undefined
+    const m = new URLSearchParams(window.location.search).get("mode")
+    return m === "dark" || m === "light" ? m : undefined
+  })
 
   React.useEffect(() => {
     if (!isInIframe()) return

--- a/www/src/modules/create/preview/group-examples/cards.tsx
+++ b/www/src/modules/create/preview/group-examples/cards.tsx
@@ -1,15 +1,8 @@
-import { CardsMasonry } from "@/components/showcase/cards-grid"
+import { CardsCanvas } from "@/components/showcase/cards-grid"
 
 // The "Cards" preview view: the same real-world card blocks as the landing
-// page, rendered inside the /create preview iframe so the user's whole design
-// system (colors, radius, density, typography, per-component params) can be
-// judged at a glance on realistic UI. Unlike the landing composition there are
-// no skeleton rails or edge fade — just a centered masonry, with fewer columns
-// to suit the narrower preview pane.
+// page, laid out on a dedicated fixed-width canvas (shadcn-create style) so the
+// user's whole design system can be judged at a glance on life-size UI.
 export default function CardsExamples() {
-  return (
-    <div className="w-full p-4 sm:p-6">
-      <CardsMasonry className="mx-auto max-w-6xl" />
-    </div>
-  )
+  return <CardsCanvas />
 }

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -1,21 +1,25 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { getRouteApi } from "@tanstack/react-router"
 import {
-  ChevronDownIcon,
+  ChevronsUpDownIcon,
   ExternalLinkIcon,
   MaximizeIcon,
   MinimizeIcon,
   MonitorIcon,
   MoonIcon,
+  SlidersHorizontalIcon,
   SmartphoneIcon,
   SunIcon,
   TabletIcon,
 } from "lucide-react"
 import { useTheme } from "starter-themes"
 
+import { useIsMobile } from "@/registry/hooks/use-mobile"
 import { cn } from "@/registry/lib/utils"
 import { Button } from "@/registry/ui/button"
 import { Command } from "@/registry/ui/command"
+import { DialogContent } from "@/registry/ui/dialog"
+import { Drawer, DrawerHandle } from "@/registry/ui/drawer"
 import { Input } from "@/registry/ui/input"
 import {
   ListBox,
@@ -24,11 +28,10 @@ import {
   ListBoxSectionHeader,
 } from "@/registry/ui/list-box"
 import { Menu, MenuContent, MenuItem } from "@/registry/ui/menu"
+import { Modal } from "@/registry/ui/modal"
 import { Popover } from "@/registry/ui/popover"
 import { SearchField } from "@/registry/ui/search-field"
-import { Select, SelectValue } from "@/registry/ui/select"
-import { ToggleButton } from "@/registry/ui/toggle-button"
-import { ToggleButtonGroup } from "@/registry/ui/toggle-button-group"
+import { Select } from "@/registry/ui/select"
 import { Tooltip, TooltipContent } from "@/registry/ui/tooltip"
 import {
   pingIframe,
@@ -58,6 +61,15 @@ const SIZE_OPTIONS: {
   { id: "desktop", label: "Desktop", Icon: MonitorIcon },
 ]
 
+const ALL_COMPONENTS = componentsData
+  .flatMap((category) => category.components)
+  .sort((a, b) => a.name.localeCompare(b.name))
+
+const PREVIEW_LABELS: Record<string, string> = {
+  cards: "Cards",
+  overview: "Brand Guidelines",
+}
+
 // Zoom magnifies the rendered iframe (CSS `zoom`, no reflow) — distinct from device
 // size, which reflows the content. Combined, they behave like a browser's device bar.
 const ZOOM_LEVELS = [0.5, 0.75, 1, 1.25, 1.5, 2]
@@ -67,7 +79,24 @@ const PREVIEW_READY_TIMEOUT = 8000
 
 const routeApi = getRouteApi("/_app/create")
 
-export function PreviewPanel({ className }: { className?: string }) {
+// Pill tooltips pop with no enter / exit transition — neutralizes the scale /
+// fade / slide the base tooltip ships with.
+function PillTooltipContent({ children }: { children: React.ReactNode }) {
+  return (
+    <TooltipContent className="transition-none entering:scale-100 entering:transform-none entering:opacity-100 exiting:scale-100 exiting:transform-none exiting:opacity-100">
+      {children}
+    </TooltipContent>
+  )
+}
+
+export function PreviewPanel({
+  className,
+  onCustomize,
+}: {
+  className?: string
+  /** Mobile only — opens the customize sheet from the floating toolbar. */
+  onCustomize?: () => void
+}) {
   const { preview, preset } = routeApi.useSearch()
   const navigate = routeApi.useNavigate()
   const { designSystem } = useDesignSystem()
@@ -80,9 +109,18 @@ export function PreviewPanel({ className }: { className?: string }) {
   const [zoom, setZoom] = useState(1)
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [isLoaded, setIsLoaded] = useState(false)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const isMobile = useIsMobile()
 
   const effectivePreview = preview
   const constrained = size !== "desktop"
+  // Always found: `size` is a DeviceSize and SIZE_OPTIONS covers all three.
+  const sizeOption = SIZE_OPTIONS.find((o) => o.id === size)!
+  const SizeIcon = sizeOption.Icon
+  const previewLabel =
+    PREVIEW_LABELS[effectivePreview] ??
+    ALL_COMPONENTS.find((comp) => comp.slug === effectivePreview)?.name ??
+    effectivePreview
 
   // Open the preview in the same light / dark mode the site is currently in. Seeded on
   // mount rather than via the useState initializer: this page is server-rendered and the
@@ -195,186 +233,64 @@ export function PreviewPanel({ className }: { className?: string }) {
     }
   }
 
+  // Picker body shared by the desktop modal and the mobile drawer — only the
+  // list's sizing differs between the two containers.
+  const renderPicker = (listClassName: string) => (
+    <Command className="min-h-0 flex-1">
+      <SearchField autoFocus aria-label="Search previews">
+        <Input placeholder="Search previews…" />
+      </SearchField>
+      <ListBox
+        aria-label="Previews"
+        selectionMode="single"
+        disallowEmptySelection
+        selectedKeys={[effectivePreview]}
+        onSelectionChange={(keys) => {
+          if (keys === "all") return
+          const next = keys.values().next().value
+          if (next == null) return
+          navigate({ search: (prev) => ({ ...prev, preview: String(next) }) })
+          setPickerOpen(false)
+        }}
+        className={listClassName}
+      >
+        <ListBoxSection>
+          <ListBoxSectionHeader>Preview</ListBoxSectionHeader>
+          {/* Composed, real-world UI (the landing cards grid), themed live. */}
+          <ListBoxItem id="cards" textValue="Cards">
+            <span className="truncate">Cards</span>
+          </ListBoxItem>
+          {/* A designer walkthrough of the whole system. */}
+          <ListBoxItem id="overview" textValue="Brand Guidelines">
+            <span className="truncate">Brand Guidelines</span>
+          </ListBoxItem>
+        </ListBoxSection>
+        <ListBoxSection>
+          <ListBoxSectionHeader>Components</ListBoxSectionHeader>
+          {ALL_COMPONENTS.map((comp) => (
+            <ListBoxItem key={comp.slug} id={comp.slug} textValue={comp.name}>
+              <span className="truncate">{comp.name}</span>
+            </ListBoxItem>
+          ))}
+        </ListBoxSection>
+      </ListBox>
+    </Command>
+  )
+
   return (
     <div
       ref={panelRef}
       className={cn(
-        "relative flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border/45 bg-neutral shadow-xs",
+        "relative flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border/45 bg-bg shadow-xs",
         className,
       )}
     >
-      {/* Toolbar — an in-flow bar attached above the stage. The wrapper owns the
-          neutral surface; the bar itself stays transparent. */}
-      <div className="flex items-center gap-2 p-1">
-        {/* Preview selector */}
-        <div className="max-w-[45%] min-w-0">
-          <Select
-            value={effectivePreview}
-            onChange={(v) =>
-              navigate({
-                search: (prev) => ({ ...prev, preview: v as string }),
-              })
-            }
-            className="w-fit"
-            aria-label="Preview"
-          >
-            <Button size="sm" variant="quiet">
-              <SelectValue className="truncate" />
-              <ChevronDownIcon data-icon-end="" />
-            </Button>
-            <Popover>
-              <Command>
-                <SearchField autoFocus aria-label="Search previews">
-                  <Input />
-                </SearchField>
-                <ListBox>
-                  <ListBoxSection>
-                    <ListBoxSectionHeader>Preview</ListBoxSectionHeader>
-                    {/* Composed, real-world UI (the landing cards grid), themed live. */}
-                    <ListBoxItem id="cards" textValue="Cards">
-                      <span className="truncate">Cards</span>
-                    </ListBoxItem>
-                    {/* A designer walkthrough of the whole system. */}
-                    <ListBoxItem id="overview" textValue="Brand Guidelines">
-                      <span className="truncate">Brand Guidelines</span>
-                    </ListBoxItem>
-                  </ListBoxSection>
-                  <ListBoxSection>
-                    <ListBoxSectionHeader>Components</ListBoxSectionHeader>
-                    {componentsData
-                      .flatMap((category) => category.components)
-                      .sort((a, b) => a.name.localeCompare(b.name))
-                      .map((comp) => (
-                        <ListBoxItem
-                          key={comp.slug}
-                          id={comp.slug}
-                          textValue={comp.name}
-                        >
-                          <span className="truncate">{comp.name}</span>
-                        </ListBoxItem>
-                      ))}
-                  </ListBoxSection>
-                </ListBox>
-              </Command>
-            </Popover>
-          </Select>
-        </div>
-
-        {/* Right cluster */}
-        <div className="ml-auto flex items-center gap-1">
-          {/* Device size — desktop only; the mobile pane is already viewport-width. */}
-          <ToggleButtonGroup
-            aria-label="Preview size"
-            selectionMode="single"
-            disallowEmptySelection
-            size="sm"
-            isIconOnly
-            selectedKeys={[size]}
-            onSelectionChange={(keys) => {
-              const next = keys.values().next().value
-              if (next) setSize(next as DeviceSize)
-            }}
-            className="max-lg:hidden"
-          >
-            {SIZE_OPTIONS.map(({ id, label, Icon }) => (
-              <ToggleButton key={id} id={id} aria-label={label}>
-                <Icon />
-              </ToggleButton>
-            ))}
-          </ToggleButtonGroup>
-
-          {/* Zoom level */}
-          <Menu>
-            <Button
-              size="sm"
-              variant="quiet"
-              className="gap-1 tabular-nums max-lg:hidden"
-            >
-              {Math.round(zoom * 100)}%
-              <ChevronDownIcon data-icon-end="" />
-            </Button>
-            <Popover placement="bottom end" className="min-w-28">
-              <MenuContent
-                selectionMode="single"
-                selectedKeys={[String(zoom)]}
-                onSelectionChange={(keys) => {
-                  if (keys === "all") return
-                  const v = keys.values().next().value
-                  if (v != null) setZoom(Number(v))
-                }}
-              >
-                {ZOOM_LEVELS.map((z) => (
-                  <MenuItem key={z} id={String(z)} textValue={`${z * 100}%`}>
-                    {Math.round(z * 100)}%
-                  </MenuItem>
-                ))}
-              </MenuContent>
-            </Popover>
-          </Menu>
-
-          <div className="mx-0.5 h-5 w-px bg-border max-lg:hidden" />
-
-          {/* Light / dark preview mode */}
-          <Tooltip>
-            <Button
-              size="sm"
-              variant="quiet"
-              isIconOnly
-              onPress={() =>
-                setPreviewMode((m) => (m === "dark" ? "light" : "dark"))
-              }
-              aria-label="Toggle preview mode"
-            >
-              {previewMode === "dark" ? <SunIcon /> : <MoonIcon />}
-            </Button>
-            <TooltipContent>
-              {previewMode === "dark" ? "Light mode" : "Dark mode"}
-            </TooltipContent>
-          </Tooltip>
-
-          {/* Open in new tab */}
-          <Tooltip>
-            <Button
-              size="sm"
-              variant="quiet"
-              isIconOnly
-              onPress={() =>
-                window.open(iframeSrc, "_blank", "noopener,noreferrer")
-              }
-              aria-label="Open preview in new tab"
-            >
-              <ExternalLinkIcon />
-            </Button>
-            <TooltipContent>Open in new tab</TooltipContent>
-          </Tooltip>
-
-          {/* Fullscreen */}
-          <Tooltip>
-            <Button
-              size="sm"
-              variant="quiet"
-              isIconOnly
-              onPress={toggleFullscreen}
-              aria-label="Toggle fullscreen"
-            >
-              {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}
-            </Button>
-            <TooltipContent>
-              {isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
-
-      {/* Stage — holds the iframe at full height for every device size. Smaller sizes
-          narrow the iframe and center it on the surface. Scrolls when zoomed past fit.
-          Inset on three sides so the panel's surface frames the artifact; the top
-          stays flush under the toolbar. Radius is the panel's minus the inset. */}
+      {/* Stage — the preview fills the panel edge to edge; there is no chrome row.
+          Smaller device sizes narrow the iframe and center it on a recessed,
+          dot-gridded surface so tool chrome and artifact read as layers. */}
       <div
         className={cn(
-          "relative mx-1 mb-1 min-h-0 flex-1 overflow-auto rounded-lg border border-border/45 bg-bg",
-          // Constrained sizes reveal the stage: a recessed, dot-gridded surface
-          // the device "floats" on, so tool chrome and artifact read as layers.
+          "relative min-h-0 flex-1 overflow-auto",
           constrained &&
             "bg-neutral [background-image:radial-gradient(var(--color-border)_1px,transparent_1px)] [background-size:14px_14px]",
         )}
@@ -399,21 +315,216 @@ export function PreviewPanel({ className }: { className?: string }) {
             }}
           />
         </div>
-        {/* Stage skeleton — the preview never opens on a black void. One surface
-            rather than mock content: the incoming preview is an arbitrary page,
-            so any guessed layout would be wrong more often than right. */}
-        <div
-          aria-hidden
-          className={cn(
-            "absolute inset-0 z-10 transition-opacity duration-300",
-            isLoaded && "pointer-events-none opacity-0",
-          )}
-        >
-          {/* The pulse lives on the inner surface: `animate-pulse` drives opacity,
-              which would otherwise override the fade-out above and never clear. */}
-          <div className="skeleton size-full animate-pulse" />
-        </div>
       </div>
+
+      {/* Stage skeleton — the preview never opens on a black void. One surface
+          rather than mock content: the incoming preview is an arbitrary page,
+          so any guessed layout would be wrong more often than right. */}
+      <div
+        aria-hidden
+        className={cn(
+          "absolute inset-0 z-10 transition-opacity duration-300",
+          isLoaded && "pointer-events-none opacity-0",
+        )}
+      >
+        {/* The pulse lives on the inner surface: `animate-pulse` drives opacity,
+            which would otherwise override the fade-out above and never clear. */}
+        <div className="skeleton size-full animate-pulse" />
+      </div>
+
+      {/* Floating toolbar — the panel's only chrome. It overlays the user's page,
+          which can be any color in either mode, so the surface is always
+          site-themed and earns separation from contrast, not size: a solid
+          neutral surface, full-strength border, and a deep layered shadow.
+          Sits above the skeleton so the switcher works while loading. */}
+      <div className="absolute bottom-3 left-1/2 z-20 flex max-w-[calc(100%-1.5rem)] -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-neutral p-1 shadow-[0_8px_24px_-6px_rgb(0_0_0/0.3),0_2px_8px_-2px_rgb(0_0_0/0.18)]">
+        {/* Preview switcher — opens the picker (modal on desktop, drawer on mobile). */}
+        <Button
+          size="sm"
+          variant="quiet"
+          className="max-w-44 rounded-full"
+          onPress={() => setPickerOpen(true)}
+        >
+          <span className="truncate">{previewLabel}</span>
+          <ChevronsUpDownIcon data-icon-end="" />
+        </Button>
+
+        <div className="h-4 w-px shrink-0 bg-border max-lg:hidden" />
+
+        {/* Device size — desktop only; the mobile pane is already viewport-width. */}
+        <Select
+          value={size}
+          onChange={(v) => setSize(v as DeviceSize)}
+          aria-label="Device size"
+          className="max-lg:hidden"
+        >
+          <Tooltip delay={0}>
+            <Button
+              size="sm"
+              variant="quiet"
+              isIconOnly
+              className="rounded-full"
+            >
+              <SizeIcon />
+            </Button>
+            <PillTooltipContent>
+              Device{" "}
+              <span className="text-fg-on-tooltip/60">{sizeOption.label}</span>
+            </PillTooltipContent>
+          </Tooltip>
+          <Popover placement="top" className="min-w-32">
+            <ListBox>
+              {SIZE_OPTIONS.map(({ id, label, Icon }) => (
+                <ListBoxItem key={id} id={id} textValue={label}>
+                  <Icon />
+                  {label}
+                </ListBoxItem>
+              ))}
+            </ListBox>
+          </Popover>
+        </Select>
+
+        {/* Zoom level */}
+        <Menu>
+          <Tooltip delay={0}>
+            <Button
+              size="sm"
+              variant="quiet"
+              className="rounded-full tabular-nums max-lg:hidden"
+            >
+              {Math.round(zoom * 100)}%
+            </Button>
+            <PillTooltipContent>
+              Zoom{" "}
+              <span className="text-fg-on-tooltip/60">
+                {Math.round(zoom * 100)}%
+              </span>
+            </PillTooltipContent>
+          </Tooltip>
+          <Popover placement="top" className="min-w-28">
+            <MenuContent
+              selectionMode="single"
+              selectedKeys={[String(zoom)]}
+              onSelectionChange={(keys) => {
+                if (keys === "all") return
+                const v = keys.values().next().value
+                if (v != null) setZoom(Number(v))
+              }}
+            >
+              {ZOOM_LEVELS.map((z) => (
+                <MenuItem key={z} id={String(z)} textValue={`${z * 100}%`}>
+                  {Math.round(z * 100)}%
+                </MenuItem>
+              ))}
+            </MenuContent>
+          </Popover>
+        </Menu>
+
+        <div className="h-4 w-px shrink-0 bg-border" />
+
+        {/* Light / dark preview mode */}
+        <Tooltip delay={0}>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            className="rounded-full"
+            onPress={() =>
+              setPreviewMode((m) => (m === "dark" ? "light" : "dark"))
+            }
+            aria-label="Toggle preview mode"
+          >
+            {previewMode === "dark" ? <SunIcon /> : <MoonIcon />}
+          </Button>
+          <PillTooltipContent>
+            Preview mode{" "}
+            <span className="text-fg-on-tooltip/60">
+              {previewMode === "dark" ? "Dark" : "Light"}
+            </span>
+          </PillTooltipContent>
+        </Tooltip>
+
+        {/* Open in new tab */}
+        <Tooltip delay={0}>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            className="rounded-full"
+            onPress={() =>
+              window.open(iframeSrc, "_blank", "noopener,noreferrer")
+            }
+            aria-label="Open preview in new tab"
+          >
+            <ExternalLinkIcon />
+          </Button>
+          <PillTooltipContent>Open in new tab</PillTooltipContent>
+        </Tooltip>
+
+        {/* Fullscreen */}
+        <Tooltip delay={0}>
+          <Button
+            size="sm"
+            variant="quiet"
+            isIconOnly
+            className="rounded-full"
+            onPress={toggleFullscreen}
+            aria-label="Toggle fullscreen"
+          >
+            {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}
+          </Button>
+          <PillTooltipContent>
+            Fullscreen{" "}
+            <span className="text-fg-on-tooltip/60">
+              {isFullscreen ? "On" : "Off"}
+            </span>
+          </PillTooltipContent>
+        </Tooltip>
+
+        {/* Mobile — the customize sheet joins the pill so the page has a single
+            floating cluster instead of two stacked bottom-center controls. */}
+        {onCustomize && (
+          <>
+            <div className="h-4 w-px shrink-0 bg-border lg:hidden" />
+            <Button
+              size="sm"
+              className="rounded-full lg:hidden"
+              onPress={onCustomize}
+            >
+              <SlidersHorizontalIcon data-icon-start="" />
+              Customize
+            </Button>
+          </>
+        )}
+      </div>
+
+      {/* Preview picker — a searchable palette: centered modal on desktop,
+          bottom drawer on mobile. */}
+      {isMobile ? (
+        <Drawer
+          isOpen={pickerOpen}
+          onOpenChange={setPickerOpen}
+          className="h-[80svh]"
+        >
+          <DialogContent
+            aria-label="Select preview"
+            className="flex h-full min-h-0 flex-col gap-0 p-0"
+          >
+            <DrawerHandle />
+            {renderPicker("min-h-0 flex-1 overflow-y-auto")}
+          </DialogContent>
+        </Drawer>
+      ) : (
+        <Modal
+          isOpen={pickerOpen}
+          onOpenChange={setPickerOpen}
+          className="w-full sm:max-w-sm"
+        >
+          <DialogContent aria-label="Select preview" className="p-0">
+            {renderPicker("max-h-96 overflow-y-auto")}
+          </DialogContent>
+        </Modal>
+      )}
     </div>
   )
 }

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -28,7 +28,6 @@ import {
   ListBoxSectionHeader,
 } from "@/registry/ui/list-box"
 import { Menu, MenuContent, MenuItem } from "@/registry/ui/menu"
-import { Modal } from "@/registry/ui/modal"
 import { Popover } from "@/registry/ui/popover"
 import { SearchField } from "@/registry/ui/search-field"
 import { Select } from "@/registry/ui/select"
@@ -104,6 +103,7 @@ export function PreviewPanel({
 
   const panelRef = useRef<HTMLDivElement>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const switcherRef = useRef<HTMLButtonElement>(null)
   const [previewMode, setPreviewMode] = useState<PreviewMode>("light")
   const [size, setSize] = useState<DeviceSize>("desktop")
   const [zoom, setZoom] = useState(1)
@@ -338,8 +338,10 @@ export function PreviewPanel({
           neutral surface, full-strength border, and a deep layered shadow.
           Sits above the skeleton so the switcher works while loading. */}
       <div className="absolute bottom-3 left-1/2 z-20 flex max-w-[calc(100%-1.5rem)] -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-neutral p-1 shadow-[0_8px_24px_-6px_rgb(0_0_0/0.3),0_2px_8px_-2px_rgb(0_0_0/0.18)]">
-        {/* Preview switcher — opens the picker (modal on desktop, drawer on mobile). */}
+        {/* Preview switcher — opens the picker (anchored popover on desktop,
+            drawer on mobile). */}
         <Button
+          ref={switcherRef}
           size="sm"
           variant="quiet"
           className="max-w-44 rounded-full"
@@ -498,8 +500,9 @@ export function PreviewPanel({
         )}
       </div>
 
-      {/* Preview picker — a searchable palette: centered modal on desktop,
-          bottom drawer on mobile. */}
+      {/* Preview picker — a searchable palette: popover anchored to the
+          switcher on desktop (list capped so the popover keeps a fixed max
+          height instead of spanning the panel), bottom drawer on mobile. */}
       {isMobile ? (
         <Drawer
           isOpen={pickerOpen}
@@ -515,15 +518,17 @@ export function PreviewPanel({
           </DialogContent>
         </Drawer>
       ) : (
-        <Modal
+        <Popover
+          triggerRef={switcherRef}
           isOpen={pickerOpen}
           onOpenChange={setPickerOpen}
-          className="w-full sm:max-w-sm"
+          placement="top"
+          className="w-64"
         >
           <DialogContent aria-label="Select preview" className="p-0">
-            {renderPicker("max-h-96 overflow-y-auto")}
+            {renderPicker("max-h-72 overflow-y-auto")}
           </DialogContent>
-        </Modal>
+        </Popover>
       )}
     </div>
   )

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -31,7 +31,7 @@ import { Loader } from "@/registry/ui/loader"
 import { Menu, MenuContent, MenuItem } from "@/registry/ui/menu"
 import { Popover } from "@/registry/ui/popover"
 import { SearchField } from "@/registry/ui/search-field"
-import { Select } from "@/registry/ui/select"
+import { Select, SelectValue } from "@/registry/ui/select"
 import { Tooltip, TooltipContent } from "@/registry/ui/tooltip"
 import {
   pingIframe,
@@ -64,11 +64,6 @@ const SIZE_OPTIONS: {
 const ALL_COMPONENTS = componentsData
   .flatMap((category) => category.components)
   .sort((a, b) => a.name.localeCompare(b.name))
-
-const PREVIEW_LABELS: Record<string, string> = {
-  cards: "Cards",
-  overview: "Brand Guidelines",
-}
 
 // Zoom magnifies the rendered iframe (CSS `zoom`, no reflow) — distinct from device
 // size, which reflows the content. Combined, they behave like a browser's device bar.
@@ -104,7 +99,6 @@ export function PreviewPanel({
 
   const panelRef = useRef<HTMLDivElement>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
-  const switcherRef = useRef<HTMLButtonElement>(null)
   const [previewMode, setPreviewMode] = useState<PreviewMode>("light")
   const [size, setSize] = useState<DeviceSize>("desktop")
   const [zoom, setZoom] = useState(1)
@@ -118,10 +112,6 @@ export function PreviewPanel({
   // Always found: `size` is a DeviceSize and SIZE_OPTIONS covers all three.
   const sizeOption = SIZE_OPTIONS.find((o) => o.id === size)!
   const SizeIcon = sizeOption.Icon
-  const previewLabel =
-    PREVIEW_LABELS[effectivePreview] ??
-    ALL_COMPONENTS.find((comp) => comp.slug === effectivePreview)?.name ??
-    effectivePreview
 
   // Open the preview in the same light / dark mode the site is currently in. Seeded on
   // mount rather than via the useState initializer: this page is server-rendered and the
@@ -244,27 +234,15 @@ export function PreviewPanel({
     }
   }
 
-  // Picker body shared by the desktop modal and the mobile drawer — only the
-  // list's sizing differs between the two containers.
+  // Picker body shared by the desktop popover and the mobile drawer — only the
+  // list's sizing differs between the two containers. Selection state comes
+  // from the wrapping Select, so the ListBox carries no props of its own.
   const renderPicker = (listClassName: string) => (
     <Command className="min-h-0 flex-1">
       <SearchField autoFocus aria-label="Search previews">
         <Input placeholder="Search previews…" />
       </SearchField>
-      <ListBox
-        aria-label="Previews"
-        selectionMode="single"
-        disallowEmptySelection
-        selectedKeys={[effectivePreview]}
-        onSelectionChange={(keys) => {
-          if (keys === "all") return
-          const next = keys.values().next().value
-          if (next == null) return
-          navigate({ search: (prev) => ({ ...prev, preview: String(next) }) })
-          setPickerOpen(false)
-        }}
-        className={listClassName}
-      >
+      <ListBox className={listClassName}>
         <ListBoxSection>
           <ListBoxSectionHeader>Preview</ListBoxSectionHeader>
           {/* Composed, real-world UI (the landing cards grid), themed live. */}
@@ -347,18 +325,46 @@ export function PreviewPanel({
           neutral surface, full-strength border, and a deep layered shadow.
           Sits above the skeleton so the switcher works while loading. */}
       <div className="absolute bottom-3 left-1/2 z-20 flex max-w-[calc(100%-1.5rem)] -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-neutral p-1 shadow-[0_8px_24px_-6px_rgb(0_0_0/0.3),0_2px_8px_-2px_rgb(0_0_0/0.18)]">
-        {/* Preview switcher — opens the picker (anchored popover on desktop,
-            drawer on mobile). */}
-        <Button
-          ref={switcherRef}
-          size="sm"
-          variant="quiet"
-          className="max-w-44 rounded-full"
-          onPress={() => setPickerOpen(true)}
+        {/* Preview switcher — a real Select (trigger a11y, typeahead, focus
+            restoration for free). Its overlay is the anchored popover on
+            desktop and the bottom drawer on mobile; open state is controlled
+            so the drawer can be driven by the same Select. */}
+        <Select
+          value={effectivePreview}
+          onChange={(v) =>
+            navigate({
+              search: (prev) => ({ ...prev, preview: v as string }),
+            })
+          }
+          isOpen={pickerOpen}
+          onOpenChange={setPickerOpen}
+          aria-label="Preview"
+          className="min-w-0"
         >
-          <span className="truncate">{previewLabel}</span>
-          <ChevronsUpDownIcon data-icon-end="" />
-        </Button>
+          <Button size="sm" variant="quiet" className="max-w-44 rounded-full">
+            <SelectValue className="truncate" />
+            <ChevronsUpDownIcon data-icon-end="" />
+          </Button>
+          {isMobile ? (
+            <Drawer
+              isOpen={pickerOpen}
+              onOpenChange={setPickerOpen}
+              className="h-[80svh]"
+            >
+              <DialogContent
+                aria-label="Select preview"
+                className="flex h-full min-h-0 flex-col gap-0 p-0"
+              >
+                <DrawerHandle />
+                {renderPicker("min-h-0 flex-1 overflow-y-auto")}
+              </DialogContent>
+            </Drawer>
+          ) : (
+            <Popover placement="top" className="w-64">
+              {renderPicker("max-h-72 overflow-y-auto")}
+            </Popover>
+          )}
+        </Select>
 
         <div className="h-4 w-px shrink-0 bg-border max-lg:hidden" />
 
@@ -508,37 +514,6 @@ export function PreviewPanel({
           </>
         )}
       </div>
-
-      {/* Preview picker — a searchable palette: popover anchored to the
-          switcher on desktop (list capped so the popover keeps a fixed max
-          height instead of spanning the panel), bottom drawer on mobile. */}
-      {isMobile ? (
-        <Drawer
-          isOpen={pickerOpen}
-          onOpenChange={setPickerOpen}
-          className="h-[80svh]"
-        >
-          <DialogContent
-            aria-label="Select preview"
-            className="flex h-full min-h-0 flex-col gap-0 p-0"
-          >
-            <DrawerHandle />
-            {renderPicker("min-h-0 flex-1 overflow-y-auto")}
-          </DialogContent>
-        </Drawer>
-      ) : (
-        <Popover
-          triggerRef={switcherRef}
-          isOpen={pickerOpen}
-          onOpenChange={setPickerOpen}
-          placement="top"
-          className="w-64"
-        >
-          <DialogContent aria-label="Select preview" className="p-0">
-            {renderPicker("max-h-72 overflow-y-auto")}
-          </DialogContent>
-        </Popover>
-      )}
     </div>
   )
 }

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -27,6 +27,7 @@ import {
   ListBoxSection,
   ListBoxSectionHeader,
 } from "@/registry/ui/list-box"
+import { Loader } from "@/registry/ui/loader"
 import { Menu, MenuContent, MenuItem } from "@/registry/ui/menu"
 import { Popover } from "@/registry/ui/popover"
 import { SearchField } from "@/registry/ui/search-field"
@@ -127,8 +128,10 @@ export function PreviewPanel({
   // server can't know the client's stored theme (it always resolves "light"), so reading
   // it during render would mismatch the SSR'd toggle icon on hydration. Runs once — the
   // preview mode is toggled independently of the site theme afterwards.
+  const modeSeeded = useRef(false)
   useEffect(() => {
     setPreviewMode(resolvedTheme)
+    modeSeeded.current = true
     // oxlint-disable-next-line react/exhaustive-deps -- seed once from the site theme at open; preview mode is independent thereafter
   }, [])
 
@@ -137,8 +140,16 @@ export function PreviewPanel({
   // — further updates go through postMessage without reloading the iframe.
   const iframeSrc = useMemo(() => {
     const base = `/preview/${effectivePreview}`
-    return preset ? `${base}?preset=${encodeURIComponent(preset)}` : base
-    // oxlint-disable-next-line react/exhaustive-deps -- keep live preset changes on the postMessage channel to avoid iframe reloads
+    const params = new URLSearchParams()
+    if (preset) params.set("preset", preset)
+    // Bake the current mode in so a remounted iframe first-paints in the
+    // previewed mode instead of flashing from its own stored theme. Skipped on
+    // the very first compute — previewMode hasn't seeded yet and the fresh
+    // iframe's stored theme already matches the site's.
+    if (modeSeeded.current) params.set("mode", previewMode)
+    const qs = params.toString()
+    return qs ? `${base}?${qs}` : base
+    // oxlint-disable-next-line react/exhaustive-deps -- keep live preset / mode changes on the postMessage channel to avoid iframe reloads
   }, [effectivePreview])
 
   // The iframe remounts per previewed component (key below) — show the stage
@@ -317,19 +328,17 @@ export function PreviewPanel({
         </div>
       </div>
 
-      {/* Stage skeleton — the preview never opens on a black void. One surface
-          rather than mock content: the incoming preview is an arbitrary page,
-          so any guessed layout would be wrong more often than right. */}
+      {/* Loading — a plain surface with a centered spinner. One surface rather
+          than mock content: the incoming preview is an arbitrary page, so any
+          guessed layout would be wrong more often than right. */}
       <div
         aria-hidden
         className={cn(
-          "absolute inset-0 z-10 transition-opacity duration-300",
+          "absolute inset-0 z-10 flex items-center justify-center bg-bg transition-opacity duration-300",
           isLoaded && "pointer-events-none opacity-0",
         )}
       >
-        {/* The pulse lives on the inner surface: `animate-pulse` drives opacity,
-            which would otherwise override the fade-out above and never clear. */}
-        <div className="skeleton size-full animate-pulse" />
+        <Loader className="size-5 text-fg-muted" />
       </div>
 
       {/* Floating toolbar — the panel's only chrome. It overlays the user's page,

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -374,11 +374,12 @@ export function PreviewPanel({
         <div className="h-4 w-px shrink-0 bg-border max-lg:hidden" />
 
         {/* Device size — desktop only; the mobile pane is already viewport-width. */}
+        {/* w-fit: the field base's w-full would absorb the pill's width. */}
         <Select
           value={size}
           onChange={(v) => setSize(v as DeviceSize)}
           aria-label="Device size"
-          className="max-lg:hidden"
+          className="w-fit shrink-0 max-lg:hidden"
         >
           <Tooltip delay={0}>
             <Button

--- a/www/src/modules/create/preview/preview-panel.tsx
+++ b/www/src/modules/create/preview/preview-panel.tsx
@@ -339,10 +339,15 @@ export function PreviewPanel({
           isOpen={pickerOpen}
           onOpenChange={setPickerOpen}
           aria-label="Preview"
-          className="min-w-0"
+          // w-fit overrides the field base's w-full, which would collapse the
+          // trigger inside the pill's shrink-to-fit absolute box.
+          className="w-fit min-w-0"
         >
           <Button size="sm" variant="quiet" className="max-w-44 rounded-full">
-            <SelectValue className="truncate" />
+            {/* flex-initial overrides the base flex-1 (basis-0), which has no
+                space to grow into inside the pill's shrink-to-fit box and
+                collapses the value to a sliver. */}
+            <SelectValue className="min-w-0 flex-initial" />
             <ChevronsUpDownIcon data-icon-end="" />
           </Button>
           {isMobile ? (

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -5,15 +5,13 @@ import { z } from "zod"
 import { DialogContent } from "@/registry/ui/dialog"
 import { Drawer, DrawerHandle } from "@/registry/ui/drawer"
 import { ExportHeaderAction } from "@/modules/create/export"
+import { CreatePanel } from "@/modules/create/panel"
 import { DEFAULTS, useDesignSystem } from "@/modules/create/preset"
 import {
   loadStoredPreset,
   saveStoredPreset,
 } from "@/modules/create/preset/storage"
 import { PreviewPanel } from "@/modules/create/preview/preview-panel"
-import { PanelFrame } from "@/modules/panel-lab/panel"
-import { CHAPTERS } from "@/modules/panel-lab/state"
-import { useLab } from "@/modules/panel-lab/use-lab"
 
 export const createSearchSchema = z.object({
   panel: z.string().optional().catch(undefined),
@@ -39,9 +37,6 @@ export const Route = createFileRoute("/_app/create")({
 function CreatePage() {
   const { preset } = Route.useSearch()
   const { designSystem, setDesignSystem } = useDesignSystem()
-  // Design-phase swap: the panel-lab panel rides in the real page while its
-  // design settles; it drives its own lab state, not the design system yet.
-  const lab = useLab()
   // Below `lg` the preview is the whole page and the panel rides over it as a
   // bottom sheet — edits stay visible on the live stage while adjusting.
   const [sheetOpen, setSheetOpen] = useState(false)
@@ -70,11 +65,11 @@ function CreatePage() {
   }, [designSystem])
 
   return (
-    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2">
+    // lg:pr-4 matches the header's md:pr-4 so the preview panel's right edge
+    // lines up with the Export button above it.
+    <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2 lg:pr-4">
       <ExportHeaderAction />
-      <div className="relative flex w-full flex-1 flex-col max-lg:hidden lg:w-90 lg:flex-none lg:shrink-0">
-        <PanelFrame chapters={CHAPTERS} lab={lab} />
-      </div>
+      <CreatePanel className="max-lg:hidden" />
       <PreviewPanel onCustomize={() => setSheetOpen(true)} />
 
       {/* Mobile: the panel is a bottom sheet over the live stage, opened from
@@ -90,9 +85,7 @@ function CreatePage() {
             className="flex h-full min-h-0 flex-col gap-0 p-0"
           >
             <DrawerHandle />
-            <div className="flex min-h-0 flex-1 flex-col p-3">
-              <PanelFrame chapters={CHAPTERS} lab={lab} />
-            </div>
+            <CreatePanel className="min-h-0 flex-1" />
           </DialogContent>
         </Drawer>
       </div>

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -7,13 +7,15 @@ import { Button } from "@/registry/ui/button"
 import { DialogContent } from "@/registry/ui/dialog"
 import { Drawer, DrawerHandle } from "@/registry/ui/drawer"
 import { ExportHeaderAction } from "@/modules/create/export"
-import { CreatePanel } from "@/modules/create/panel"
 import { DEFAULTS, useDesignSystem } from "@/modules/create/preset"
 import {
   loadStoredPreset,
   saveStoredPreset,
 } from "@/modules/create/preset/storage"
 import { PreviewPanel } from "@/modules/create/preview/preview-panel"
+import { PanelFrame } from "@/modules/panel-lab/panel"
+import { CHAPTERS } from "@/modules/panel-lab/state"
+import { useLab } from "@/modules/panel-lab/use-lab"
 
 export const createSearchSchema = z.object({
   panel: z.string().optional().catch(undefined),
@@ -39,6 +41,9 @@ export const Route = createFileRoute("/_app/create")({
 function CreatePage() {
   const { preset } = Route.useSearch()
   const { designSystem, setDesignSystem } = useDesignSystem()
+  // Design-phase swap: the panel-lab panel rides in the real page while its
+  // design settles; it drives its own lab state, not the design system yet.
+  const lab = useLab()
   // Below `lg` the preview is the whole page and the panel rides over it as a
   // bottom sheet — edits stay visible on the live stage while adjusting.
   const [sheetOpen, setSheetOpen] = useState(false)
@@ -69,7 +74,9 @@ function CreatePage() {
   return (
     <div className="flex h-[calc(100svh-var(--header-height))] min-h-0 flex-1 flex-col gap-3 p-4 pt-2 lg:flex-row lg:gap-6 lg:p-6 lg:pt-2">
       <ExportHeaderAction />
-      <CreatePanel className="max-lg:hidden" />
+      <div className="relative flex w-full flex-1 flex-col max-lg:hidden lg:w-90 lg:flex-none lg:shrink-0">
+        <PanelFrame chapters={CHAPTERS} lab={lab} />
+      </div>
       <PreviewPanel />
 
       {/* Mobile: the panel is a bottom sheet over the live stage. */}
@@ -91,7 +98,9 @@ function CreatePage() {
             className="flex h-full min-h-0 flex-col gap-0 p-0"
           >
             <DrawerHandle />
-            <CreatePanel className="min-h-0 flex-1" />
+            <div className="flex min-h-0 flex-1 flex-col p-3">
+              <PanelFrame chapters={CHAPTERS} lab={lab} />
+            </div>
           </DialogContent>
         </Drawer>
       </div>

--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import { createFileRoute, stripSearchParams } from "@tanstack/react-router"
-import { SlidersHorizontalIcon } from "lucide-react"
 import { z } from "zod"
 
-import { Button } from "@/registry/ui/button"
 import { DialogContent } from "@/registry/ui/dialog"
 import { Drawer, DrawerHandle } from "@/registry/ui/drawer"
 import { ExportHeaderAction } from "@/modules/create/export"
@@ -77,17 +75,11 @@ function CreatePage() {
       <div className="relative flex w-full flex-1 flex-col max-lg:hidden lg:w-90 lg:flex-none lg:shrink-0">
         <PanelFrame chapters={CHAPTERS} lab={lab} />
       </div>
-      <PreviewPanel />
+      <PreviewPanel onCustomize={() => setSheetOpen(true)} />
 
-      {/* Mobile: the panel is a bottom sheet over the live stage. */}
+      {/* Mobile: the panel is a bottom sheet over the live stage, opened from
+          the preview's floating toolbar. */}
       <div className="contents lg:hidden">
-        <Button
-          onPress={() => setSheetOpen(true)}
-          className="fixed bottom-4 left-1/2 z-30 -translate-x-1/2 shadow-lg lg:hidden"
-        >
-          <SlidersHorizontalIcon data-icon-start="" />
-          Customize
-        </Button>
         <Drawer
           isOpen={sheetOpen}
           onOpenChange={setSheetOpen}

--- a/www/src/routes/preview/$slug.tsx
+++ b/www/src/routes/preview/$slug.tsx
@@ -44,7 +44,12 @@ html::-webkit-scrollbar { display: none; }
 `
 
 export const Route = createFileRoute("/preview/$slug")({
-  validateSearch: z.object({ preset: z.string().optional().catch(undefined) }),
+  validateSearch: z.object({
+    preset: z.string().optional().catch(undefined),
+    // Initial display mode, baked in by the /create parent (read directly from
+    // location by usePreviewForcedTheme; declared so the router keeps it).
+    mode: z.enum(["light", "dark"]).optional().catch(undefined),
+  }),
   ssr: false,
   beforeLoad: ({ params }) => {
     getExamplesPromise(params.slug)


### PR DESCRIPTION
## Summary

Redesigns the /create preview panel: the toolbar header is gone and the preview fills the panel edge to edge, with all chrome living in one floating bottom-center pill.

- **Floating pill toolbar** — solid neutral surface, full-strength border, deep layered shadow, always site-themed so it reads as tool chrome over any preview.
- **Pill controls, left to right**: preview switcher (name + chevrons-up-down), device-size select (icon-only trigger, no chevron), zoom dropdown (no chevron), light/dark preview toggle, open-in-new-tab, fullscreen. Device + zoom hidden below `lg`.
- **Preview picker** — searchable command palette in a max-height popover anchored to the switcher; bottom drawer on mobile.
- **Instant two-tone tooltips** — `delay={0}`, no enter/exit transition, label + subtle current value (e.g. "Device *Desktop*").
- **Mobile** — the Customize trigger joins the pill, so the page has a single floating cluster; sheet unchanged.
- **Layout** — single rounded frame (double frame dropped with the header); page right padding matches the header so the preview edge aligns with the Export button; the panel-lab design swap is reverted to the working `CreatePanel`.

## Testing

- Verified live at desktop / tablet / mobile widths: picker popover + drawer, device select reflow (768px tablet stage), zoom, tooltips (instant, no transition, correct values), fullscreen, Export-button edge alignment (both at the same x).
- `pnpm check` and `pnpm typecheck` clean.