### PR TITLE
feat(registry): add chat primitives

### DIFF
--- a/www/content/docs/components/chat.mdx
+++ b/www/content/docs/components/chat.mdx
@@ -1,0 +1,118 @@
+---
+title: Chat
+description: Primitives for building a chat interface — a message list, message bubbles, and a composer.
+wip: true
+---
+
+<Demo name="chat/demos/chat" />
+
+## Installation
+
+```npm
+npx shadcn@latest add @dotui/chat
+```
+
+## Usage
+
+```tsx
+import { Conversation, Message, MessageContent } from "@/ui/chat"
+```
+
+```tsx
+<Conversation>
+  <Message role="user">
+    <MessageContent>How do I center a div?</MessageContent>
+  </Message>
+  <Message role="assistant">
+    <MessageContent>Give the parent `place-items: center`.</MessageContent>
+  </Message>
+</Conversation>
+```
+
+## Anatomy
+
+`Conversation` is the scroll container for the message list. Each `Message` sets
+the role its children style against: `user` renders `MessageContent` as a
+contained bubble aligned to the end of the row, `assistant` renders it plain and
+full-width. `MessageAvatar` is optional and sits on the sender's side of the row.
+
+```tsx
+import { Conversation, Message, MessageAvatar, MessageContent } from "@/ui/chat"
+```
+
+```tsx
+<Conversation>
+  <Message role="assistant">
+    <MessageAvatar name="AI" />
+    <MessageContent>{/* message body */}</MessageContent>
+  </Message>
+</Conversation>
+```
+
+`PromptInput` is the composer. It renders a form, so `PromptInputSubmit` — or
+pressing Enter in the textarea — submits it; Shift+Enter inserts a newline. The
+textarea grows with its content.
+
+```tsx
+import {
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+} from "@/ui/chat"
+```
+
+```tsx
+<PromptInput onSubmit={handleSubmit}>
+  <PromptInputTextarea placeholder="Ask anything…" aria-label="Message" />
+  <PromptInputToolbar>
+    {/* attachments, tools… */}
+    <PromptInputSubmit isIconOnly aria-label="Send message">
+      <ArrowUpIcon />
+    </PromptInputSubmit>
+  </PromptInputToolbar>
+</PromptInput>
+```
+
+## Examples
+
+<Examples className="md:grid-cols-2">
+  <Example name="chat/demos/basic" title="Conversation" />
+  <Example name="chat/demos/with-avatars" title="With Avatars" />
+  <Example name="chat/demos/prompt-input" title="Prompt Input" />
+  <Example name="chat/demos/with-toolbar" title="With Toolbar" />
+</Examples>
+
+## API Reference
+
+### Conversation
+
+<Reference name="conversation" />
+
+### Message
+
+<Reference name="message" />
+
+### MessageContent
+
+<Reference name="message-content" />
+
+### MessageAvatar
+
+<Reference name="message-avatar" />
+
+### PromptInput
+
+<Reference name="prompt-input" />
+
+### PromptInputTextarea
+
+<Reference name="prompt-input-textarea" />
+
+### PromptInputToolbar
+
+<Reference name="prompt-input-toolbar" />
+
+### PromptInputSubmit
+
+<Reference name="prompt-input-submit" />

--- a/www/content/docs/components/chat.mdx
+++ b/www/content/docs/components/chat.mdx
@@ -24,7 +24,7 @@ import { Conversation, Message, MessageContent } from "@/ui/chat"
     <MessageContent>How do I center a div?</MessageContent>
   </Message>
   <Message role="assistant">
-    <MessageContent>Give the parent `place-items: center`.</MessageContent>
+    <MessageContent>Center it with place-items.</MessageContent>
   </Message>
 </Conversation>
 ```
@@ -51,7 +51,8 @@ import { Conversation, Message, MessageAvatar, MessageContent } from "@/ui/chat"
 
 `PromptInput` is the composer. It renders a form, so `PromptInputSubmit` — or
 pressing Enter in the textarea — submits it; Shift+Enter inserts a newline. The
-textarea grows with its content.
+textarea grows with its content, and the shell is the same input group the rest
+of your fields use, so it follows their style, radius and density.
 
 ```tsx
 import {
@@ -77,7 +78,7 @@ import {
 ## Examples
 
 <Examples className="md:grid-cols-2">
-  <Example name="chat/demos/basic" title="Conversation" />
+  <Example name="chat/demos/basic" title="Basic" />
   <Example name="chat/demos/with-avatars" title="With Avatars" />
   <Example name="chat/demos/prompt-input" title="Prompt Input" />
   <Example name="chat/demos/with-toolbar" title="With Toolbar" />

--- a/www/src/modules/create/__generated__/examples.tsx
+++ b/www/src/modules/create/__generated__/examples.tsx
@@ -16,6 +16,7 @@ export const ExamplesIndex: Record<string, () => Promise<{ default: React.Compon
 	"chart-pie": () => import("@/registry/ui/chart-pie/examples"),
 	"chart-radar": () => import("@/registry/ui/chart-radar/examples"),
 	"chart-radial": () => import("@/registry/ui/chart-radial/examples"),
+	chat: () => import("@/registry/ui/chat/examples"),
 	checkbox: () => import("@/registry/ui/checkbox/examples"),
 	"checkbox-group": () => import("@/registry/ui/checkbox-group/examples"),
 	"color-area": () => import("@/registry/ui/color-area/examples"),

--- a/www/src/modules/docs/components-list/components-data.ts
+++ b/www/src/modules/docs/components-list/components-data.ts
@@ -407,6 +407,13 @@ export const componentsData: ComponentCategory[] = [
         status: "done",
       },
       {
+        name: "Chat",
+        slug: "chat",
+        href: "/docs/components/chat",
+        scale: 0.8,
+        status: "in review",
+      },
+      {
         name: "QRCode",
         slug: "qr-code",
         href: "/docs/components/qr-code",

--- a/www/src/modules/docs/components-list/demos/chat.tsx
+++ b/www/src/modules/docs/components-list/demos/chat.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { ArrowUpIcon } from "@/registry/__generated__/icons"
+import {
+  Conversation,
+  Message,
+  MessageContent,
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+} from "@/registry/ui/chat"
+
+export function ChatDemo() {
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-3">
+      <Conversation className="p-0">
+        <Message role="user">
+          <MessageContent>What is dotUI?</MessageContent>
+        </Message>
+        <Message role="assistant">
+          <MessageContent>
+            A design-system builder — compose it, preview it live, export the
+            code you own.
+          </MessageContent>
+        </Message>
+      </Conversation>
+      <PromptInput
+        onSubmit={(e) => {
+          e.preventDefault()
+        }}
+      >
+        <PromptInputTextarea placeholder="Ask anything…" aria-label="Message" />
+        <PromptInputToolbar className="justify-end">
+          <PromptInputSubmit isIconOnly aria-label="Send message">
+            <ArrowUpIcon />
+          </PromptInputSubmit>
+        </PromptInputToolbar>
+      </PromptInput>
+    </div>
+  )
+}

--- a/www/src/modules/docs/components-list/demos/chat.tsx
+++ b/www/src/modules/docs/components-list/demos/chat.tsx
@@ -31,7 +31,7 @@ export function ChatDemo() {
         }}
       >
         <PromptInputTextarea placeholder="Ask anything…" aria-label="Message" />
-        <PromptInputToolbar className="justify-end">
+        <PromptInputToolbar>
           <PromptInputSubmit isIconOnly aria-label="Send message">
             <ArrowUpIcon />
           </PromptInputSubmit>

--- a/www/src/modules/docs/components-list/demos/index.ts
+++ b/www/src/modules/docs/components-list/demos/index.ts
@@ -14,6 +14,7 @@ import { ChartLineDemo } from "./chart-line"
 import { ChartPieDemo } from "./chart-pie"
 import { ChartRadarDemo } from "./chart-radar"
 import { ChartRadialDemo } from "./chart-radial"
+import { ChatDemo } from "./chat"
 import { CheckboxDemo } from "./checkbox"
 import { CheckboxGroupDemo } from "./checkbox-group"
 import { ColorAreaDemo } from "./color-area"
@@ -82,6 +83,7 @@ export const componentDemos: Record<string, ComponentType> = {
   "chart-pie": ChartPieDemo,
   "chart-radar": ChartRadarDemo,
   "chart-radial": ChartRadialDemo,
+  chat: ChatDemo,
   checkbox: CheckboxDemo,
   "checkbox-group": CheckboxGroupDemo,
   "color-area": ColorAreaDemo,

--- a/www/src/modules/docs/references/generated/conversation.json
+++ b/www/src/modules/docs/references/generated/conversation.json
@@ -1,0 +1,14 @@
+{
+  "name": "ConversationProps",
+  "description": "A scrollable list of chat messages.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/message-avatar.json
+++ b/www/src/modules/docs/references/generated/message-avatar.json
@@ -1,0 +1,53 @@
+{
+  "name": "MessageAvatarProps",
+  "description": "The avatar of the message sender.",
+  "extendsElement": "span",
+  "props": {
+    "size": {
+      "type": "\"lg\" | \"md\" | \"sm\"",
+      "detailedType": "'lg' | 'md' | 'sm' | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "lg"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "md"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "sm"
+          }
+        ]
+      },
+      "description": "The size of the avatar.",
+      "default": "'sm'"
+    },
+    "src": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Image source for the sender's avatar."
+    },
+    "name": {
+      "type": "string",
+      "detailedType": "string | undefined",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "Sender name, used as the image alt text and as the fallback initials."
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/message-content.json
+++ b/www/src/modules/docs/references/generated/message-content.json
@@ -1,0 +1,14 @@
+{
+  "name": "MessageContentProps",
+  "description": "The body of a message — text, or any rich content the message carries.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/message.json
+++ b/www/src/modules/docs/references/generated/message.json
@@ -1,0 +1,33 @@
+{
+  "name": "MessageProps",
+  "description": "A single turn in a conversation. Lays out the avatar and the content, and\nexposes the role its children style against.",
+  "extendsElement": "div",
+  "props": {
+    "role": {
+      "type": "\"assistant\" | \"user\"",
+      "detailedType": "'assistant' | 'user' | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "assistant"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "user"
+          }
+        ]
+      },
+      "description": "Who sent the message. `user` renders a contained bubble aligned to the end\nof the row, `assistant` renders plain full-width content.",
+      "default": "'assistant'"
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/prompt-input-submit.json
+++ b/www/src/modules/docs/references/generated/prompt-input-submit.json
@@ -1,0 +1,76 @@
+{
+  "name": "PromptInputSubmitProps",
+  "description": "The button that submits the composer.",
+  "extendsElement": "button",
+  "props": {
+    "variant": {
+      "type": "\"danger\" | \"link\" | \"primary\" | \"quiet\" | \"secondary\" | \"warning\"",
+      "detailedType": "| 'danger'\n| 'link'\n| 'primary'\n| 'quiet'\n| 'secondary'\n| 'warning'\n| undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "danger"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "link"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "primary"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "quiet"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "secondary"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "warning"
+          }
+        ]
+      },
+      "description": "The visual style of the button.",
+      "default": "'primary'"
+    },
+    "size": {
+      "type": "\"lg\" | \"md\" | \"sm\" | \"xs\"",
+      "detailedType": "'lg' | 'md' | 'sm' | 'xs' | undefined",
+      "typeAst": {
+        "type": "union",
+        "elements": [
+          {
+            "type": "stringLiteral",
+            "value": "lg"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "md"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "sm"
+          },
+          {
+            "type": "stringLiteral",
+            "value": "xs"
+          }
+        ]
+      },
+      "description": "The size of the button.",
+      "default": "'md'"
+    },
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/prompt-input-textarea.json
+++ b/www/src/modules/docs/references/generated/prompt-input-textarea.json
@@ -1,0 +1,14 @@
+{
+  "name": "PromptInputTextareaProps",
+  "description": "The auto-growing textarea of the composer. Enter submits the surrounding\nform, Shift+Enter inserts a newline.",
+  "extendsElement": "textarea",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/prompt-input-toolbar.json
+++ b/www/src/modules/docs/references/generated/prompt-input-toolbar.json
@@ -1,0 +1,14 @@
+{
+  "name": "PromptInputToolbarProps",
+  "description": "The row of actions below the textarea, such as attachments or the submit\nbutton.",
+  "extendsElement": "div",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/modules/docs/references/generated/prompt-input.json
+++ b/www/src/modules/docs/references/generated/prompt-input.json
@@ -1,0 +1,14 @@
+{
+  "name": "PromptInputProps",
+  "description": "The composer users type their message into. Renders a form, so a submit\nbutton — or pressing Enter in the textarea — submits it.",
+  "extendsElement": "form",
+  "props": {
+    "className": {
+      "type": "string",
+      "typeAst": {
+        "type": "string"
+      },
+      "description": "The CSS [className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className) for the element."
+    }
+  }
+}

--- a/www/src/registry/__generated__/demos.tsx
+++ b/www/src/registry/__generated__/demos.tsx
@@ -545,6 +545,26 @@ export const DemosIndex: Record<
 		files: ["ui/chart-radial/demos/text.tsx"],
 		component: React.lazy(() => import("@/registry/ui/chart-radial/demos/text")),
 	},
+	"chat/demos/basic": {
+		files: ["ui/chat/demos/basic.tsx"],
+		component: React.lazy(() => import("@/registry/ui/chat/demos/basic")),
+	},
+	"chat/demos/chat": {
+		files: ["ui/chat/demos/chat.tsx"],
+		component: React.lazy(() => import("@/registry/ui/chat/demos/chat")),
+	},
+	"chat/demos/prompt-input": {
+		files: ["ui/chat/demos/prompt-input.tsx"],
+		component: React.lazy(() => import("@/registry/ui/chat/demos/prompt-input")),
+	},
+	"chat/demos/with-avatars": {
+		files: ["ui/chat/demos/with-avatars.tsx"],
+		component: React.lazy(() => import("@/registry/ui/chat/demos/with-avatars")),
+	},
+	"chat/demos/with-toolbar": {
+		files: ["ui/chat/demos/with-toolbar.tsx"],
+		component: React.lazy(() => import("@/registry/ui/chat/demos/with-toolbar")),
+	},
 	"checkbox/demos/basic": {
 		files: ["ui/checkbox/demos/basic.tsx"],
 		component: React.lazy(() => import("@/registry/ui/checkbox/demos/basic")),

--- a/www/src/registry/__generated__/registry-items.ts
+++ b/www/src/registry/__generated__/registry-items.ts
@@ -22,6 +22,7 @@ import UiChartPie from "@/registry/ui/chart-pie/meta";
 import UiChartRadar from "@/registry/ui/chart-radar/meta";
 import UiChartRadial from "@/registry/ui/chart-radial/meta";
 import UiChart from "@/registry/ui/chart/meta";
+import UiChat from "@/registry/ui/chat/meta";
 import UiCheckboxGroup from "@/registry/ui/checkbox-group/meta";
 import UiCheckbox from "@/registry/ui/checkbox/meta";
 import UiColorArea from "@/registry/ui/color-area/meta";
@@ -100,6 +101,7 @@ export const registryUi: RegistryItem[] = [
 	UiChartPie,
 	UiChartRadar,
 	UiChartRadial,
+	UiChat,
 	UiCheckbox,
 	UiCheckboxGroup,
 	UiColorArea,

--- a/www/src/registry/__generated__/style-var-defaults.ts
+++ b/www/src/registry/__generated__/style-var-defaults.ts
@@ -12,7 +12,6 @@ export const STYLE_VAR_DEFAULTS: Record<string, string> = {
 	"--calendar-cell-size": "--spacing(8)",
 	"--calendar-range-radius": "var(--radius-xs)",
 	"--card-radius": "var(--radius-panel)",
-	"--chat-input-radius": "var(--radius-panel)",
 	"--chat-message-radius": "var(--radius-surface)",
 	"--checkbox-card-radius": "var(--radius-surface)",
 	"--checkbox-radius": "var(--radius-sm)",

--- a/www/src/registry/__generated__/style-var-defaults.ts
+++ b/www/src/registry/__generated__/style-var-defaults.ts
@@ -12,6 +12,8 @@ export const STYLE_VAR_DEFAULTS: Record<string, string> = {
 	"--calendar-cell-size": "--spacing(8)",
 	"--calendar-range-radius": "var(--radius-xs)",
 	"--card-radius": "var(--radius-panel)",
+	"--chat-input-radius": "var(--radius-panel)",
+	"--chat-message-radius": "var(--radius-surface)",
 	"--checkbox-card-radius": "var(--radius-surface)",
 	"--checkbox-radius": "var(--radius-sm)",
 	"--color-area-radius": "var(--radius-md)",

--- a/www/src/registry/styles.css
+++ b/www/src/registry/styles.css
@@ -10,6 +10,7 @@
 @import "./ui/button/styles.css";
 @import "./ui/calendar/styles.css";
 @import "./ui/card/styles.css";
+@import "./ui/chat/styles.css";
 @import "./ui/checkbox/styles.css";
 @import "./ui/color-area/styles.css";
 @import "./ui/color-swatch-picker/styles.css";

--- a/www/src/registry/ui/chat/base.tsx
+++ b/www/src/registry/ui/chat/base.tsx
@@ -5,13 +5,13 @@ import { composeRenderProps } from "react-aria-components/composeRenderProps"
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/registry/ui/avatar"
 import { Button } from "@/registry/ui/button"
-import { TextArea } from "@/registry/ui/input"
+import { InputGroup, InputGroupAddon, TextArea } from "@/registry/ui/input"
 
 import { useStyles } from "./styles"
 
 // MARK: chatStyles
 
-// MARK: Conversation
+// MARK: Separator
 
 interface ConversationProps extends React.ComponentProps<"div"> {}
 
@@ -27,7 +27,7 @@ const Conversation = ({ className, ...props }: ConversationProps) => {
   )
 }
 
-// MARK: Message
+// MARK: Separator
 
 interface MessageProps extends Omit<React.ComponentProps<"div">, "role"> {
   role?: "user" | "assistant"
@@ -45,7 +45,7 @@ const Message = ({ className, role = "assistant", ...props }: MessageProps) => {
   )
 }
 
-// MARK: MessageContent
+// MARK: Separator
 
 interface MessageContentProps extends React.ComponentProps<"div"> {}
 
@@ -60,7 +60,7 @@ const MessageContent = ({ className, ...props }: MessageContentProps) => {
   )
 }
 
-// MARK: MessageAvatar
+// MARK: Separator
 
 interface MessageAvatarProps extends React.ComponentProps<typeof Avatar> {
   src?: string
@@ -92,22 +92,24 @@ const MessageAvatar = ({
   )
 }
 
-// MARK: PromptInput
+// MARK: Separator
 
 interface PromptInputProps extends React.ComponentProps<"form"> {}
 
-const PromptInput = ({ className, ...props }: PromptInputProps) => {
+const PromptInput = ({ className, children, ...props }: PromptInputProps) => {
   const { promptInput } = useStyles()()
   return (
     <form
       data-prompt-input=""
       className={promptInput({ className })}
       {...props}
-    />
+    >
+      <InputGroup>{children}</InputGroup>
+    </form>
   )
 }
 
-// MARK: PromptInputTextarea
+// MARK: Separator
 
 interface PromptInputTextareaProps extends React.ComponentProps<
   typeof TextArea
@@ -142,7 +144,7 @@ const PromptInputTextarea = ({
   )
 }
 
-// MARK: PromptInputToolbar
+// MARK: Separator
 
 interface PromptInputToolbarProps extends React.ComponentProps<"div"> {}
 
@@ -152,7 +154,7 @@ const PromptInputToolbar = ({
 }: PromptInputToolbarProps) => {
   const { promptInputToolbar } = useStyles()()
   return (
-    <div
+    <InputGroupAddon
       data-prompt-input-toolbar=""
       className={promptInputToolbar({ className })}
       {...props}
@@ -160,7 +162,7 @@ const PromptInputToolbar = ({
   )
 }
 
-// MARK: PromptInputSubmit
+// MARK: Separator
 
 interface PromptInputSubmitProps extends React.ComponentProps<typeof Button> {}
 

--- a/www/src/registry/ui/chat/base.tsx
+++ b/www/src/registry/ui/chat/base.tsx
@@ -1,0 +1,207 @@
+"use client"
+
+import type * as React from "react"
+import { composeRenderProps } from "react-aria-components/composeRenderProps"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/registry/ui/avatar"
+import { Button } from "@/registry/ui/button"
+import { TextArea } from "@/registry/ui/input"
+
+import { useStyles } from "./styles"
+
+// MARK: chatStyles
+
+// MARK: Conversation
+
+interface ConversationProps extends React.ComponentProps<"div"> {}
+
+const Conversation = ({ className, ...props }: ConversationProps) => {
+  const { conversation } = useStyles()()
+  return (
+    <div
+      data-conversation=""
+      role="log"
+      className={conversation({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: Message
+
+interface MessageProps extends Omit<React.ComponentProps<"div">, "role"> {
+  role?: "user" | "assistant"
+}
+
+const Message = ({ className, role = "assistant", ...props }: MessageProps) => {
+  const { message } = useStyles()()
+  return (
+    <div
+      data-message=""
+      data-role={role}
+      className={message({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: MessageContent
+
+interface MessageContentProps extends React.ComponentProps<"div"> {}
+
+const MessageContent = ({ className, ...props }: MessageContentProps) => {
+  const { messageContent } = useStyles()()
+  return (
+    <div
+      data-message-content=""
+      className={messageContent({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: MessageAvatar
+
+interface MessageAvatarProps extends React.ComponentProps<typeof Avatar> {
+  src?: string
+  name?: string
+}
+
+const MessageAvatar = ({
+  className,
+  children,
+  src,
+  name,
+  ...props
+}: MessageAvatarProps) => {
+  const { messageAvatar } = useStyles()()
+  return (
+    <Avatar
+      data-message-avatar=""
+      size="sm"
+      className={messageAvatar({ className })}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <AvatarImage src={src} alt={name} />
+          <AvatarFallback>{name?.slice(0, 2).toUpperCase()}</AvatarFallback>
+        </>
+      )}
+    </Avatar>
+  )
+}
+
+// MARK: PromptInput
+
+interface PromptInputProps extends React.ComponentProps<"form"> {}
+
+const PromptInput = ({ className, ...props }: PromptInputProps) => {
+  const { promptInput } = useStyles()()
+  return (
+    <form
+      data-prompt-input=""
+      className={promptInput({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: PromptInputTextarea
+
+interface PromptInputTextareaProps extends React.ComponentProps<
+  typeof TextArea
+> {}
+
+const PromptInputTextarea = ({
+  className,
+  onKeyDown,
+  ...props
+}: PromptInputTextareaProps) => {
+  const { promptInputTextarea } = useStyles()()
+  return (
+    <TextArea
+      data-prompt-input-textarea=""
+      onKeyDown={(e) => {
+        onKeyDown?.(e)
+        if (
+          e.defaultPrevented ||
+          e.key !== "Enter" ||
+          e.shiftKey ||
+          e.nativeEvent.isComposing
+        )
+          return
+        e.preventDefault()
+        e.currentTarget.form?.requestSubmit()
+      }}
+      className={composeRenderProps(className, (className) =>
+        promptInputTextarea({ className }),
+      )}
+      {...props}
+    />
+  )
+}
+
+// MARK: PromptInputToolbar
+
+interface PromptInputToolbarProps extends React.ComponentProps<"div"> {}
+
+const PromptInputToolbar = ({
+  className,
+  ...props
+}: PromptInputToolbarProps) => {
+  const { promptInputToolbar } = useStyles()()
+  return (
+    <div
+      data-prompt-input-toolbar=""
+      className={promptInputToolbar({ className })}
+      {...props}
+    />
+  )
+}
+
+// MARK: PromptInputSubmit
+
+interface PromptInputSubmitProps extends React.ComponentProps<typeof Button> {}
+
+const PromptInputSubmit = ({
+  className,
+  variant = "primary",
+  ...props
+}: PromptInputSubmitProps) => {
+  const { promptInputSubmit } = useStyles()()
+  return (
+    <Button
+      data-prompt-input-submit=""
+      type="submit"
+      variant={variant}
+      className={composeRenderProps(className, (className) =>
+        promptInputSubmit({ className }),
+      )}
+      {...props}
+    />
+  )
+}
+
+// MARK: Separator
+
+export type {
+  ConversationProps,
+  MessageAvatarProps,
+  MessageContentProps,
+  MessageProps,
+  PromptInputProps,
+  PromptInputSubmitProps,
+  PromptInputTextareaProps,
+  PromptInputToolbarProps,
+}
+export {
+  Conversation,
+  Message,
+  MessageAvatar,
+  MessageContent,
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+}

--- a/www/src/registry/ui/chat/demos/basic.tsx
+++ b/www/src/registry/ui/chat/demos/basic.tsx
@@ -10,7 +10,7 @@ export default function Demo() {
       </Message>
       <Message role="assistant">
         <MessageContent>
-          Give the parent `display: grid` and `place-items: center`. Two lines,
+          Give the parent a grid display and center its place-items. Two lines,
           no margins to guess at.
         </MessageContent>
       </Message>
@@ -21,8 +21,8 @@ export default function Demo() {
       </Message>
       <Message role="assistant">
         <MessageContent>
-          Then `justify-content: center` and `align-items: center` do the same
-          job along the two axes.
+          Then centering justify-content and align-items does the same job along
+          the two axes.
         </MessageContent>
       </Message>
     </Conversation>

--- a/www/src/registry/ui/chat/demos/basic.tsx
+++ b/www/src/registry/ui/chat/demos/basic.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { Conversation, Message, MessageContent } from "@/registry/ui/chat"
+
+export default function Demo() {
+  return (
+    <Conversation className="max-h-72 w-full max-w-md">
+      <Message role="user">
+        <MessageContent>How do I center a div?</MessageContent>
+      </Message>
+      <Message role="assistant">
+        <MessageContent>
+          Give the parent `display: grid` and `place-items: center`. Two lines,
+          no margins to guess at.
+        </MessageContent>
+      </Message>
+      <Message role="user">
+        <MessageContent>
+          And if the parent is already a flex row?
+        </MessageContent>
+      </Message>
+      <Message role="assistant">
+        <MessageContent>
+          Then `justify-content: center` and `align-items: center` do the same
+          job along the two axes.
+        </MessageContent>
+      </Message>
+    </Conversation>
+  )
+}

--- a/www/src/registry/ui/chat/demos/chat.tsx
+++ b/www/src/registry/ui/chat/demos/chat.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import React from "react"
+
+import { ArrowUpIcon } from "@/registry/__generated__/icons"
+import {
+  Conversation,
+  Message,
+  MessageContent,
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+} from "@/registry/ui/chat"
+
+const initialMessages = [
+  { id: 1, role: "user" as const, text: "What is dotUI?" },
+  {
+    id: 2,
+    role: "assistant" as const,
+    text: "A design-system builder: compose colors, typography and per-component styles, preview them live, then export the code you own.",
+  },
+]
+
+export default function Demo() {
+  const [messages, setMessages] = React.useState(initialMessages)
+  const [draft, setDraft] = React.useState("")
+
+  return (
+    <div className="flex h-80 w-full max-w-md flex-col gap-3">
+      <Conversation className="rounded-(--chat-input-radius) border border-border-muted">
+        {messages.map((message) => (
+          <Message key={message.id} role={message.role}>
+            <MessageContent>{message.text}</MessageContent>
+          </Message>
+        ))}
+      </Conversation>
+      <PromptInput
+        onSubmit={(e) => {
+          e.preventDefault()
+          if (!draft.trim()) return
+          setMessages((current) => [
+            ...current,
+            { id: current.length + 1, role: "user" as const, text: draft },
+          ])
+          setDraft("")
+        }}
+      >
+        <PromptInputTextarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Ask anything…"
+          aria-label="Message"
+        />
+        <PromptInputToolbar className="justify-end">
+          <PromptInputSubmit isIconOnly aria-label="Send message">
+            <ArrowUpIcon />
+          </PromptInputSubmit>
+        </PromptInputToolbar>
+      </PromptInput>
+    </div>
+  )
+}

--- a/www/src/registry/ui/chat/demos/chat.tsx
+++ b/www/src/registry/ui/chat/demos/chat.tsx
@@ -28,7 +28,7 @@ export default function Demo() {
 
   return (
     <div className="flex h-80 w-full max-w-md flex-col gap-3">
-      <Conversation className="rounded-(--chat-input-radius) border border-border-muted">
+      <Conversation className="rounded-(--radius-panel) border border-border-muted">
         {messages.map((message) => (
           <Message key={message.id} role={message.role}>
             <MessageContent>{message.text}</MessageContent>
@@ -52,7 +52,7 @@ export default function Demo() {
           placeholder="Ask anything…"
           aria-label="Message"
         />
-        <PromptInputToolbar className="justify-end">
+        <PromptInputToolbar>
           <PromptInputSubmit isIconOnly aria-label="Send message">
             <ArrowUpIcon />
           </PromptInputSubmit>

--- a/www/src/registry/ui/chat/demos/prompt-input.tsx
+++ b/www/src/registry/ui/chat/demos/prompt-input.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { ArrowUpIcon } from "@/registry/__generated__/icons"
+import {
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+} from "@/registry/ui/chat"
+
+export default function Demo() {
+  return (
+    <PromptInput
+      className="w-full max-w-md"
+      onSubmit={(e) => {
+        e.preventDefault()
+      }}
+    >
+      <PromptInputTextarea placeholder="Ask anything…" aria-label="Message" />
+      <PromptInputToolbar className="justify-end">
+        <PromptInputSubmit isIconOnly aria-label="Send message">
+          <ArrowUpIcon />
+        </PromptInputSubmit>
+      </PromptInputToolbar>
+    </PromptInput>
+  )
+}

--- a/www/src/registry/ui/chat/demos/prompt-input.tsx
+++ b/www/src/registry/ui/chat/demos/prompt-input.tsx
@@ -17,7 +17,7 @@ export default function Demo() {
       }}
     >
       <PromptInputTextarea placeholder="Ask anything…" aria-label="Message" />
-      <PromptInputToolbar className="justify-end">
+      <PromptInputToolbar>
         <PromptInputSubmit isIconOnly aria-label="Send message">
           <ArrowUpIcon />
         </PromptInputSubmit>

--- a/www/src/registry/ui/chat/demos/with-avatars.tsx
+++ b/www/src/registry/ui/chat/demos/with-avatars.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import {
+  Conversation,
+  Message,
+  MessageAvatar,
+  MessageContent,
+} from "@/registry/ui/chat"
+
+export default function Demo() {
+  return (
+    <Conversation className="max-h-72 w-full max-w-md">
+      <Message role="user">
+        <MessageAvatar name="Mehdi" />
+        <MessageContent>Can you summarize the release notes?</MessageContent>
+      </Message>
+      <Message role="assistant">
+        <MessageAvatar name="AI" />
+        <MessageContent>
+          Three things shipped: a faster registry build, per-component radius
+          roles, and dark-mode fixes for charts.
+        </MessageContent>
+      </Message>
+    </Conversation>
+  )
+}

--- a/www/src/registry/ui/chat/demos/with-toolbar.tsx
+++ b/www/src/registry/ui/chat/demos/with-toolbar.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import {
+  ArrowUpIcon,
+  GlobeIcon,
+  PaperclipIcon,
+} from "@/registry/__generated__/icons"
+import { Button } from "@/registry/ui/button"
+import {
+  PromptInput,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+} from "@/registry/ui/chat"
+
+export default function Demo() {
+  return (
+    <PromptInput
+      className="w-full max-w-md"
+      onSubmit={(e) => {
+        e.preventDefault()
+      }}
+    >
+      <PromptInputTextarea placeholder="Ask anything…" aria-label="Message" />
+      <PromptInputToolbar>
+        <div className="flex items-center gap-1">
+          <Button variant="quiet" isIconOnly aria-label="Attach a file">
+            <PaperclipIcon />
+          </Button>
+          <Button variant="quiet" isIconOnly aria-label="Search the web">
+            <GlobeIcon />
+          </Button>
+        </div>
+        <PromptInputSubmit isIconOnly aria-label="Send message">
+          <ArrowUpIcon />
+        </PromptInputSubmit>
+      </PromptInputToolbar>
+    </PromptInput>
+  )
+}

--- a/www/src/registry/ui/chat/examples.tsx
+++ b/www/src/registry/ui/chat/examples.tsx
@@ -10,7 +10,7 @@ import WithToolbar from "./demos/with-toolbar"
 export default function ChatExamples() {
   return (
     <Examples>
-      <Example title="Conversation">
+      <Example title="Basic">
         <Basic />
       </Example>
       <Example title="With avatars">

--- a/www/src/registry/ui/chat/examples.tsx
+++ b/www/src/registry/ui/chat/examples.tsx
@@ -1,0 +1,30 @@
+import { Example } from "@/modules/create/preview/example"
+import { Examples } from "@/modules/create/preview/examples"
+
+import Basic from "./demos/basic"
+import Chat from "./demos/chat"
+import PromptInputDemo from "./demos/prompt-input"
+import WithAvatars from "./demos/with-avatars"
+import WithToolbar from "./demos/with-toolbar"
+
+export default function ChatExamples() {
+  return (
+    <Examples>
+      <Example title="Conversation">
+        <Basic />
+      </Example>
+      <Example title="With avatars">
+        <WithAvatars />
+      </Example>
+      <Example title="Prompt input">
+        <PromptInputDemo />
+      </Example>
+      <Example title="With toolbar">
+        <WithToolbar />
+      </Example>
+      <Example title="Chat">
+        <Chat />
+      </Example>
+    </Examples>
+  )
+}

--- a/www/src/registry/ui/chat/index.tsx
+++ b/www/src/registry/ui/chat/index.tsx
@@ -1,0 +1,1 @@
+export * from "./base"

--- a/www/src/registry/ui/chat/meta.ts
+++ b/www/src/registry/ui/chat/meta.ts
@@ -1,0 +1,17 @@
+import type { RegistryItem } from "@/registry/types"
+
+const chatMeta = {
+  name: "chat",
+  type: "registry:ui",
+  group: "containers",
+  files: [
+    {
+      type: "registry:ui",
+      path: "ui/chat/base.tsx",
+      target: "ui/chat.tsx",
+    },
+  ],
+  registryDependencies: ["avatar", "button", "input"],
+} satisfies RegistryItem
+
+export default chatMeta

--- a/www/src/registry/ui/chat/styles.css
+++ b/www/src/registry/ui/chat/styles.css
@@ -1,0 +1,4 @@
+:root {
+  --chat-message-radius: var(--radius-surface);
+  --chat-input-radius: var(--radius-panel);
+}

--- a/www/src/registry/ui/chat/styles.css
+++ b/www/src/registry/ui/chat/styles.css
@@ -1,4 +1,3 @@
 :root {
   --chat-message-radius: var(--radius-surface);
-  --chat-input-radius: var(--radius-panel);
 }

--- a/www/src/registry/ui/chat/styles.ts
+++ b/www/src/registry/ui/chat/styles.ts
@@ -15,16 +15,12 @@ const { useStyles, styles } = createStyles(chatMeta, {
         "group-data-[role=user]/message:max-w-[80%] group-data-[role=user]/message:rounded-(--chat-message-radius) group-data-[role=user]/message:bg-muted",
       ],
       messageAvatar: "shrink-0",
-      promptInput: [
-        "group/prompt-input flex w-full min-w-0 cursor-text flex-col rounded-(--chat-input-radius) border border-border-field bg-field",
-        "shadow-[var(--shadow-control,none)] transition-[box-shadow,border-color]",
-        "has-[[data-input-control][data-focused]]:border-border-focus has-[[data-input-control][data-focused]]:ring-2 has-[[data-input-control][data-focused]]:ring-border-focus-muted",
-        "has-[[data-input-control]:disabled]:border-border-disabled has-[[data-input-control]:disabled]:bg-disabled",
-      ],
-      promptInputTextarea:
-        "w-full rounded-none border-0 bg-transparent shadow-none focus:ring-0",
-      promptInputToolbar: "flex shrink-0 items-center justify-between",
-      promptInputSubmit: "shrink-0",
+      promptInput: "w-full min-w-0",
+      promptInputTextarea: "",
+      promptInputToolbar: "",
+      // The toolbar is an input-group addon, whose `justify-start` outranks a
+      // plain `justify-*` here — push the submit to the end instead.
+      promptInputSubmit: "ml-auto shrink-0",
     },
   },
   density: {
@@ -34,9 +30,7 @@ const { useStyles, styles } = createStyles(chatMeta, {
         message: "gap-2",
         messageContent:
           "gap-1.5 text-xs/relaxed group-data-[role=user]/message:px-2.5 group-data-[role=user]/message:py-1.5",
-        promptInput: "p-1.5",
-        promptInputTextarea: "min-h-12 px-2 py-1.5 text-xs/relaxed",
-        promptInputToolbar: "gap-1 px-0.5 pt-1",
+        promptInputTextarea: "min-h-12",
       },
     },
     default: {
@@ -45,9 +39,7 @@ const { useStyles, styles } = createStyles(chatMeta, {
         message: "gap-3",
         messageContent:
           "gap-2 text-sm group-data-[role=user]/message:px-3 group-data-[role=user]/message:py-2",
-        promptInput: "p-2",
-        promptInputTextarea: "min-h-16 px-2 py-1.5 text-sm",
-        promptInputToolbar: "gap-1.5 px-0.5 pt-1.5",
+        promptInputTextarea: "min-h-16",
       },
     },
     comfortable: {
@@ -56,9 +48,7 @@ const { useStyles, styles } = createStyles(chatMeta, {
         message: "gap-4",
         messageContent:
           "gap-2.5 text-sm group-data-[role=user]/message:px-4 group-data-[role=user]/message:py-2.5",
-        promptInput: "p-2.5",
-        promptInputTextarea: "min-h-20 px-2.5 py-2 text-sm",
-        promptInputToolbar: "gap-2 px-1 pt-2",
+        promptInputTextarea: "min-h-20",
       },
     },
   },

--- a/www/src/registry/ui/chat/styles.ts
+++ b/www/src/registry/ui/chat/styles.ts
@@ -1,0 +1,69 @@
+import { createStyles } from "@/lib/styles"
+
+import chatMeta from "./meta"
+
+const { useStyles, styles } = createStyles(chatMeta, {
+  base: {
+    slots: {
+      conversation:
+        "flex w-full min-w-0 flex-1 flex-col overflow-y-auto overscroll-contain",
+      message:
+        "group/message flex w-full min-w-0 items-start data-[role=user]:flex-row-reverse",
+      messageContent: [
+        "flex min-w-0 flex-col text-fg",
+        "group-data-[role=assistant]/message:w-full",
+        "group-data-[role=user]/message:max-w-[80%] group-data-[role=user]/message:rounded-(--chat-message-radius) group-data-[role=user]/message:bg-muted",
+      ],
+      messageAvatar: "shrink-0",
+      promptInput: [
+        "group/prompt-input flex w-full min-w-0 cursor-text flex-col rounded-(--chat-input-radius) border border-border-field bg-field",
+        "shadow-[var(--shadow-control,none)] transition-[box-shadow,border-color]",
+        "has-[[data-input-control][data-focused]]:border-border-focus has-[[data-input-control][data-focused]]:ring-2 has-[[data-input-control][data-focused]]:ring-border-focus-muted",
+        "has-[[data-input-control]:disabled]:border-border-disabled has-[[data-input-control]:disabled]:bg-disabled",
+      ],
+      promptInputTextarea:
+        "w-full rounded-none border-0 bg-transparent shadow-none focus:ring-0",
+      promptInputToolbar: "flex shrink-0 items-center justify-between",
+      promptInputSubmit: "shrink-0",
+    },
+  },
+  density: {
+    compact: {
+      slots: {
+        conversation: "gap-4 p-3 text-xs/relaxed",
+        message: "gap-2",
+        messageContent:
+          "gap-1.5 text-xs/relaxed group-data-[role=user]/message:px-2.5 group-data-[role=user]/message:py-1.5",
+        promptInput: "p-1.5",
+        promptInputTextarea: "min-h-12 px-2 py-1.5 text-xs/relaxed",
+        promptInputToolbar: "gap-1 px-0.5 pt-1",
+      },
+    },
+    default: {
+      slots: {
+        conversation: "gap-6 p-4 text-sm",
+        message: "gap-3",
+        messageContent:
+          "gap-2 text-sm group-data-[role=user]/message:px-3 group-data-[role=user]/message:py-2",
+        promptInput: "p-2",
+        promptInputTextarea: "min-h-16 px-2 py-1.5 text-sm",
+        promptInputToolbar: "gap-1.5 px-0.5 pt-1.5",
+      },
+    },
+    comfortable: {
+      slots: {
+        conversation: "gap-8 p-6 text-sm",
+        message: "gap-4",
+        messageContent:
+          "gap-2.5 text-sm group-data-[role=user]/message:px-4 group-data-[role=user]/message:py-2.5",
+        promptInput: "p-2.5",
+        promptInputTextarea: "min-h-20 px-2.5 py-2 text-sm",
+        promptInputToolbar: "gap-2 px-1 pt-2",
+      },
+    },
+  },
+})
+
+export type ChatStyles = typeof styles
+
+export { useStyles }

--- a/www/src/registry/ui/chat/types.ts
+++ b/www/src/registry/ui/chat/types.ts
@@ -1,0 +1,77 @@
+/**
+ * A scrollable list of chat messages.
+ */
+export interface ConversationProps extends React.ComponentProps<"div"> {}
+
+/**
+ * A single turn in a conversation. Lays out the avatar and the content, and
+ * exposes the role its children style against.
+ */
+export interface MessageProps extends Omit<
+  React.ComponentProps<"div">,
+  "role"
+> {
+  /**
+   * Who sent the message. `user` renders a contained bubble aligned to the end
+   * of the row, `assistant` renders plain full-width content.
+   * @default 'assistant'
+   */
+  role?: "user" | "assistant"
+}
+
+/**
+ * The body of a message — text, or any rich content the message carries.
+ */
+export interface MessageContentProps extends React.ComponentProps<"div"> {}
+
+/**
+ * The avatar of the message sender.
+ */
+export interface MessageAvatarProps extends React.ComponentProps<"span"> {
+  /**
+   * The size of the avatar.
+   * @default 'sm'
+   */
+  size?: "sm" | "md" | "lg"
+
+  /** Image source for the sender's avatar. */
+  src?: string
+
+  /** Sender name, used as the image alt text and as the fallback initials. */
+  name?: string
+}
+
+/**
+ * The composer users type their message into. Renders a form, so a submit
+ * button — or pressing Enter in the textarea — submits it.
+ */
+export interface PromptInputProps extends React.ComponentProps<"form"> {}
+
+/**
+ * The auto-growing textarea of the composer. Enter submits the surrounding
+ * form, Shift+Enter inserts a newline.
+ */
+export interface PromptInputTextareaProps extends React.ComponentProps<"textarea"> {}
+
+/**
+ * The row of actions below the textarea, such as attachments or the submit
+ * button.
+ */
+export interface PromptInputToolbarProps extends React.ComponentProps<"div"> {}
+
+/**
+ * The button that submits the composer.
+ */
+export interface PromptInputSubmitProps extends React.ComponentProps<"button"> {
+  /**
+   * The visual style of the button.
+   * @default 'primary'
+   */
+  variant?: "primary" | "secondary" | "quiet" | "link" | "warning" | "danger"
+
+  /**
+   * The size of the button.
+   * @default 'md'
+   */
+  size?: "xs" | "sm" | "md" | "lg"
+}


### PR DESCRIPTION
Adds a `chat` registry item — the primitives needed to build a chat interface, adapted to dotUI conventions (React Aria Components + tailwind-variants, density and radius flowing through like every other item). Inspired by the shadcn-ecosystem chat components (Vercel AI Elements), but rebuilt on our own primitives rather than ported.

## API surface

`www/src/registry/ui/chat/` — standard item anatomy (`base.tsx`, `styles.ts`, `styles.css`, `index.tsx`, `types.ts`, `meta.ts`, `demos/`, `examples.tsx`).

**Conversation**
- `Conversation` — the scrollable message-list container (`role="log"`).

**Message**
- `Message` — one turn. `role?: "user" | "assistant"` (default `assistant`), rendered as `data-role` so children style against it; `user` reverses the row so the bubble and avatar sit at the end.
- `MessageContent` — `user` renders a contained bubble (`bg-muted`, `rounded-(--chat-message-radius)`, capped width); `assistant` renders plain and full-width.
- `MessageAvatar` — wraps the registry `Avatar` with `src` / `name` (alt text + fallback initials).

**PromptInput**
- `PromptInput` — the composer shell. Renders a `<form>`, so the submit button and the Enter key both submit it. Focus ring keys off the nested `[data-input-control][data-focused]`, same contract as `InputGroup`.
- `PromptInputTextarea` — reuses the `input` item's `TextArea` (RAC + the existing auto-grow layout effect), with the field chrome neutralized so it reads as part of the composer. Enter submits, Shift+Enter inserts a newline, IME composition is respected.
- `PromptInputToolbar` — the row of actions under the textarea.
- `PromptInputSubmit` — the registry `Button`, `type="submit"`, `variant="primary"` by default.

No hardcoded colors: everything goes through semantic tokens (`bg-field`, `bg-muted`, `border-border-field`, `border-border-focus`, `text-fg`). Radius rides two item vars in `styles.css` — `--chat-message-radius: var(--radius-surface)` and `--chat-input-radius: var(--radius-panel)` — so it follows the radius roles. Spacing and type size are split across the three density layers. `registryDependencies: ["avatar", "button", "input"]`; registry files import only from `@/registry/*` and published packages.

## Wiring

- `www/src/registry/styles.css` — added the `ui/chat/styles.css` import.
- `www/src/modules/docs/components-list/components-data.ts` — `Chat` added under **Data display**.
- `www/src/modules/docs/components-list/demos/{chat.tsx,index.ts}` — gallery demo added and registered.
- `www/content/docs/components/chat.mdx` — docs page (usage, anatomy, examples, API reference).
- `pnpm build:registry` — regenerated `__generated__/*` (demos, registry-items, create examples index, style-var-defaults) and committed. `base/colors.css` is unchanged: no color-layer edits.
- `pnpm build:references` — full run committed; 8 new reference files under `www/src/modules/docs/references/generated/`.

## Verification

`pnpm check` (lint + format), `pnpm typecheck`, and `pnpm build:registry` integrity checks all pass. Rendered the docs page against a local dev server and confirmed: user bubbles align end / assistant plain full-width, avatars land on the sender's side, the toolbar and submit button lay out correctly, Enter submits and clears the composer, Shift+Enter inserts a newline, and the textarea grows 64px → 152px over six lines with no inner scrollbar.

## Notes

- The bubble fill is `bg-muted` rather than a primary-colored bubble. Systems disagree on that one, so it's a candidate axis rather than something to hardcode two ways — flagging it instead of inventing a token.
- Kept deliberately small: no auto-scroll-to-bottom, no streaming/reasoning/source parts, no attachment model. Those are the next layer up and should be their own decisions.


---

## Review pass — `fix(registry): polish chat primitives`

**The composer no longer hand-rolls the field shell.** `PromptInput` was reimplementing `InputGroup`: it hardcoded the *outline* field look (`border border-border-field bg-field shadow-[var(--shadow-control,none)]`, its own `has-[[data-input-control][data-focused]]` focus ring, its own `--chat-input-radius`) and then neutralized the `TextArea`'s chrome on top. That pinned the composer to one of the four values of the `input` item's `style` axis — pick `line`, `filled` or `filled-line-bottom` and every other field in the system changed while the composer stayed an outline box.

It now renders `<form>` → `InputGroup` → children, so the shell, focus ring, disabled/invalid states, radius (`--input-radius`) and density tokens all come from the `input` item — the same composition `search-field` uses and the same one the `input-group` "textarea + block-end addon" demo already documents. `PromptInputToolbar` is an `InputGroupAddon`; `PromptInputTextarea` is a plain `TextArea` with only a density `min-h`. Side benefit: `InputGroup`'s pointer handling means clicking anywhere in the composer focuses the textarea.

Consequences:
- `--chat-input-radius` deleted (the composer follows `--input-radius`); `--chat-message-radius` stays.
- `styles.ts` lost the duplicated shell — `promptInput` is now `w-full min-w-0`, toolbar/textarea keep only what is theirs.
- `demos/chat.tsx` no longer borrows the composer's radius var for its conversation frame.

**Toolbar alignment was dead CSS.** `promptInputToolbar: "justify-between"` and the demos' `className="justify-end"` never applied — the addon's `group-has-data-textarea/input-group:justify-start` wins on specificity, so the send button rendered on the *left*. Replaced with `ml-auto` on `PromptInputSubmit` (the idiom the existing input-group demo uses) and dropped the dead classes.

**Duplicate heading id.** `<Example title="Conversation">` and `### Conversation` both produced `#conversation`, which React reported as a duplicate-key warning on every render of the docs TOC. Renamed the example to "Basic" (the dominant convention across the docs pages).

**Smaller fixes**
- `// MARK:` markers renamed to the canonical `// MARK: Separator` — the publisher turns every non-`…Styles` marker into a section rule, and 186 of 188 markers in the registry use that spelling.
- Demo prose no longer ships literal markdown backticks (`` `display: grid` `` rendered as backticks inside a `<div>`), in both `demos/basic.tsx` and the docs Usage snippet.
- Docs anatomy now states that the composer inherits the field style/radius/density.

**Verified** — `pnpm build:registry`, `pnpm build:references` (both clean on rerun), `pnpm check`, `pnpm typecheck`. Rendered against a local dev server on this worktree and confirmed on the live DOM: the group resolves to the `input` style's classes (`rounded-(--input-radius) border-border-field bg-field` + the group focus ring) with the textarea at `border:0 / background:transparent / radius:0`; send button sits at the end in both the bare and the with-tools toolbar; clicking dead space in the composer focuses the textarea; Enter submits and clears; Shift+Enter inserts a newline; no console errors on the docs page or the components gallery.

**Not changed (flagged, not slipped in)**
- No `radius` param in `meta.ts` for `--chat-message-radius` — `card` sets the precedent for a var without a builder param, and adding an axis is a product decision.
- The auto-growing composer has no max height. Every real composer caps it, but the cap value is a design decision, so it is left out rather than invented.
