### PR TITLE
feat(www): panel-lab untitled index clusters, focus demoted, family order

### DIFF
--- a/www/src/modules/panel-lab/variants/groups.ts
+++ b/www/src/modules/panel-lab/variants/groups.ts
@@ -1,10 +1,12 @@
-/* The drill-in index taxonomy (docs/create-experience-spec.md, revised by the
-   Aug 2026 taxonomy panel): two sections — Foundations, then Components
-   (Templates planned) — built from COMPOSITE index chapters. A composite
-   bundles one or more state.ts chapters into a single index card and chapter
-   page: the first member is the host body, later members render as titled
-   subsections, and the card's modified dot covers every member's axes. The
-   flat chapter list in state.ts stays untouched. */
+/* The drill-in index taxonomy (docs/create-experience-spec.md, revised Aug
+   2026): untitled family clusters — each renders as its own card, grouping
+   alone carries the structure. Identity comes first; set-once axes (focus,
+   icons, motion, interaction) sit in their own lesser-weight cluster. Built
+   from COMPOSITE index chapters: a composite bundles one or more state.ts
+   chapters into a single index card and chapter page — the first member is
+   the host body, later members render as titled subsections, and the card's
+   modified dot covers every member's axes. The flat chapter list in state.ts
+   stays untouched. */
 
 import type { Chapter, LabState } from "../state"
 
@@ -33,28 +35,16 @@ const COMPOSITES: CompositeDef[] = [
   },
 ]
 
-export const SECTIONS: Array<{ label: string; ids: string[] }> = [
+export const GROUPS: Array<{ ids: string[] }> = [
+  // Identity — how the system reads at a glance.
+  { ids: ["color", "typography", "shape", "space", "surfaces"] },
+  // Set-once foundations — inherited everywhere, rarely revisited.
+  { ids: ["focus", "icons", "motion", "interaction"] },
+  // Core components.
+  { ids: ["buttons", "inputs"] },
+  // Forms.
   {
-    label: "Foundations",
     ids: [
-      "color",
-      "typography",
-      "shape",
-      "space",
-      "surfaces",
-      "focus",
-      "icons",
-      "motion",
-      "interaction",
-    ],
-  },
-  {
-    label: "Components",
-    ids: [
-      "buttons",
-      "inputs",
-      "links",
-      "kbd",
       "switch",
       "checkbox",
       "radio",
@@ -62,23 +52,16 @@ export const SECTIONS: Array<{ label: string; ids: string[] }> = [
       "pickers",
       "calendar",
       "sliders",
-      "menus",
-      "dialogs",
-      "popovers",
-      "tooltips",
-      "tabs",
-      "breadcrumbs",
-      "pagination",
-      "notices",
-      "skeleton",
-      "spinner",
-      "progress",
-      "badges",
-      "avatars",
-      "tables",
-      "accordion",
     ],
   },
+  // Overlays.
+  { ids: ["menus", "dialogs", "popovers", "tooltips"] },
+  // Navigation.
+  { ids: ["links", "tabs", "breadcrumbs", "pagination"] },
+  // Feedback.
+  { ids: ["notices", "skeleton", "spinner", "progress"] },
+  // Display.
+  { ids: ["badges", "kbd", "avatars", "tables", "accordion"] },
 ]
 
 export interface IndexChapter {
@@ -92,11 +75,11 @@ export interface IndexChapter {
   hostless: boolean
 }
 
-/** Resolve the sections' ids (plain chapter ids or composite ids) against the
+/** Resolve the groups' ids (plain chapter ids or composite ids) against the
  *  flat chapter list. */
 export function resolveIndex(
   chapters: Chapter[],
-): Array<{ label: string; chapters: IndexChapter[] }> {
+): Array<{ chapters: IndexChapter[] }> {
   const byId = new Map(chapters.map((chapter) => [chapter.id, chapter]))
   const toIndexChapter = (id: string): IndexChapter | undefined => {
     const composite = COMPOSITES.find((c) => c.id === id)
@@ -124,9 +107,8 @@ export function resolveIndex(
       hostless: !host,
     }
   }
-  return SECTIONS.map((section) => ({
-    label: section.label,
-    chapters: section.ids
+  return GROUPS.map((group) => ({
+    chapters: group.ids
       .map(toIndexChapter)
       .filter((chapter): chapter is IndexChapter => chapter !== undefined),
   }))

--- a/www/src/modules/panel-lab/variants/panel-b.tsx
+++ b/www/src/modules/panel-lab/variants/panel-b.tsx
@@ -1,9 +1,11 @@
 "use client"
 
-/* The drill-in panel — the chosen frame (Aug 2026). Two index sections only —
-   Foundations, then Components (Templates planned). Each category fuses its
-   rows into one ControlGroup card — the grouped-list look: label over its
-   muted value on the left, a state-driven micro-preview on the right.
+/* The drill-in panel — the chosen frame (Aug 2026). The index is a run of
+   UNTITLED family clusters — each fuses its rows into one ControlGroup card,
+   and the gaps alone carry the structure (the iOS-Settings grouped look):
+   label over its muted value on the left, a state-driven micro-preview on the
+   right. Weight survives as ordering — identity first. (Per-cluster row
+   heights were tried and reverted — uniform h-16 keeps the scan rhythm.)
    Tapping a row swaps panes INSTANTLY — the Raycast/Linear/cmdk school:
    this navigation fires constantly, and the Aug 2026 animation research
    found instant to be the most common choice among high-frequency tools.
@@ -124,20 +126,17 @@ export function PanelB({ chapters, lab }: { chapters: Chapter[]; lab: Lab }) {
           className={cn(PANE, "gap-5", active && PANE_HIDDEN)}
           aria-hidden={!!active}
         >
-          {index.map((group) => (
-            <section key={group.label} className="flex flex-col gap-1.5">
-              <GroupTitle>{group.label}</GroupTitle>
-              <ControlGroup>
-                {group.chapters.map((chapter) => (
-                  <IndexRow
-                    key={chapter.id}
-                    chapter={chapter}
-                    lab={lab}
-                    onPress={() => setActiveId(chapter.id)}
-                  />
-                ))}
-              </ControlGroup>
-            </section>
+          {index.map((group, i) => (
+            <ControlGroup key={i}>
+              {group.chapters.map((chapter) => (
+                <IndexRow
+                  key={chapter.id}
+                  chapter={chapter}
+                  lab={lab}
+                  onPress={() => setActiveId(chapter.id)}
+                />
+              ))}
+            </ControlGroup>
           ))}
         </div>
 


### PR DESCRIPTION
## What changed

Reworks the panel-lab drill-in index (`/internal/panel-lab`) per Mehdi's direction:

- **Section titles removed** — the index is now a run of untitled `ControlGroup` cards; gaps alone carry the structure (the iOS-Settings grouped look). `GroupTitle` still opens member subsections inside chapter pages.
- **Focus demoted out of the identity cluster** — it now sits in a lesser-weight cluster with Icons, Motion, and Interaction (the set-once foundations). This amends the spec's Identity 8 in practice; the spec doc itself is untouched pending validation.
- **Components reordered into family clusters** — the former 26-row Components section is split into Buttons+Inputs, Forms, Overlays, Navigation, Feedback, and Display cards, following the spec's family grouping; `kbd` sinks to the display tail.

`SECTIONS` (labeled) becomes `GROUPS` (unlabeled) in `variants/groups.ts`; `panel-b.tsx` drops the index `GroupTitle` rendering. Rows stay uniform h-16 — a per-cluster hero-row tier was tried in this session and reverted.

## Why

Focus was carrying the same visual weight as Color; two titled sections (9 + 26 rows) hid the family structure inside Components. Grouping by family with weight expressed as ordering keeps identity first without extra chrome. Judged against a three-lens agent review (IA, visual design, product pragmatism) — this lands Mehdi's variant; the review's dissent (keep quiet titles, two-tier rows) is documented in the session for later comparison.

## Reviewer notes

- Prototype-only surface — no registry or publisher changes, so no `__generated__` churn.
- Verified live: clusters render, drill-in navigation works, `pnpm check` + `typecheck` pass.
- Watch-item for validation: with 8 unlabeled cards, family boundaries are only discoverable by reading rows (the spec's Tooltip test). The clusters are already in place to take quiet labels back if lostness shows up.