### PR TITLE
ci(www): add client bundle perf budget check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,18 @@ jobs:
           git status --porcelain -- www/src/modules/docs/references/generated/ | grep -q . \
           && { git status --porcelain -- www/src/modules/docs/references/generated/; echo '::error::Committed API reference files are out of date. Run `pnpm build:references` and commit the result.'; exit 1; } \
           || true
+
+  perf-budget:
+    runs-on: ubuntu-latest
+    name: Check client bundle stays within perf budget
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+
+      - name: Build www (production)
+        run: pnpm build:www
+
+      - name: Assert client bundle within perf budget
+        run: node www/scripts/perf-budget.mjs

--- a/www/package.json
+++ b/www/package.json
@@ -10,6 +10,7 @@
     "build": "pnpm build:registry && NODE_OPTIONS='--max-old-space-size=8192' vite build && pnpm build:postprocess",
     "build:postprocess": "node scripts/patch-vercel-config.mjs",
     "preview": "vite preview",
+    "perf:budget": "node scripts/perf-budget.mjs",
     "typecheck": "pnpm build:registry && tsc --noEmit",
     "clean": "git clean -xdf .output .nitro .cache .turbo node_modules",
     "build:references": "tsx scripts/api-docs-builder/src/index.ts",

--- a/www/scripts/perf-budget.json
+++ b/www/scripts/perf-budget.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Client-bundle perf budget for the production build. Thresholds sit just above the post-fix numbers from the landing-page performance work (entry ~215 KB gz, landing 46 preloads / ~406 KB gz first-load). They exist to catch silent regressions — chiefly heavy deps returning to the entry chunk and the modulepreload storm coming back. Measured by scripts/perf-budget.mjs against www/.output/public. Raise a threshold only with a deliberate, reviewed reason.",
+  "entryChunkGzKB": 240,
+  "pages": {
+    "home": { "path": "index.html", "initialGzKB": 450, "preloads": 60 }
+  }
+}

--- a/www/scripts/perf-budget.mjs
+++ b/www/scripts/perf-budget.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Fail the build when the production client bundle regresses past its budget.
+//
+// Guards the entry-graph perf wins — chiefly shiki staying off the entry chunk
+// and the modulepreload storm staying tamed — by asserting, against the real
+// production build (www/.output/public), that:
+//   - the entry chunk stays under a gzip size cap (shiki/react-aria back in it
+//     would blow this),
+//   - key pages stay under a first-load JS gzip cap and a modulepreload count.
+//
+// Thresholds live in scripts/perf-budget.json. Run after `pnpm build`:
+//   node scripts/perf-budget.mjs [outputPublicDir]
+import { readFileSync, existsSync } from "node:fs"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { gzipSync } from "node:zlib"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const budget = JSON.parse(readFileSync(join(here, "perf-budget.json"), "utf8"))
+const PUB = process.argv[2] || join(here, "..", ".output", "public")
+const ASSETS = join(PUB, "assets")
+
+if (!existsSync(ASSETS)) {
+  console.error(
+    `perf-budget: no build at ${PUB} — run \`pnpm build\` first (or pass the output dir).`,
+  )
+  process.exit(2)
+}
+
+const gzCache = new Map()
+function gzKB(file) {
+  if (gzCache.has(file)) return gzCache.get(file)
+  const p = join(ASSETS, file)
+  const kb = existsSync(p) ? gzipSync(readFileSync(p)).length / 1024 : 0
+  gzCache.set(file, kb)
+  return kb
+}
+
+function jsRefs(html) {
+  return [
+    ...new Set([...html.matchAll(/\/assets\/([^"']+?\.js)/g)].map((m) => m[1])),
+  ]
+}
+
+/** The entry chunk is what the inline bootstrap dynamically imports. */
+function entryChunk(html) {
+  const m = html.match(/import\(\s*["']\/assets\/([^"']+?\.js)["']\s*\)/)
+  return m?.[1] ?? null
+}
+
+const round = (n) => Math.round(n * 10) / 10
+const results = []
+let failed = false
+function check(label, actual, limit, unit) {
+  const over = actual > limit
+  if (over) failed = true
+  results.push({ label, actual: round(actual), limit, unit, over })
+}
+
+// Entry chunk gz (shared across pages — read it from home).
+const homeHtml = readFileSync(join(PUB, budget.pages.home.path), "utf8")
+const entry = entryChunk(homeHtml)
+if (!entry) {
+  console.error("perf-budget: could not find the entry chunk in home HTML.")
+  process.exit(2)
+}
+check("entry chunk", gzKB(entry), budget.entryChunkGzKB, "KB gz")
+
+// Per-page first-load JS gz + modulepreload count.
+for (const [name, page] of Object.entries(budget.pages)) {
+  const f = join(PUB, page.path)
+  if (!existsSync(f)) {
+    console.error(`perf-budget: missing prerendered page ${page.path}`)
+    process.exit(2)
+  }
+  const refs = jsRefs(readFileSync(f, "utf8"))
+  const gz = refs.reduce((sum, r) => sum + gzKB(r), 0)
+  check(`${name} first-load JS`, gz, page.initialGzKB, "KB gz")
+  check(`${name} modulepreloads`, refs.length, page.preloads, "chunks")
+}
+
+const pad = (s, n) => String(s).padEnd(n)
+console.log(`\nperf budget — ${PUB}\n`)
+console.log(pad("metric", 22), pad("actual", 12), pad("budget", 10), "status")
+for (const r of results) {
+  console.log(
+    pad(r.label, 22),
+    pad(`${r.actual} ${r.unit}`, 12),
+    pad(`${r.limit} ${r.unit}`, 10),
+    r.over ? "❌ OVER" : "✅ ok",
+  )
+}
+
+if (failed) {
+  console.error(
+    "\n::error::perf budget exceeded. A client-bundle perf win regressed. " +
+      "Investigate (shiki back in the entry chunk? preload storm returned?) " +
+      "or, if the growth is intended and reviewed, raise the threshold in www/scripts/perf-budget.json.",
+  )
+  process.exit(1)
+}
+console.log("\nperf budget: all metrics within budget ✅")


### PR DESCRIPTION
Resurrects the perf-budget check from #419 (closed) and wires it into CI.

Adds `www/scripts/perf-budget.{mjs,json}` and a `perf-budget` CI job (plus `pnpm --filter=www perf:budget`) that builds the production client bundle and fails if it regresses past budget:

- **entry chunk** gzip size — budget 240 KB gz
- **landing first-load JS** gzip total — budget 450 KB gz
- **landing modulepreload count** — budget 60 chunks

Thresholds sit just above the post-fix numbers from the landing-page performance work (entry ~215 KB gz, 46 preloads, ~406 KB gz first-load).

## ⚠️ Fails on current main — by design, but sequencing needed

The perf fixes this budget encodes (#415 shiki off entry, #416 zod dedupe, #417 lazy search dialog, #418 vendor chunks) were **closed unmerged**, so main today measures:

| metric | main today | budget |
|---|---|---|
| entry chunk | 440.3 KB gz | 240 KB gz |
| landing first-load JS | 845.5 KB gz | 450 KB gz |
| landing modulepreloads | 140 | 60 |

The job will be red on this PR and every PR until those fixes are resurrected and landed. For that reason the job is **not** added to the `main` ruleset's required checks yet — doing so now would block all merges (including this PR). Add "Check client bundle stays within perf budget" to the ruleset once main is under budget.

Verified locally: script runs against a fresh `pnpm build:www` output and correctly reports all three metrics OVER.

Refs #395, #419.