### PR TITLE
perf(www): drop zod from route search validation

### DIFF
--- a/www/src/routes/_app/create.tsx
+++ b/www/src/routes/_app/create.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { createFileRoute, stripSearchParams } from "@tanstack/react-router"
-import { z } from "zod"
+import type { SearchSchemaInput } from "@tanstack/react-router"
 
 import { DialogContent } from "@/registry/ui/dialog"
 import { Drawer, DrawerHandle } from "@/registry/ui/drawer"
@@ -13,16 +13,30 @@ import {
 } from "@/modules/create/preset/storage"
 import { PreviewPanel } from "@/modules/create/preview/preview-panel"
 
-export const createSearchSchema = z.object({
-  panel: z.string().optional().catch(undefined),
-  preview: z.string().default("cards").catch("cards"),
-  preset: z.string().optional().catch(undefined),
-  // Opens the preset gallery modal — set by the panel's Presets button and the
-  // /presets permanent redirect. Coerced boolean: the search parser reads bare
-  // `1`/`true` as non-strings, so a plain `z.string()` would reject them and
-  // the param would be dropped.
-  gallery: z.coerce.boolean().optional().catch(undefined),
-})
+export function createSearchSchema(
+  search: {
+    panel?: string
+    preview?: string
+    preset?: string
+    gallery?: boolean
+  } & SearchSchemaInput,
+): {
+  panel?: string
+  preview: string
+  preset?: string
+  gallery?: boolean
+} {
+  return {
+    panel: typeof search.panel === "string" ? search.panel : undefined,
+    preview: typeof search.preview === "string" ? search.preview : "cards",
+    preset: typeof search.preset === "string" ? search.preset : undefined,
+    // Opens the preset gallery modal — set by the panel's Presets button and the
+    // /presets permanent redirect. Coerced boolean: the search parser reads bare
+    // `1`/`true` as non-strings, so a string check would reject them and the
+    // param would be dropped.
+    gallery: search.gallery === undefined ? undefined : Boolean(search.gallery),
+  }
+}
 
 const searchDefaults = { preview: "cards" }
 

--- a/www/src/routes/preview/$slug.tsx
+++ b/www/src/routes/preview/$slug.tsx
@@ -1,6 +1,5 @@
 import { type ReactNode, use, useCallback, useState } from "react"
 import { createFileRoute } from "@tanstack/react-router"
-import { z } from "zod"
 
 import { DesignSystemProvider } from "@/lib/styles"
 import {
@@ -44,11 +43,16 @@ html::-webkit-scrollbar { display: none; }
 `
 
 export const Route = createFileRoute("/preview/$slug")({
-  validateSearch: z.object({
-    preset: z.string().optional().catch(undefined),
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { preset?: string; mode?: "light" | "dark" } => ({
+    preset: typeof search.preset === "string" ? search.preset : undefined,
     // Initial display mode, baked in by the /create parent (read directly from
     // location by usePreviewForcedTheme; declared so the router keeps it).
-    mode: z.enum(["light", "dark"]).optional().catch(undefined),
+    mode:
+      search.mode === "light" || search.mode === "dark"
+        ? search.mode
+        : undefined,
   }),
   ssr: false,
   beforeLoad: ({ params }) => {


### PR DESCRIPTION
Zod (~35 KB gz) sat in the client entry chunk of every page because two route files used it for `validateSearch`. TanStack Router accepts plain validator functions, so both schemas are now hand-rolled.

## Changes

- `www/src/routes/_app/create.tsx` — `createSearchSchema` is a plain function. Fallback semantics preserved: non-string `panel`/`preset` → `undefined`, non-string `preview` → `"cards"`, `gallery` → `Boolean(value)` when present (matches `z.coerce.boolean()`, so bare `?gallery=1` still works). The input is typed `{...} & SearchSchemaInput` — zod's `.default()` previously made `preview` optional on the navigate side; without the marker, `stripSearchParams(searchDefaults)` and the `/presets` redirect (`search: { gallery: true }`) fail typecheck.
- `www/src/routes/preview/$slug.tsx` — inline validator: `preset` string-or-undefined, `mode` only accepts `"light"`/`"dark"`, else `undefined`.

## Verification

- Vite production build: `grep -c ZodError` on the entry chunk (`index-*.js`, 1.7 MB, largest asset) returns 0.
- `pnpm check` and `pnpm typecheck` pass.

## Reviewer note

Zod still ships eagerly: it now lives in the shared styles chunk (236 KB), statically imported by the entry, because `www/src/registry/theme/color-config.ts` uses a large runtime zod schema reachable from `registry/theme/index.ts`. That's color-system territory (queued rewrite), so it's untouched here — this PR removes zod from the entry chunk itself but not yet from the critical download path.