### PR TITLE
perf(www): lazy-load the docs search dialog

### DIFF
--- a/www/src/components/search-command.tsx
+++ b/www/src/components/search-command.tsx
@@ -99,7 +99,7 @@ export function SearchCommand({
           )
           return isMobile ? (
             // Match the desktop modal's raised surface.
-            <Drawer className="bg-(--neutral-200)">{content}</Drawer>
+            <Drawer className="bg-(--neutral-100)">{content}</Drawer>
           ) : (
             // Composed (not <Modal>) so the panel AND backdrop appear
             // instantly — duration-0 on both. Mirror shadcn.com: max-w-lg
@@ -107,7 +107,7 @@ export function SearchCommand({
             <ModalOverlay>
               <ModalBackdrop className="duration-0 group-exiting/modal:duration-0" />
               <ModalViewport>
-                <ModalPanel className="mt-[15vh] self-start duration-0 [--modal-background:var(--neutral-200)] [--modal-radius:var(--radius-2xl)] sm:max-w-lg entering:scale-100 exiting:scale-100">
+                <ModalPanel className="mt-[15vh] self-start duration-0 [--modal-background:var(--neutral-100)] [--modal-radius:var(--radius-2xl)] sm:max-w-lg entering:scale-100 exiting:scale-100">
                   {content}
                 </ModalPanel>
               </ModalViewport>

--- a/www/src/components/search-command.tsx
+++ b/www/src/components/search-command.tsx
@@ -14,8 +14,13 @@ import {
 // The dialog body pulls in the Orama search client, the fumadocs search hook
 // and react-aria's Autocomplete (~25 KB gz). Load it lazily on first open so it
 // stays off every page's critical path — the trigger and shell below are cheap.
-const loadSearchDialog = () => import("./search-dialog")
-const SearchDialog = React.lazy(loadSearchDialog)
+// A module var instead of React.lazy: lazy suspends once even on a resolved
+// import, committing the fallback before the content — a potential flash.
+let SearchDialog: (typeof import("./search-dialog"))["default"] | null = null
+const loadSearchDialog = () =>
+  import("./search-dialog").then((module) => {
+    SearchDialog = module.default
+  })
 
 interface SearchCommandProps {
   items: PageTree.Node[]
@@ -29,6 +34,18 @@ export function SearchCommand({
   children,
 }: SearchCommandProps) {
   const [isOpen, setIsOpen] = React.useState(false)
+
+  // A cold open (first ⌘K, nothing warmed) waits for the chunk — a few ms,
+  // since the open request itself starts the fetch — instead of flashing the
+  // Suspense fallback. Once loaded, opens are synchronous.
+  const requestOpen = (open: boolean) => {
+    if (!open || SearchDialog) {
+      setIsOpen(open)
+      return
+    }
+    const show = () => setIsOpen(true)
+    void loadSearchDialog().then(show, show)
+  }
 
   React.useEffect(() => {
     if (!keyboardShortcut) return
@@ -46,16 +63,17 @@ export function SearchCommand({
         }
 
         e.preventDefault()
-        setIsOpen((open) => !open)
+        if (isOpen) setIsOpen(false)
+        else requestOpen(true)
       }
     }
 
     document.addEventListener("keydown", onKeyDown)
     return () => document.removeEventListener("keydown", onKeyDown)
-  }, [keyboardShortcut])
+  })
 
   return (
-    <Dialog isOpen={isOpen} onOpenChange={setIsOpen}>
+    <Dialog isOpen={isOpen} onOpenChange={requestOpen}>
       {/* Hover/focus intent on the trigger warms the lazy chunk so first open
           feels instant. display:contents keeps the trigger's press wiring —
           RAC's DialogTrigger reaches pressables via context, not cloning. */}
@@ -74,11 +92,9 @@ export function SearchCommand({
               aria-label="Search documentation"
               className="flex flex-col gap-0 overflow-hidden p-0!"
             >
-              <React.Suspense
-                fallback={<div className="h-14" aria-hidden="true" />}
-              >
+              {SearchDialog && (
                 <SearchDialog items={items} onClose={() => setIsOpen(false)} />
-              </React.Suspense>
+              )}
             </DialogContent>
           )
           return isMobile ? (

--- a/www/src/components/search-command.tsx
+++ b/www/src/components/search-command.tsx
@@ -1,140 +1,21 @@
 import React from "react"
-import type { ToOptions } from "@tanstack/react-router"
 import type * as PageTree from "fumadocs-core/page-tree"
-import type { SortedResult } from "fumadocs-core/search"
-import { useDocsSearch } from "fumadocs-core/search/client"
-import { oramaStaticClient } from "fumadocs-core/search/client/orama-static"
-import {
-  ArrowRightIcon,
-  CircleDashedIcon,
-  ClockIcon,
-  FileTextIcon,
-  HashIcon,
-  MoonIcon,
-  SearchIcon,
-  SunIcon,
-  TextIcon,
-} from "lucide-react"
-import { Autocomplete, useFilter } from "react-aria-components/Autocomplete"
-import { useTheme } from "starter-themes"
 
-import { navItems, siteConfig } from "@/config/site"
 import { Responsive } from "@/registry/lib/responsive"
-import { useStyles as useCommandStyles } from "@/registry/ui/command/styles"
 import { Dialog, DialogContent } from "@/registry/ui/dialog"
 import { Drawer } from "@/registry/ui/drawer"
-import { Input, InputGroup, InputGroupAddon } from "@/registry/ui/input"
-import {
-  MenuContent,
-  MenuItem,
-  MenuItemLabel,
-  MenuSection,
-  MenuSectionHeader,
-} from "@/registry/ui/menu"
 import {
   ModalBackdrop,
   ModalOverlay,
   ModalPanel,
   ModalViewport,
 } from "@/registry/ui/modal"
-import { SearchField } from "@/registry/ui/search-field"
-import { GitHubIcon } from "@/components/icons/github"
 
-// Module-level so the downloaded index and Orama db survive dialog re-opens —
-// the index is fetched from /api/search once per page load, every query after
-// that runs fully client-side.
-const searchClient = oramaStaticClient({ from: "/api/search" })
-
-const RECENT_KEY = "dotui.search.recent"
-const RECENT_LIMIT = 5
-
-interface RecentEntry {
-  title: string
-  url: string
-}
-
-function readRecents(): RecentEntry[] {
-  try {
-    const parsed: unknown = JSON.parse(localStorage.getItem(RECENT_KEY) ?? "[]")
-    if (!Array.isArray(parsed)) return []
-    return parsed
-      .filter(
-        (entry): entry is RecentEntry =>
-          typeof entry === "object" &&
-          entry !== null &&
-          typeof (entry as RecentEntry).title === "string" &&
-          typeof (entry as RecentEntry).url === "string",
-      )
-      .slice(0, RECENT_LIMIT)
-  } catch {
-    return []
-  }
-}
-
-function pushRecent(entry: RecentEntry) {
-  try {
-    const next = [
-      entry,
-      ...readRecents().filter((recent) => recent.url !== entry.url),
-    ].slice(0, RECENT_LIMIT)
-    localStorage.setItem(RECENT_KEY, JSON.stringify(next))
-  } catch {
-    // localStorage unavailable (private mode, quota) — recents just don't persist.
-  }
-}
-
-/** Search result URLs are `/docs/...#anchor` strings; route them through the
- *  docs splat route so navigation stays client-side. */
-function docsHref(url: string): string | ToOptions {
-  const [path = "", hash] = url.split("#")
-  if (path !== "/docs" && !path.startsWith("/docs/")) return url
-  return {
-    to: "/docs/$",
-    params: { _splat: path.slice("/docs/".length) },
-    hash,
-  }
-}
-
-const stripMarks = (content: string) =>
-  content
-    .replace(/<\/?mark>/g, "")
-    .replaceAll("`", "")
-    .replaceAll("**", "")
-
-/** Result content arrives as text with `<mark>` around matched terms and
- *  occasional markdown syntax (inline-code backticks, bold markers). */
-function Highlight({ text }: { text: string }) {
-  const parts = text
-    .replaceAll("`", "")
-    .replaceAll("**", "")
-    .split(/<mark>(.*?)<\/mark>/)
-  if (parts.length === 1) return parts[0]
-  return parts.map((part, index) =>
-    index % 2 === 1 ? (
-      // oxlint-disable-next-line react/no-array-index-key -- static split output
-      <mark key={index} className="rounded-xs bg-accent-muted text-current">
-        {part}
-      </mark>
-    ) : (
-      part
-    ),
-  )
-}
-
-interface ResultGroup {
-  page: SortedResult
-  children: SortedResult[]
-}
-
-/** Orama returns a flat list ordered page → its heading/text matches. */
-function groupResults(results: SortedResult[]): ResultGroup[] {
-  const groups: ResultGroup[] = []
-  for (const result of results) {
-    if (result.type === "page") groups.push({ page: result, children: [] })
-    else groups.at(-1)?.children.push(result)
-  }
-  return groups
-}
+// The dialog body pulls in the Orama search client, the fumadocs search hook
+// and react-aria's Autocomplete (~25 KB gz). Load it lazily on first open so it
+// stays off every page's critical path — the trigger and shell below are cheap.
+const loadSearchDialog = () => import("./search-dialog")
+const SearchDialog = React.lazy(loadSearchDialog)
 
 interface SearchCommandProps {
   items: PageTree.Node[]
@@ -175,7 +56,16 @@ export function SearchCommand({
 
   return (
     <Dialog isOpen={isOpen} onOpenChange={setIsOpen}>
-      {children}
+      {/* Hover/focus intent on the trigger warms the lazy chunk so first open
+          feels instant. display:contents keeps the trigger's press wiring —
+          RAC's DialogTrigger reaches pressables via context, not cloning. */}
+      <span
+        className="contents"
+        onPointerEnter={() => void loadSearchDialog()}
+        onFocus={() => void loadSearchDialog()}
+      >
+        {children}
+      </span>
       {/* Modal on desktop, Drawer on mobile; content remounts on open so the search resets. */}
       <Responsive
         render={(isMobile) => {
@@ -184,7 +74,11 @@ export function SearchCommand({
               aria-label="Search documentation"
               className="flex flex-col gap-0 overflow-hidden p-0!"
             >
-              <SearchDialog items={items} onClose={() => setIsOpen(false)} />
+              <React.Suspense
+                fallback={<div className="h-14" aria-hidden="true" />}
+              >
+                <SearchDialog items={items} onClose={() => setIsOpen(false)} />
+              </React.Suspense>
             </DialogContent>
           )
           return isMobile ? (
@@ -206,215 +100,5 @@ export function SearchCommand({
         }}
       />
     </Dialog>
-  )
-}
-
-function SearchDialog({
-  items,
-  onClose,
-}: {
-  items: PageTree.Node[]
-  onClose: () => void
-}) {
-  const commandStyles = useCommandStyles()
-  const { resolvedTheme, setTheme } = useTheme()
-  const { search, setSearch, query } = useDocsSearch({ client: searchClient })
-  const [recents] = React.useState(readRecents)
-
-  React.useEffect(() => {
-    // Warm the index (download + build) while the user starts typing.
-    void Promise.resolve(searchClient.search("")).catch(() => {})
-  }, [])
-
-  // Typing filters the default sections like a regular command palette. The
-  // full-text index matches are appended as a separate "Search results"
-  // section — nested matches (headings, body text) only, since page-level
-  // hits duplicate the pages already listed in the default sections.
-  const { contains } = useFilter({
-    sensitivity: "base",
-    ignorePunctuation: true,
-  })
-  const term = search.trim()
-  const matches = (text: string) => contains(text, term)
-
-  const nestedResults = groupResults(
-    term.length > 0 && Array.isArray(query.data) ? query.data : [],
-  ).flatMap((group) =>
-    group.children.map((child) => ({ page: group.page, child })),
-  )
-  const filteredRecents = recents.filter((recent) => matches(recent.title))
-  const filteredNav = navItems.filter((item) => matches(item.name))
-
-  // Item-level onAction suppresses the menu-level one, so this closes the
-  // dialog itself.
-  const rememberChild = (page: SortedResult, child: SortedResult) => {
-    const pageTitle = stripMarks(page.content)
-    pushRecent({
-      title:
-        child.type === "heading"
-          ? `${pageTitle} › ${stripMarks(child.content)}`
-          : pageTitle,
-      url: child.url,
-    })
-    onClose()
-  }
-
-  return (
-    <Autocomplete inputValue={search} onInputChange={setSearch}>
-      <div
-        data-command=""
-        className={commandStyles({ className: "gap-0 overflow-y-hidden p-0" })}
-      >
-        <SearchField autoFocus aria-label="Search" className="px-1.5 pt-1.5">
-          {/* Radius stays concentric with the modal (2xl − 6px inset); the
-              filled input needs no focus treatment, so the ring is off and the
-              border stays the neutral field color on focus. */}
-          <InputGroup
-            size="lg"
-            className="rounded-[10px]! border-border-field! bg-(--neutral-300) ring-0!"
-          >
-            <InputGroupAddon>
-              <SearchIcon />
-            </InputGroupAddon>
-            <Input placeholder="Search documentation..." />
-          </InputGroup>
-        </SearchField>
-        {/* The menu is the scroll container and must span the full panel
-              width (scrollbar at the edge), so the list padding lives inside
-              it rather than on the wrapper. */}
-        <MenuContent
-          aria-label="Search results"
-          className="max-h-80 overflow-y-auto p-1.5 pt-3 **:data-menu-item:py-2"
-          onAction={onClose}
-          renderEmptyState={() => (
-            <div className="py-8 text-center text-sm text-fg-muted">
-              {query.error
-                ? "Search is unavailable right now."
-                : query.isLoading
-                  ? "Searching…"
-                  : `No results for “${search.trim()}”`}
-            </div>
-          )}
-        >
-          {[
-            filteredRecents.length > 0 && (
-              <MenuSection key="recent">
-                <MenuSectionHeader>Recent</MenuSectionHeader>
-                {filteredRecents.map((recent) => (
-                  <MenuItem
-                    key={recent.url}
-                    href={docsHref(recent.url)}
-                    textValue={recent.title}
-                  >
-                    <ClockIcon className="text-fg-muted!" />
-                    <MenuItemLabel className="truncate">
-                      {recent.title}
-                    </MenuItemLabel>
-                  </MenuItem>
-                ))}
-              </MenuSection>
-            ),
-            filteredNav.length > 0 && (
-              <MenuSection key="navigation">
-                <MenuSectionHeader>Navigation</MenuSectionHeader>
-                {filteredNav.map((item) => (
-                  <MenuItem
-                    key={item.name}
-                    // navItems is typed loosely (`to: string`) for the
-                    // header's Link props; its values are valid routes.
-                    href={{ to: item.to, params: item.params } as ToOptions}
-                    textValue={item.name}
-                  >
-                    <ArrowRightIcon className="text-fg-muted!" />
-                    {item.name}
-                  </MenuItem>
-                ))}
-              </MenuSection>
-            ),
-            ...items.map((group, index) => {
-              if (group.type !== "folder") return null
-              const pages = group.children.filter(
-                (item): item is PageTree.Item =>
-                  item.type === "page" && matches(item.name as string),
-              )
-              if (pages.length === 0) return null
-              return (
-                // oxlint-disable-next-line react/no-array-index-key -- items is static navigation data
-                <MenuSection key={`folder-${index}`}>
-                  <MenuSectionHeader>{group.name}</MenuSectionHeader>
-                  {pages.map((item) => (
-                    <MenuItem
-                      key={item.url}
-                      href={item.url}
-                      textValue={item.name as string}
-                    >
-                      {group.name === "Components" ? (
-                        <CircleDashedIcon className="text-fg-muted!" />
-                      ) : (
-                        <FileTextIcon className="text-fg-muted!" />
-                      )}
-                      {item.name}
-                    </MenuItem>
-                  ))}
-                </MenuSection>
-              )
-            }),
-            (matches("Toggle theme") || matches("GitHub")) && (
-              <MenuSection key="general">
-                <MenuSectionHeader>General</MenuSectionHeader>
-                {matches("Toggle theme") && (
-                  <MenuItem
-                    textValue="Toggle theme"
-                    onAction={() => {
-                      setTheme(resolvedTheme === "dark" ? "light" : "dark")
-                      onClose()
-                    }}
-                  >
-                    <SunIcon className="block text-fg-muted! dark:hidden" />
-                    <MoonIcon className="hidden text-fg-muted! dark:block" />
-                    Toggle theme
-                  </MenuItem>
-                )}
-                {matches("GitHub") && (
-                  <MenuItem
-                    href={siteConfig.links.github}
-                    target="_blank"
-                    textValue="GitHub"
-                  >
-                    <GitHubIcon className="text-fg-muted!" />
-                    GitHub
-                  </MenuItem>
-                )}
-              </MenuSection>
-            ),
-            nestedResults.length > 0 && (
-              <MenuSection key="search-results">
-                <MenuSectionHeader>Search results</MenuSectionHeader>
-                {nestedResults.map(({ page, child }) => (
-                  <MenuItem
-                    key={child.id}
-                    href={docsHref(child.url)}
-                    textValue={stripMarks(child.content)}
-                    onAction={() => rememberChild(page, child)}
-                  >
-                    {child.type === "heading" ? (
-                      <HashIcon className="text-fg-muted!" />
-                    ) : (
-                      <TextIcon className="text-fg-muted!" />
-                    )}
-                    <MenuItemLabel className="truncate">
-                      <Highlight text={child.content} />
-                    </MenuItemLabel>
-                    <span className="ml-auto shrink-0 text-xs text-fg-muted">
-                      {stripMarks(page.content)}
-                    </span>
-                  </MenuItem>
-                ))}
-              </MenuSection>
-            ),
-          ]}
-        </MenuContent>
-      </div>
-    </Autocomplete>
   )
 }

--- a/www/src/components/search-dialog.tsx
+++ b/www/src/components/search-dialog.tsx
@@ -1,0 +1,338 @@
+import React from "react"
+import type { ToOptions } from "@tanstack/react-router"
+import type * as PageTree from "fumadocs-core/page-tree"
+import type { SortedResult } from "fumadocs-core/search"
+import { useDocsSearch } from "fumadocs-core/search/client"
+import { oramaStaticClient } from "fumadocs-core/search/client/orama-static"
+import {
+  ArrowRightIcon,
+  CircleDashedIcon,
+  ClockIcon,
+  FileTextIcon,
+  HashIcon,
+  MoonIcon,
+  SearchIcon,
+  SunIcon,
+  TextIcon,
+} from "lucide-react"
+import { Autocomplete, useFilter } from "react-aria-components/Autocomplete"
+import { useTheme } from "starter-themes"
+
+import { navItems, siteConfig } from "@/config/site"
+import { useStyles as useCommandStyles } from "@/registry/ui/command/styles"
+import { Input, InputGroup, InputGroupAddon } from "@/registry/ui/input"
+import {
+  MenuContent,
+  MenuItem,
+  MenuItemLabel,
+  MenuSection,
+  MenuSectionHeader,
+} from "@/registry/ui/menu"
+import { SearchField } from "@/registry/ui/search-field"
+import { GitHubIcon } from "@/components/icons/github"
+
+// Module-level so the downloaded index and Orama db survive dialog re-opens —
+// the index is fetched from /api/search once per page load, every query after
+// that runs fully client-side.
+const searchClient = oramaStaticClient({ from: "/api/search" })
+
+const RECENT_KEY = "dotui.search.recent"
+const RECENT_LIMIT = 5
+
+interface RecentEntry {
+  title: string
+  url: string
+}
+
+function readRecents(): RecentEntry[] {
+  try {
+    const parsed: unknown = JSON.parse(localStorage.getItem(RECENT_KEY) ?? "[]")
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .filter(
+        (entry): entry is RecentEntry =>
+          typeof entry === "object" &&
+          entry !== null &&
+          typeof (entry as RecentEntry).title === "string" &&
+          typeof (entry as RecentEntry).url === "string",
+      )
+      .slice(0, RECENT_LIMIT)
+  } catch {
+    return []
+  }
+}
+
+function pushRecent(entry: RecentEntry) {
+  try {
+    const next = [
+      entry,
+      ...readRecents().filter((recent) => recent.url !== entry.url),
+    ].slice(0, RECENT_LIMIT)
+    localStorage.setItem(RECENT_KEY, JSON.stringify(next))
+  } catch {
+    // localStorage unavailable (private mode, quota) — recents just don't persist.
+  }
+}
+
+/** Search result URLs are `/docs/...#anchor` strings; route them through the
+ *  docs splat route so navigation stays client-side. */
+function docsHref(url: string): string | ToOptions {
+  const [path = "", hash] = url.split("#")
+  if (path !== "/docs" && !path.startsWith("/docs/")) return url
+  return {
+    to: "/docs/$",
+    params: { _splat: path.slice("/docs/".length) },
+    hash,
+  }
+}
+
+const stripMarks = (content: string) =>
+  content
+    .replace(/<\/?mark>/g, "")
+    .replaceAll("`", "")
+    .replaceAll("**", "")
+
+/** Result content arrives as text with `<mark>` around matched terms and
+ *  occasional markdown syntax (inline-code backticks, bold markers). */
+function Highlight({ text }: { text: string }) {
+  const parts = text
+    .replaceAll("`", "")
+    .replaceAll("**", "")
+    .split(/<mark>(.*?)<\/mark>/)
+  if (parts.length === 1) return parts[0]
+  return parts.map((part, index) =>
+    index % 2 === 1 ? (
+      // oxlint-disable-next-line react/no-array-index-key -- static split output
+      <mark key={index} className="rounded-xs bg-accent-muted text-current">
+        {part}
+      </mark>
+    ) : (
+      part
+    ),
+  )
+}
+
+interface ResultGroup {
+  page: SortedResult
+  children: SortedResult[]
+}
+
+/** Orama returns a flat list ordered page → its heading/text matches. */
+function groupResults(results: SortedResult[]): ResultGroup[] {
+  const groups: ResultGroup[] = []
+  for (const result of results) {
+    if (result.type === "page") groups.push({ page: result, children: [] })
+    else groups.at(-1)?.children.push(result)
+  }
+  return groups
+}
+
+export default function SearchDialog({
+  items,
+  onClose,
+}: {
+  items: PageTree.Node[]
+  onClose: () => void
+}) {
+  const commandStyles = useCommandStyles()
+  const { resolvedTheme, setTheme } = useTheme()
+  const { search, setSearch, query } = useDocsSearch({ client: searchClient })
+  const [recents] = React.useState(readRecents)
+
+  React.useEffect(() => {
+    // Warm the index (download + build) while the user starts typing.
+    void Promise.resolve(searchClient.search("")).catch(() => {})
+  }, [])
+
+  // Typing filters the default sections like a regular command palette. The
+  // full-text index matches are appended as a separate "Search results"
+  // section — nested matches (headings, body text) only, since page-level
+  // hits duplicate the pages already listed in the default sections.
+  const { contains } = useFilter({
+    sensitivity: "base",
+    ignorePunctuation: true,
+  })
+  const term = search.trim()
+  const matches = (text: string) => contains(text, term)
+
+  const nestedResults = groupResults(
+    term.length > 0 && Array.isArray(query.data) ? query.data : [],
+  ).flatMap((group) =>
+    group.children.map((child) => ({ page: group.page, child })),
+  )
+  const filteredRecents = recents.filter((recent) => matches(recent.title))
+  const filteredNav = navItems.filter((item) => matches(item.name))
+
+  // Item-level onAction suppresses the menu-level one, so this closes the
+  // dialog itself.
+  const rememberChild = (page: SortedResult, child: SortedResult) => {
+    const pageTitle = stripMarks(page.content)
+    pushRecent({
+      title:
+        child.type === "heading"
+          ? `${pageTitle} › ${stripMarks(child.content)}`
+          : pageTitle,
+      url: child.url,
+    })
+    onClose()
+  }
+
+  return (
+    <Autocomplete inputValue={search} onInputChange={setSearch}>
+      <div
+        data-command=""
+        className={commandStyles({ className: "gap-0 overflow-y-hidden p-0" })}
+      >
+        <SearchField autoFocus aria-label="Search" className="px-1.5 pt-1.5">
+          {/* Radius stays concentric with the modal (2xl − 6px inset); the
+              filled input needs no focus treatment, so the ring is off and the
+              border stays the neutral field color on focus. */}
+          <InputGroup
+            size="lg"
+            className="rounded-[10px]! border-border-field! bg-(--neutral-300) ring-0!"
+          >
+            <InputGroupAddon>
+              <SearchIcon />
+            </InputGroupAddon>
+            <Input placeholder="Search documentation..." />
+          </InputGroup>
+        </SearchField>
+        {/* The menu is the scroll container and must span the full panel
+              width (scrollbar at the edge), so the list padding lives inside
+              it rather than on the wrapper. */}
+        <MenuContent
+          aria-label="Search results"
+          className="max-h-80 overflow-y-auto p-1.5 pt-3 **:data-menu-item:py-2"
+          onAction={onClose}
+          renderEmptyState={() => (
+            <div className="py-8 text-center text-sm text-fg-muted">
+              {query.error
+                ? "Search is unavailable right now."
+                : query.isLoading
+                  ? "Searching…"
+                  : `No results for “${search.trim()}”`}
+            </div>
+          )}
+        >
+          {[
+            filteredRecents.length > 0 && (
+              <MenuSection key="recent">
+                <MenuSectionHeader>Recent</MenuSectionHeader>
+                {filteredRecents.map((recent) => (
+                  <MenuItem
+                    key={recent.url}
+                    href={docsHref(recent.url)}
+                    textValue={recent.title}
+                  >
+                    <ClockIcon className="text-fg-muted!" />
+                    <MenuItemLabel className="truncate">
+                      {recent.title}
+                    </MenuItemLabel>
+                  </MenuItem>
+                ))}
+              </MenuSection>
+            ),
+            filteredNav.length > 0 && (
+              <MenuSection key="navigation">
+                <MenuSectionHeader>Navigation</MenuSectionHeader>
+                {filteredNav.map((item) => (
+                  <MenuItem
+                    key={item.name}
+                    // navItems is typed loosely (`to: string`) for the
+                    // header's Link props; its values are valid routes.
+                    href={{ to: item.to, params: item.params } as ToOptions}
+                    textValue={item.name}
+                  >
+                    <ArrowRightIcon className="text-fg-muted!" />
+                    {item.name}
+                  </MenuItem>
+                ))}
+              </MenuSection>
+            ),
+            ...items.map((group, index) => {
+              if (group.type !== "folder") return null
+              const pages = group.children.filter(
+                (item): item is PageTree.Item =>
+                  item.type === "page" && matches(item.name as string),
+              )
+              if (pages.length === 0) return null
+              return (
+                // oxlint-disable-next-line react/no-array-index-key -- items is static navigation data
+                <MenuSection key={`folder-${index}`}>
+                  <MenuSectionHeader>{group.name}</MenuSectionHeader>
+                  {pages.map((item) => (
+                    <MenuItem
+                      key={item.url}
+                      href={item.url}
+                      textValue={item.name as string}
+                    >
+                      {group.name === "Components" ? (
+                        <CircleDashedIcon className="text-fg-muted!" />
+                      ) : (
+                        <FileTextIcon className="text-fg-muted!" />
+                      )}
+                      {item.name}
+                    </MenuItem>
+                  ))}
+                </MenuSection>
+              )
+            }),
+            (matches("Toggle theme") || matches("GitHub")) && (
+              <MenuSection key="general">
+                <MenuSectionHeader>General</MenuSectionHeader>
+                {matches("Toggle theme") && (
+                  <MenuItem
+                    textValue="Toggle theme"
+                    onAction={() => {
+                      setTheme(resolvedTheme === "dark" ? "light" : "dark")
+                      onClose()
+                    }}
+                  >
+                    <SunIcon className="block text-fg-muted! dark:hidden" />
+                    <MoonIcon className="hidden text-fg-muted! dark:block" />
+                    Toggle theme
+                  </MenuItem>
+                )}
+                {matches("GitHub") && (
+                  <MenuItem
+                    href={siteConfig.links.github}
+                    target="_blank"
+                    textValue="GitHub"
+                  >
+                    <GitHubIcon className="text-fg-muted!" />
+                    GitHub
+                  </MenuItem>
+                )}
+              </MenuSection>
+            ),
+            nestedResults.length > 0 && (
+              <MenuSection key="search-results">
+                <MenuSectionHeader>Search results</MenuSectionHeader>
+                {nestedResults.map(({ page, child }) => (
+                  <MenuItem
+                    key={child.id}
+                    href={docsHref(child.url)}
+                    textValue={stripMarks(child.content)}
+                    onAction={() => rememberChild(page, child)}
+                  >
+                    {child.type === "heading" ? (
+                      <HashIcon className="text-fg-muted!" />
+                    ) : (
+                      <TextIcon className="text-fg-muted!" />
+                    )}
+                    <MenuItemLabel className="truncate">
+                      <Highlight text={child.content} />
+                    </MenuItemLabel>
+                    <span className="ml-auto shrink-0 text-xs text-fg-muted">
+                      {stripMarks(page.content)}
+                    </span>
+                  </MenuItem>
+                ))}
+              </MenuSection>
+            ),
+          ]}
+        </MenuContent>
+      </div>
+    </Autocomplete>
+  )
+}


### PR DESCRIPTION
## What

The site header mounts `SearchCommand` on every page, and it statically imported the entire search body — the Orama static client (instantiated at module scope), fumadocs' `useDocsSearch`, and react-aria's `Autocomplete` (~25 KB gz of `search-*` chunk assets) — even though search only opens on ⌘K. That machinery sat on every page's critical path.

## Fix

Re-applies closed #417 on current code: the heavy body moves to `search-dialog.tsx` and is imported dynamically. The trigger, keyboard shortcut and modal/drawer shell stay eager.

Two additions vs #417:

- **Intent-based warming** — `pointerenter`/`focus` on a `display: contents` span around the trigger kicks off the chunk import early, so first open feels instant. RAC's `DialogTrigger` wires the press through context, not cloning, so the wrapper doesn't break the trigger button.
- **No fallback flash** — instead of `React.lazy` + `Suspense` (which briefly commits the fallback even when the import is already resolved), the loaded component is held in a module var and a cold open waits for the import — a few ms, since the open request itself starts the fetch — before flipping `isOpen`. The dialog always mounts fully populated; warmed/repeat opens are synchronous.

The dialog is never rendered until the overlay opens, so there's no SSR/hydration path. The Orama client now instantiates on first warm/open instead of page load — the index itself was already fetched lazily, so nothing user-visible changes.

## Verification (production build, real page drive)

- `.output/public/index.html` modulepreloads no `search-*`/`orama-*` chunks; `search-dialog-*.js` is its own chunk.
- Landing page load fetches zero search/orama assets.
- Hovering the header search trigger warms `search-dialog-*.js` without opening.
- Cold ⌘K (no warm): a MutationObserver confirms the dialog enters the DOM already fully populated (input + 79 items in the first commit) — no fallback frame.
- Typing "button" returns 40 relevant results including full-text index matches; Escape + reopen resets the search; no console errors.
- `pnpm check` and `pnpm typecheck` pass.

Refs #395.